### PR TITLE
docs: add agent-readiness page, stress /run-tests in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ When implementing features, write a corresponding markdown doc in `docs/` descri
 
 ## Testing
 
-- **Always use `/run-tests`** — this is the standard way to run tests. It handles parallel execution, coverage, and verbose output. Do not run `pytest` directly; use the skill.
-- Stack: `pytest` + `pytest-asyncio` + `pytest-xdist` — runs with `-n auto` for parallel execution
+- **Always use `/run-tests`** — this is the standard way to run tests. By default it runs in parallel with verbose output. Use `/run-tests --ci` (or `-c`) for coverage. Do not run `pytest` directly; use the skill.
+- Stack: `pytest` + `pytest-asyncio` + `pytest-xdist` — default `/run-tests` uses `-n auto` for parallel execution
 - No mocks for the server — tests spin up real server instances on random ports with real TCP connections
 - Validate each layer with real IRC clients (weechat/irssi)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ When implementing features, write a corresponding markdown doc in `docs/` descri
 
 ## Testing
 
-- Use `/run-tests` to run the test suite (parallel + verbose by default)
-- `pytest` + `pytest-asyncio`, always run with `-n auto` for parallel execution
+- **Always use `/run-tests`** — this is the standard way to run tests. It handles parallel execution, coverage, and verbose output. Do not run `pytest` directly; use the skill.
+- Stack: `pytest` + `pytest-asyncio` + `pytest-xdist` — runs with `-n auto` for parallel execution
 - No mocks for the server — tests spin up real server instances on random ports with real TCP connections
 - Validate each layer with real IRC clients (weechat/irssi)
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,16 @@ Full docs at **[culture.dev](https://culture.dev)** — or browse below.
 
 </details>
 
+<details open>
+<summary><b>Project Quality</b></summary>
+
+| Doc | Description |
+|-----|-------------|
+| [Agent Readiness](docs/agent-readiness.md) | How the project stays ready for agents — skills, pipelines, testing, [Introspective Development](docs/reflective-development.md) |
+| [CI / Testing](docs/operations/ci.md) | GitHub Actions test workflow |
+
+</details>
+
 ---
 
 ## License

--- a/docs/agent-readiness.md
+++ b/docs/agent-readiness.md
@@ -1,0 +1,102 @@
+---
+title: "Agent Readiness"
+nav_order: 8
+---
+
+<!-- markdownlint-disable MD025 -->
+
+# Agent Readiness
+
+How Culture stays ready for agents to maintain, test, and extend it.
+
+---
+
+## Agent-First Design
+
+Culture is built for agents as primary operators. Every design decision reflects this:
+
+- **IRC protocol** — text-native and LLM-familiar. Agents read and write messages without adapters, parsers, or GUI abstractions.
+- **Declarative configuration** — `culture.yaml` and `server.yaml` are plain YAML. Agents read, write, and validate config without navigating settings UIs.
+- **Documentation as development medium** — specs, plans, changelogs, and CLAUDE.md are the working surface. Agents consume and produce docs as part of their normal workflow, not as an afterthought.
+- **CLI designed for invocation** — `culture server start`, `culture join`, `culture agent start/stop/status` — all non-interactive, composable, and scriptable.
+
+---
+
+## Skills for Maintenance
+
+Repeated workflows are encoded as skills — slash commands that agents invoke directly. Each skill encapsulates a multi-step procedure into a single invocation, reducing cognitive load and eliminating manual error.
+
+| Skill | Purpose |
+|-------|---------|
+| `/run-tests` | Run the test suite — parallel, verbose, coverage |
+| `/version-bump` | Bump semver in pyproject.toml, `__init__.py`, CHANGELOG.md |
+| `/pr-review` | Fetch, reply to, and resolve PR review threads |
+| `/review-and-fix` | Full cycle: fetch comments, triage, fix, push, reply, resolve |
+
+Agents don't need to remember flags, file paths, or multi-step procedures. The skill handles it.
+
+---
+
+## PR Pipelines
+
+Every PR passes through automated quality checks before merge. Fast, deterministic pipelines keep agent-submitted PRs from degrading quality.
+
+### GitHub Actions
+
+- **tests.yml** — pytest with parallel execution (`-n auto`) and coverage on every PR. Version bump check ensures semver discipline.
+- **security-checks.yml** — Bandit, Pylint, Safety, CodeQL analysis, and dependency review. High-severity vulnerabilities block merge.
+- **publish.yml** — TestPyPI on PR (dev versions), PyPI on merge to main.
+
+### Pre-commit hooks
+
+flake8, isort, black, bandit, pylint (fail-under 9.0) — all run locally before commit via `pre-commit`.
+
+### Quality gates
+
+| Gate | Threshold | Blocks merge? |
+|------|-----------|:-------------:|
+| Tests pass | All green | Yes |
+| Coverage | >= 50% | Yes |
+| Pylint score | >= 9.0 | Yes (local) |
+| SonarCloud quality gate | Pass (with `wait=true`) | Yes |
+| Dependency review | No high-severity vulns | Yes |
+| Version bump | Changed vs. main | Yes |
+
+No mocks — tests spin up real server instances on random ports with real TCP connections. What passes in CI passes in production.
+
+---
+
+## Platform as Test Bed
+
+Culture uses its own platform for exploratory testing. Four agent backends exercise the system from different angles:
+
+| Backend | SDK / Runtime | What it tests |
+|---------|--------------|---------------|
+| **Claude** | Claude Agent SDK | Native tool use, supervisor whispers |
+| **Codex** | JSON-RPC app-server | Stateless session model, RPC transport |
+| **Copilot** | GitHub Copilot SDK | BYOK auth flow, streaming responses |
+| **ACP** | Cline / OpenCode / Gemini / Kiro | ACP protocol compliance, broad compatibility |
+
+Each harness is a distinct test vector — different SDKs, different constraints, different failure modes. The mesh itself is the integration test: federation, cross-server messaging, and @mention routing are validated by agents using the system they're part of.
+
+The [harness conformance checks](architecture/harness-conformance.md) (enforced by Qodo on every PR) ensure all four backends stay in sync — generic files are identical, interfaces match, dispatch handlers are consistent.
+
+---
+
+## Introspective Development
+
+The development process examines itself. This is [Reflective Development](reflective-development.md) applied specifically to how agents validate and strengthen the project they maintain.
+
+- **Multi-lens documentation review** — docs are reviewed through audio (NotebookLM), AI conversations, and user-story demos to catch gaps that reading alone misses
+- **Agents test what they build** — the same agents that develop Culture run on Culture, surfacing issues that external test suites cannot
+- **Environment self-improvement** — friction discovered during work flows back as new skills, MCP integrations, CLAUDE.md updates, and code-for-agents restructuring
+
+The loop is: **work -> notice friction -> improve the environment -> work better -> notice new friction**. The project doesn't just get tested — it gets introspected.
+
+---
+
+## See Also
+
+- [Reflective Development](reflective-development.md) — the paradigm: work, docs, and participants reflect back on themselves
+- [Agentic Self-Learn](agentic-self-learn.md) — the two-tier skill system that enables environment self-improvement
+- [CI / Testing](operations/ci.md) — GitHub Actions test workflow details

--- a/docs/agent-readiness.md
+++ b/docs/agent-readiness.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent Readiness"
-nav_order: 8
+nav_order: 80
 ---
 
 <!-- markdownlint-disable MD025 -->
@@ -28,7 +28,7 @@ Repeated workflows are encoded as skills — slash commands that agents invoke d
 
 | Skill | Purpose |
 |-------|---------|
-| `/run-tests` | Run the test suite — parallel, verbose, coverage |
+| `/run-tests` | Run the test suite — parallel, verbose; coverage optional via `--ci` or `-c` |
 | `/version-bump` | Bump semver in pyproject.toml, `__init__.py`, CHANGELOG.md |
 | `/pr-review` | Fetch, reply to, and resolve PR review threads |
 | `/review-and-fix` | Full cycle: fetch comments, triage, fix, push, reply, resolve |
@@ -44,7 +44,7 @@ Every PR passes through automated quality checks before merge. Fast, determinist
 ### GitHub Actions
 
 - **tests.yml** — pytest with parallel execution (`-n auto`) and coverage on every PR. Version bump check ensures semver discipline.
-- **security-checks.yml** — Bandit, Pylint, Safety, CodeQL analysis, and dependency review. High-severity vulnerabilities block merge.
+- **security-checks.yml** — Bandit, Pylint, Safety, CodeQL analysis, and dependency review run on every PR. Only dependency review is configured to block merge on high-severity vulnerabilities.
 - **publish.yml** — TestPyPI on PR (dev versions), PyPI on merge to main.
 
 ### Pre-commit hooks
@@ -56,9 +56,9 @@ flake8, isort, black, bandit, pylint (fail-under 9.0) — all run locally before
 | Gate | Threshold | Blocks merge? |
 |------|-----------|:-------------:|
 | Tests pass | All green | Yes |
-| Coverage | >= 50% | Yes |
+| Coverage | Reported in CI (no minimum enforced) | No |
 | Pylint score | >= 9.0 | Yes (local) |
-| SonarCloud quality gate | Pass (with `wait=true`) | Yes |
+| SonarCloud quality gate | Automatic analysis (not CI-gated) | No |
 | Dependency review | No high-severity vulns | Yes |
 | Version bump | Changed vs. main | Yes |
 
@@ -89,7 +89,7 @@ The development process examines itself. This is [Reflective Development](reflec
 
 - **Multi-lens documentation review** — docs are reviewed through audio (NotebookLM), AI conversations, and user-story demos to catch gaps that reading alone misses
 - **Agents test what they build** — the same agents that develop Culture run on Culture, surfacing issues that external test suites cannot
-- **Environment self-improvement** — friction discovered during work flows back as new skills, MCP integrations, CLAUDE.md updates, and code-for-agents restructuring
+- **Environment self-improvement** — friction discovered during work feeds back as new skills, MCP integrations, CLAUDE.md updates, and code-for-agents restructuring
 
 The loop is: **work -> notice friction -> improve the environment -> work better -> notice new friction**. The project doesn't just get tested — it gets introspected.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,5 +127,6 @@ Read more: **[Reflective Development](reflective-development.md)** · **[Agent L
 - [What is Culture?](what-is-culture.md) — the philosophy behind Culture
 - [Reflective Development](reflective-development.md) — the paradigm: how work, docs, and participants reflect back on themselves
 - [Agent Lifecycle](agent-lifecycle.md) — the Introduce → Educate → Join → Mentor → Promote lifecycle
+- [Agent Readiness](agent-readiness.md) — how the project stays ready for agents: skills, pipelines, and [Introspective Development](reflective-development.md)
 - [Getting Started](getting-started.md) — full setup walkthrough from fresh machine to living culture
 - [Use Cases](use-cases-index.md) — practical collaboration scenarios


### PR DESCRIPTION
## Summary
- Add `docs/agent-readiness.md` documenting how Culture stays ready for agents: agent-first design, maintenance skills, PR pipelines with quality gates, platform-as-test-bed across 4 backends, and Introspective Development
- Strengthen CLAUDE.md Testing section to require `/run-tests` skill instead of raw pytest
- Link agent-readiness from README (new "Project Quality" section) and docs index ("What's Next")
- "Introspective Development" links to Reflective Development page throughout

## Test plan
- [ ] `markdownlint-cli2` passes on all 4 files (verified locally, 0 errors)
- [ ] Jekyll site builds and new page appears in sidebar at nav_order 8
- [ ] All cross-links resolve: agent-readiness → reflective-development, operations/ci, agentic-self-learn, harness-conformance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude