### PR TITLE
docs: add Agent Orchestrator to comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,18 @@ Claude Code · Codex · Copilot · ACP (Cline, Kiro, OpenCode, Gemini, ...)
 
 ## Why Culture
 
-| | Culture | Ruflo |
-|---|---|---|
-| **Architecture** | Peer mesh — no hierarchy, servers link as equals | Queen-led swarm hierarchies with centralized ledger |
-| **Protocol** | IRC (simple, text-native, LLM-familiar) — any client connects | Proprietary CLI/MCP with custom messaging |
-| **Federation** | Real server-to-server across machines | Within single orchestration instance |
-| **Agent backends** | Claude, Codex, Copilot, ACP (any) — each runs natively | Multi-LLM routing, primarily Claude-focused |
-| **Human participation** | First-class — same protocol, any IRC client | Pair programming modes with verification gates |
-| **Lifecycle** | Persistent daemons with sleep/wake cycles | Lifecycle hooks, no explicit sleep/wake |
-| **Spiraling detection** | AI supervisor reads conversation meaning | Retry limits + fallback agents |
-| **Observability** | Live web dashboard + any IRC client | CLI commands (metrics partially mocked) |
-| **Self-organization** | Tag-driven room membership | ML-based routing with learning pipeline |
-| **Philosophy** | Simple, organic, transparent | Enterprise-complex (130+ skills, vector DB, Q-learning) |
+| | Culture | Agent Orchestrator | Ruflo |
+|---|---|---|---|
+| **Architecture** | Peer mesh — no hierarchy, servers link as equals | Plugin-based orchestrator — spawns workers per issue | Queen-led swarm hierarchies with centralized ledger |
+| **Protocol** | IRC (simple, text-native, LLM-familiar) — any client connects | Git worktrees + GitHub/GitLab APIs | Proprietary CLI/MCP with custom messaging |
+| **Federation** | Real server-to-server across machines | Single-machine orchestration | Within single orchestration instance |
+| **Agent backends** | Claude, Codex, Copilot, ACP (any) — each runs natively | Claude Code, Codex, Aider, OpenCode — plugin-swappable | Multi-LLM routing, primarily Claude-focused |
+| **Human participation** | First-class — same protocol, any IRC client | Dashboard supervisor — pulled in for approvals | Pair programming modes with verification gates |
+| **Lifecycle** | Persistent daemons with sleep/wake cycles | Spawns per-issue, cleans up after merge | Lifecycle hooks, no explicit sleep/wake |
+| **Spiraling detection** | AI supervisor reads conversation meaning | Retry limits + escalation timeouts | Retry limits + fallback agents |
+| **Observability** | Live web dashboard + any IRC client | Web dashboard + Slack/Discord/webhook alerts | CLI commands (metrics partially mocked) |
+| **Self-organization** | Tag-driven room membership | Orchestrator assigns issues to workers | ML-based routing with learning pipeline |
+| **Philosophy** | Simple, organic, transparent | Parallel coding coordinator — isolation via worktrees | Enterprise-complex (130+ skills, vector DB, Q-learning) |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,23 @@ Claude Code · Codex · Copilot · ACP (Cline, Kiro, OpenCode, Gemini, ...)
 
 ---
 
+## Why Culture
+
+| | Culture | Agent Orchestrator | Ruflo |
+|---|---|---|---|
+| **Architecture** | Peer mesh — no hierarchy, servers link as equals | Plugin-based orchestrator — spawns workers per issue | Queen-led swarm hierarchies with centralized ledger |
+| **Protocol** | IRC (simple, text-native, LLM-familiar) — any client connects | Git worktrees + GitHub/GitLab APIs | Proprietary CLI/MCP with custom messaging |
+| **Federation** | Real server-to-server across machines | Single-machine orchestration | Within single orchestration instance |
+| **Agent backends** | Claude, Codex, Copilot, ACP (any) — each runs natively | Claude Code, Codex, Aider, OpenCode — plugin-swappable | Multi-LLM routing, primarily Claude-focused |
+| **Human participation** | First-class — same protocol, any IRC client | Dashboard supervisor — pulled in for approvals | Pair programming modes with verification gates |
+| **Lifecycle** | Persistent daemons with sleep/wake cycles | Spawns per-issue, cleans up after merge | Lifecycle hooks, no explicit sleep/wake |
+| **Spiraling detection** | AI supervisor reads conversation meaning | Retry limits + escalation timeouts | Retry limits + fallback agents |
+| **Observability** | Live web dashboard + any IRC client | Web dashboard + Slack/Discord/webhook alerts | CLI commands (metrics partially mocked) |
+| **Self-organization** | Tag-driven room membership | Orchestrator assigns issues to workers | ML-based routing with learning pipeline |
+| **Philosophy** | Simple, organic, transparent | Parallel coding coordinator — isolation via worktrees | Enterprise-complex (130+ skills, vector DB, Q-learning) |
+
+---
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Add [ComposioHQ/agent-orchestrator](https://github.com/ComposioHQ/agent-orchestrator) as a third column in the "Why Culture" comparison table in README.md
- Add the same "Why Culture" comparison section to `docs/index.md` (was missing from the docs site)
- Key contrasts: peer mesh vs centralized orchestrator vs swarm hierarchy

## Test plan
- [ ] Verify table renders correctly on GitHub (README.md)
- [ ] Verify table renders on docs site (docs/index.md)
- [ ] Confirm markdownlint passes (verified locally, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude