### PR TITLE
fix: reduce cognitive complexity in channel CLI topic handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [5.0.4] - 2026-04-10
+
+
+### Fixed
+
+- Reduce cognitive complexity of _cmd_topic in channel CLI
+- Fix f-string with no replacement fields in topic error message
+
 ## [5.0.3] - 2026-04-10
 
 

--- a/culture/cli/channel.py
+++ b/culture/cli/channel.py
@@ -291,31 +291,36 @@ def _cmd_topic(args: argparse.Namespace) -> None:
     target = args.target if args.target.startswith("#") else f"#{args.target}"
 
     if args.text is not None:
-        # Setting topic requires the daemon (must act as agent nick)
-        resp = _require_ipc("irc_topic", channel=target, topic=args.text)
-        if resp.get("ok"):
-            print(f"Topic set for {target}")
-        else:
-            print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
-            sys.exit(1)
+        _topic_set(target, args.text)
     else:
-        # Reading topic — the daemon IPC handler returns results
-        # asynchronously via IRC numerics, so use IPC to fire the query
-        # and report that it was sent.
-        resp = _try_ipc("irc_topic", channel=target)
-        if resp and resp.get("ok"):
-            data = resp.get("data") or {}
-            if "topic" in data:
-                topic = data["topic"]
-                print(f"Topic for {target}: {topic}" if topic else f"No topic set for {target}")
-            else:
-                print(f"Topic query sent for {target} (result arrives asynchronously)")
-        else:
-            print(
-                f"Error: topic query requires a running agent daemon (CULTURE_NICK).",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        _topic_read(target)
+
+
+def _topic_set(target: str, text: str) -> None:
+    """Set channel topic via agent daemon."""
+    resp = _require_ipc("irc_topic", channel=target, topic=text)
+    if resp.get("ok"):
+        print(f"Topic set for {target}")
+    else:
+        print(f"Error: {resp.get('error', 'unknown error')}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _topic_read(target: str) -> None:
+    """Read channel topic via agent daemon IPC."""
+    resp = _try_ipc("irc_topic", channel=target)
+    if not resp or not resp.get("ok"):
+        print(
+            "Error: topic query requires a running agent daemon (CULTURE_NICK).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    data = resp.get("data") or {}
+    if "topic" not in data:
+        print(f"Topic query sent for {target} (result arrives asynchronously)")
+        return
+    topic = data["topic"]
+    print(f"Topic for {target}: {topic}" if topic else f"No topic set for {target}")
 
 
 def _cmd_compact(args: argparse.Namespace) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "5.0.3"
+version = "5.0.4"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "5.0.3"
+version = "5.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Extract `_topic_set` and `_topic_read` helpers from `_cmd_topic` to reduce cognitive complexity from 20 to under 15
- Fix f-string with no replacement fields in topic error message (now a plain string)

## Test plan
- [x] All 735 tests pass (`/run-tests`)
- [x] `flake8` clean on `culture/cli/channel.py`
- [x] All pre-commit hooks pass

- Claude