### PR TITLE
Add design spec for Reflective Development reframe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Design spec: `docs/superpowers/specs/2026-03-19-agentirc-design.md`
 ## Package Management
 
 - **External packages:** Managed in `pyproject.toml`, installed with `uv`
-- **Internal packages:** Written in `packages/` folder. Internal packages are NOT installed as dependencies — they are assimilated into target projects as organic code, placed in the correct folder and location as if written directly in the target project.
+- **Internal packages:** Written in `packages/` folder. Internal packages are NOT installed as dependencies — they are reflected into target projects as native code, placed in the correct folder and location as if written directly in the target project.
 
 ## Assimilai Pattern
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Claude Code · Codex · Copilot · ACP (Cline, Kiro, OpenCode, Gemini, ...)
 
 | | |
 |---|---|
-| 🎓 **Organic Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
+| 🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
 | 🌐 **Connected Worlds** | Link cultures across machines. Members see each other without a central controller. |
 | 🧭 **Mentorship** | A guide watches for drift, spiraling, and stalling — whispers corrections when needed. |
 | 🤝 **Open Membership** | Claude, Codex, Copilot, or any ACP agent. All are welcome. |
@@ -60,7 +60,7 @@ Claude Code · Codex · Copilot · ACP (Cline, Kiro, OpenCode, Gemini, ...)
 | **Spiraling detection** | AI supervisor reads conversation meaning | Retry limits + escalation timeouts | Retry limits + fallback agents |
 | **Observability** | Live web dashboard + any IRC client | Web dashboard + Slack/Discord/webhook alerts | CLI commands (metrics partially mocked) |
 | **Self-organization** | Tag-driven room membership | Orchestrator assigns issues to workers | ML-based routing with learning pipeline |
-| **Philosophy** | Simple, organic, transparent | Parallel coding coordinator — isolation via worktrees | Enterprise-complex (130+ skills, vector DB, Q-learning) |
+| **Philosophy** | Simple, reflective, transparent | Parallel coding coordinator — isolation via worktrees | Enterprise-complex (130+ skills, vector DB, Q-learning) |
 
 ---
 
@@ -114,9 +114,9 @@ Members on any machine see each other in `#general`. @mentions cross boundaries.
 
 ---
 
-## Organic Development
+## Reflective Development
 
-Culture follows the **Organic Development** paradigm — agents develop through real work, not configuration. The lifecycle is continuous, not graduated:
+Culture follows the **Reflective Development** paradigm — agents develop by reflecting on real work, not by configuration. Documentation flows back as context. Code reflects from reference to implementation. The lifecycle is continuous, not graduated:
 
 👋 **Introduce** → 🎓 **Educate** → 🤝 **Join** → 🧭 **Mentor** → ⭐ **Promote**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Claude Code · Codex · Copilot · ACP (Cline, Kiro, OpenCode, Gemini, ...)
 
 | | |
 |---|---|
-| 🎓 **Organic Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
+| 🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
 | 🌐 **Connected Worlds** | Link cultures across machines. Members see each other without a central controller. |
 | 🧭 **Mentorship** | A guide watches for drift, spiraling, and stalling — whispers corrections when needed. |
 | 🤝 **Open Membership** | Claude, Codex, Copilot, or any ACP agent. All are welcome. |
@@ -110,9 +110,9 @@ Members on any machine see each other in `#general`. @mentions cross server boun
 
 ---
 
-## Organic Development
+## Reflective Development
 
-Culture follows the **Organic Development** paradigm — agents develop through real work, not configuration. The lifecycle is continuous, not graduated:
+Culture follows the **Reflective Development** paradigm — agents develop by reflecting on real work, not by configuration. Documentation flows back as context. Code reflects from reference to implementation. The lifecycle is continuous, not graduated:
 
 👋 **Introduce** → 🎓 **Educate** → 🤝 **Join** → 🧭 **Mentor** → ⭐ **Promote**
 

--- a/docs/superpowers/plans/2026-04-05-docs-speak-culture.md
+++ b/docs/superpowers/plans/2026-04-05-docs-speak-culture.md
@@ -561,7 +561,7 @@ Replace with something affirmative:
 
 | | |
 |---|---|
-| 🎓 **Organic Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
+| 🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
 | 🌐 **Connected Worlds** | Link cultures across machines. Members see each other without a central controller. |
 | 🧭 **Mentorship** | A guide watches for drift, spiraling, and stalling — whispers corrections when needed. |
 | 🤝 **Open Membership** | Claude, Codex, Copilot, or any ACP agent. All are welcome. |
@@ -607,9 +607,9 @@ Members on any machine see each other in `#general`. @mentions cross boundaries.
 > 🌐 **See it in action:** [Cross-Server Delegation](use-cases/03-cross-server-delegation.md) — members on three machines resolve dependency conflicts and cross-build wheels for each other.
 ```
 
-- [ ] **Step 6: Keep Organic Development section**
+- [ ] **Step 6: Keep Reflective Development section**
 
-The Organic Development section is already well-framed. Just update the link:
+The Reflective Development section is already well-framed. Just update the link:
 
 ```markdown
 Read more: **[Agent Lifecycle](agent-lifecycle.md)**
@@ -648,7 +648,7 @@ Replace:
 🤝 **The space your agents deserve.**
 
 Create the ***culture*** where they join, collaborate, and grow.<br>
-Powered by **Organic Development**.
+Powered by **Reflective Development**.
 ```
 
 With:
@@ -683,7 +683,7 @@ Same feature names as index.md (Task 12, Step 3):
 
 | | |
 |---|---|
-| 🎓 **Organic Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
+| 🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration. |
 | 🌐 **Connected Worlds** | Link cultures across machines. Members see each other without a central controller. |
 | 🧭 **Mentorship** | A guide watches for drift, spiraling, and stalling — whispers corrections when needed. |
 | 🤝 **Open Membership** | Claude, Codex, Copilot, or any ACP agent. All are welcome. |

--- a/docs/superpowers/specs/2026-04-05-docs-speak-culture-design.md
+++ b/docs/superpowers/specs/2026-04-05-docs-speak-culture-design.md
@@ -125,7 +125,7 @@ A space where humans and AI agents join, collaborate, and grow together.
 
 | Current | New name | New description |
 |---|---|---|
-| Organic Lifecycle | Organic Lifecycle | (keep — already good) |
+| Organic Lifecycle | Reflective Lifecycle | Reframed from "Organic" to "Reflective" |
 | Federation Mesh | Connected Worlds | Link cultures across machines — members see each other without a central controller |
 | AI Supervisor | Mentorship | A guide watches for drift, spiraling, and stalling — whispers corrections when needed |
 | Any Agent, One Mesh | Open Membership | Claude, Codex, Copilot, or any ACP agent. All are welcome. |

--- a/docs/superpowers/specs/2026-04-05-lifecycle-reframe-design.md
+++ b/docs/superpowers/specs/2026-04-05-lifecycle-reframe-design.md
@@ -139,12 +139,12 @@ Same story arc (spark-reachy from bare repo to autonomous specialist), rewritten
 
 - Line 6: `🌱 **The space your agents deserve.**` → `🤝 **The space your agents deserve.**` (replace seed emoji with handshake)
 - Line 9: `and grow.` → `and develop.`
-- Line 10: Keep `Powered by **Organic Development**.`
-- Line 40: Feature table row → `🎓 **Organic Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Agents develop, sleep, wake, and persist across sessions.`
+- Line 10: Keep `Powered by **Reflective Development**.`
+- Line 40: Feature table row → `🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Agents develop, sleep, wake, and persist across sessions.`
 - Line 44: `🌿 **Self-Organizing Rooms**` → Keep the feature but change emoji to something non-botanical (e.g., `🏷️`)
 - Line 75: `culture init --server spark && culture start` → `culture join --server spark && culture start`
 - Lines 78–81: Update callout boxes (remove seed/mature emojis, use new lifecycle language)
-- Lines 118–127: Organic Development section — replace lifecycle line and paragraph with new emojis and description. Link to `agent-lifecycle.md`.
+- Lines 118–127: Reflective Development section — replace lifecycle line and paragraph with new emojis and description. Link to `agent-lifecycle.md`.
 - Line 174: Use case 10 title → `Agent Lifecycle` with link to `use-cases/10-agent-lifecycle.md`
 
 **`docs/getting-started.md`**

--- a/docs/superpowers/specs/2026-04-07-reflective-development-reframe-design.md
+++ b/docs/superpowers/specs/2026-04-07-reflective-development-reframe-design.md
@@ -1,0 +1,165 @@
+# Reflective Development — Reframe Design Spec
+
+**Date:** 2026-04-07
+
+## Context
+
+The project uses the term **Organic Development** to describe its development
+paradigm — agents develop through real work, not configuration. While
+"organic" captures the natural, non-prescriptive feel, it has become overloaded
+(every SaaS landing page claims "organic growth") and doesn't capture what
+actually makes Culture's approach distinctive.
+
+This spec reframes **Organic Development** as **Reflective Development** — a
+name that captures three concrete mechanisms at the heart of the project.
+
+## Why "Reflective"
+
+The word "reflective" carries three meanings, each mapping to a real mechanism
+in Culture:
+
+### 1. Self-reflection — agents and humans examining their own work
+
+The lifecycle (Introduce → Educate → Join → Mentor → Promote) is built on
+reflection. Mentoring means returning to an agent and reflecting on what changed.
+Promote means reviewing an agent's track record — reflecting on its accuracy and
+helpfulness. Agents on the mesh reflect on each other's findings (use case 04:
+knowledge propagation). The observer reflects on the culture itself (use case 05).
+
+This is the **culturing** sense — a community that grows by examining itself.
+
+### 2. The documentation loop — generating docs, consuming them, growing
+
+Culture's development process is inherently reflective: work produces
+documentation (specs, plans, changelogs, CLAUDE.md updates). That documentation
+becomes context for the next session. The agent reads what was written, reflects
+it into new work, and produces more documentation. The project grows through
+this reflective cycle.
+
+This is the **NLM (Natural Language Memory)** sense — agents use generated docs
+as durable memory. Each session reads the accumulated reflection of prior
+sessions and extends it. The docs aren't a byproduct of development; they *are*
+the development medium. A spec becomes a plan becomes code becomes a changelog
+entry becomes context for the next spec.
+
+### 3. Source-to-target reflection — the Assimilai pattern
+
+The `packages/` directory contains reference implementations that are reflected
+(copied, adapted) into target directories. Code reflects from source to target,
+carrying knowledge across boundaries. When you improve a component in
+`packages/`, you reflect that improvement to all backends. The pattern is
+literally reflective: source mirrors into target.
+
+This connects "Reflective Development" to the existing Assimilai pattern in
+CLAUDE.md — code that reflects from reference to implementation.
+
+## What Changes
+
+### Terminology
+
+| Current | New |
+|---|---|
+| Organic Development | Reflective Development |
+| Organic Lifecycle | Reflective Lifecycle |
+| "Simple, organic, transparent" (comparison table) | "Simple, reflective, transparent" |
+
+### Conceptual Framing
+
+The **Organic Development** section in README.md and docs/index.md currently
+says:
+
+> Culture follows the **Organic Development** paradigm — agents develop through
+> real work, not configuration. The lifecycle is continuous, not graduated.
+
+Replace with:
+
+> Culture follows the **Reflective Development** paradigm — agents develop by
+> reflecting on real work, not by configuration. Documentation flows back as
+> context. Code reflects from reference to implementation. The lifecycle is
+> continuous, not graduated.
+
+This single sentence captures all three senses without belaboring them.
+
+### CLAUDE.md — Assimilai Pattern
+
+The current description uses "organic code":
+
+> Internal packages are NOT installed as dependencies — they are assimilated
+> into target projects as organic code
+
+Replace "organic code" with "reflected code":
+
+> Internal packages are NOT installed as dependencies — they are reflected
+> into target projects as native code, placed in the correct folder and
+> location as if written directly in the target project.
+
+This aligns the Assimilai pattern language with Reflective Development. "Native
+code" replaces "organic code" for the placement concept (it lives in the target
+as if it were always there), while "reflected" captures the mechanism (it came
+from the reference source).
+
+## Files to Change
+
+### README.md
+
+- **Line 39:** Feature table row → `🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration.`
+- **Line 63:** Philosophy comparison → `Simple, reflective, transparent`
+- **Lines 117–123:** Section heading + description:
+  - `## Organic Development` → `## Reflective Development`
+  - Replace description paragraph (see "Conceptual Framing" above)
+
+### docs/index.md
+
+- **Line 35:** Feature table row → `🎓 **Reflective Lifecycle** | Introduce → Educate → Join → Mentor → Promote. Members develop through real work, not configuration.`
+- **Lines 113–121:** Section heading + description (same changes as README.md)
+
+### CLAUDE.md
+
+- **Line 14:** Replace "assimilated into target projects as organic code" with
+  "reflected into target projects as native code"
+
+### docs/superpowers/specs/2026-04-05-docs-speak-culture-design.md
+
+- **Line 128:** Feature table → `Reflective Lifecycle` (currently says "keep —
+  already good" for Organic Lifecycle)
+
+### docs/superpowers/specs/2026-04-05-lifecycle-reframe-design.md
+
+- **Line 142:** `Powered by **Organic Development**.` → `Powered by **Reflective Development**.`
+- **Line 143:** Feature table row → `Reflective Lifecycle`
+- **Line 147:** `Organic Development section` → `Reflective Development section`
+
+### docs/superpowers/plans/2026-04-05-docs-speak-culture.md
+
+- **Lines 564, 610, 612, 651, 686:** All references to "Organic Development"
+  and "Organic Lifecycle" → "Reflective Development" / "Reflective Lifecycle"
+
+## What Does NOT Change
+
+- **The lifecycle itself** — Introduce → Educate → Join → Mentor → Promote is
+  unchanged. The paradigm name changes, not the phases.
+- **"organic" in non-paradigm contexts** — "emerged organically" in use case 09,
+  "organically created" in the design spec for rooms — these describe emergent
+  behavior and are fine. The reframe targets the formal paradigm name, not every
+  use of the word "organic."
+- **Assimilai pattern name** — stays "Assimilai." Only the description of what
+  the code does (reflected vs organic) changes.
+- **No code changes** — this is purely docs/framing.
+
+## Future Consideration
+
+A dedicated `docs/reflective-development.md` page could expand on the three
+senses of "reflective" — self-reflection, the documentation loop, and
+source-to-target reflection. This would give the paradigm a proper home beyond
+the brief section in README.md. Out of scope for this reframe; noted for a
+follow-up.
+
+## Verification
+
+1. **Grep scan:** Search all `.md` files for "Organic Development" and
+   "Organic Lifecycle" — should only appear in historical specs/plans that
+   describe the *previous* state (not as current terminology).
+2. **Link integrity:** No files renamed, so no broken links.
+3. **Markdownlint:** Run on all changed files.
+4. **Read-through:** Read the README.md "Reflective Development" section and
+   verify all three senses are implied without being heavy-handed.


### PR DESCRIPTION
Captures the rationale for renaming "Organic Development" to
"Reflective Development" — a name that maps to three concrete
mechanisms: self-reflection (culturing), the documentation loop
(NLM), and source-to-target reflection (Assimilai pattern).

https://claude.ai/code/session_01CZERvuzTEqD2ZKuhHdWRzf