### PR TITLE
fix: tighten CI workflow permissions to job level

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,11 +5,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -17,6 +12,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,6 +44,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,11 @@ on:
       - "pyproject.toml"
       - "culture/**"
 
-permissions:
-  contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -9,13 +9,12 @@ on:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   security-scans:
     name: Security Scans
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,12 +4,11 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Moves workflow-level `permissions` blocks to job level in all four CI workflows (`pages.yml`, `publish.yml`, `security-checks.yml`, `tests.yml`)
- Each job now declares only the permissions it actually needs, following the principle of least privilege
- Resolves #92 (SonarCloud S8233/S8264)

## Test plan
- [ ] All four workflows pass on this PR (Tests, Security Checks, Publish dry-run)
- [ ] Pages deployment still works after merge (deploy job has `pages: write` + `id-token: write`)
- [ ] SonarCloud no longer flags S8233/S8264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude