### PR TITLE
fix: handle missing credential tool, report mesh update failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.0.2] - 2026-04-09
+
+
+### Fixed
+
+- Handle missing credential tool (secret-tool/security/powershell) gracefully instead of crashing the server
+- Report restart failures in mesh update instead of claiming success
+
 ## [5.0.1] - 2026-04-09
 
 

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -469,16 +469,17 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
         os.execvp(culture_bin, reexec_args)
 
 
-def _wait_for_server_port(port: int, retries: int = 50, interval: float = 0.1) -> None:
-    """Poll until *port* accepts a TCP connection."""
+def _wait_for_server_port(port: int, retries: int = 50, interval: float = 0.1) -> bool:
+    """Poll until *port* accepts a TCP connection. Returns True on success."""
     import socket as _socket
 
     for _ in range(retries):
         try:
             with _socket.create_connection(("localhost", port), timeout=1):
-                return
+                return True
         except OSError:
             time.sleep(interval)
+    return False
 
 
 def _dry_run_restart(mesh, server_name: str) -> None:
@@ -509,13 +510,16 @@ def _restart_single_service(svc_name: str, fallback_cmd: list[str], restart_serv
 
 def _restart_mesh_services(
     mesh, server_name: str, culture_bin: str, config_path: str, dry_run: bool
-) -> None:
-    """Stop agents and server, regenerate service entries, then restart everything."""
+) -> bool:
+    """Stop agents and server, regenerate service entries, then restart everything.
+
+    Returns True if the server came up successfully, False otherwise.
+    """
     print(f"Restarting mesh node '{server_name}'...")
 
     if dry_run:
         _dry_run_restart(mesh, server_name)
-        return
+        return True
 
     for agent in mesh.agents:
         full_nick = f"{server_name}-{agent.nick}"
@@ -561,7 +565,13 @@ def _restart_mesh_services(
     ]
     _restart_single_service(server_svc, server_fallback, restart_service)
 
-    _wait_for_server_port(mesh.server.port)
+    if not _wait_for_server_port(mesh.server.port):
+        print(
+            f"  Error: server {server_name} did not start on port {mesh.server.port}. "
+            f"Check logs: journalctl --user -u culture-server-{server_name}",
+            file=sys.stderr,
+        )
+        return False
 
     for agent in mesh.agents:
         full_nick = f"{server_name}-{agent.nick}"
@@ -579,6 +589,7 @@ def _restart_mesh_services(
         _restart_single_service(agent_svc, agent_fallback, restart_service)
 
     print()
+    return True
 
 
 def _resolve_mesh_for_server(server_name: str, config_path: str):
@@ -630,6 +641,7 @@ def _cmd_update(args: argparse.Namespace) -> None:
     culture_bin = shutil.which("culture") or "culture"
 
     running = list_servers()
+    failed = []
 
     if running:
         for srv in running:
@@ -640,7 +652,10 @@ def _cmd_update(args: argparse.Namespace) -> None:
                     file=sys.stderr,
                 )
                 continue
-            _restart_mesh_services(mesh, srv["name"], culture_bin, args.config, args.dry_run)
+            if not _restart_mesh_services(
+                mesh, srv["name"], culture_bin, args.config, args.dry_run
+            ):
+                failed.append(srv["name"])
     else:
         try:
             mesh = load_mesh_config(args.config)
@@ -648,6 +663,16 @@ def _cmd_update(args: argparse.Namespace) -> None:
             mesh = generate_mesh_from_agents(args.config)
             if mesh is None:
                 sys.exit(1)
-        _restart_mesh_services(mesh, mesh.server.name, culture_bin, args.config, args.dry_run)
+        if not _restart_mesh_services(
+            mesh, mesh.server.name, culture_bin, args.config, args.dry_run
+        ):
+            failed.append(mesh.server.name)
+
+    if failed:
+        print(
+            f"Update finished with errors. Failed to restart: {', '.join(failed)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     print("Update complete. All services restarted.")

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -469,13 +469,14 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
         os.execvp(culture_bin, reexec_args)
 
 
-def _wait_for_server_port(port: int, retries: int = 50, interval: float = 0.1) -> bool:
-    """Poll until *port* accepts a TCP connection. Returns True on success."""
+def _wait_for_server_port(host: str, port: int, retries: int = 50, interval: float = 0.1) -> bool:
+    """Poll until *host*:*port* accepts a TCP connection. Returns True on success."""
     import socket as _socket
 
+    probe = "localhost" if host in ("0.0.0.0", "::", "") else host
     for _ in range(retries):
         try:
-            with _socket.create_connection(("localhost", port), timeout=1):
+            with _socket.create_connection((probe, port), timeout=1):
                 return True
         except OSError:
             time.sleep(interval)
@@ -565,10 +566,14 @@ def _restart_mesh_services(
     ]
     _restart_single_service(server_svc, server_fallback, restart_service)
 
-    if not _wait_for_server_port(mesh.server.port):
+    if not _wait_for_server_port(mesh.server.host, mesh.server.port):
+        if sys.platform == "linux":
+            hint = f"journalctl --user -u culture-server-{server_name}"
+        else:
+            hint = f"~/.culture/logs/server-{server_name}.log"
         print(
             f"  Error: server {server_name} did not start on port {mesh.server.port}. "
-            f"Check logs: journalctl --user -u culture-server-{server_name}",
+            f"Check logs: {hint}",
             file=sys.stderr,
         )
         return False
@@ -675,4 +680,7 @@ def _cmd_update(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    print("Update complete. All services restarted.")
+    if args.dry_run:
+        print("Dry run complete. No services were restarted.")
+    else:
+        print("Update complete. All services restarted.")

--- a/culture/credentials.py
+++ b/culture/credentials.py
@@ -21,12 +21,16 @@ SERVICE_NAME = "culture"
 
 def _run(args: list[str], input: str | None = None) -> tuple[int, str]:
     """Run a command and return (returncode, stdout)."""
-    result = subprocess.run(
-        args,
-        input=input,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            args,
+            input=input,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        logger.warning("Command not found: %s", args[0])
+        return 127, ""
     return result.returncode, result.stdout.strip()
 
 

--- a/culture/credentials.py
+++ b/culture/credentials.py
@@ -29,7 +29,8 @@ def _run(args: list[str], input: str | None = None) -> tuple[int, str]:
             text=True,
         )
     except FileNotFoundError:
-        logger.warning("Command not found: %s", args[0])
+        tool = {"darwin": "security", "win32": "powershell"}.get(sys.platform, "secret-tool")
+        logger.warning("Credential tool '%s' not found — is it installed?", tool)
         return 127, ""
     return result.returncode, result.stdout.strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "5.0.1"
+version = "5.0.2"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,24 @@
+"""Tests for culture.credentials — OS credential store helpers."""
+
+from unittest.mock import patch
+
+from culture.credentials import _run, lookup_credential, store_credential
+
+
+def test_run_missing_binary():
+    """_run() returns (127, '') when the binary is not found."""
+    rc, out = _run(["nonexistent-binary-xyz-12345"])
+    assert rc == 127
+    assert out == ""
+
+
+def test_lookup_credential_missing_tool():
+    """lookup_credential() returns None when the credential tool is missing."""
+    with patch("culture.credentials._run", return_value=(127, "")):
+        assert lookup_credential("some-peer") is None
+
+
+def test_store_credential_missing_tool():
+    """store_credential() returns False when the credential tool is missing."""
+    with patch("culture.credentials._run", return_value=(127, "")):
+        assert store_credential("some-peer", "password") is False

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "5.0.1"
+version = "5.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- `credentials._run()` now catches `FileNotFoundError` when `secret-tool` (Linux), `security` (macOS), or `powershell` (Windows) is missing — returns `(127, "")` instead of crashing the server process
- `mesh update` now detects restart failures and reports them with `journalctl` hints instead of unconditionally printing "All services restarted"
- Server starts without mesh links (graceful degradation) rather than crash-looping in systemd

## Root cause

`subprocess.run(["secret-tool", ...])` throws `FileNotFoundError` when the binary isn't installed. This unhandled exception crashes the server at startup during link credential lookup, causing a systemd restart loop (12,000+ attempts observed).

## Test plan

- [x] `pytest tests/test_credentials.py -v` — 3 new tests for missing binary handling
- [x] `pytest -n auto` — 717 tests pass
- [x] Manual: server starts with warning logs when `secret-tool` is absent
- [x] Manual: `culture mesh overview` works after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude