### PR TITLE
fix: remove unnecessary list() calls on iterables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [4.3.1] - 2026-04-07
+
+
+### Fixed
+
+- Remove unnecessary list() wrapping on already-iterable values (SonarCloud S7504/S7494)
+
 ## [4.3.0] - 2026-04-07
 
 

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -86,7 +86,7 @@ class BotManager:
 
     def list_bots(self, owner: str | None = None) -> list[Bot]:
         """List bots, optionally filtered by owner."""
-        bots = list(self.bots.values())
+        bots = self.bots.values()
         if owner:
             bots = [b for b in bots if b.config.owner == owner]
         return sorted(bots, key=lambda b: b.name)

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -448,10 +448,10 @@ async def _run_single_agent(config: DaemonConfig, agent: AgentConfig) -> None:
                 agent="acp",
                 acp_command=getattr(agent, "acp_command", None) or ["opencode", "acp"],
                 directory=agent.directory,
-                channels=list(agent.channels),
+                channels=agent.channels,
                 model=agent.model,
                 system_prompt=agent.system_prompt,
-                tags=list(agent.tags),
+                tags=agent.tags,
             )
         else:
             acp_agent = agent

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -324,7 +324,7 @@ def _generate_agent_configs(mesh, server_name: str) -> None:
                     nick=full_nick,
                     agent=a.type,
                     directory=workdir,
-                    channels=list(a.channels),
+                    channels=a.channels,
                 )
             )
 

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -230,7 +230,7 @@ def _server_start(args: argparse.Namespace) -> None:
         print(f"Server '{args.name}' is already running (PID {existing})")
         sys.exit(1)
 
-    links = list(args.link)
+    links = args.link
     if getattr(args, "mesh_config", None):
         links = resolve_links_from_mesh(args.mesh_config)
 

--- a/culture/console/client.py
+++ b/culture/console/client.py
@@ -199,7 +199,7 @@ class ConsoleIRCClient:
         finally:
             self._pending.pop("323", None)
 
-        channels = list(self._collect_buffers.pop(key, []))
+        channels = self._collect_buffers.pop(key, [])
         return sorted(channels)
 
     async def who(self, target: str) -> list[dict]:
@@ -221,7 +221,7 @@ class ConsoleIRCClient:
         finally:
             self._pending.pop(f"315:{target}", None)
 
-        entries = list(self._collect_buffers.pop(key, []))
+        entries = self._collect_buffers.pop(key, [])
         return entries
 
     async def history(self, channel: str, limit: int = 50) -> list[dict]:
@@ -243,7 +243,7 @@ class ConsoleIRCClient:
         finally:
             self._pending.pop(f"HISTORYEND:{channel}", None)
 
-        entries = list(self._collect_buffers.pop(key, []))
+        entries = self._collect_buffers.pop(key, [])
         return entries
 
     # ------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "4.3.0"
+version = "4.3.1"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "4.3.0"
+version = "4.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Removes 8 unnecessary `list()` calls wrapping values that are already lists or only need iteration (SonarCloud S7504/S7494)
- Keeps ~35 instances that are **necessary defensive copies** in async code — `channel.members` is a `set[Client]`, and removing `list()` would risk `RuntimeError` if another coroutine modifies the set during `await`

### Files changed
- `culture/bots/bot_manager.py` — `list(dict.values())` in sync method
- `culture/cli/agent.py` — `list()` wrapping already-list config fields
- `culture/cli/mesh.py` — same
- `culture/cli/server.py` — `list()` on argparse list result
- `culture/console/client.py` — `list()` on `.pop()` returns (3 instances)

### Why not all 40?

Most flagged instances follow the pattern `for member in list(channel.members):` in async server code. Since `channel.members` is a `set`, and the loop body contains `await` (which yields to the event loop), removing `list()` could cause `RuntimeError: Set changed size during iteration` if another client connects/disconnects concurrently. These are correct defensive copies that SonarCloud's static analysis doesn't recognize as necessary.

Closes #87

## Test plan

- [x] All 581 tests pass (`pytest -n auto`)
- [ ] Verify no behavioral changes in bot listing, agent startup, mesh config, server start, console client queries

- Claude