### PR TITLE
fix: culture update used wrong package name for uv upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [3.1.2] - 2026-04-06
+
+
+### Fixed
+
+- culture update used wrong package name (culture-cli) for uv tool upgrade
+
 ## [3.1.1] - 2026-04-06
 
 

--- a/culture/cli.py
+++ b/culture/cli.py
@@ -2100,7 +2100,7 @@ def _server_stop_by_name(name: str) -> None:
 
 
 def _upgrade_culture_package(args: argparse.Namespace) -> bool:
-    """Upgrade the culture-cli package via uv or pip, then re-exec with --skip-upgrade.
+    """Upgrade the culture package via uv or pip, then re-exec with --skip-upgrade.
 
     Returns True if the caller should proceed with the restart phase
     (``--skip-upgrade`` was set). Returns False for dry-run (caller should stop).
@@ -2110,7 +2110,7 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
         return True
 
     if args.dry_run:
-        print("[dry-run] Would run: uv tool upgrade culture-cli")
+        print("[dry-run] Would run: uv tool upgrade culture")
         print("[dry-run] Would re-exec with --skip-upgrade")
         return False
 
@@ -2119,7 +2119,7 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
     if uv:
         print("Upgrading via uv...")
         result = subprocess.run(
-            [uv, "tool", "upgrade", "culture-cli"],
+            [uv, "tool", "upgrade", "culture"],
             capture_output=True,
             text=True,
         )
@@ -2132,7 +2132,7 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
         if pip:
             print("Upgrading via pip...")
             result = subprocess.run(
-                [pip, "install", "--upgrade", "culture-cli"],
+                [pip, "install", "--upgrade", "culture"],
                 capture_output=True,
                 text=True,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "3.1.1"
+version = "3.1.2"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- `culture update` called `uv tool upgrade culture-cli` but the package is installed as `culture` (matching `pyproject.toml`)
- Replaced the stale `culture-cli` name in all 4 references in `_upgrade_culture_package()`

## Test plan

- [ ] `culture update --dry-run` prints `uv tool upgrade culture` (not `culture-cli`)
- [ ] `pytest -n auto` — 540 tests pass

- Claude