### PR TITLE
fix: channel IPC routing, CLI skill refs, PID check, docs (#200-203)

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -179,8 +179,7 @@ Report completion back to the IRC channel:
 
 ```bash
 # Using the IRC skill
-CULTURE_NICK=<your-nick> python3 -m culture.clients.claude.skill.irc_client \
-  send "#general" "PR #<N> — all review threads addressed and resolved. Ready for merge."
+culture channel message "#general" "PR #<N> — all review threads addressed and resolved. Ready for merge."
 ```
 
 ## Script reference

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -179,7 +179,7 @@ Report completion back to the IRC channel:
 
 ```bash
 # Using the IRC skill
-culture channel message "#general" "PR #<N> — all review threads addressed and resolved. Ready for merge."
+CULTURE_NICK="<agent-nick>" culture channel message "#general" "PR #<N> — all review threads addressed and resolved. Ready for merge."
 ```
 
 ## Script reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.0.3] - 2026-04-10
+
+
+### Added
+
+- New channel subcommands: join, part, ask, topic, compact, clear
+
+
+### Changed
+
+- Channel CLI routes through agent daemon IPC when CULTURE_NICK is set
+- All SKILL.md files and learn prompt use culture channel CLI instead of python3 -m
+- Mesh update readiness probe verifies PID-based server identity
+
+
+### Fixed
+
+- culture channel message sends as agent nick instead of temporary peek nick (#203)
+- IRC skill references culture channel CLI instead of broken python3 -m path (#202)
+
 ## [5.0.2] - 2026-04-09
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ When implementing features, write a corresponding markdown doc in `docs/` descri
 
 ## Testing
 
+- Use `/run-tests` to run the test suite (parallel + verbose by default)
 - `pytest` + `pytest-asyncio`, always run with `-n auto` for parallel execution
 - No mocks for the server — tests spin up real server instances on random ports with real TCP connections
 - Validate each layer with real IRC clients (weechat/irssi)

--- a/culture/cli/channel.py
+++ b/culture/cli/channel.py
@@ -1,15 +1,54 @@
-"""Channel subcommands: culture channel {list,read,message,who}."""
+"""Channel subcommands: culture channel {list,read,message,who,join,part,ask,topic,compact,clear}."""
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import json
+import os
 import sys
 
 from .shared.constants import _CONFIG_HELP, DEFAULT_CONFIG
-from .shared.ipc import get_observer
+from .shared.ipc import agent_socket_path, get_observer, ipc_request
 
 NAME = "channel"
+
+_ALL_CMDS = "list|read|message|who|join|part|ask|topic|compact|clear"
+
+
+def _try_ipc(msg_type: str, **kwargs) -> dict | None:
+    """Try to route a command through the agent daemon's IPC socket.
+
+    Returns the response dict if CULTURE_NICK is set and the daemon is
+    reachable, otherwise None (caller should fall back to observer).
+    """
+    nick = os.environ.get("CULTURE_NICK")
+    if not nick:
+        return None
+    sock = agent_socket_path(nick)
+    return asyncio.run(ipc_request(sock, msg_type, **kwargs))
+
+
+def _require_ipc(msg_type: str, **kwargs) -> dict:
+    """Route a command through IPC, erroring if CULTURE_NICK is unset or daemon unreachable."""
+    nick = os.environ.get("CULTURE_NICK")
+    if not nick:
+        print(
+            "Error: CULTURE_NICK environment variable is required for this command.\n"
+            "  Set it to your agent nick (e.g. export CULTURE_NICK=spark-claude)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    sock = agent_socket_path(nick)
+    resp = asyncio.run(ipc_request(sock, msg_type, **kwargs))
+    if resp is None:
+        print(
+            f"Error: cannot reach agent daemon for {nick}.\n"
+            f"  Is the agent running? Check: culture agent status {nick}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return resp
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -37,10 +76,36 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     who_parser.add_argument("target", help="Channel or nick target")
     who_parser.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
 
+    # -- join -----------------------------------------------------------------
+    join_parser = channel_sub.add_parser("join", help="Join a channel")
+    join_parser.add_argument("target", help="Channel to join (e.g. #ops)")
+
+    # -- part -----------------------------------------------------------------
+    part_parser = channel_sub.add_parser("part", help="Leave a channel")
+    part_parser.add_argument("target", help="Channel to leave (e.g. #ops)")
+
+    # -- ask ------------------------------------------------------------------
+    ask_parser = channel_sub.add_parser("ask", help="Send a question and trigger webhook alert")
+    ask_parser.add_argument("target", help="Channel (e.g. #general)")
+    ask_parser.add_argument("text", help="Question text")
+    ask_parser.add_argument("--timeout", type=int, default=30, help="Timeout in seconds")
+
+    # -- topic ----------------------------------------------------------------
+    topic_parser = channel_sub.add_parser("topic", help="Get or set channel topic")
+    topic_parser.add_argument("target", help="Channel (e.g. #general)")
+    topic_parser.add_argument("text", nargs="?", default=None, help="New topic (omit to read)")
+    topic_parser.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
+
+    # -- compact --------------------------------------------------------------
+    channel_sub.add_parser("compact", help="Compact the agent's context window")
+
+    # -- clear ----------------------------------------------------------------
+    channel_sub.add_parser("clear", help="Clear the agent's context window")
+
 
 def dispatch(args: argparse.Namespace) -> None:
     if not args.channel_command:
-        print("Usage: culture channel {list|read|message|who}", file=sys.stderr)
+        print(f"Usage: culture channel {{{_ALL_CMDS}}}", file=sys.stderr)
         sys.exit(1)
 
     handlers = {
@@ -48,6 +113,12 @@ def dispatch(args: argparse.Namespace) -> None:
         "read": _cmd_read,
         "message": _cmd_message,
         "who": _cmd_who,
+        "join": _cmd_join,
+        "part": _cmd_part,
+        "ask": _cmd_ask,
+        "topic": _cmd_topic,
+        "compact": _cmd_compact,
+        "clear": _cmd_clear,
     }
     handler = handlers.get(args.channel_command)
     if not handler:
@@ -78,6 +149,17 @@ def dispatch(args: argparse.Namespace) -> None:
 
 
 def _cmd_list(args: argparse.Namespace) -> None:
+    resp = _try_ipc("irc_channels")
+    if resp and resp.get("ok"):
+        channels = resp.get("data", {}).get("channels", [])
+        if not channels:
+            print("No active channels")
+            return
+        print("Active channels:")
+        for ch in channels:
+            print(f"  {ch}")
+        return
+
     observer = get_observer(args.config)
     channels = asyncio.run(observer.list_channels())
 
@@ -94,8 +176,21 @@ def _cmd_read(args: argparse.Namespace) -> None:
     if not args.target.strip():
         print("Error: channel name cannot be empty", file=sys.stderr)
         sys.exit(1)
-    observer = get_observer(args.config)
     channel = args.target if args.target.startswith("#") else f"#{args.target}"
+
+    resp = _try_ipc("irc_read", channel=channel, limit=args.limit)
+    if resp and resp.get("ok"):
+        messages = resp.get("data", {}).get("messages", [])
+        if not messages:
+            print(f"No messages in {channel}")
+            return
+        for msg in messages:
+            nick = msg.get("nick", "???")
+            text = msg.get("text", "")
+            print(f"<{nick}> {text}")
+        return
+
+    observer = get_observer(args.config)
     messages = asyncio.run(observer.read_channel(channel, limit=args.limit))
 
     if not messages:
@@ -113,8 +208,14 @@ def _cmd_message(args: argparse.Namespace) -> None:
     if not args.text.strip():
         print("Error: message text cannot be empty", file=sys.stderr)
         sys.exit(1)
-    observer = get_observer(args.config)
     target = args.target if args.target.startswith("#") else f"#{args.target}"
+
+    resp = _try_ipc("irc_send", channel=target, message=args.text)
+    if resp and resp.get("ok"):
+        print(f"Sent to {target}")
+        return
+
+    observer = get_observer(args.config)
     asyncio.run(observer.send_message(target, args.text))
     print(f"Sent to {target}")
 
@@ -123,8 +224,20 @@ def _cmd_who(args: argparse.Namespace) -> None:
     if not args.target.strip():
         print("Error: channel name cannot be empty", file=sys.stderr)
         sys.exit(1)
-    observer = get_observer(args.config)
     target = args.target
+
+    resp = _try_ipc("irc_who", channel=target)
+    if resp and resp.get("ok"):
+        nicks = resp.get("data", {}).get("nicks", [])
+        if not nicks:
+            print(f"No users in {target}")
+            return
+        print(f"Users in {target}:")
+        for nick in nicks:
+            print(f"  {nick}")
+        return
+
+    observer = get_observer(args.config)
     nicks = asyncio.run(observer.who(target))
 
     if not nicks:
@@ -134,3 +247,79 @@ def _cmd_who(args: argparse.Namespace) -> None:
     print(f"Users in {target}:")
     for nick in nicks:
         print(f"  {nick}")
+
+
+def _cmd_join(args: argparse.Namespace) -> None:
+    target = args.target if args.target.startswith("#") else f"#{args.target}"
+    resp = _require_ipc("irc_join", channel=target)
+    if resp.get("ok"):
+        print(f"Joined {target}")
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _cmd_part(args: argparse.Namespace) -> None:
+    target = args.target if args.target.startswith("#") else f"#{args.target}"
+    resp = _require_ipc("irc_part", channel=target)
+    if resp.get("ok"):
+        print(f"Left {target}")
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _cmd_ask(args: argparse.Namespace) -> None:
+    if not args.target.strip():
+        print("Error: channel name cannot be empty", file=sys.stderr)
+        sys.exit(1)
+    if not args.text.strip():
+        print("Error: question text cannot be empty", file=sys.stderr)
+        sys.exit(1)
+    target = args.target if args.target.startswith("#") else f"#{args.target}"
+    resp = _require_ipc("irc_ask", channel=target, message=args.text, timeout=args.timeout)
+    if resp.get("ok"):
+        print(json.dumps(resp, indent=2))
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _cmd_topic(args: argparse.Namespace) -> None:
+    if not args.target.strip():
+        print("Error: channel name cannot be empty", file=sys.stderr)
+        sys.exit(1)
+    target = args.target if args.target.startswith("#") else f"#{args.target}"
+
+    kwargs = {"channel": target}
+    if args.text is not None:
+        kwargs["topic"] = args.text
+
+    resp = _require_ipc("irc_topic", **kwargs)
+    if resp.get("ok"):
+        if args.text is not None:
+            print(f"Topic set for {target}")
+        else:
+            topic = resp.get("data", {}).get("topic", "")
+            print(f"Topic for {target}: {topic}" if topic else f"No topic set for {target}")
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _cmd_compact(args: argparse.Namespace) -> None:
+    resp = _require_ipc("compact")
+    if resp.get("ok"):
+        print("Context window compacted")
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _cmd_clear(args: argparse.Namespace) -> None:
+    resp = _require_ipc("clear")
+    if resp.get("ok"):
+        print("Context window cleared")
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)

--- a/culture/cli/channel.py
+++ b/culture/cli/channel.py
@@ -14,6 +14,13 @@ from .shared.ipc import agent_socket_path, get_observer, ipc_request
 NAME = "channel"
 
 _ALL_CMDS = "list|read|message|who|join|part|ask|topic|compact|clear"
+_CHANNEL_HELP = "Channel (e.g. #general)"
+
+
+def _valid_nick(nick: str) -> bool:
+    """Check nick matches the required <server>-<agent> format."""
+    parts = nick.split("-", 1)
+    return len(parts) == 2 and all(parts)
 
 
 def _try_ipc(msg_type: str, **kwargs) -> dict | None:
@@ -23,7 +30,7 @@ def _try_ipc(msg_type: str, **kwargs) -> dict | None:
     reachable, otherwise None (caller should fall back to observer).
     """
     nick = os.environ.get("CULTURE_NICK")
-    if not nick:
+    if not nick or not _valid_nick(nick):
         return None
     sock = agent_socket_path(nick)
     return asyncio.run(ipc_request(sock, msg_type, **kwargs))
@@ -32,10 +39,10 @@ def _try_ipc(msg_type: str, **kwargs) -> dict | None:
 def _require_ipc(msg_type: str, **kwargs) -> dict:
     """Route a command through IPC, erroring if CULTURE_NICK is unset or daemon unreachable."""
     nick = os.environ.get("CULTURE_NICK")
-    if not nick:
+    if not nick or not _valid_nick(nick):
         print(
-            "Error: CULTURE_NICK environment variable is required for this command.\n"
-            "  Set it to your agent nick (e.g. export CULTURE_NICK=spark-claude)",
+            "Error: CULTURE_NICK must be set to a valid <server>-<agent> nick.\n"
+            "  Example: export CULTURE_NICK=spark-claude",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -67,7 +74,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
     # -- message --------------------------------------------------------------
     message_parser = channel_sub.add_parser("message", help="Send a message to a channel")
-    message_parser.add_argument("target", help="Channel (e.g. #general)")
+    message_parser.add_argument("target", help=_CHANNEL_HELP)
     message_parser.add_argument("text", help="Message text to send")
     message_parser.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
 
@@ -86,13 +93,13 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
     # -- ask ------------------------------------------------------------------
     ask_parser = channel_sub.add_parser("ask", help="Send a question and trigger webhook alert")
-    ask_parser.add_argument("target", help="Channel (e.g. #general)")
+    ask_parser.add_argument("target", help=_CHANNEL_HELP)
     ask_parser.add_argument("text", help="Question text")
     ask_parser.add_argument("--timeout", type=int, default=30, help="Timeout in seconds")
 
     # -- topic ----------------------------------------------------------------
     topic_parser = channel_sub.add_parser("topic", help="Get or set channel topic")
-    topic_parser.add_argument("target", help="Channel (e.g. #general)")
+    topic_parser.add_argument("target", help=_CHANNEL_HELP)
     topic_parser.add_argument("text", nargs="?", default=None, help="New topic (omit to read)")
     topic_parser.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
 
@@ -226,7 +233,7 @@ def _cmd_who(args: argparse.Namespace) -> None:
         sys.exit(1)
     target = args.target
 
-    resp = _try_ipc("irc_who", channel=target)
+    resp = _try_ipc("irc_who", target=target)
     if resp and resp.get("ok"):
         nicks = resp.get("data", {}).get("nicks", [])
         if not nicks:

--- a/culture/cli/channel.py
+++ b/culture/cli/channel.py
@@ -233,17 +233,9 @@ def _cmd_who(args: argparse.Namespace) -> None:
         sys.exit(1)
     target = args.target
 
-    resp = _try_ipc("irc_who", target=target)
-    if resp and resp.get("ok"):
-        nicks = resp.get("data", {}).get("nicks", [])
-        if not nicks:
-            print(f"No users in {target}")
-            return
-        print(f"Users in {target}:")
-        for nick in nicks:
-            print(f"  {nick}")
-        return
-
+    # WHO always uses the observer — the daemon IPC handler fires the query
+    # but returns results asynchronously via IRC numerics, so the CLI can't
+    # collect the nick list through IPC.
     observer = get_observer(args.config)
     nicks = asyncio.run(observer.who(target))
 
@@ -298,20 +290,32 @@ def _cmd_topic(args: argparse.Namespace) -> None:
         sys.exit(1)
     target = args.target if args.target.startswith("#") else f"#{args.target}"
 
-    kwargs = {"channel": target}
     if args.text is not None:
-        kwargs["topic"] = args.text
-
-    resp = _require_ipc("irc_topic", **kwargs)
-    if resp.get("ok"):
-        if args.text is not None:
+        # Setting topic requires the daemon (must act as agent nick)
+        resp = _require_ipc("irc_topic", channel=target, topic=args.text)
+        if resp.get("ok"):
             print(f"Topic set for {target}")
         else:
-            topic = resp.get("data", {}).get("topic", "")
-            print(f"Topic for {target}: {topic}" if topic else f"No topic set for {target}")
+            print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+            sys.exit(1)
     else:
-        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
-        sys.exit(1)
+        # Reading topic — the daemon IPC handler returns results
+        # asynchronously via IRC numerics, so use IPC to fire the query
+        # and report that it was sent.
+        resp = _try_ipc("irc_topic", channel=target)
+        if resp and resp.get("ok"):
+            data = resp.get("data") or {}
+            if "topic" in data:
+                topic = data["topic"]
+                print(f"Topic for {target}: {topic}" if topic else f"No topic set for {target}")
+            else:
+                print(f"Topic query sent for {target} (result arrives asynchronously)")
+        else:
+            print(
+                f"Error: topic query requires a running agent daemon (CULTURE_NICK).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 def _cmd_compact(args: argparse.Namespace) -> None:

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -469,14 +469,31 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
         os.execvp(culture_bin, reexec_args)
 
 
-def _wait_for_server_port(host: str, port: int, retries: int = 50, interval: float = 0.1) -> bool:
-    """Poll until *host*:*port* accepts a TCP connection. Returns True on success."""
+def _wait_for_server_port(
+    host: str,
+    port: int,
+    retries: int = 50,
+    interval: float = 0.1,
+    server_name: str | None = None,
+) -> bool:
+    """Poll until *host*:*port* accepts a TCP connection.
+
+    If *server_name* is given, also verify via PID file that the process
+    listening on the port is actually a culture server (defense-in-depth
+    against port collision with an unrelated process).
+    """
     import socket as _socket
+
+    from culture.pidfile import is_culture_process, read_pid
 
     probe = "localhost" if host in ("0.0.0.0", "::", "") else host
     for _ in range(retries):
         try:
             with _socket.create_connection((probe, port), timeout=1):
+                if server_name:
+                    pid = read_pid(f"server-{server_name}")
+                    if pid is not None and not is_culture_process(pid):
+                        return False
                 return True
         except OSError:
             time.sleep(interval)
@@ -566,7 +583,7 @@ def _restart_mesh_services(
     ]
     _restart_single_service(server_svc, server_fallback, restart_service)
 
-    if not _wait_for_server_port(mesh.server.host, mesh.server.port):
+    if not _wait_for_server_port(mesh.server.host, mesh.server.port, server_name=server_name):
         if sys.platform == "linux":
             hint = f"journalctl --user -u culture-server-{server_name}"
         else:

--- a/culture/clients/acp/skill/SKILL.md
+++ b/culture/clients/acp/skill/SKILL.md
@@ -23,7 +23,7 @@ $XDG_RUNTIME_DIR/culture-<nick>.sock   (falls back to /tmp/culture-<nick>.sock)
 ## Invocation
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client <subcommand> [args...]
+culture channel <subcommand> [args...]
 ```
 
 All commands print a JSON result to stdout. Whispers from the daemon are printed
@@ -33,16 +33,16 @@ to stderr as `[whisper:<type>] <message>`.
 
 ## Commands
 
-### send — post a message to a channel
+### message — post a message to a channel
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client send <channel> <message>
+culture channel message <channel> <message>
 ```
 
 Example:
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client send "#general" "hello from ACP"
+culture channel message "#general" "hello from ACP"
 ```
 
 Output:
@@ -56,13 +56,13 @@ Output:
 ### read — read recent messages from a channel
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client read <channel> [limit]
+culture channel read <channel> [--limit N]
 ```
 
-`limit` defaults to 50. Example:
+`--limit` defaults to 50. Example:
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 Output:
@@ -85,13 +85,13 @@ Output:
 ### ask — send a question and trigger a webhook alert
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client ask <channel> [--timeout N] <question>
+culture channel ask <channel> [--timeout N] <question>
 ```
 
 `--timeout` is in seconds (default 30). Example:
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client ask "#general" --timeout 60 "What is the status of the deploy?"
+culture channel ask "#general" --timeout 60 "What is the status of the deploy?"
 ```
 
 ---
@@ -99,7 +99,7 @@ python3 -m culture.clients.acp.skill.irc_client ask "#general" --timeout 60 "Wha
 ### join — join a channel
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client join <channel>
+culture channel join <channel>
 ```
 
 ---
@@ -107,15 +107,15 @@ python3 -m culture.clients.acp.skill.irc_client join <channel>
 ### part — leave a channel
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client part <channel>
+culture channel part <channel>
 ```
 
 ---
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client channels
+culture channel list
 ```
 
 Output:
@@ -134,7 +134,7 @@ Output:
 ### who — send a WHO query
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client who <target>
+culture channel who <target>
 ```
 
 `target` can be a channel or a nick.
@@ -144,19 +144,19 @@ python3 -m culture.clients.acp.skill.irc_client who <target>
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client topic <channel> [topic text]
+culture channel topic <channel> [topic text]
 ```
 
 Get current topic:
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client topic "#general"
+culture channel topic "#general"
 ```
 
 Set topic:
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client topic "#general" "Welcome to general chat"
+culture channel topic "#general" "Welcome to general chat"
 ```
 
 ---
@@ -164,7 +164,7 @@ python3 -m culture.clients.acp.skill.irc_client topic "#general" "Welcome to gen
 ### compact — compact the agent's context window
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client compact
+culture channel compact
 ```
 
 Sends `/compact` to the agent session via the daemon's prompt queue.
@@ -174,7 +174,7 @@ Sends `/compact` to the agent session via the daemon's prompt queue.
 ### clear — clear the agent's context window
 
 ```bash
-python3 -m culture.clients.acp.skill.irc_client clear
+culture channel clear
 ```
 
 Sends `/clear` to the agent session via the daemon's prompt queue.

--- a/culture/clients/claude/skill/SKILL.md
+++ b/culture/clients/claude/skill/SKILL.md
@@ -2,7 +2,7 @@
 
 This skill lets Claude Code communicate over IRC through the culture daemon.
 The daemon runs as a background process and maintains a persistent IRC connection.
-Claude Code calls the skill via Bash, using the CLI entry point.
+Claude Code calls the skill via the `culture channel` CLI.
 
 ## Setup
 
@@ -16,7 +16,7 @@ $XDG_RUNTIME_DIR/culture-<nick>.sock   (falls back to /tmp/culture-<nick>.sock)
 ## Invocation
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client <subcommand> [args...]
+culture channel <subcommand> [args...]
 ```
 
 All commands print a JSON result to stdout. Whispers from the daemon are printed
@@ -26,16 +26,16 @@ to stderr as `[whisper:<type>] <message>`.
 
 ## Commands
 
-### send — post a message to a channel
+### message — post a message to a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client send <channel> <message>
+culture channel message <channel> <message>
 ```
 
 Example:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client send "#general" "hello from Claude"
+culture channel message "#general" "hello from Claude"
 ```
 
 Output:
@@ -49,13 +49,13 @@ Output:
 ### read — read recent messages from a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client read <channel> [limit]
+culture channel read <channel> [--limit N]
 ```
 
-`limit` defaults to 50. Example:
+`--limit` defaults to 50. Example:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 Output:
@@ -78,13 +78,13 @@ Output:
 ### ask — send a question and trigger a webhook alert
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client ask <channel> [--timeout N] <question>
+culture channel ask <channel> [--timeout N] <question>
 ```
 
 `--timeout` is in seconds (default 30). Example:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client ask "#general" --timeout 60 "What is the status of the deploy?"
+culture channel ask "#general" --timeout 60 "What is the status of the deploy?"
 ```
 
 ---
@@ -92,7 +92,7 @@ python3 -m culture.clients.claude.skill.irc_client ask "#general" --timeout 60 "
 ### join — join a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client join <channel>
+culture channel join <channel>
 ```
 
 ---
@@ -100,15 +100,15 @@ python3 -m culture.clients.claude.skill.irc_client join <channel>
 ### part — leave a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client part <channel>
+culture channel part <channel>
 ```
 
 ---
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client channels
+culture channel list
 ```
 
 Output:
@@ -127,7 +127,7 @@ Output:
 ### who — send a WHO query
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client who <target>
+culture channel who <target>
 ```
 
 `target` can be a channel or a nick.
@@ -137,19 +137,19 @@ python3 -m culture.clients.claude.skill.irc_client who <target>
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client topic <channel> [topic text]
+culture channel topic <channel> [topic text]
 ```
 
 Get current topic:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client topic "#general"
+culture channel topic "#general"
 ```
 
 Set topic:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client topic "#general" "Welcome to general chat"
+culture channel topic "#general" "Welcome to general chat"
 ```
 
 ---
@@ -157,7 +157,7 @@ python3 -m culture.clients.claude.skill.irc_client topic "#general" "Welcome to 
 ### compact — compact the agent's context window
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client compact
+culture channel compact
 ```
 
 Sends `/compact` to the agent session via the daemon's prompt queue.
@@ -167,7 +167,7 @@ Sends `/compact` to the agent session via the daemon's prompt queue.
 ### clear — clear the agent's context window
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client clear
+culture channel clear
 ```
 
 Sends `/clear` to the agent session via the daemon's prompt queue.

--- a/culture/clients/codex/skill/SKILL.md
+++ b/culture/clients/codex/skill/SKILL.md
@@ -23,7 +23,7 @@ $XDG_RUNTIME_DIR/culture-<nick>.sock   (falls back to /tmp/culture-<nick>.sock)
 ## Invocation
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client <subcommand> [args...]
+culture channel <subcommand> [args...]
 ```
 
 All commands print a JSON result to stdout. Whispers from the daemon are printed
@@ -33,16 +33,16 @@ to stderr as `[whisper:<type>] <message>`.
 
 ## Commands
 
-### send — post a message to a channel
+### message — post a message to a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client send <channel> <message>
+culture channel message <channel> <message>
 ```
 
 Example:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client send "#general" "hello from Codex"
+culture channel message "#general" "hello from Codex"
 ```
 
 Output:
@@ -56,13 +56,13 @@ Output:
 ### read — read recent messages from a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client read <channel> [limit]
+culture channel read <channel> [--limit N]
 ```
 
-`limit` defaults to 50. Example:
+`--limit` defaults to 50. Example:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 Output:
@@ -85,13 +85,13 @@ Output:
 ### ask — send a question and trigger a webhook alert
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client ask <channel> [--timeout N] <question>
+culture channel ask <channel> [--timeout N] <question>
 ```
 
 `--timeout` is in seconds (default 30). Example:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client ask "#general" --timeout 60 "What is the status of the deploy?"
+culture channel ask "#general" --timeout 60 "What is the status of the deploy?"
 ```
 
 ---
@@ -99,7 +99,7 @@ python3 -m culture.clients.codex.skill.irc_client ask "#general" --timeout 60 "W
 ### join — join a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client join <channel>
+culture channel join <channel>
 ```
 
 ---
@@ -107,15 +107,15 @@ python3 -m culture.clients.codex.skill.irc_client join <channel>
 ### part — leave a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client part <channel>
+culture channel part <channel>
 ```
 
 ---
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client channels
+culture channel list
 ```
 
 Output:
@@ -134,7 +134,7 @@ Output:
 ### who — send a WHO query
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client who <target>
+culture channel who <target>
 ```
 
 `target` can be a channel or a nick.
@@ -144,19 +144,19 @@ python3 -m culture.clients.codex.skill.irc_client who <target>
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client topic <channel> [topic text]
+culture channel topic <channel> [topic text]
 ```
 
 Get current topic:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client topic "#general"
+culture channel topic "#general"
 ```
 
 Set topic:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client topic "#general" "Welcome to general chat"
+culture channel topic "#general" "Welcome to general chat"
 ```
 
 ---
@@ -164,7 +164,7 @@ python3 -m culture.clients.codex.skill.irc_client topic "#general" "Welcome to g
 ### compact — compact the agent's context window
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client compact
+culture channel compact
 ```
 
 Sends `/compact` to the agent session via the daemon's prompt queue.
@@ -174,7 +174,7 @@ Sends `/compact` to the agent session via the daemon's prompt queue.
 ### clear — clear the agent's context window
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client clear
+culture channel clear
 ```
 
 Sends `/clear` to the agent session via the daemon's prompt queue.

--- a/culture/clients/copilot/skill/SKILL.md
+++ b/culture/clients/copilot/skill/SKILL.md
@@ -23,7 +23,7 @@ $XDG_RUNTIME_DIR/culture-<nick>.sock   (falls back to /tmp/culture-<nick>.sock)
 ## Invocation
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client <subcommand> [args...]
+culture channel <subcommand> [args...]
 ```
 
 All commands print a JSON result to stdout. Whispers from the daemon are printed
@@ -33,16 +33,16 @@ to stderr as `[whisper:<type>] <message>`.
 
 ## Commands
 
-### send — post a message to a channel
+### message — post a message to a channel
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client send <channel> <message>
+culture channel message <channel> <message>
 ```
 
 Example:
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client send "#general" "hello from Copilot"
+culture channel message "#general" "hello from Copilot"
 ```
 
 Output:
@@ -56,13 +56,13 @@ Output:
 ### read — read recent messages from a channel
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client read <channel> [limit]
+culture channel read <channel> [--limit N]
 ```
 
-`limit` defaults to 50. Example:
+`--limit` defaults to 50. Example:
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 Output:
@@ -85,13 +85,13 @@ Output:
 ### ask — send a question and trigger a webhook alert
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client ask <channel> [--timeout N] <question>
+culture channel ask <channel> [--timeout N] <question>
 ```
 
 `--timeout` is in seconds (default 30). Example:
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client ask "#general" --timeout 60 "What is the status of the deploy?"
+culture channel ask "#general" --timeout 60 "What is the status of the deploy?"
 ```
 
 ---
@@ -99,7 +99,7 @@ python3 -m culture.clients.copilot.skill.irc_client ask "#general" --timeout 60 
 ### join — join a channel
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client join <channel>
+culture channel join <channel>
 ```
 
 ---
@@ -107,15 +107,15 @@ python3 -m culture.clients.copilot.skill.irc_client join <channel>
 ### part — leave a channel
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client part <channel>
+culture channel part <channel>
 ```
 
 ---
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client channels
+culture channel list
 ```
 
 Output:
@@ -134,7 +134,7 @@ Output:
 ### who — send a WHO query
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client who <target>
+culture channel who <target>
 ```
 
 `target` can be a channel or a nick.
@@ -144,19 +144,19 @@ python3 -m culture.clients.copilot.skill.irc_client who <target>
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client topic <channel> [topic text]
+culture channel topic <channel> [topic text]
 ```
 
 Get current topic:
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client topic "#general"
+culture channel topic "#general"
 ```
 
 Set topic:
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client topic "#general" "Welcome to general chat"
+culture channel topic "#general" "Welcome to general chat"
 ```
 
 ---
@@ -164,7 +164,7 @@ python3 -m culture.clients.copilot.skill.irc_client topic "#general" "Welcome to
 ### compact — compact the agent's context window
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client compact
+culture channel compact
 ```
 
 Sends `/compact` to the agent session via the daemon's prompt queue.
@@ -174,7 +174,7 @@ Sends `/compact` to the agent session via the daemon's prompt queue.
 ### clear — clear the agent's context window
 
 ```bash
-python3 -m culture.clients.copilot.skill.irc_client clear
+culture channel clear
 ```
 
 Sends `/clear` to the agent session via the daemon's prompt queue.

--- a/culture/learn_prompt.py
+++ b/culture/learn_prompt.py
@@ -37,7 +37,7 @@ def generate_learn_prompt(
     skill_subdir = SKILL_SUBDIR.get(backend, "irc")
     nick_display = nick or "<your-agent-nick>"
     channels_display = ", ".join(channels)
-    cli = f"python3 -m culture.clients.{backend}.skill.irc_client"
+    cli = "culture channel"
 
     return f"""\
 # Culture — Learn to Use the Mesh
@@ -63,7 +63,7 @@ culture skills install {backend}
 ```
 
 This creates:
-- **Messaging skill** (`{skill_dir}/{skill_subdir}/SKILL.md`) — send, read,
+- **Messaging skill** (`{skill_dir}/{skill_subdir}/SKILL.md`) — message, read,
   who, join/part for daily agent use
 - **Admin skill** (`{skill_dir}/culture/SKILL.md`) — server setup, mesh
   linking, agent lifecycle, federation, trust model
@@ -74,7 +74,7 @@ infrastructure). Run the command above from a terminal, not from an agent.
 ## Setup
 
 Before using IRC tools, ensure the `CULTURE_NICK` environment variable
-is set to your nick. The skill client uses it to find the daemon socket:
+is set to your nick. The CLI uses it to route commands through your daemon:
 
 ```bash
 export CULTURE_NICK="{nick_display}"
@@ -85,17 +85,17 @@ Add this to your shell profile so it persists across sessions.
 ## IRC Tools Available
 
 Your agent daemon is connected to the IRC server. You communicate via
-a skill client that talks to the daemon over a Unix socket:
+the `culture channel` CLI, which routes through the daemon over a Unix socket:
 
 | Command | What it does | Example |
 |---------|-------------|---------|
-| `send` | Post a message to a channel or DM | `{cli} send "#general" "hello"` |
-| `read` | Read recent messages (default 50) | `{cli} read "#general" 20` |
+| `message` | Post a message to a channel or DM | `{cli} message "#general" "hello"` |
+| `read` | Read recent messages (default 50) | `{cli} read "#general" --limit 20` |
 | `ask` | Send a question + alert webhook | `{cli} ask "#general" --timeout 60 "status?"` |
 | `join` | Join a channel | `{cli} join "#ops"` |
 | `part` | Leave a channel | `{cli} part "#ops"` |
 | `who` | See who's in a channel | `{cli} who "#general"` |
-| `channels` | List your channels | `{cli} channels` |
+| `list` | List your channels | `{cli} list` |
 | `compact` | Compact your context window | `{cli} compact` |
 | `clear` | Clear your context window | `{cli} clear` |
 
@@ -212,7 +212,7 @@ share it with the mesh:
 ## Share a finding
 
 ```bash
-{cli} send "#knowledge" "[FINDING] <your discovery here>"
+{cli} message "#knowledge" "[FINDING] <your discovery here>"
 ```
 
 ## Ask for help
@@ -226,7 +226,7 @@ When you're stuck or need input from another agent:
 ## Check what others are doing
 
 ```bash
-{cli} read "#general" 20
+{cli} read "#general" --limit 20
 ```
 ```
 
@@ -242,7 +242,7 @@ patterns:
 
 **After completing work:**
 ```bash
-{cli} send "#general" "Completed <task> — results at <location>"
+{cli} message "#general" "Completed <task> — results at <location>"
 ```
 
 **When blocked:**
@@ -252,12 +252,12 @@ patterns:
 
 **Sharing knowledge:**
 ```bash
-{cli} send "#knowledge" "[FINDING] <what you learned>"
+{cli} message "#knowledge" "[FINDING] <what you learned>"
 ```
 
 **Alerting on issues:**
 ```bash
-{cli} send "#ops" "[ALERT] <what happened>"
+{cli} message "#ops" "[ALERT] <what happened>"
 ```
 
 ## Collaboration Patterns
@@ -283,7 +283,7 @@ patterns:
 
 3. **Introduce yourself:**
    ```bash
-   {cli} send "#general" "{nick_display} here — learning the mesh"
+   {cli} message "#general" "{nick_display} here — learning the mesh"
    ```
 
 4. **Check if skills are installed:**

--- a/docs/architecture/agent-harness-spec.md
+++ b/docs/architecture/agent-harness-spec.md
@@ -391,14 +391,11 @@ in the agent's environment before starting it.
 
 ### Invocation
 
-Currently the skill client lives at:
+The skill client is now available as a CLI subcommand:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client <command> [args...]
+culture channel <command> [args...]
 ```
-
-This will move to `culture.clients.shared.skill.irc_client` when the shared
-components are extracted (Phase 1 of the multi-agent harness plan).
 
 ## Configuration Schema
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,19 +135,19 @@ ask Claude to interact with the network:
 
 ```bash
 # Read recent messages
-python3 -m culture.clients.claude.skill.irc_client read "#general"
+culture channel read "#general"
 
 # Send a message
-python3 -m culture.clients.claude.skill.irc_client send "#general" "hello everyone"
+culture channel message "#general" "hello everyone"
 
 # See who's online
-python3 -m culture.clients.claude.skill.irc_client who "#general"
+culture channel who "#general"
 
 # Ask a question (triggers webhook alert)
-python3 -m culture.clients.claude.skill.irc_client ask "#general" "status update?"
+culture channel ask "#general" "status update?"
 
 # List channels
-python3 -m culture.clients.claude.skill.irc_client channels
+culture channel list
 ```
 
 ### Step 4: Install the IRC skill (recommended)
@@ -208,8 +208,8 @@ culture channel who "#general"      # all participants visible
 Send a test message and verify an agent responds:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client send "#general" "@spark-your-project hello"
-python3 -m culture.clients.claude.skill.irc_client read "#general"
+culture channel message "#general" "@spark-your-project hello"
+culture channel read "#general"
 ```
 
 ## Member Names

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -366,6 +366,23 @@ culture mesh update --config /path/mesh.yaml
 | `--skip-upgrade` | off | Skip the package upgrade step; just restart services |
 | `--config PATH` | `~/.culture/mesh.yaml` | Path to `mesh.yaml` |
 
+#### Failure modes
+
+If the server fails to restart after `culture mesh update`, the command
+exits with a non-zero status code. Check logs for details:
+
+- **Linux (systemd):** `journalctl --user -u culture-server-<name>`
+- **macOS / other:** `~/.culture/logs/server-<name>.log`
+
+If the package upgrade step fails (e.g. network error, version conflict),
+the update aborts before restarting any services. The existing version
+continues running. Re-run `culture mesh update` to retry, or use
+`--skip-upgrade` to restart services with the current version.
+
+After a successful TCP probe, the command also verifies via PID file that
+the process listening on the port is actually a culture server. If an
+unrelated process occupies the port, the update reports failure.
+
 ## Bots
 
 ### `culture bot archive`

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -379,9 +379,10 @@ the update aborts before restarting any services. The existing version
 continues running. Re-run `culture mesh update` to retry, or use
 `--skip-upgrade` to restart services with the current version.
 
-After a successful TCP probe, the command also verifies via PID file that
-the process listening on the port is actually a culture server. If an
-unrelated process occupies the port, the update reports failure.
+After a successful TCP probe, the command may also use the PID file, when
+present, as a best-effort check that the listener appears to be the expected
+culture server. If no PID file is available, readiness is determined by the
+TCP probe alone.
 
 ## Bots
 

--- a/docs/operations/ops-tooling.md
+++ b/docs/operations/ops-tooling.md
@@ -69,6 +69,21 @@ Linux, macOS Keychain, or Windows Credential Manager) — never in config files
 or command lines. `culture setup` prompts for passwords and stores them
 securely. The server retrieves them at startup via `--mesh-config`.
 
+#### Credential tool prerequisites
+
+The credential store requires a platform-specific CLI tool:
+
+| Platform | Tool | Notes |
+|----------|------|-------|
+| Linux | `secret-tool` | Part of `libsecret-tools` (`apt install libsecret-tools` on Ubuntu/Debian) |
+| macOS | `security` | Built-in, no installation needed |
+| Windows | `powershell` with `CredentialManager` module | `Install-Module -Name CredentialManager` |
+
+If the credential tool is not installed, `culture setup` and
+`culture server start` skip links that require stored passwords and print
+a warning. The server starts without those links — install the tool and
+re-run to enable them.
+
 ### agents fields
 
 | Field | Type | Default | Description |

--- a/packages/agent-harness/skill/SKILL.md
+++ b/packages/agent-harness/skill/SKILL.md
@@ -1,6 +1,6 @@
 # IRC Skill for [YOUR AGENT]
 
-This skill lets [YOUR AGENT] communicate over IRC through the culture daemon.
+This skill lets [YOUR AGENT] communicate over IRC using the `culture channel` CLI.
 
 ## Setup
 
@@ -8,50 +8,50 @@ Set the `CULTURE_NICK` environment variable to your agent's nick.
 
 ## Commands
 
-All commands use the IRC skill client CLI.
+All commands use the `culture channel` CLI.
 
-### send — post a message
+### message — post a message
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client send "#general" "hello"
+culture channel message "#general" "hello"
 ```
 
 ### read — read recent messages
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 ### ask — send a question (triggers webhook)
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client ask "#general" "status?"
+culture channel ask "#general" "status?"
 ```
 
 ### join / part — join or leave a channel
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client join "#ops"
-python3 -m culture.clients.[backend].skill.irc_client part "#ops"
+culture channel join "#ops"
+culture channel part "#ops"
 ```
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client channels
+culture channel list
 ```
 
 ### who — list channel members
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client who "#general"
+culture channel who "#general"
 ```
 
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.[backend].skill.irc_client topic "#general"
-python3 -m culture.clients.[backend].skill.irc_client topic "#general" "Welcome"
+culture channel topic "#general"
+culture channel topic "#general" "Welcome"
 ```
 
 All commands print JSON to stdout. Check the `ok` field in the response.

--- a/plugins/claude-code/skills/irc/SKILL.md
+++ b/plugins/claude-code/skills/irc/SKILL.md
@@ -2,7 +2,7 @@
 
 This skill lets Claude Code communicate over IRC through the culture daemon.
 The daemon runs as a background process and maintains a persistent IRC connection.
-Claude Code calls the skill via Bash, using the CLI entry point.
+Claude Code calls the skill via the `culture channel` CLI.
 
 ## Setup
 
@@ -16,7 +16,7 @@ $XDG_RUNTIME_DIR/culture-<nick>.sock   (falls back to /tmp/culture-<nick>.sock)
 ## Invocation
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client <subcommand> [args...]
+culture channel <subcommand> [args...]
 ```
 
 All commands print a JSON result to stdout. Whispers from the daemon are printed
@@ -26,16 +26,16 @@ to stderr as `[whisper:<type>] <message>`.
 
 ## Commands
 
-### send — post a message to a channel
+### message — post a message to a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client send <channel> <message>
+culture channel message <channel> <message>
 ```
 
 Example:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client send "#general" "hello from Claude"
+culture channel message "#general" "hello from Claude"
 ```
 
 Output:
@@ -49,13 +49,13 @@ Output:
 ### read — read recent messages from a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client read <channel> [limit]
+culture channel read <channel> [--limit N]
 ```
 
-`limit` defaults to 50. Example:
+`--limit` defaults to 50. Example:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 Output:
@@ -78,13 +78,13 @@ Output:
 ### ask — send a question and trigger a webhook alert
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client ask <channel> [--timeout N] <question>
+culture channel ask <channel> [--timeout N] <question>
 ```
 
 `--timeout` is in seconds (default 30). Example:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client ask "#general" --timeout 60 "What is the status of the deploy?"
+culture channel ask "#general" --timeout 60 "What is the status of the deploy?"
 ```
 
 ---
@@ -92,7 +92,7 @@ python3 -m culture.clients.claude.skill.irc_client ask "#general" --timeout 60 "
 ### join — join a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client join <channel>
+culture channel join <channel>
 ```
 
 ---
@@ -100,15 +100,15 @@ python3 -m culture.clients.claude.skill.irc_client join <channel>
 ### part — leave a channel
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client part <channel>
+culture channel part <channel>
 ```
 
 ---
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client channels
+culture channel list
 ```
 
 Output:
@@ -127,7 +127,7 @@ Output:
 ### who — send a WHO query
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client who <target>
+culture channel who <target>
 ```
 
 `target` can be a channel or a nick.
@@ -137,19 +137,19 @@ python3 -m culture.clients.claude.skill.irc_client who <target>
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client topic <channel> [topic text]
+culture channel topic <channel> [topic text]
 ```
 
 Get current topic:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client topic "#general"
+culture channel topic "#general"
 ```
 
 Set topic:
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client topic "#general" "Welcome to general chat"
+culture channel topic "#general" "Welcome to general chat"
 ```
 
 ---
@@ -157,7 +157,7 @@ python3 -m culture.clients.claude.skill.irc_client topic "#general" "Welcome to 
 ### compact — compact the agent's context window
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client compact
+culture channel compact
 ```
 
 Sends `/compact` to the agent session via the daemon's prompt queue.
@@ -167,7 +167,7 @@ Sends `/compact` to the agent session via the daemon's prompt queue.
 ### clear — clear the agent's context window
 
 ```bash
-python3 -m culture.clients.claude.skill.irc_client clear
+culture channel clear
 ```
 
 Sends `/clear` to the agent session via the daemon's prompt queue.

--- a/plugins/codex/skills/culture-irc/SKILL.md
+++ b/plugins/codex/skills/culture-irc/SKILL.md
@@ -23,7 +23,7 @@ $XDG_RUNTIME_DIR/culture-<nick>.sock   (falls back to /tmp/culture-<nick>.sock)
 ## Invocation
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client <subcommand> [args...]
+culture channel <subcommand> [args...]
 ```
 
 All commands print a JSON result to stdout. Whispers from the daemon are printed
@@ -33,16 +33,16 @@ to stderr as `[whisper:<type>] <message>`.
 
 ## Commands
 
-### send — post a message to a channel
+### message — post a message to a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client send <channel> <message>
+culture channel message <channel> <message>
 ```
 
 Example:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client send "#general" "hello from Codex"
+culture channel message "#general" "hello from Codex"
 ```
 
 Output:
@@ -56,13 +56,13 @@ Output:
 ### read — read recent messages from a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client read <channel> [limit]
+culture channel read <channel> [--limit N]
 ```
 
-`limit` defaults to 50. Example:
+`--limit` defaults to 50. Example:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client read "#general" 20
+culture channel read "#general" --limit 20
 ```
 
 Output:
@@ -85,13 +85,13 @@ Output:
 ### ask — send a question and trigger a webhook alert
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client ask <channel> [--timeout N] <question>
+culture channel ask <channel> [--timeout N] <question>
 ```
 
 `--timeout` is in seconds (default 30). Example:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client ask "#general" --timeout 60 "What is the status of the deploy?"
+culture channel ask "#general" --timeout 60 "What is the status of the deploy?"
 ```
 
 ---
@@ -99,7 +99,7 @@ python3 -m culture.clients.codex.skill.irc_client ask "#general" --timeout 60 "W
 ### join — join a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client join <channel>
+culture channel join <channel>
 ```
 
 ---
@@ -107,15 +107,15 @@ python3 -m culture.clients.codex.skill.irc_client join <channel>
 ### part — leave a channel
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client part <channel>
+culture channel part <channel>
 ```
 
 ---
 
-### channels — list joined channels
+### list — list joined channels
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client channels
+culture channel list
 ```
 
 Output:
@@ -134,7 +134,7 @@ Output:
 ### who — send a WHO query
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client who <target>
+culture channel who <target>
 ```
 
 `target` can be a channel or a nick.
@@ -144,19 +144,19 @@ python3 -m culture.clients.codex.skill.irc_client who <target>
 ### topic — get or set a channel topic
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client topic <channel> [topic text]
+culture channel topic <channel> [topic text]
 ```
 
 Get current topic:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client topic "#general"
+culture channel topic "#general"
 ```
 
 Set topic:
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client topic "#general" "Welcome to general chat"
+culture channel topic "#general" "Welcome to general chat"
 ```
 
 ---
@@ -164,7 +164,7 @@ python3 -m culture.clients.codex.skill.irc_client topic "#general" "Welcome to g
 ### compact — compact the agent's context window
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client compact
+culture channel compact
 ```
 
 Sends `/compact` to the agent session via the daemon's prompt queue.
@@ -174,7 +174,7 @@ Sends `/compact` to the agent session via the daemon's prompt queue.
 ### clear — clear the agent's context window
 
 ```bash
-python3 -m culture.clients.codex.skill.irc_client clear
+culture channel clear
 ```
 
 Sends `/clear` to the agent session via the daemon's prompt queue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "5.0.2"
+version = "5.0.3"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_channel_cli.py
+++ b/tests/test_channel_cli.py
@@ -11,6 +11,7 @@ import pytest
 from culture.cli.channel import (
     _require_ipc,
     _try_ipc,
+    _valid_nick,
     dispatch,
     register,
 )
@@ -95,6 +96,33 @@ class TestMessageIpcRouting:
         monkeypatch.delenv("CULTURE_NICK", raising=False)
         result = _try_ipc("irc_send", channel="#general", message="hello")
         assert result is None
+
+
+class TestNickValidation:
+    """Issue #202 review: CULTURE_NICK must match <server>-<agent> format."""
+
+    def test_valid_nick(self):
+        assert _valid_nick("spark-claude") is True
+        assert _valid_nick("thor-ori") is True
+        assert _valid_nick("a-b") is True
+
+    def test_invalid_nick_no_dash(self):
+        assert _valid_nick("justanick") is False
+
+    def test_invalid_nick_empty_parts(self):
+        assert _valid_nick("-claude") is False
+        assert _valid_nick("spark-") is False
+
+    def test_try_ipc_rejects_invalid_nick(self, monkeypatch):
+        monkeypatch.setenv("CULTURE_NICK", "nodash")
+        result = _try_ipc("irc_send", channel="#general", message="hello")
+        assert result is None
+
+    def test_require_ipc_rejects_invalid_nick(self, monkeypatch):
+        monkeypatch.setenv("CULTURE_NICK", "nodash")
+        with pytest.raises(SystemExit) as exc_info:
+            _require_ipc("irc_join", channel="#ops")
+        assert exc_info.value.code == 1
 
 
 class TestRequireIpc:

--- a/tests/test_channel_cli.py
+++ b/tests/test_channel_cli.py
@@ -1,0 +1,196 @@
+"""Tests for culture channel CLI with IPC routing."""
+
+import argparse
+import asyncio
+import json
+import os
+import tempfile
+
+import pytest
+
+from culture.cli.channel import (
+    _require_ipc,
+    _try_ipc,
+    dispatch,
+    register,
+)
+from culture.cli.shared.ipc import ipc_request
+from culture.clients.claude.ipc import encode_message, make_response
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs):
+    """Build a minimal Namespace for channel dispatch."""
+    defaults = {"config": "~/.culture/server.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+async def _mock_ipc_server(sock_path, handler):
+    """Start a mock Unix socket server that handles one request."""
+
+    async def _handler(reader, writer):
+        data = await reader.readline()
+        msg = json.loads(data)
+        resp = handler(msg)
+        writer.write(encode_message(resp))
+        await writer.drain()
+        writer.close()
+
+    srv = await asyncio.start_unix_server(_handler, path=sock_path)
+    return srv
+
+
+# ---------------------------------------------------------------------------
+# IPC routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessageIpcRouting:
+    """Issue #203: culture channel message should route through daemon IPC."""
+
+    def test_message_routes_through_ipc_when_nick_set(self, monkeypatch, capsys):
+        """When CULTURE_NICK is set and daemon is reachable, use IPC."""
+        sock_dir = tempfile.mkdtemp()
+        sock_path = os.path.join(sock_dir, "culture-spark-claude.sock")
+
+        def handler(msg):
+            assert msg["type"] == "irc_send"
+            assert msg["channel"] == "#general"
+            assert msg["message"] == "hello"
+            return make_response(msg["id"], ok=True)
+
+        async def _run():
+            srv = await asyncio.start_unix_server(
+                lambda r, w: _mock_ipc_server_handle(r, w, handler),
+                path=sock_path,
+            )
+            try:
+                resp = await ipc_request(sock_path, "irc_send", channel="#general", message="hello")
+                assert resp is not None
+                assert resp["ok"] is True
+            finally:
+                srv.close()
+                await srv.wait_closed()
+                os.unlink(sock_path)
+
+        monkeypatch.setenv("CULTURE_NICK", "spark-claude")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", sock_dir)
+        asyncio.run(_run())
+
+    def test_message_falls_back_when_no_daemon(self, monkeypatch):
+        """When CULTURE_NICK is set but daemon unreachable, _try_ipc returns None."""
+        monkeypatch.setenv("CULTURE_NICK", "spark-claude")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", tempfile.mkdtemp())
+
+        # _try_ipc should return None when socket doesn't exist
+        result = _try_ipc("irc_send", channel="#general", message="hello")
+        assert result is None
+
+    def test_message_uses_observer_when_no_nick(self, monkeypatch):
+        """When CULTURE_NICK is not set, _try_ipc returns None."""
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        result = _try_ipc("irc_send", channel="#general", message="hello")
+        assert result is None
+
+
+class TestRequireIpc:
+    """Commands that require CULTURE_NICK should error clearly."""
+
+    def test_join_requires_culture_nick(self, monkeypatch):
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        with pytest.raises(SystemExit) as exc_info:
+            _require_ipc("irc_join", channel="#ops")
+        assert exc_info.value.code == 1
+
+    def test_compact_requires_culture_nick(self, monkeypatch):
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        with pytest.raises(SystemExit) as exc_info:
+            _require_ipc("compact")
+        assert exc_info.value.code == 1
+
+    def test_clear_requires_culture_nick(self, monkeypatch):
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        with pytest.raises(SystemExit) as exc_info:
+            _require_ipc("clear")
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Subcommand registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubcommandRegistration:
+    """Issue #202: all channel subcommands should be registered."""
+
+    def test_all_subcommands_registered(self):
+        parser = argparse.ArgumentParser()
+        subs = parser.add_subparsers()
+        register(subs)
+
+        expected = [
+            "list",
+            "read",
+            "message",
+            "who",
+            "join",
+            "part",
+            "ask",
+            "topic",
+            "compact",
+            "clear",
+        ]
+        # Parse each subcommand to verify it's registered
+        for cmd in expected:
+            # Build minimal args for each command
+            argv = ["channel"]
+            if cmd in ("list", "compact", "clear"):
+                argv.append(cmd)
+            elif cmd in ("read", "who", "join", "part"):
+                argv.extend([cmd, "#general"])
+            elif cmd == "message":
+                argv.extend([cmd, "#general", "hello"])
+            elif cmd == "ask":
+                argv.extend([cmd, "#general", "question?"])
+            elif cmd == "topic":
+                argv.extend([cmd, "#general"])
+
+            args = parser.parse_args(argv)
+            assert args.channel_command == cmd, f"Subcommand {cmd} not registered"
+
+    def test_dispatch_usage_lists_all_commands(self, capsys):
+        args = _make_args(channel_command=None)
+        with pytest.raises(SystemExit):
+            dispatch(args)
+        captured = capsys.readouterr()
+        for cmd in [
+            "list",
+            "read",
+            "message",
+            "who",
+            "join",
+            "part",
+            "ask",
+            "topic",
+            "compact",
+            "clear",
+        ]:
+            assert cmd in captured.err, f"Missing {cmd} in usage output"
+
+
+# ---------------------------------------------------------------------------
+# Helper for async mock server
+# ---------------------------------------------------------------------------
+
+
+async def _mock_ipc_server_handle(reader, writer, handler):
+    data = await reader.readline()
+    msg = json.loads(data)
+    resp = handler(msg)
+    writer.write(encode_message(resp))
+    await writer.drain()
+    writer.close()

--- a/tests/test_learn_prompt.py
+++ b/tests/test_learn_prompt.py
@@ -6,7 +6,7 @@ from culture.learn_prompt import generate_learn_prompt
 def test_learn_prompt_contains_all_nine_commands():
     """Issue #181: learn prompt should document all 9 IRC commands."""
     output = generate_learn_prompt(nick="spark-claude", server="spark")
-    for cmd in ["send", "read", "ask", "join", "part", "who", "channels", "compact", "clear"]:
+    for cmd in ["message", "read", "ask", "join", "part", "who", "list", "compact", "clear"]:
         assert f"`{cmd}`" in output, f"Missing command: {cmd}"
 
 
@@ -16,12 +16,12 @@ def test_learn_prompt_ask_has_timeout():
     assert "--timeout" in output
 
 
-def test_learn_prompt_backend_cli_paths():
-    """Each backend should use its own module path."""
+def test_learn_prompt_uses_culture_channel_cli():
+    """All backends should use 'culture channel' CLI instead of python3 -m."""
     for backend in ["claude", "codex", "copilot", "acp"]:
         output = generate_learn_prompt(nick=f"spark-{backend}", backend=backend)
-        expected = f"culture.clients.{backend}.skill.irc_client"
-        assert expected in output, f"Missing module path for {backend}"
+        assert "culture channel" in output, f"Missing 'culture channel' for {backend}"
+        assert "python3 -m" not in output, f"Stale python3 -m reference for {backend}"
 
 
 def test_learn_prompt_has_bot_management():
@@ -50,4 +50,5 @@ def test_learn_prompt_has_mesh_observability():
 def test_learn_prompt_opencode_backend_normalized():
     """Legacy 'opencode' backend should be normalized to 'acp'."""
     output = generate_learn_prompt(nick="spark-acp", backend="opencode")
-    assert "culture.clients.acp.skill.irc_client" in output
+    assert "culture channel" in output
+    assert "python3 -m" not in output

--- a/tests/test_mesh_readiness.py
+++ b/tests/test_mesh_readiness.py
@@ -1,0 +1,93 @@
+"""Tests for mesh update readiness probe (issue #201)."""
+
+import socket
+import threading
+
+import pytest
+
+from culture.cli.mesh import _wait_for_server_port
+
+
+def _start_listener():
+    """Start a TCP listener on a random port, return (port, server_socket)."""
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    port = srv.getsockname()[1]
+
+    def _accept_loop():
+        try:
+            while True:
+                conn, _ = srv.accept()
+                conn.close()
+        except OSError:
+            pass
+
+    t = threading.Thread(target=_accept_loop, daemon=True)
+    t.start()
+    return port, srv
+
+
+class TestWaitForServerPort:
+    def test_tcp_only_no_server_name(self):
+        """Without server_name, TCP probe alone determines success."""
+        port, srv = _start_listener()
+        try:
+            assert _wait_for_server_port("127.0.0.1", port, retries=5) is True
+        finally:
+            srv.close()
+
+    def test_tcp_unreachable(self):
+        """Returns False when port is not listening."""
+        assert _wait_for_server_port("127.0.0.1", 1, retries=2, interval=0.01) is False
+
+    def test_with_valid_culture_pid(self, monkeypatch):
+        """TCP ok + valid culture PID → True."""
+        import os
+
+        port, srv = _start_listener()
+        try:
+            # Mock read_pid to return current process PID
+            # Mock is_culture_process to return True
+            monkeypatch.setattr(
+                "culture.pidfile.read_pid",
+                lambda name: os.getpid(),
+            )
+            monkeypatch.setattr(
+                "culture.pidfile.is_culture_process",
+                lambda pid: True,
+            )
+            assert _wait_for_server_port("127.0.0.1", port, retries=5, server_name="test") is True
+        finally:
+            srv.close()
+
+    def test_with_wrong_process_pid(self, monkeypatch):
+        """TCP ok + wrong process on PID → False."""
+        import os
+
+        port, srv = _start_listener()
+        try:
+            monkeypatch.setattr(
+                "culture.pidfile.read_pid",
+                lambda name: os.getpid(),
+            )
+            monkeypatch.setattr(
+                "culture.pidfile.is_culture_process",
+                lambda pid: False,
+            )
+            assert _wait_for_server_port("127.0.0.1", port, retries=5, server_name="test") is False
+        finally:
+            srv.close()
+
+    def test_pid_file_missing_still_succeeds(self, monkeypatch):
+        """TCP ok + no PID file → True (graceful, PID file may not exist yet)."""
+        port, srv = _start_listener()
+        try:
+            monkeypatch.setattr(
+                "culture.pidfile.read_pid",
+                lambda name: None,
+            )
+            assert _wait_for_server_port("127.0.0.1", port, retries=5, server_name="test") is True
+        finally:
+            srv.close()

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "5.0.2"
+version = "5.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **#203** — `culture channel message` now routes through the agent daemon IPC socket when `CULTURE_NICK` is set, sending messages under the agent's real nick instead of a temporary `_peek` nick. Falls back to observer for human use.
- **#202** — Replaced all `python3 -m culture.clients.<backend>.skill.irc_client` references with `culture channel` CLI across 16 files. Added 6 new channel subcommands: `join`, `part`, `ask`, `topic`, `compact`, `clear`.
- **#201** — `_wait_for_server_port()` now verifies via PID file that the process on the port is a culture server (defense-in-depth against port collision).
- **#200** — Documented mesh update failure modes in `cli.md` and credential tool prerequisites in `ops-tooling.md`.

Closes #200, closes #201, closes #202, closes #203

## Changes

| Area | Files | What |
|------|-------|------|
| Channel CLI | `culture/cli/channel.py` | IPC routing + 6 new subcommands |
| Mesh readiness | `culture/cli/mesh.py` | PID-based identity check |
| Learn prompt | `culture/learn_prompt.py` | `culture channel` CLI references |
| SKILL.md (×8) | `clients/*/skill/`, `plugins/`, `packages/` | Replace `python3 -m` with `culture channel` |
| Docs (×4) | `docs/operations/`, `docs/getting-started.md`, `docs/architecture/` | Failure modes, credential prereqs, updated refs |
| Tests | `tests/test_channel_cli.py`, `tests/test_mesh_readiness.py` | 13 new tests |

## Test plan

- [x] 730 tests pass (`/run-tests` — parallel, all green)
- [ ] Manual: `culture skills install claude` → verify SKILL.md uses `culture channel`
- [ ] Manual: `CULTURE_NICK=<nick> culture channel message "#general" "test"` → verify message appears under agent nick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude