### PR TITLE
fix: agent create/join/delete fails with manifest-format server.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.0.1] - 2026-04-10
+
+
+### Fixed
+
+- agent create/join/delete/archive/unarchive/rename crash with manifest-format server.yaml (#208)
+- Auto-migrate legacy agents.yaml to manifest format on first load
+- Server rename/archive/unarchive now work with manifest format
+
 ## [6.0.0] - 2026-04-10
 
 

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -362,7 +362,15 @@ def _cmd_create(args: argparse.Namespace) -> None:
         extras=extras,
     )
 
-    save_culture_yaml(agent.directory, [agent])
+    # Merge with existing culture.yaml to preserve other agents in the directory
+    culture_yaml_path = Path(agent.directory) / "culture.yaml"
+    if culture_yaml_path.exists():
+        existing = load_culture_yaml(agent.directory)
+        agents_to_save = [a for a in existing if a.suffix != suffix]
+        agents_to_save.append(agent)
+    else:
+        agents_to_save = [agent]
+    save_culture_yaml(agent.directory, agents_to_save)
     add_to_manifest(args.config, suffix, agent.directory)
 
     print(f"Agent created: {full_nick}")
@@ -1057,8 +1065,6 @@ def _cmd_migrate(args: argparse.Namespace) -> None:
 
     config = migrate_legacy_to_manifest(legacy_path)
 
-    # Back up the original (now overwritten with manifest format)
-    # The file has already been converted in-place by migrate_legacy_to_manifest
     agent_count = len(config.manifest)
     dir_count = len(set(config.manifest.values()))
     print(f"\nMigration complete: {agent_count} agent(s) across {dir_count} directory(ies)")

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -12,12 +12,6 @@ from pathlib import Path
 
 import yaml
 
-from culture.clients.claude.config import (
-    add_agent_to_config,
-    archive_agent,
-    remove_agent,
-    unarchive_agent,
-)
 from culture.config import (
     AgentConfig,
     DaemonConfig,
@@ -26,13 +20,17 @@ from culture.config import (
     SupervisorConfig,
     WebhookConfig,
     add_to_manifest,
+    archive_manifest_agent,
     load_config,
     load_config_or_default,
     load_culture_yaml,
     remove_from_manifest,
+    remove_manifest_agent,
+    rename_manifest_agent,
     sanitize_agent_name,
     save_culture_yaml,
     save_server_config,
+    unarchive_manifest_agent,
 )
 from culture.pidfile import (
     is_process_alive,
@@ -198,9 +196,6 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "migrate", help="Migrate agents.yaml to server.yaml + culture.yaml"
     )
     migrate_parser.add_argument("--config", default=LEGACY_CONFIG, help="Legacy agents.yaml path")
-    migrate_parser.add_argument(
-        "--output", default=DEFAULT_SERVER_CONFIG, help="Output server.yaml path"
-    )
 
 
 def dispatch(args: argparse.Namespace) -> None:
@@ -338,7 +333,7 @@ def _cmd_create(args: argparse.Namespace) -> None:
         if existing.nick == full_nick:
             if existing.archived:
                 print(f"Replacing archived agent '{full_nick}'")
-                remove_agent(args.config, full_nick)
+                remove_manifest_agent(args.config, full_nick)
                 break
             channels = existing.channels if isinstance(existing.channels, list) else []
             print(f"Agent '{full_nick}' already exists in config", file=sys.stderr)
@@ -351,9 +346,24 @@ def _cmd_create(args: argparse.Namespace) -> None:
             print(f"Start with: culture agent start {full_nick}", file=sys.stderr)
             sys.exit(1)
 
-    agent = _create_agent_config(args, full_nick)
+    raw_agent = _create_agent_config(args, full_nick)
 
-    add_agent_to_config(args.config, agent, server_name=server_name)
+    # Convert backend-specific AgentConfig to manifest-format AgentConfig
+    backend = getattr(raw_agent, "backend", None) or getattr(raw_agent, "agent", "claude")
+    extras = {}
+    if hasattr(raw_agent, "acp_command") and backend == "acp":
+        extras["acp_command"] = raw_agent.acp_command
+    agent = AgentConfig(
+        suffix=suffix,
+        backend=backend,
+        channels=raw_agent.channels,
+        model=raw_agent.model,
+        directory=raw_agent.directory,
+        extras=extras,
+    )
+
+    save_culture_yaml(agent.directory, [agent])
+    add_to_manifest(args.config, suffix, agent.directory)
 
     print(f"Agent created: {full_nick}")
     print(f"  Directory: {agent.directory}")
@@ -717,11 +727,6 @@ def _cmd_status(args: argparse.Namespace) -> None:
 
 def _cmd_rename(args: argparse.Namespace) -> None:
     """Rename an agent's suffix within the same server."""
-    from culture.clients.claude.config import (
-        load_config_or_default,
-        rename_agent,
-        sanitize_agent_name,
-    )
     from culture.pidfile import rename_pid
 
     config = load_config_or_default(args.config)
@@ -749,7 +754,7 @@ def _cmd_rename(args: argparse.Namespace) -> None:
         return
 
     try:
-        rename_agent(args.config, old_nick, new_nick)
+        rename_manifest_agent(args.config, old_nick, new_nick)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)
@@ -765,11 +770,6 @@ def _cmd_rename(args: argparse.Namespace) -> None:
 
 def _cmd_assign(args: argparse.Namespace) -> None:
     """Move an agent to a different server (change nick prefix)."""
-    from culture.clients.claude.config import (
-        load_config_or_default,
-        rename_agent,
-        sanitize_agent_name,
-    )
     from culture.pidfile import rename_pid
 
     config = load_config_or_default(args.config)
@@ -799,7 +799,7 @@ def _cmd_assign(args: argparse.Namespace) -> None:
         return
 
     try:
-        rename_agent(args.config, old_nick, new_nick)
+        rename_manifest_agent(args.config, old_nick, new_nick)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)
@@ -941,7 +941,7 @@ def _cmd_archive(args: argparse.Namespace) -> None:
     if pid and is_process_alive(pid):
         stop_agent(args.nick)
 
-    archive_agent(args.config, args.nick, reason=args.reason)
+    archive_manifest_agent(args.config, args.nick, reason=args.reason)
 
     print(f"Agent archived: {args.nick}")
     if args.reason:
@@ -952,7 +952,7 @@ def _cmd_archive(args: argparse.Namespace) -> None:
 def _cmd_unarchive(args: argparse.Namespace) -> None:
     """Restore an archived agent."""
     try:
-        unarchive_agent(args.config, args.nick)
+        unarchive_manifest_agent(args.config, args.nick)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)
@@ -974,7 +974,7 @@ def _cmd_delete(args: argparse.Namespace) -> None:
     if pid and is_process_alive(pid):
         stop_agent(args.nick)
 
-    remove_agent(args.config, args.nick)
+    remove_manifest_agent(args.config, args.nick)
     print(f"Agent deleted: {args.nick}")
 
 
@@ -1044,77 +1044,23 @@ def _cmd_unregister(args: argparse.Namespace) -> None:
 
 def _cmd_migrate(args: argparse.Namespace) -> None:
     """Migrate from agents.yaml to server.yaml + per-directory culture.yaml."""
+    from culture.config import _is_legacy_format, migrate_legacy_to_manifest
+
     legacy_path = Path(args.config)
     if not legacy_path.exists():
         print(f"No agents.yaml found at {legacy_path}", file=sys.stderr)
         sys.exit(1)
 
-    with open(legacy_path) as f:
-        raw = yaml.safe_load(f) or {}
+    if not _is_legacy_format(legacy_path):
+        print(f"{legacy_path} is already in manifest format", file=sys.stderr)
+        sys.exit(1)
 
-    server_name = raw.get("server", {}).get("name", "culture")
-    prefix = f"{server_name}-"
+    config = migrate_legacy_to_manifest(legacy_path)
 
-    # Group agents by directory
-    by_dir: dict[str, list[tuple[str, dict]]] = {}
-    for agent_raw in raw.get("agents", []):
-        nick = agent_raw.get("nick", "")
-        suffix = nick.removeprefix(prefix) if nick.startswith(prefix) else nick
-        directory = str(Path(agent_raw.get("directory", ".")).resolve())
-        by_dir.setdefault(directory, []).append((suffix, agent_raw))
-
-    # Create culture.yaml in each directory
-    manifest: dict[str, str] = {}
-    for directory, entries in by_dir.items():
-        agents = []
-        for suffix, agent_raw in entries:
-            backend = agent_raw.get("agent", "claude")
-            known_fields = {
-                "suffix": suffix,
-                "backend": backend,
-                "channels": agent_raw.get("channels", ["#general"]),
-                "model": agent_raw.get("model", "claude-opus-4-6"),
-                "thinking": agent_raw.get("thinking", "medium"),
-                "system_prompt": agent_raw.get("system_prompt", ""),
-                "tags": agent_raw.get("tags", []),
-                "icon": agent_raw.get("icon"),
-                "archived": agent_raw.get("archived", False),
-                "archived_at": agent_raw.get("archived_at", ""),
-                "archived_reason": agent_raw.get("archived_reason", ""),
-            }
-            skip_keys = set(known_fields.keys()) | {"nick", "directory", "agent"}
-            extras = {k: v for k, v in agent_raw.items() if k not in skip_keys}
-            agents.append(AgentConfig(**known_fields, extras=extras))
-            manifest[suffix] = directory
-
-        dir_path = Path(directory)
-        dir_path.mkdir(parents=True, exist_ok=True)
-        save_culture_yaml(directory, agents)
-        print(f"  Created {directory}/culture.yaml ({len(agents)} agent(s))")
-
-    # Create server.yaml
-    server = ServerConnConfig(**raw.get("server", {}))
-    supervisor = SupervisorConfig(**raw.get("supervisor", {}))
-    webhooks = WebhookConfig(**raw.get("webhooks", {}))
-    server_config = ServerConfig(
-        server=server,
-        supervisor=supervisor,
-        webhooks=webhooks,
-        buffer_size=raw.get("buffer_size", 500),
-        poll_interval=raw.get("poll_interval", 60),
-        sleep_start=raw.get("sleep_start", "23:00"),
-        sleep_end=raw.get("sleep_end", "08:00"),
-        manifest=manifest,
-    )
-
-    output_path = Path(args.output)
-    save_server_config(str(output_path), server_config)
-    print(f"  Created {output_path}")
-
-    # Back up agents.yaml
-    backup = legacy_path.with_suffix(".yaml.bak")
-    legacy_path.rename(backup)
-    print(f"  Backed up {legacy_path} -> {backup}")
-    print(f"\nMigration complete: {len(manifest)} agent(s) across {len(by_dir)} directory(ies)")
-    print(f"\nAgent commands now use {output_path} by default.")
-    print(f"Verify with: culture agent status")
+    # Back up the original (now overwritten with manifest format)
+    # The file has already been converted in-place by migrate_legacy_to_manifest
+    agent_count = len(config.manifest)
+    dir_count = len(set(config.manifest.values()))
+    print(f"\nMigration complete: {agent_count} agent(s) across {dir_count} directory(ies)")
+    print(f"\nAgent commands now use {legacy_path} by default.")
+    print("Verify with: culture agent status")

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -316,44 +316,34 @@ def _create_agent_config(args: argparse.Namespace, full_nick: str) -> AgentConfi
     return _create_default_config(full_nick, args.agent)
 
 
-def _cmd_create(args: argparse.Namespace) -> None:
-    config = load_config_or_default(args.config)
-
-    server_name = args.server or config.server.name or "culture"
-
-    if args.nick:
-        suffix = args.nick
-    else:
-        dirname = os.path.basename(os.getcwd())
-        suffix = sanitize_agent_name(dirname)
-
-    full_nick = f"{server_name}-{suffix}"
-
+def _check_existing_agent(config, full_nick: str, config_path: str) -> None:
+    """Check for duplicate agent nick.  Removes archived duplicates; exits on active ones."""
     for existing in config.agents:
-        if existing.nick == full_nick:
-            if existing.archived:
-                print(f"Replacing archived agent '{full_nick}'")
-                remove_manifest_agent(args.config, full_nick)
-                break
-            channels = existing.channels if isinstance(existing.channels, list) else []
-            print(f"Agent '{full_nick}' already exists in config", file=sys.stderr)
-            print(f"  Directory: {existing.directory}", file=sys.stderr)
-            print(f"  Backend:   {existing.agent}", file=sys.stderr)
-            print(f"  Channels:  {', '.join(channels)}", file=sys.stderr)
-            print(f"  Model:     {existing.model}", file=sys.stderr)
-            print(f"  Config:    {args.config}", file=sys.stderr)
-            print(file=sys.stderr)
-            print(f"Start with: culture agent start {full_nick}", file=sys.stderr)
-            sys.exit(1)
+        if existing.nick != full_nick:
+            continue
+        if existing.archived:
+            print(f"Replacing archived agent '{full_nick}'")
+            remove_manifest_agent(config_path, full_nick)
+            return
+        channels = existing.channels if isinstance(existing.channels, list) else []
+        print(f"Agent '{full_nick}' already exists in config", file=sys.stderr)
+        print(f"  Directory: {existing.directory}", file=sys.stderr)
+        print(f"  Backend:   {existing.agent}", file=sys.stderr)
+        print(f"  Channels:  {', '.join(channels)}", file=sys.stderr)
+        print(f"  Model:     {existing.model}", file=sys.stderr)
+        print(f"  Config:    {config_path}", file=sys.stderr)
+        print(file=sys.stderr)
+        print(f"Start with: culture agent start {full_nick}", file=sys.stderr)
+        sys.exit(1)
 
-    raw_agent = _create_agent_config(args, full_nick)
 
-    # Convert backend-specific AgentConfig to manifest-format AgentConfig
+def _to_manifest_agent(raw_agent, suffix: str) -> AgentConfig:
+    """Convert a backend-specific AgentConfig to a manifest-format AgentConfig."""
     backend = getattr(raw_agent, "backend", None) or getattr(raw_agent, "agent", "claude")
     extras = {}
     if hasattr(raw_agent, "acp_command") and backend == "acp":
         extras["acp_command"] = raw_agent.acp_command
-    agent = AgentConfig(
+    return AgentConfig(
         suffix=suffix,
         backend=backend,
         channels=raw_agent.channels,
@@ -362,18 +352,34 @@ def _cmd_create(args: argparse.Namespace) -> None:
         extras=extras,
     )
 
-    # Merge with existing culture.yaml to preserve other agents in the directory
+
+def _save_agent_to_directory(agent: AgentConfig) -> None:
+    """Save agent to culture.yaml, merging with existing agents in the directory."""
     culture_yaml_path = Path(agent.directory) / "culture.yaml"
     if culture_yaml_path.exists():
         existing = load_culture_yaml(agent.directory)
-        agents_to_save = [a for a in existing if a.suffix != suffix]
+        agents_to_save = [a for a in existing if a.suffix != agent.suffix]
         agents_to_save.append(agent)
     else:
         agents_to_save = [agent]
     save_culture_yaml(agent.directory, agents_to_save)
+
+
+def _cmd_create(args: argparse.Namespace) -> None:
+    config = load_config_or_default(args.config)
+
+    server_name = args.server or config.server.name or "culture"
+    suffix = args.nick or sanitize_agent_name(os.path.basename(os.getcwd()))
+    full_nick = f"{server_name}-{suffix}"
+
+    _check_existing_agent(config, full_nick, args.config)
+
+    raw_agent = _create_agent_config(args, full_nick)
+    agent = _to_manifest_agent(raw_agent, suffix)
+
+    _save_agent_to_directory(agent)
     add_to_manifest(args.config, suffix, agent.directory)
 
-    # Persist --server into server.yaml if explicitly provided
     if args.server and args.server != config.server.name:
         config.server.name = args.server
         save_server_config(str(args.config), config)

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -373,6 +373,11 @@ def _cmd_create(args: argparse.Namespace) -> None:
     save_culture_yaml(agent.directory, agents_to_save)
     add_to_manifest(args.config, suffix, agent.directory)
 
+    # Persist --server into server.yaml if explicitly provided
+    if args.server and args.server != config.server.name:
+        config.server.name = args.server
+        save_server_config(str(args.config), config)
+
     print(f"Agent created: {full_nick}")
     print(f"  Directory: {agent.directory}")
     print(f"  Channels: {', '.join(agent.channels)}")

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -191,7 +191,7 @@ def dispatch(args: argparse.Namespace) -> None:
 
 def _server_rename(args: argparse.Namespace) -> None:
     """Rename the server: update config, agent nicks, and PID files."""
-    from culture.clients.claude.config import rename_server, sanitize_agent_name
+    from culture.config import rename_manifest_server, sanitize_agent_name
     from culture.pidfile import (
         is_process_alive,
         read_default_server,
@@ -207,7 +207,7 @@ def _server_rename(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     try:
-        old_name, renamed = rename_server(args.config, new_name)
+        old_name, renamed = rename_manifest_server(args.config, new_name)
     except ValueError as exc:
         print(str(exc), file=sys.stderr)
         sys.exit(1)
@@ -578,10 +578,7 @@ def _set_bots_archive_state(agent_nicks: set, *, archive: bool, reason: str = ""
 
 def _server_archive(args: argparse.Namespace) -> None:
     """Archive the server and cascade to all agents and bots."""
-    from culture.clients.claude.config import (
-        archive_server,
-        load_config_or_default,
-    )
+    from culture.config import archive_manifest_server, load_config_or_default
 
     config = load_config_or_default(args.config)
     server_name = _validate_config_name(config, args.name)
@@ -606,7 +603,7 @@ def _server_archive(args: argparse.Namespace) -> None:
             stop_agent(agent.nick)
 
     # Archive server + agents in config
-    archived_nicks = archive_server(args.config, reason=args.reason)
+    archived_nicks = archive_manifest_server(args.config, reason=args.reason)
 
     # Archive bots whose owner matches any agent on this server
     agent_nicks = {a.nick for a in config.agents}
@@ -624,10 +621,7 @@ def _server_archive(args: argparse.Namespace) -> None:
 
 def _server_unarchive(args: argparse.Namespace) -> None:
     """Restore an archived server and cascade to agents and bots."""
-    from culture.clients.claude.config import (
-        load_config_or_default,
-        unarchive_server,
-    )
+    from culture.config import load_config_or_default, unarchive_manifest_server
 
     config = load_config_or_default(args.config)
     server_name = _validate_config_name(config, args.name)
@@ -637,7 +631,7 @@ def _server_unarchive(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     # Unarchive server + agents
-    unarchived_nicks = unarchive_server(args.config)
+    unarchived_nicks = unarchive_manifest_server(args.config)
 
     # Unarchive bots whose owner matches any agent on this server
     agent_nicks = {a.nick for a in config.agents}

--- a/culture/config.py
+++ b/culture/config.py
@@ -303,14 +303,13 @@ def _is_legacy_format(path: str | Path) -> bool:
 
 
 def migrate_legacy_to_manifest(path: str | Path) -> ServerConfig:
-    """Auto-migrate legacy agents.yaml format to server.yaml + culture.yaml files.
+    """Auto-migrate legacy agents.yaml format to manifest format in place.
 
-    Reads the legacy YAML, groups agents by directory, writes culture.yaml in
-    each directory, converts the agents list to a manifest dict, and saves the
-    config as manifest format.  Returns the loaded ServerConfig.
+    Reads the legacy YAML from *path*, groups agents by directory, writes a
+    ``culture.yaml`` file in each directory, converts the ``agents`` list to a
+    manifest dict, and overwrites *path* with the manifest-format server
+    config.  Returns the loaded ``ServerConfig``.
     """
-    import time as _time
-
     path = Path(path)
     with open(path) as f:
         raw = yaml.safe_load(f) or {}
@@ -612,8 +611,11 @@ def rename_manifest_agent(config_path: str | Path, old_nick: str, new_nick: str)
         raise ValueError(f"Nick {old_nick!r} does not match server {server_name!r}")
     old_suffix = old_nick[len(old_prefix) :]
 
-    # new_nick may have a different server prefix (for assign)
-    if "-" in new_nick:
+    # Strip the known server prefix to get the new suffix, handling
+    # hyphenated server names correctly (e.g. "my-server-bot" → "bot").
+    if new_nick.startswith(old_prefix):
+        new_suffix = new_nick[len(old_prefix) :]
+    elif "-" in new_nick:
         new_suffix = new_nick.split("-", 1)[1]
     else:
         new_suffix = new_nick
@@ -624,9 +626,12 @@ def rename_manifest_agent(config_path: str | Path, old_nick: str, new_nick: str)
     if old_suffix != new_suffix and new_suffix in config.manifest:
         raise ValueError(f"Agent with suffix {new_suffix!r} already exists in manifest")
 
-    # Update manifest
-    remove_from_manifest(config_path, old_suffix)
-    add_to_manifest(config_path, new_suffix, directory)
+    # Update manifest atomically (single write instead of remove + add)
+    if old_suffix != new_suffix:
+        config.manifest = {
+            (new_suffix if s == old_suffix else s): d for s, d in config.manifest.items()
+        }
+        save_server_config(str(config_path), config)
 
     # Update suffix in culture.yaml
     agents = load_culture_yaml(directory)

--- a/culture/config.py
+++ b/culture/config.py
@@ -286,22 +286,102 @@ def _load_legacy_config(path: str | Path) -> ServerConfig:
     )
 
 
-def load_config(path: str | Path) -> ServerConfig:
-    """Load config, auto-detecting format (server.yaml vs legacy agents.yaml)."""
+def _is_legacy_format(path: str | Path) -> bool:
+    """Check if config file uses legacy agents.yaml format (list-of-dicts)."""
     path = Path(path)
+    if not path.exists():
+        return False
     with open(path) as f:
         raw = yaml.safe_load(f) or {}
-
     agents_val = raw.get("agents")
-    is_legacy = (
+    return (
         isinstance(agents_val, list)
-        and agents_val
+        and bool(agents_val)
         and isinstance(agents_val[0], dict)
         and "nick" in agents_val[0]
     )
 
-    if is_legacy:
-        return _load_legacy_config(path)
+
+def migrate_legacy_to_manifest(path: str | Path) -> ServerConfig:
+    """Auto-migrate legacy agents.yaml format to server.yaml + culture.yaml files.
+
+    Reads the legacy YAML, groups agents by directory, writes culture.yaml in
+    each directory, converts the agents list to a manifest dict, and saves the
+    config as manifest format.  Returns the loaded ServerConfig.
+    """
+    import time as _time
+
+    path = Path(path)
+    with open(path) as f:
+        raw = yaml.safe_load(f) or {}
+
+    server_name = raw.get("server", {}).get("name", "culture")
+    prefix = f"{server_name}-"
+
+    by_dir: dict[str, list[tuple[str, dict]]] = {}
+    for agent_raw in raw.get("agents", []):
+        nick = agent_raw.get("nick", "")
+        suffix = nick.removeprefix(prefix) if nick.startswith(prefix) else nick
+        directory = str(Path(agent_raw.get("directory", ".")).resolve())
+        by_dir.setdefault(directory, []).append((suffix, agent_raw))
+
+    manifest: dict[str, str] = {}
+    for directory, entries in by_dir.items():
+        agents: list[AgentConfig] = []
+        for suffix, agent_raw in entries:
+            backend = agent_raw.get("agent", "claude")
+            known_fields = {
+                "suffix": suffix,
+                "backend": backend,
+                "channels": agent_raw.get("channels", ["#general"]),
+                "model": agent_raw.get("model", "claude-opus-4-6"),
+                "thinking": agent_raw.get("thinking", "medium"),
+                "system_prompt": agent_raw.get("system_prompt", ""),
+                "tags": agent_raw.get("tags", []),
+                "icon": agent_raw.get("icon"),
+                "archived": agent_raw.get("archived", False),
+                "archived_at": agent_raw.get("archived_at", ""),
+                "archived_reason": agent_raw.get("archived_reason", ""),
+            }
+            skip_keys = set(known_fields.keys()) | {"nick", "directory", "agent"}
+            extras = {k: v for k, v in agent_raw.items() if k not in skip_keys}
+            agents.append(AgentConfig(**known_fields, extras=extras))
+            manifest[suffix] = directory
+
+        dir_path = Path(directory)
+        dir_path.mkdir(parents=True, exist_ok=True)
+        save_culture_yaml(directory, agents)
+
+    server = ServerConnConfig(**raw.get("server", {}))
+    supervisor = SupervisorConfig(**raw.get("supervisor", {}))
+    webhooks = WebhookConfig(**raw.get("webhooks", {}))
+    config = ServerConfig(
+        server=server,
+        supervisor=supervisor,
+        webhooks=webhooks,
+        buffer_size=raw.get("buffer_size", 500),
+        poll_interval=raw.get("poll_interval", 60),
+        sleep_start=raw.get("sleep_start", "23:00"),
+        sleep_end=raw.get("sleep_end", "08:00"),
+        manifest=manifest,
+    )
+    save_server_config(str(path), config)
+
+    logger.info("Auto-migrated legacy config %s to manifest format", path)
+
+    resolve_agents(config)
+    return config
+
+
+def load_config(path: str | Path) -> ServerConfig:
+    """Load config, auto-detecting format (server.yaml vs legacy agents.yaml).
+
+    Legacy format is automatically migrated to manifest format on first load.
+    """
+    path = Path(path)
+
+    if _is_legacy_format(path):
+        return migrate_legacy_to_manifest(path)
 
     config = load_server_config(path)
     resolve_agents(config)
@@ -455,3 +535,195 @@ def save_server_config(path: str | Path, config: ServerConfig) -> None:
         except OSError:
             pass
         raise
+
+
+# -----------------------------------------------------------------------
+# Manifest-aware agent CRUD
+# -----------------------------------------------------------------------
+
+
+def _nick_to_suffix(config_path: str | Path, nick: str) -> tuple[str, str]:
+    """Extract suffix and directory from a nick using the manifest.
+
+    Returns (suffix, directory).  Raises ValueError if not found.
+    """
+    config = load_server_config(config_path)
+    server_name = config.server.name
+    prefix = f"{server_name}-"
+    if not nick.startswith(prefix):
+        raise ValueError(f"Nick {nick!r} does not match server {server_name!r}")
+    suffix = nick[len(prefix) :]
+    directory = config.manifest.get(suffix)
+    if directory is None:
+        raise ValueError(f"Agent {nick!r} not found in manifest")
+    return suffix, directory
+
+
+def remove_manifest_agent(config_path: str | Path, nick: str) -> None:
+    """Remove an agent from the manifest by nick."""
+    suffix, _directory = _nick_to_suffix(config_path, nick)
+    remove_from_manifest(config_path, suffix)
+
+
+def archive_manifest_agent(config_path: str | Path, nick: str, reason: str = "") -> None:
+    """Archive an agent: set archived flag in its culture.yaml."""
+    import time as _time
+
+    suffix, directory = _nick_to_suffix(config_path, nick)
+    agents = load_culture_yaml(directory)
+    found = False
+    for agent in agents:
+        if agent.suffix == suffix:
+            agent.archived = True
+            agent.archived_at = _time.strftime("%Y-%m-%d")
+            agent.archived_reason = reason
+            found = True
+            break
+    if not found:
+        raise ValueError(f"Agent {nick!r} not found in {directory}/culture.yaml")
+    save_culture_yaml(directory, agents)
+
+
+def unarchive_manifest_agent(config_path: str | Path, nick: str) -> None:
+    """Unarchive an agent: clear archived flag in its culture.yaml."""
+    suffix, directory = _nick_to_suffix(config_path, nick)
+    agents = load_culture_yaml(directory)
+    found = False
+    for agent in agents:
+        if agent.suffix == suffix:
+            if not agent.archived:
+                raise ValueError(f"Agent {nick!r} is not archived")
+            agent.archived = False
+            agent.archived_at = ""
+            agent.archived_reason = ""
+            found = True
+            break
+    if not found:
+        raise ValueError(f"Agent {nick!r} not found in {directory}/culture.yaml")
+    save_culture_yaml(directory, agents)
+
+
+def rename_manifest_agent(config_path: str | Path, old_nick: str, new_nick: str) -> None:
+    """Rename an agent: update suffix in manifest and culture.yaml."""
+    config = load_server_config(config_path)
+    server_name = config.server.name
+    old_prefix = f"{server_name}-"
+    if not old_nick.startswith(old_prefix):
+        raise ValueError(f"Nick {old_nick!r} does not match server {server_name!r}")
+    old_suffix = old_nick[len(old_prefix) :]
+
+    # new_nick may have a different server prefix (for assign)
+    if "-" in new_nick:
+        new_suffix = new_nick.split("-", 1)[1]
+    else:
+        new_suffix = new_nick
+
+    directory = config.manifest.get(old_suffix)
+    if directory is None:
+        raise ValueError(f"Agent {old_nick!r} not found in manifest")
+    if old_suffix != new_suffix and new_suffix in config.manifest:
+        raise ValueError(f"Agent with suffix {new_suffix!r} already exists in manifest")
+
+    # Update manifest
+    remove_from_manifest(config_path, old_suffix)
+    add_to_manifest(config_path, new_suffix, directory)
+
+    # Update suffix in culture.yaml
+    agents = load_culture_yaml(directory)
+    for agent in agents:
+        if agent.suffix == old_suffix:
+            agent.suffix = new_suffix
+            break
+    save_culture_yaml(directory, agents)
+
+
+def rename_manifest_server(
+    config_path: str | Path, new_name: str
+) -> tuple[str, list[tuple[str, str]]]:
+    """Rename the server. Nicks are computed at load time, so only server.name changes.
+
+    Returns (old_name, [(old_nick, new_nick), ...]) for informational purposes.
+    """
+    config = load_server_config(config_path)
+    old_name = config.server.name
+
+    if old_name == new_name:
+        return old_name, []
+
+    config.server.name = new_name
+    save_server_config(str(config_path), config)
+
+    renamed = [(f"{old_name}-{suffix}", f"{new_name}-{suffix}") for suffix in config.manifest]
+    return old_name, renamed
+
+
+def archive_manifest_server(config_path: str | Path, reason: str = "") -> list[str]:
+    """Archive all agents on the server via their culture.yaml files.
+
+    Returns list of archived nicks.
+    """
+    import time as _time
+
+    config = load_server_config(config_path)
+    server_name = config.server.name
+    archived_nicks = []
+
+    for suffix, directory in config.manifest.items():
+        try:
+            agents = load_culture_yaml(directory, suffix=suffix)
+        except (FileNotFoundError, ValueError):
+            continue
+        for agent in agents:
+            if agent.suffix == suffix and not agent.archived:
+                agent.archived = True
+                agent.archived_at = _time.strftime("%Y-%m-%d")
+                agent.archived_reason = reason
+                archived_nicks.append(f"{server_name}-{suffix}")
+        # Save all agents in that directory (may include others)
+        all_agents = load_culture_yaml(directory)
+        for a in all_agents:
+            if a.suffix == suffix and not a.archived:
+                a.archived = True
+                a.archived_at = _time.strftime("%Y-%m-%d")
+                a.archived_reason = reason
+        save_culture_yaml(directory, all_agents)
+
+    # Also archive the server itself
+    config.server.archived = True
+    config.server.archived_at = _time.strftime("%Y-%m-%d")
+    config.server.archived_reason = reason
+    save_server_config(str(config_path), config)
+
+    return archived_nicks
+
+
+def unarchive_manifest_server(
+    config_path: str | Path,
+) -> list[str]:
+    """Unarchive all agents on the server via their culture.yaml files.
+
+    Returns list of unarchived nicks.
+    """
+    config = load_server_config(config_path)
+    server_name = config.server.name
+    unarchived_nicks = []
+
+    for suffix, directory in config.manifest.items():
+        try:
+            all_agents = load_culture_yaml(directory)
+        except (FileNotFoundError, ValueError):
+            continue
+        for a in all_agents:
+            if a.suffix == suffix and a.archived:
+                a.archived = False
+                a.archived_at = ""
+                a.archived_reason = ""
+                unarchived_nicks.append(f"{server_name}-{suffix}")
+        save_culture_yaml(directory, all_agents)
+
+    config.server.archived = False
+    config.server.archived_at = ""
+    config.server.archived_reason = ""
+    save_server_config(str(config_path), config)
+
+    return unarchived_nicks

--- a/docs/manifest-migration.md
+++ b/docs/manifest-migration.md
@@ -1,0 +1,74 @@
+# Manifest Format Migration
+
+Culture has two config formats for agent registration:
+
+- **Legacy format** (`agents.yaml`): agents listed as a YAML array of dicts with `nick`, `directory`, `agent`, etc.
+- **Manifest format** (`server.yaml`): agents registered as a dict mapping `suffix -> directory`, with per-directory `culture.yaml` files holding agent config.
+
+## Auto-Migration
+
+When any CLI command loads a config file in legacy format, it is **automatically migrated** to manifest format. The migration:
+
+1. Groups agents by directory
+2. Writes a `culture.yaml` in each agent directory
+3. Converts the `agents` list to a manifest dict
+4. Overwrites the config file in-place with manifest format
+
+No manual action is required. The `culture agent migrate` command is still available for explicit migration but is no longer necessary.
+
+## Manifest CRUD Operations
+
+All agent management commands work with the manifest format:
+
+| Command | What it does |
+|---------|-------------|
+| `culture agent create` | Saves `culture.yaml` in the agent directory and adds suffix to manifest |
+| `culture agent delete` | Removes suffix from manifest |
+| `culture agent archive` | Sets `archived: true` in the agent's `culture.yaml` |
+| `culture agent unarchive` | Clears `archived` flag in `culture.yaml` |
+| `culture agent rename` | Updates suffix in both manifest and `culture.yaml` |
+| `culture agent register` | Adds an existing `culture.yaml` directory to the manifest |
+| `culture agent unregister` | Removes a suffix from the manifest |
+
+Server-level commands (`culture server rename`, `archive`, `unarchive`) also operate on the manifest format.
+
+## File Layout
+
+```text
+~/.culture/server.yaml        # Server config + agent manifest
+~/git/project/culture.yaml    # Per-directory agent config
+```
+
+### server.yaml (manifest format)
+
+```yaml
+server:
+  name: spark
+  host: localhost
+  port: 6667
+agents:
+  culture: /home/user/git/culture
+  daria: /home/user/git/daria
+```
+
+### culture.yaml (single agent)
+
+```yaml
+suffix: culture
+backend: claude
+channels:
+  - "#general"
+model: claude-opus-4-6
+```
+
+### culture.yaml (multi-agent)
+
+```yaml
+agents:
+  - suffix: culture
+    backend: claude
+    channels: ["#general"]
+  - suffix: codex
+    backend: codex
+    channels: ["#general"]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.0.0"
+version = "6.0.1"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -610,9 +610,9 @@ def test_cli_create_replaces_archived_agent():
         DaemonConfig,
         ServerConnConfig,
         archive_agent,
-        load_config,
         save_config,
     )
+    from culture.config import load_config
 
     tmpdir = tempfile.mkdtemp()
     try:
@@ -625,7 +625,7 @@ def test_cli_create_replaces_archived_agent():
                     AgentConfig(
                         nick="spark-daria",
                         agent="claude",
-                        directory="/tmp/daria",
+                        directory=os.path.join(tmpdir, "daria"),
                         channels=["#general"],
                     ),
                 ],
@@ -654,7 +654,7 @@ def test_cli_create_replaces_archived_agent():
         assert len(loaded.agents) == 1
         agent = loaded.agents[0]
         assert agent.nick == "spark-daria"
-        assert agent.agent == "acp"
+        assert agent.backend == "acp"
         assert agent.archived is False
     finally:
         shutil.rmtree(tmpdir)
@@ -682,7 +682,7 @@ def test_cli_create_blocks_active_agent():
                     AgentConfig(
                         nick="spark-daria",
                         agent="claude",
-                        directory="/tmp/daria",
+                        directory=os.path.join(tmpdir, "daria"),
                         channels=["#general"],
                     ),
                 ],
@@ -719,9 +719,9 @@ def test_cli_delete_removes_agent():
         AgentConfig,
         DaemonConfig,
         ServerConnConfig,
-        load_config,
         save_config,
     )
+    from culture.config import load_config
 
     tmpdir = tempfile.mkdtemp()
     try:
@@ -734,13 +734,13 @@ def test_cli_delete_removes_agent():
                     AgentConfig(
                         nick="spark-daria",
                         agent="claude",
-                        directory="/tmp/daria",
+                        directory=os.path.join(tmpdir, "daria"),
                         channels=["#general"],
                     ),
                     AgentConfig(
                         nick="spark-ori",
                         agent="claude",
-                        directory="/tmp/ori",
+                        directory=os.path.join(tmpdir, "ori"),
                         channels=["#dev"],
                     ),
                 ],

--- a/tests/test_manifest_config.py
+++ b/tests/test_manifest_config.py
@@ -1,0 +1,317 @@
+"""Tests for manifest-format config operations (server.yaml + culture.yaml)."""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+import yaml
+
+from culture.config import (
+    AgentConfig,
+    ServerConfig,
+    ServerConnConfig,
+    add_to_manifest,
+    archive_manifest_agent,
+    load_config,
+    load_config_or_default,
+    load_culture_yaml,
+    migrate_legacy_to_manifest,
+    remove_from_manifest,
+    remove_manifest_agent,
+    rename_manifest_agent,
+    rename_manifest_server,
+    save_culture_yaml,
+    save_server_config,
+    unarchive_manifest_agent,
+)
+
+
+@pytest.fixture()
+def tmpdir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+def _write_yaml(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False)
+
+
+def _make_manifest_setup(tmpdir):
+    """Create a manifest-format server.yaml with one agent directory."""
+    agent_dir = os.path.join(tmpdir, "project")
+    os.makedirs(agent_dir, exist_ok=True)
+
+    # Write culture.yaml in agent directory
+    save_culture_yaml(
+        agent_dir,
+        [
+            AgentConfig(suffix="bot", backend="claude", channels=["#general"]),
+        ],
+    )
+
+    # Write server.yaml with manifest
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"bot": agent_dir},
+    )
+    server_path = os.path.join(tmpdir, "server.yaml")
+    save_server_config(server_path, config)
+    return server_path, agent_dir
+
+
+# -----------------------------------------------------------------------
+# Auto-migration
+# -----------------------------------------------------------------------
+
+
+def test_load_config_auto_migrates_legacy(tmpdir):
+    """Legacy format is auto-migrated to manifest format on load."""
+    agent_dir = os.path.join(tmpdir, "project")
+    os.makedirs(agent_dir, exist_ok=True)
+
+    legacy_path = os.path.join(tmpdir, "agents.yaml")
+    _write_yaml(
+        legacy_path,
+        {
+            "server": {"name": "spark"},
+            "agents": [
+                {
+                    "nick": "spark-bot",
+                    "directory": agent_dir,
+                    "agent": "claude",
+                    "channels": ["#general"],
+                },
+            ],
+        },
+    )
+
+    config = load_config(legacy_path)
+    assert config.server.name == "spark"
+    assert "bot" in config.manifest
+    assert config.manifest["bot"] == agent_dir
+
+    # culture.yaml should have been created
+    agents = load_culture_yaml(agent_dir)
+    assert len(agents) == 1
+    assert agents[0].suffix == "bot"
+    assert agents[0].backend == "claude"
+
+    # The file should now be in manifest format (re-load without migration)
+    with open(legacy_path) as f:
+        raw = yaml.safe_load(f)
+    assert isinstance(raw.get("agents"), dict)
+
+
+def test_migrate_legacy_preserves_extras(tmpdir):
+    """Extra fields (e.g. acp_command) survive migration."""
+    agent_dir = os.path.join(tmpdir, "project")
+    os.makedirs(agent_dir, exist_ok=True)
+
+    legacy_path = os.path.join(tmpdir, "agents.yaml")
+    _write_yaml(
+        legacy_path,
+        {
+            "server": {"name": "spark"},
+            "agents": [
+                {
+                    "nick": "spark-acp",
+                    "directory": agent_dir,
+                    "agent": "acp",
+                    "channels": ["#general"],
+                    "acp_command": ["opencode", "acp"],
+                },
+            ],
+        },
+    )
+
+    migrate_legacy_to_manifest(legacy_path)
+
+    agents = load_culture_yaml(agent_dir)
+    assert agents[0].backend == "acp"
+    assert agents[0].extras.get("acp_command") == ["opencode", "acp"]
+
+
+# -----------------------------------------------------------------------
+# Manifest CRUD: add / remove
+# -----------------------------------------------------------------------
+
+
+def test_add_to_manifest_creates_entry(tmpdir):
+    """add_to_manifest adds a suffix→directory mapping."""
+    server_path = os.path.join(tmpdir, "server.yaml")
+    _write_yaml(server_path, {"server": {"name": "spark"}, "agents": {}})
+
+    add_to_manifest(server_path, "bot", "/tmp/bot")
+
+    with open(server_path) as f:
+        raw = yaml.safe_load(f)
+    assert raw["agents"]["bot"] == "/tmp/bot"
+
+
+def test_add_to_manifest_duplicate_raises(tmpdir):
+    """Adding a suffix that already exists raises ValueError."""
+    server_path = os.path.join(tmpdir, "server.yaml")
+    _write_yaml(server_path, {"server": {"name": "spark"}, "agents": {"bot": "/tmp/bot"}})
+
+    with pytest.raises(ValueError, match="already registered"):
+        add_to_manifest(server_path, "bot", "/tmp/other")
+
+
+def test_remove_manifest_agent_by_nick(tmpdir):
+    """remove_manifest_agent removes the agent from the manifest."""
+    server_path, agent_dir = _make_manifest_setup(tmpdir)
+
+    remove_manifest_agent(server_path, "spark-bot")
+
+    with open(server_path) as f:
+        raw = yaml.safe_load(f)
+    assert "bot" not in raw.get("agents", {})
+
+
+def test_remove_manifest_agent_not_found(tmpdir):
+    """Removing a nonexistent agent raises ValueError."""
+    server_path, _ = _make_manifest_setup(tmpdir)
+
+    with pytest.raises(ValueError, match="not found"):
+        remove_manifest_agent(server_path, "spark-nonexistent")
+
+
+# -----------------------------------------------------------------------
+# Archive / Unarchive
+# -----------------------------------------------------------------------
+
+
+def test_archive_manifest_agent(tmpdir):
+    """archive_manifest_agent sets archived flag in culture.yaml."""
+    server_path, agent_dir = _make_manifest_setup(tmpdir)
+
+    archive_manifest_agent(server_path, "spark-bot", reason="testing")
+
+    agents = load_culture_yaml(agent_dir)
+    assert agents[0].archived is True
+    assert agents[0].archived_reason == "testing"
+    assert agents[0].archived_at != ""
+
+
+def test_unarchive_manifest_agent(tmpdir):
+    """unarchive_manifest_agent clears archived flag."""
+    server_path, agent_dir = _make_manifest_setup(tmpdir)
+
+    # Archive first
+    archive_manifest_agent(server_path, "spark-bot")
+
+    # Then unarchive
+    unarchive_manifest_agent(server_path, "spark-bot")
+
+    agents = load_culture_yaml(agent_dir)
+    assert agents[0].archived is False
+    assert agents[0].archived_at == ""
+    assert agents[0].archived_reason == ""
+
+
+def test_unarchive_not_archived_raises(tmpdir):
+    """Unarchiving an agent that isn't archived raises ValueError."""
+    server_path, _ = _make_manifest_setup(tmpdir)
+
+    with pytest.raises(ValueError, match="not archived"):
+        unarchive_manifest_agent(server_path, "spark-bot")
+
+
+# -----------------------------------------------------------------------
+# Rename
+# -----------------------------------------------------------------------
+
+
+def test_rename_manifest_agent(tmpdir):
+    """rename_manifest_agent updates manifest key and culture.yaml suffix."""
+    server_path, agent_dir = _make_manifest_setup(tmpdir)
+
+    rename_manifest_agent(server_path, "spark-bot", "spark-newbot")
+
+    # Manifest updated
+    with open(server_path) as f:
+        raw = yaml.safe_load(f)
+    assert "newbot" in raw["agents"]
+    assert "bot" not in raw["agents"]
+
+    # culture.yaml suffix updated
+    agents = load_culture_yaml(agent_dir)
+    assert agents[0].suffix == "newbot"
+
+
+def test_rename_manifest_agent_collision(tmpdir):
+    """Renaming to an existing suffix raises ValueError."""
+    server_path, agent_dir = _make_manifest_setup(tmpdir)
+
+    # Add a second agent
+    agent_dir2 = os.path.join(tmpdir, "project2")
+    os.makedirs(agent_dir2, exist_ok=True)
+    save_culture_yaml(
+        agent_dir2,
+        [
+            AgentConfig(suffix="other", backend="claude"),
+        ],
+    )
+    add_to_manifest(server_path, "other", agent_dir2)
+
+    with pytest.raises(ValueError, match="already exists"):
+        rename_manifest_agent(server_path, "spark-bot", "spark-other")
+
+
+# -----------------------------------------------------------------------
+# Server rename
+# -----------------------------------------------------------------------
+
+
+def test_rename_manifest_server(tmpdir):
+    """rename_manifest_server changes server name and reports nick changes."""
+    server_path, _ = _make_manifest_setup(tmpdir)
+
+    old_name, renamed = rename_manifest_server(server_path, "thor")
+
+    assert old_name == "spark"
+    assert ("spark-bot", "thor-bot") in renamed
+
+    # Verify server.yaml updated
+    with open(server_path) as f:
+        raw = yaml.safe_load(f)
+    assert raw["server"]["name"] == "thor"
+
+
+def test_rename_manifest_server_noop(tmpdir):
+    """Renaming to the same name is a no-op."""
+    server_path, _ = _make_manifest_setup(tmpdir)
+
+    old_name, renamed = rename_manifest_server(server_path, "spark")
+
+    assert old_name == "spark"
+    assert renamed == []
+
+
+# -----------------------------------------------------------------------
+# Load manifest format directly
+# -----------------------------------------------------------------------
+
+
+def test_load_manifest_format(tmpdir):
+    """load_config properly loads manifest-format server.yaml."""
+    server_path, agent_dir = _make_manifest_setup(tmpdir)
+
+    config = load_config(server_path)
+
+    assert config.server.name == "spark"
+    assert len(config.agents) == 1
+    assert config.agents[0].nick == "spark-bot"
+    assert config.agents[0].directory == agent_dir
+
+
+def test_load_config_or_default_missing(tmpdir):
+    """Missing config returns default ServerConfig."""
+    path = os.path.join(tmpdir, "nonexistent.yaml")
+    config = load_config_or_default(path, fallback=os.path.join(tmpdir, "also-missing.yaml"))
+    assert config.server.name == "culture"
+    assert config.agents == []

--- a/tests/test_manifest_config.py
+++ b/tests/test_manifest_config.py
@@ -163,7 +163,7 @@ def test_add_to_manifest_duplicate_raises(tmpdir):
 
 def test_remove_manifest_agent_by_nick(tmpdir):
     """remove_manifest_agent removes the agent from the manifest."""
-    server_path, agent_dir = _make_manifest_setup(tmpdir)
+    server_path, _ = _make_manifest_setup(tmpdir)
 
     remove_manifest_agent(server_path, "spark-bot")
 
@@ -245,7 +245,7 @@ def test_rename_manifest_agent(tmpdir):
 
 def test_rename_manifest_agent_collision(tmpdir):
     """Renaming to an existing suffix raises ValueError."""
-    server_path, agent_dir = _make_manifest_setup(tmpdir)
+    server_path, _ = _make_manifest_setup(tmpdir)
 
     # Add a second agent
     agent_dir2 = os.path.join(tmpdir, "project2")

--- a/tests/test_migrate_cli.py
+++ b/tests/test_migrate_cli.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test_migrate_creates_server_yaml_and_culture_yamls(tmp_path):
-    """migrate splits agents.yaml into server.yaml + per-dir culture.yaml."""
+    """migrate converts agents.yaml in-place to manifest + per-dir culture.yaml."""
     from culture.config import load_culture_yaml, load_server_config
 
     proj_a = tmp_path / "proj-a"
@@ -53,13 +53,11 @@ agents:
 
     from culture.cli.agent import _cmd_migrate
 
-    server_yaml = tmp_path / "server.yaml"
-    args = argparse.Namespace(config=str(agents_yaml), output=str(server_yaml))
+    args = argparse.Namespace(config=str(agents_yaml))
     _cmd_migrate(args)
 
-    # server.yaml exists with manifest
-    assert server_yaml.exists()
-    config = load_server_config(str(server_yaml))
+    # agents.yaml is now in manifest format (converted in-place)
+    config = load_server_config(str(agents_yaml))
     assert config.server.name == "spark"
     assert config.supervisor.model == "claude-sonnet-4-6"
     assert config.webhooks.url == "https://hooks.example.com"
@@ -82,13 +80,9 @@ agents:
     assert agents_b[0].backend == "acp"
     assert agents_b[0].acp_command == ["opencode", "acp"]
 
-    # agents.yaml backed up
-    assert (tmp_path / "agents.yaml.bak").exists()
-    assert not agents_yaml.exists()
-
 
 def test_migrate_roundtrip_starts(tmp_path):
-    """After migration, load_config on server.yaml resolves all agents."""
+    """After migration, load_config on the converted file resolves all agents."""
     from culture.config import load_config
 
     proj = tmp_path / "proj"
@@ -107,11 +101,28 @@ agents:
 
     from culture.cli.agent import _cmd_migrate
 
-    server_yaml = tmp_path / "server.yaml"
-    args = argparse.Namespace(config=str(agents_yaml), output=str(server_yaml))
+    args = argparse.Namespace(config=str(agents_yaml))
     _cmd_migrate(args)
 
-    config = load_config(str(server_yaml))
+    config = load_config(str(agents_yaml))
     assert len(config.agents) == 1
     assert config.agents[0].nick == "spark-culture"
     assert config.agents[0].backend == "claude"
+
+
+def test_migrate_already_manifest(tmp_path):
+    """Migrating a file already in manifest format exits with error."""
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("""\
+server:
+  name: spark
+agents:
+  culture: /tmp/project
+""")
+
+    from culture.cli.agent import _cmd_migrate
+
+    args = argparse.Namespace(config=str(server_yaml))
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_migrate(args)
+    assert exc_info.value.code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.0.0"
+version = "6.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes #208.

- **Auto-migrate legacy format**: `load_config()` now detects legacy `agents.yaml` format (list-of-dicts) and auto-converts to manifest format (dict mapping suffix → directory) on first load, writing `culture.yaml` per directory and updating the config in-place.
- **Manifest-aware CRUD**: Added `remove_manifest_agent`, `archive_manifest_agent`, `unarchive_manifest_agent`, `rename_manifest_agent`, `rename_manifest_server`, `archive_manifest_server`, `unarchive_manifest_server` to `culture/config.py`.
- **CLI updated**: All agent commands (`create`, `join`, `delete`, `archive`, `unarchive`, `rename`, `assign`) and server commands (`rename`, `archive`, `unarchive`) now use the manifest-aware functions instead of the legacy ones from `culture/clients/claude/config.py`.
- **`_cmd_migrate` simplified**: Reuses shared `migrate_legacy_to_manifest()` instead of duplicating migration logic.
- **15 new tests** in `tests/test_manifest_config.py` covering auto-migration, CRUD, archive/unarchive, rename, and server rename.

## Test plan

- [x] All 751 tests pass (`pytest -n auto`)
- [ ] Manual test: `culture agent create --server spark --nick test --agent claude` with manifest-format server.yaml
- [ ] Verify `culture.yaml` is created in agent directory
- [ ] `culture agent delete spark-test` removes from manifest

- Claude