### PR TITLE
feat: agent delete and create-overwrite for archived agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [4.3.0] - 2026-04-07
+
+
+### Added
+
+- agent delete command to remove agents from config entirely
+- agent create now overwrites archived agents, enabling harness/model migration
+
+
+### Fixed
+
+- agent create no longer blocks when the matching nick is archived
+
 ## [4.2.1] - 2026-04-07
 
 

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -16,6 +16,7 @@ from culture.clients.claude.config import (
     archive_agent,
     load_config,
     load_config_or_default,
+    remove_agent,
     sanitize_agent_name,
     unarchive_agent,
 )
@@ -158,11 +159,16 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     unarchive_parser.add_argument("nick", help="Agent nick to unarchive")
     unarchive_parser.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
 
+    # -- delete ---------------------------------------------------------------
+    delete_parser = agent_sub.add_parser("delete", help="Remove an agent from config entirely")
+    delete_parser.add_argument("nick", help="Agent nick to delete")
+    delete_parser.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
+
 
 def dispatch(args: argparse.Namespace) -> None:
     if not args.agent_command:
         print(
-            "Usage: culture agent {create|join|start|stop|status|rename|assign|sleep|wake|learn|message|read|archive|unarchive}",
+            "Usage: culture agent {create|join|start|stop|status|rename|assign|sleep|wake|learn|message|read|archive|unarchive|delete}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -182,6 +188,7 @@ def dispatch(args: argparse.Namespace) -> None:
         "read": _cmd_read,
         "archive": _cmd_archive,
         "unarchive": _cmd_unarchive,
+        "delete": _cmd_delete,
     }
     handler = handlers.get(args.agent_command)
     if handler:
@@ -264,6 +271,10 @@ def _cmd_create(args: argparse.Namespace) -> None:
 
     for existing in config.agents:
         if existing.nick == full_nick:
+            if existing.archived:
+                print(f"Replacing archived agent '{full_nick}'")
+                remove_agent(args.config, full_nick)
+                break
             channels = existing.channels if isinstance(existing.channels, list) else []
             print(f"Agent '{full_nick}' already exists in config", file=sys.stderr)
             print(f"  Directory: {existing.directory}", file=sys.stderr)
@@ -831,3 +842,20 @@ def _cmd_unarchive(args: argparse.Namespace) -> None:
 
     print(f"Agent unarchived: {args.nick}")
     print(f"\nStart with: culture agent start {args.nick}")
+
+
+def _cmd_delete(args: argparse.Namespace) -> None:
+    """Remove an agent from config entirely."""
+    config = load_config_or_default(args.config)
+    agent = config.get_agent(args.nick)
+    if not agent:
+        print(f"Agent '{args.nick}' not found in config", file=sys.stderr)
+        sys.exit(1)
+
+    # Stop the agent if it's running
+    pid = read_pid(f"agent-{args.nick}")
+    if pid and is_process_alive(pid):
+        stop_agent(args.nick)
+
+    remove_agent(args.config, args.nick)
+    print(f"Agent deleted: {args.nick}")

--- a/culture/clients/acp/config.py
+++ b/culture/clients/acp/config.py
@@ -256,12 +256,22 @@ def remove_agent(
 ) -> None:
     """Remove an agent from config entirely.
 
+    Operates on raw YAML to preserve backend-specific fields on other
+    agents that the typed schema would strip.
     Raises ValueError if the agent is not found.
     """
-    config = load_config_or_default(path)
-    for i, agent in enumerate(config.agents):
-        if agent.nick == nick:
-            config.agents.pop(i)
-            save_config(path, config)
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"agent {nick!r} not found in config")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    agents = raw.get("agents", [])
+    for i, agent_raw in enumerate(agents):
+        if agent_raw.get("nick") == nick:
+            agents.pop(i)
+            with open(path, "w") as f:
+                yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
             return
     raise ValueError(f"agent {nick!r} not found in config")

--- a/culture/clients/acp/config.py
+++ b/culture/clients/acp/config.py
@@ -248,3 +248,20 @@ def rename_agent(
             return
 
     raise ValueError(f"agent {old_nick!r} not found in config")
+
+
+def remove_agent(
+    path: str | Path,
+    nick: str,
+) -> None:
+    """Remove an agent from config entirely.
+
+    Raises ValueError if the agent is not found.
+    """
+    config = load_config_or_default(path)
+    for i, agent in enumerate(config.agents):
+        if agent.nick == nick:
+            config.agents.pop(i)
+            save_config(path, config)
+            return
+    raise ValueError(f"agent {nick!r} not found in config")

--- a/culture/clients/claude/config.py
+++ b/culture/clients/claude/config.py
@@ -309,13 +309,23 @@ def remove_agent(
 ) -> None:
     """Remove an agent from config entirely.
 
+    Operates on raw YAML to preserve backend-specific fields (e.g.
+    acp_command) on other agents that the typed schema would strip.
     Raises ValueError if the agent is not found.
     """
-    config = load_config_or_default(path)
-    for i, agent in enumerate(config.agents):
-        if agent.nick == nick:
-            config.agents.pop(i)
-            save_config(path, config)
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"agent {nick!r} not found in config")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    agents = raw.get("agents", [])
+    for i, agent_raw in enumerate(agents):
+        if agent_raw.get("nick") == nick:
+            agents.pop(i)
+            with open(path, "w") as f:
+                yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
             return
     raise ValueError(f"agent {nick!r} not found in config")
 

--- a/culture/clients/claude/config.py
+++ b/culture/clients/claude/config.py
@@ -303,6 +303,23 @@ def unarchive_agent(
     raise ValueError(f"agent {nick!r} not found in config")
 
 
+def remove_agent(
+    path: str | Path,
+    nick: str,
+) -> None:
+    """Remove an agent from config entirely.
+
+    Raises ValueError if the agent is not found.
+    """
+    config = load_config_or_default(path)
+    for i, agent in enumerate(config.agents):
+        if agent.nick == nick:
+            config.agents.pop(i)
+            save_config(path, config)
+            return
+    raise ValueError(f"agent {nick!r} not found in config")
+
+
 def archive_server(
     path: str | Path,
     reason: str = "",

--- a/culture/clients/codex/config.py
+++ b/culture/clients/codex/config.py
@@ -256,12 +256,22 @@ def remove_agent(
 ) -> None:
     """Remove an agent from config entirely.
 
+    Operates on raw YAML to preserve backend-specific fields on other
+    agents that the typed schema would strip.
     Raises ValueError if the agent is not found.
     """
-    config = load_config_or_default(path)
-    for i, agent in enumerate(config.agents):
-        if agent.nick == nick:
-            config.agents.pop(i)
-            save_config(path, config)
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"agent {nick!r} not found in config")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    agents = raw.get("agents", [])
+    for i, agent_raw in enumerate(agents):
+        if agent_raw.get("nick") == nick:
+            agents.pop(i)
+            with open(path, "w") as f:
+                yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
             return
     raise ValueError(f"agent {nick!r} not found in config")

--- a/culture/clients/codex/config.py
+++ b/culture/clients/codex/config.py
@@ -248,3 +248,20 @@ def rename_agent(
             return
 
     raise ValueError(f"agent {old_nick!r} not found in config")
+
+
+def remove_agent(
+    path: str | Path,
+    nick: str,
+) -> None:
+    """Remove an agent from config entirely.
+
+    Raises ValueError if the agent is not found.
+    """
+    config = load_config_or_default(path)
+    for i, agent in enumerate(config.agents):
+        if agent.nick == nick:
+            config.agents.pop(i)
+            save_config(path, config)
+            return
+    raise ValueError(f"agent {nick!r} not found in config")

--- a/culture/clients/copilot/config.py
+++ b/culture/clients/copilot/config.py
@@ -256,12 +256,22 @@ def remove_agent(
 ) -> None:
     """Remove an agent from config entirely.
 
+    Operates on raw YAML to preserve backend-specific fields on other
+    agents that the typed schema would strip.
     Raises ValueError if the agent is not found.
     """
-    config = load_config_or_default(path)
-    for i, agent in enumerate(config.agents):
-        if agent.nick == nick:
-            config.agents.pop(i)
-            save_config(path, config)
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"agent {nick!r} not found in config")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    agents = raw.get("agents", [])
+    for i, agent_raw in enumerate(agents):
+        if agent_raw.get("nick") == nick:
+            agents.pop(i)
+            with open(path, "w") as f:
+                yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
             return
     raise ValueError(f"agent {nick!r} not found in config")

--- a/culture/clients/copilot/config.py
+++ b/culture/clients/copilot/config.py
@@ -248,3 +248,20 @@ def rename_agent(
             return
 
     raise ValueError(f"agent {old_nick!r} not found in config")
+
+
+def remove_agent(
+    path: str | Path,
+    nick: str,
+) -> None:
+    """Remove an agent from config entirely.
+
+    Raises ValueError if the agent is not found.
+    """
+    config = load_config_or_default(path)
+    for i, agent in enumerate(config.agents):
+        if agent.nick == nick:
+            config.agents.pop(i)
+            save_config(path, config)
+            return
+    raise ValueError(f"agent {nick!r} not found in config")

--- a/docs/superpowers/specs/2026-04-07-entity-archiving-design.md
+++ b/docs/superpowers/specs/2026-04-07-entity-archiving-design.md
@@ -264,7 +264,7 @@ automatically replaces it:
 $ culture agent archive spark-daria
 Agent archived: spark-daria
 
-$ culture agent create --server spark --nick daria --agent acp --acp-command opencode
+$ culture agent create --server spark --nick daria --agent acp
 Replacing archived agent 'spark-daria'
 Agent created: spark-daria
   ...
@@ -281,7 +281,14 @@ def remove_agent(path, nick):
 ```
 
 Added to all backend config files (`claude`, `acp`, `codex`, `copilot`) and
-`packages/agent-harness/config.py`.
+`packages/agent-harness/config.py`. Uses raw YAML manipulation to preserve
+backend-specific fields (e.g. `acp_command`) on other agents.
+
+### Protocol Details
+
+No new protocol changes. Delete and create-overwrite are CLI/config operations
+only, consistent with the existing archiving scope (CLI-only, no federation
+concern).
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-04-07-entity-archiving-design.md
+++ b/docs/superpowers/specs/2026-04-07-entity-archiving-design.md
@@ -238,6 +238,51 @@ per-file (no list to search through).
 - `test_start_refuses_archived_server` -- verify error message
 - `test_start_all_skips_archived` -- verify `--all` only starts active agents
 
+## Agent Deletion and Create-Overwrite
+
+### Problem
+
+Once an agent is archived, there's no way to recreate it with a different
+backend or model. `culture agent create` blocks with "already exists in config"
+because the archived entry is still present. Users must manually edit
+`agents.yaml` to change an agent's harness.
+
+### Delete Command
+
+```
+culture agent delete <nick> [--config PATH]
+```
+
+Removes an agent from config entirely. Stops the agent if running.
+
+### Create Overwrites Archived Agents
+
+`culture agent create` now detects when the matching agent is archived and
+automatically replaces it:
+
+```
+$ culture agent archive spark-daria
+Agent archived: spark-daria
+
+$ culture agent create --server spark --nick daria --agent acp --acp-command opencode
+Replacing archived agent 'spark-daria'
+Agent created: spark-daria
+  ...
+```
+
+Non-archived agents still block `create` with the existing error. This is the
+primary mechanism for moving an agent to a different harness or model.
+
+### Config Layer
+
+```python
+def remove_agent(path, nick):
+    """Remove an agent from config entirely. Raises ValueError if not found."""
+```
+
+Added to all backend config files (`claude`, `acp`, `codex`, `copilot`) and
+`packages/agent-harness/config.py`.
+
 ## Verification
 
 1. Create test agents: `culture agent create --nick test1 && culture agent create --nick test2`

--- a/packages/agent-harness/config.py
+++ b/packages/agent-harness/config.py
@@ -254,12 +254,22 @@ def remove_agent(
 ) -> None:
     """Remove an agent from config entirely.
 
+    Operates on raw YAML to preserve backend-specific fields on other
+    agents that the typed schema would strip.
     Raises ValueError if the agent is not found.
     """
-    config = load_config_or_default(path)
-    for i, agent in enumerate(config.agents):
-        if agent.nick == nick:
-            config.agents.pop(i)
-            save_config(path, config)
+    path = Path(path)
+    if not path.exists():
+        raise ValueError(f"agent {nick!r} not found in config")
+
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    agents = raw.get("agents", [])
+    for i, agent_raw in enumerate(agents):
+        if agent_raw.get("nick") == nick:
+            agents.pop(i)
+            with open(path, "w") as f:
+                yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
             return
     raise ValueError(f"agent {nick!r} not found in config")

--- a/packages/agent-harness/config.py
+++ b/packages/agent-harness/config.py
@@ -246,3 +246,20 @@ def rename_agent(
             return
 
     raise ValueError(f"agent {old_nick!r} not found in config")
+
+
+def remove_agent(
+    path: str | Path,
+    nick: str,
+) -> None:
+    """Remove an agent from config entirely.
+
+    Raises ValueError if the agent is not found.
+    """
+    config = load_config_or_default(path)
+    for i, agent in enumerate(config.agents):
+        if agent.nick == nick:
+            config.agents.pop(i)
+            save_config(path, config)
+            return
+    raise ValueError(f"agent {nick!r} not found in config")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "4.2.1"
+version = "4.3.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -503,8 +503,8 @@ def test_remove_agent_not_found():
 # -----------------------------------------------------------------------
 
 
-def test_create_overwrites_archived_agent():
-    """Creating an agent that is archived replaces it with the new config."""
+def test_remove_then_add_replaces_archived_agent():
+    """Removing an archived agent and re-adding produces a fresh entry."""
     from culture.clients.claude.config import (
         AgentConfig,
         DaemonConfig,
@@ -592,5 +592,250 @@ def test_create_blocked_by_active_agent():
         )
         with pytest.raises(ValueError, match="already exists"):
             add_agent_to_config(path, new_agent, server_name="spark")
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+# -----------------------------------------------------------------------
+# CLI-level: create overwrites archived, delete removes
+# -----------------------------------------------------------------------
+
+
+def test_cli_create_replaces_archived_agent():
+    """culture agent create replaces an archived agent via the CLI path."""
+    from culture.cli import _build_parser
+    from culture.cli.agent import _cmd_create
+    from culture.clients.claude.config import (
+        AgentConfig,
+        DaemonConfig,
+        ServerConnConfig,
+        archive_agent,
+        load_config,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(
+                server=ServerConnConfig(name="spark"),
+                agents=[
+                    AgentConfig(
+                        nick="spark-daria",
+                        agent="claude",
+                        directory="/tmp/daria",
+                        channels=["#general"],
+                    ),
+                ],
+            ),
+        )
+        archive_agent(path, "spark-daria", reason="switching backend")
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "agent",
+                "create",
+                "--server",
+                "spark",
+                "--nick",
+                "daria",
+                "--agent",
+                "acp",
+                "--config",
+                path,
+            ]
+        )
+        _cmd_create(args)
+
+        loaded = load_config(path)
+        assert len(loaded.agents) == 1
+        agent = loaded.agents[0]
+        assert agent.nick == "spark-daria"
+        assert agent.agent == "acp"
+        assert agent.archived is False
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cli_create_blocks_active_agent():
+    """culture agent create exits non-zero for a non-archived agent."""
+    from culture.cli import _build_parser
+    from culture.cli.agent import _cmd_create
+    from culture.clients.claude.config import (
+        AgentConfig,
+        DaemonConfig,
+        ServerConnConfig,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(
+                server=ServerConnConfig(name="spark"),
+                agents=[
+                    AgentConfig(
+                        nick="spark-daria",
+                        agent="claude",
+                        directory="/tmp/daria",
+                        channels=["#general"],
+                    ),
+                ],
+            ),
+        )
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "agent",
+                "create",
+                "--server",
+                "spark",
+                "--nick",
+                "daria",
+                "--agent",
+                "acp",
+                "--config",
+                path,
+            ]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_create(args)
+        assert exc_info.value.code == 1
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cli_delete_removes_agent():
+    """culture agent delete removes the agent from config."""
+    from culture.cli import _build_parser
+    from culture.cli.agent import _cmd_delete
+    from culture.clients.claude.config import (
+        AgentConfig,
+        DaemonConfig,
+        ServerConnConfig,
+        load_config,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(
+                server=ServerConnConfig(name="spark"),
+                agents=[
+                    AgentConfig(
+                        nick="spark-daria",
+                        agent="claude",
+                        directory="/tmp/daria",
+                        channels=["#general"],
+                    ),
+                    AgentConfig(
+                        nick="spark-ori",
+                        agent="claude",
+                        directory="/tmp/ori",
+                        channels=["#dev"],
+                    ),
+                ],
+            ),
+        )
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "agent",
+                "delete",
+                "spark-daria",
+                "--config",
+                path,
+            ]
+        )
+        _cmd_delete(args)
+
+        loaded = load_config(path)
+        assert len(loaded.agents) == 1
+        assert loaded.agents[0].nick == "spark-ori"
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_cli_delete_not_found():
+    """culture agent delete exits non-zero for unknown nick."""
+    from culture.cli import _build_parser
+    from culture.cli.agent import _cmd_delete
+    from culture.clients.claude.config import (
+        DaemonConfig,
+        ServerConnConfig,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(server=ServerConnConfig(name="spark"), agents=[]),
+        )
+
+        parser = _build_parser()
+        args = parser.parse_args(
+            [
+                "agent",
+                "delete",
+                "spark-nonexistent",
+                "--config",
+                path,
+            ]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_delete(args)
+        assert exc_info.value.code == 1
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_remove_agent_preserves_other_agent_fields():
+    """remove_agent with raw YAML preserves backend-specific fields on other agents."""
+    import yaml as _yaml
+
+    from culture.clients.claude.config import (
+        DaemonConfig,
+        ServerConnConfig,
+        remove_agent,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        # Write a config with an ACP agent that has acp_command (unknown to claude schema)
+        save_config(
+            path,
+            DaemonConfig(server=ServerConnConfig(name="spark"), agents=[]),
+        )
+        # Manually add agents with backend-specific fields
+        with open(path) as f:
+            raw = _yaml.safe_load(f)
+        raw["agents"] = [
+            {"nick": "spark-daria", "agent": "acp", "acp_command": ["opencode", "acp"]},
+            {"nick": "spark-claude", "agent": "claude", "directory": "/tmp/c"},
+        ]
+        with open(path, "w") as f:
+            _yaml.dump(raw, f, default_flow_style=False, sort_keys=False)
+
+        remove_agent(path, "spark-claude")
+
+        with open(path) as f:
+            result = _yaml.safe_load(f)
+        assert len(result["agents"]) == 1
+        assert result["agents"][0]["nick"] == "spark-daria"
+        assert result["agents"][0]["acp_command"] == ["opencode", "acp"]
     finally:
         shutil.rmtree(tmpdir)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -434,3 +434,163 @@ def test_archive_preserves_other_fields():
         assert agent.tags == ["core", "main"]
     finally:
         shutil.rmtree(tmpdir)
+
+
+# -----------------------------------------------------------------------
+# Config-level: remove_agent
+# -----------------------------------------------------------------------
+
+
+def test_remove_agent():
+    """remove_agent removes the agent from config entirely."""
+    from culture.clients.claude.config import (
+        AgentConfig,
+        DaemonConfig,
+        ServerConnConfig,
+        load_config,
+        remove_agent,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(
+                server=ServerConnConfig(name="spark"),
+                agents=[
+                    AgentConfig(nick="spark-claude", directory="/tmp/a", channels=["#general"]),
+                    AgentConfig(nick="spark-ori", directory="/tmp/b", channels=["#dev"]),
+                ],
+            ),
+        )
+
+        remove_agent(path, "spark-claude")
+
+        loaded = load_config(path)
+        assert len(loaded.agents) == 1
+        assert loaded.agents[0].nick == "spark-ori"
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_remove_agent_not_found():
+    """remove_agent raises ValueError for unknown nick."""
+    from culture.clients.claude.config import (
+        DaemonConfig,
+        ServerConnConfig,
+        remove_agent,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(server=ServerConnConfig(name="spark"), agents=[]),
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            remove_agent(path, "spark-nonexistent")
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+# -----------------------------------------------------------------------
+# Config-level: create overwrites archived agent
+# -----------------------------------------------------------------------
+
+
+def test_create_overwrites_archived_agent():
+    """Creating an agent that is archived replaces it with the new config."""
+    from culture.clients.claude.config import (
+        AgentConfig,
+        DaemonConfig,
+        ServerConnConfig,
+        add_agent_to_config,
+        archive_agent,
+        load_config,
+        remove_agent,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(
+                server=ServerConnConfig(name="spark"),
+                agents=[
+                    AgentConfig(
+                        nick="spark-daria",
+                        agent="claude",
+                        directory="/tmp/daria",
+                        channels=["#general"],
+                    ),
+                ],
+            ),
+        )
+
+        # Archive, then remove and re-add with different backend
+        archive_agent(path, "spark-daria", reason="switching backend")
+        remove_agent(path, "spark-daria")
+
+        new_agent = AgentConfig(
+            nick="spark-daria",
+            agent="acp",
+            directory="/tmp/daria",
+            channels=["#general"],
+        )
+        add_agent_to_config(path, new_agent, server_name="spark")
+
+        loaded = load_config(path)
+        assert len(loaded.agents) == 1
+        agent = loaded.agents[0]
+        assert agent.nick == "spark-daria"
+        assert agent.agent == "acp"
+        assert agent.archived is False
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_create_blocked_by_active_agent():
+    """add_agent_to_config raises ValueError when a non-archived agent exists."""
+    from culture.clients.claude.config import (
+        AgentConfig,
+        DaemonConfig,
+        ServerConnConfig,
+        add_agent_to_config,
+        save_config,
+    )
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "agents.yaml")
+        save_config(
+            path,
+            DaemonConfig(
+                server=ServerConnConfig(name="spark"),
+                agents=[
+                    AgentConfig(
+                        nick="spark-daria",
+                        agent="claude",
+                        directory="/tmp/daria",
+                        channels=["#general"],
+                    ),
+                ],
+            ),
+        )
+
+        new_agent = AgentConfig(
+            nick="spark-daria",
+            agent="acp",
+            directory="/tmp/daria",
+            channels=["#general"],
+        )
+        with pytest.raises(ValueError, match="already exists"):
+            add_agent_to_config(path, new_agent, server_name="spark")
+    finally:
+        shutil.rmtree(tmpdir)

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "4.2.1"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- `culture agent create` now detects archived agents with the same nick and replaces them automatically, enabling migration to a different harness or model without editing YAML
- New `culture agent delete <nick>` command removes an agent from config entirely (stops it if running)
- `remove_agent()` config function added to all 5 backend config files (all-backends rule)

## Test plan

- [x] `test_remove_agent` — removes agent, verifies gone
- [x] `test_remove_agent_not_found` — raises ValueError
- [x] `test_create_overwrites_archived_agent` — archive + create replaces entry
- [x] `test_create_blocked_by_active_agent` — non-archived still blocks
- [x] Full suite: 576 passed
- [ ] Manual: `culture agent archive spark-daria && culture agent create --server spark --nick daria --agent acp --acp-command opencode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude