### PR TITLE
fix: IRC skill uses culture channel CLI, remove internal Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.1.1] - 2026-04-11
+
+
+### Changed
+
+- Remove Python API sections from all backend SKILL.md files — agents should use culture channel CLI exclusively
+
+
+### Fixed
+
+- IRC skill teaches agents to use internal module path instead of culture CLI (#215)
+
 ## [6.1.0] - 2026-04-10
 
 

--- a/culture/clients/acp/skill/SKILL.md
+++ b/culture/clients/acp/skill/SKILL.md
@@ -192,31 +192,3 @@ These arrive on stderr as:
 ```
 
 Always read stderr after calling this skill.
-
-## Python API
-
-For use from Python (e.g. tests or other scripts):
-
-```python
-from culture.clients.acp.skill.irc_client import SkillClient
-
-client = SkillClient("/tmp/culture-spark-cline.sock")
-await client.connect()
-
-result = await client.irc_send("#general", "hello")
-result = await client.irc_read("#general", limit=20)
-result = await client.irc_ask("#general", "what is happening?", timeout=30)
-result = await client.irc_join("#ops")
-result = await client.irc_part("#ops")
-result = await client.irc_channels()
-result = await client.irc_who("#general")
-result = await client.irc_topic("#general")
-result = await client.irc_topic("#general", "Welcome to general chat")
-result = await client.compact()
-result = await client.clear()
-
-# Collect whispers queued during the session
-whispers = client.drain_whispers()
-
-await client.close()
-```

--- a/culture/clients/claude/skill/SKILL.md
+++ b/culture/clients/claude/skill/SKILL.md
@@ -185,31 +185,3 @@ These arrive on stderr as:
 ```
 
 Always read stderr after calling this skill.
-
-## Python API
-
-For use from Python (e.g. tests or other scripts):
-
-```python
-from culture.clients.claude.skill.irc_client import SkillClient
-
-client = SkillClient("/tmp/culture-thor-claude.sock")
-await client.connect()
-
-result = await client.irc_send("#general", "hello")
-result = await client.irc_read("#general", limit=20)
-result = await client.irc_ask("#general", "what is happening?", timeout=30)
-result = await client.irc_join("#ops")
-result = await client.irc_part("#ops")
-result = await client.irc_channels()
-result = await client.irc_who("#general")
-result = await client.irc_topic("#general")
-result = await client.irc_topic("#general", "Welcome to general chat")
-result = await client.compact()
-result = await client.clear()
-
-# Collect whispers queued during the session
-whispers = client.drain_whispers()
-
-await client.close()
-```

--- a/culture/clients/codex/skill/SKILL.md
+++ b/culture/clients/codex/skill/SKILL.md
@@ -192,31 +192,3 @@ These arrive on stderr as:
 ```
 
 Always read stderr after calling this skill.
-
-## Python API
-
-For use from Python (e.g. tests or other scripts):
-
-```python
-from culture.clients.codex.skill.irc_client import SkillClient
-
-client = SkillClient("/tmp/culture-spark-codex.sock")
-await client.connect()
-
-result = await client.irc_send("#general", "hello")
-result = await client.irc_read("#general", limit=20)
-result = await client.irc_ask("#general", "what is happening?", timeout=30)
-result = await client.irc_join("#ops")
-result = await client.irc_part("#ops")
-result = await client.irc_channels()
-result = await client.irc_who("#general")
-result = await client.irc_topic("#general")
-result = await client.irc_topic("#general", "Welcome to general chat")
-result = await client.compact()
-result = await client.clear()
-
-# Collect whispers queued during the session
-whispers = client.drain_whispers()
-
-await client.close()
-```

--- a/culture/clients/copilot/skill/SKILL.md
+++ b/culture/clients/copilot/skill/SKILL.md
@@ -192,31 +192,3 @@ These arrive on stderr as:
 ```
 
 Always read stderr after calling this skill.
-
-## Python API
-
-For use from Python (e.g. tests or other scripts):
-
-```python
-from culture.clients.copilot.skill.irc_client import SkillClient
-
-client = SkillClient("/tmp/culture-spark-copilot.sock")
-await client.connect()
-
-result = await client.irc_send("#general", "hello")
-result = await client.irc_read("#general", limit=20)
-result = await client.irc_ask("#general", "what is happening?", timeout=30)
-result = await client.irc_join("#ops")
-result = await client.irc_part("#ops")
-result = await client.irc_channels()
-result = await client.irc_who("#general")
-result = await client.irc_topic("#general")
-result = await client.irc_topic("#general", "Welcome to general chat")
-result = await client.compact()
-result = await client.clear()
-
-# Collect whispers queued during the session
-whispers = client.drain_whispers()
-
-await client.close()
-```

--- a/plugins/claude-code/skills/irc/SKILL.md
+++ b/plugins/claude-code/skills/irc/SKILL.md
@@ -185,31 +185,3 @@ These arrive on stderr as:
 ```
 
 Always read stderr after calling this skill.
-
-## Python API
-
-For use from Python (e.g. tests or other scripts):
-
-```python
-from culture.clients.claude.skill.irc_client import SkillClient
-
-client = SkillClient("/tmp/culture-thor-claude.sock")
-await client.connect()
-
-result = await client.irc_send("#general", "hello")
-result = await client.irc_read("#general", limit=20)
-result = await client.irc_ask("#general", "what is happening?", timeout=30)
-result = await client.irc_join("#ops")
-result = await client.irc_part("#ops")
-result = await client.irc_channels()
-result = await client.irc_who("#general")
-result = await client.irc_topic("#general")
-result = await client.irc_topic("#general", "Welcome to general chat")
-result = await client.compact()
-result = await client.clear()
-
-# Collect whispers queued during the session
-whispers = client.drain_whispers()
-
-await client.close()
-```

--- a/plugins/codex/skills/culture-irc/SKILL.md
+++ b/plugins/codex/skills/culture-irc/SKILL.md
@@ -192,31 +192,3 @@ These arrive on stderr as:
 ```
 
 Always read stderr after calling this skill.
-
-## Python API
-
-For use from Python (e.g. tests or other scripts):
-
-```python
-from culture.clients.codex.skill.irc_client import SkillClient
-
-client = SkillClient("/tmp/culture-spark-codex.sock")
-await client.connect()
-
-result = await client.irc_send("#general", "hello")
-result = await client.irc_read("#general", limit=20)
-result = await client.irc_ask("#general", "what is happening?", timeout=30)
-result = await client.irc_join("#ops")
-result = await client.irc_part("#ops")
-result = await client.irc_channels()
-result = await client.irc_who("#general")
-result = await client.irc_topic("#general")
-result = await client.irc_topic("#general", "Welcome to general chat")
-result = await client.compact()
-result = await client.clear()
-
-# Collect whispers queued during the session
-whispers = client.drain_whispers()
-
-await client.close()
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.1.0"
+version = "6.1.1"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -46,10 +46,13 @@ def test_all_irc_skills_have_whispers(backend):
 
 
 @pytest.mark.parametrize("backend", ["claude", "codex", "copilot", "acp"])
-def test_all_irc_skills_have_python_api(backend):
-    """Issue #182: every backend should have a Python API section."""
+def test_all_irc_skills_use_culture_channel_cli(backend):
+    """Issue #215: every backend should use culture channel CLI, not internal modules."""
     content = IRC_SKILL_FILES[backend].read_text()
-    assert "Python API" in content, f"{backend} SKILL.md missing Python API section"
+    assert "culture channel" in content, f"{backend} SKILL.md missing culture channel CLI"
+    assert (
+        "python3 -m culture" not in content
+    ), f"{backend} SKILL.md still uses internal module path"
 
 
 def test_codex_plugin_matches_source():

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.0.1"
+version = "6.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Fixes #215

- **Updated installed skill** (`~/.claude/skills/irc/SKILL.md`) — replaced all 16 `python3 -m culture.clients.claude.skill.irc_client` invocations with `culture channel` CLI commands
- **Removed Python API sections** from all 6 in-repo SKILL.md files — agents should use the CLI exclusively, not internal module imports
- Files changed: `culture/clients/{claude,codex,copilot,acp}/skill/SKILL.md`, `plugins/{claude-code,codex}/skills/*/SKILL.md`

## Test plan

- [x] `grep -r 'python3 -m culture' **/SKILL.md` returns zero matches
- [x] `grep -r 'from culture.clients' **/SKILL.md` returns zero matches
- [x] `culture channel --help` confirms all 10 subcommands work
- [x] `markdownlint-cli2` passes on all 7 edited files (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude