### PR TITLE
Add citation-cli.culture.dev site

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,6 +26,11 @@ jobs:
         env:
           JEKYLL_ENV: production
 
+      - name: Build Citation CLI docs
+        run: bundle exec jekyll build --config _config.base.yml,_config.citation-cli.yml -d _site_citation_cli
+        env:
+          JEKYLL_ENV: production
+
       - name: Verify sites tag on all doc files
         run: |
           MISSING=$(grep -rL "^sites:" docs/ --include="*.md" | grep -v superpowers | grep -v resources | grep -v README || true)

--- a/_config.citation-cli.yml
+++ b/_config.citation-cli.yml
@@ -1,0 +1,40 @@
+title: Citation CLI
+description: >-
+  Cite, don't import — track cited code with Quote / Paraphrase / Synthesize semantics.
+url: "https://citation-cli.culture.dev"
+baseurl: ""
+build_site: citation-cli
+
+twitter:
+  username: AgenticHumanOrg
+  card: summary_large_image
+
+social:
+  name: Citation CLI
+  links:
+    - https://github.com/OriNachum/citation-cli
+
+author:
+  name: Ori Nachum
+  twitter: AgenticHumanOrg
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "default"
+      image: /assets/images/og-citation-cli.png
+
+aux_links:
+  "Culture":
+    - "https://culture.dev"
+  "AgentIRC":
+    - "https://agentirc.dev"
+  "GitHub":
+    - "https://github.com/OriNachum/citation-cli"
+
+aux_links_new_tab: true
+
+footer_content: >-
+  Citation CLI — part of the <a href="https://culture.dev">Culture</a> ecosystem.
+  Source on <a href="https://github.com/OriNachum/citation-cli">GitHub</a>.

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,2 +1,3 @@
 agentirc: https://agentirc.dev
 culture: https://culture.dev
+citation-cli: https://citation-cli.culture.dev

--- a/docs/citation-cli/concept.md
+++ b/docs/citation-cli/concept.md
@@ -1,0 +1,108 @@
+---
+title: The Concept
+nav_order: 1
+permalink: /concept/
+sites: [citation-cli]
+---
+
+## The Concept
+
+### The citation metaphor
+
+In any academic or intellectual discipline, there are exactly
+three ways to use a source:
+
+- **Quote** — take it as-is. You are citing the text verbatim
+  because you need exactly what it is. A quote is a conscious
+  choice.
+- **Paraphrase** — rewrite it in your terms. The logic stays,
+  but you have adapted it to fit your codebase, your language,
+  your style. A paraphrase means you understood the source well
+  enough to restate it.
+- **Synthesize** — absorb it into your own work. The idea
+  informed your thinking, but the code is yours now. The boundary
+  is gone. A synthesis means you internalized the source
+  completely.
+
+Each level implies deeper introspection, which is exactly what
+this pattern encodes in the metadata of every cited file.
+
+### The assumption gap
+
+Traditional package management assumes every consumer wants
+identical behavior from a shared dependency. You publish a
+package, pin a version, and every consumer gets the same code.
+
+That assumption works when consumers are interchangeable. It
+breaks when consumers are **expected to diverge** — when each
+one wraps a different SDK, speaks a different protocol, or
+integrates at fundamentally different points.
+
+Citation CLI starts from the opposite assumption: consumers will
+diverge, and the system should make that safe.
+
+### Why cite beats import
+
+When you import a shared package, you accept a contract: the
+package controls its own internals, and you call its public API.
+That works until you need to change the internals — add a field
+to a data structure, swap an I/O layer, rearrange the module
+boundaries.
+
+When you cite the reference, you own the result. The reference is
+a starting point, not a constraint. You quote what you need
+verbatim, paraphrase what has to bend to fit your shape, and
+synthesize what dissolves naturally into existing files.
+
+The trade-off is explicit: you give up automatic updates in
+exchange for full independence. But the metadata tracks what came
+from where, so updates are informed rather than blind.
+
+### Monorepos
+
+Citation CLI is a natural fit for monorepos. In a monorepo, you
+already own the source code for your internal packages — publishing
+them to a registry just to import them back is unnecessary
+ceremony.
+
+Traditional monorepo tooling (npm workspaces, Python namespace
+packages, Bazel targets) uses import-time linking to share code
+between packages. This avoids the publish step, but creates its
+own friction: symlinks, workspace hoisting, version conflicts
+between internal and external dependencies, and debugging through
+package boundaries instead of just reading the file.
+
+Citation CLI removes the middleman entirely. Copy from `packages/`
+into your target directory, modify freely, debug directly. The
+code lives where it runs — no indirection, no build-tool magic,
+no "which version of the internal package am I actually using?"
+
+The metadata in `pyproject.toml` or `package.json` tracks what
+came from where, so you maintain provenance without maintaining a
+package registry.
+
+### How it compares
+
+**Vendoring** copies dependencies into your tree, but vendored
+code is usually kept separate and untouched — `vendor/` is a
+frozen snapshot. Citation CLI expects you to engage with the code
+and synthesize it into your own structure.
+
+**Git submodules** link a subdirectory to another repo. You get
+updates by pulling, but you don't own the code — changes require
+forking or patching. Citation CLI gives you full ownership from
+the start.
+
+**Monorepo workspace tooling** (npm workspaces, Python namespace
+packages, Bazel) uses import-time linking within the monorepo.
+This avoids the external publish step but couples all consumers to
+the same version of shared code — changes propagate immediately to
+every consumer. Citation CLI is also designed for monorepos but
+takes the opposite approach: each consumer gets its own copy and
+evolves independently.
+
+**Citation CLI** is closest to vendoring but with three
+differences: you are expected to modify the code, you can
+synthesize it into existing files, and the metadata tracks
+provenance so you can propagate reference updates when you choose
+to.

--- a/docs/citation-cli/index.md
+++ b/docs/citation-cli/index.md
@@ -1,0 +1,96 @@
+---
+title: Citation CLI
+nav_order: 0
+permalink: /
+sites: [citation-cli]
+description: Cite, don't import — a code distribution pattern with Quote / Paraphrase / Synthesize semantics.
+---
+
+## Citation CLI
+
+**Cite, don't import.** A code distribution pattern for codebases
+where consumers are expected to diverge — each consumer copies
+the reference into its own tree and owns the result.
+
+```text
+packages/reference/       -->  cite  -->  clients/backend-a/
+                          -->  cite  -->  clients/backend-b/
+                          -->  cite  -->  clients/backend-c/
+```
+
+No shared imports. No version pinning. No breakage when one
+project evolves.
+
+### Quote, Paraphrase, Synthesize
+
+The citation metaphor is literal. Every file lands at one of three
+levels of engagement with the source:
+
+- **Quote** — copied verbatim. You are saying: *this code, exactly
+  as it is, is what I need.* Integrity is checked via sha256 so
+  drift is detected.
+- **Paraphrase** — rewritten in your terms. The logic stays, but
+  the code has been adapted to fit your codebase. A paraphrase
+  means you understood the source well enough to restate it.
+- **Synthesize** — absorbed into an existing consumer file. No
+  standalone copy remains. A synthesis means you internalized the
+  source completely — the boundary is gone.
+
+### Install
+
+Python (`[tool.citation]` in `pyproject.toml`):
+
+```bash
+uv tool install citation-cli
+cite add my-pkg --source ../ref --version 1.0.0 --target ./src/my-pkg
+cite check
+```
+
+Node.js (`"citation"` key in `package.json`):
+
+```bash
+npm install -g citation-cli
+cite add my-pkg --source ../ref --version 1.0.0 --target ./src/my-pkg
+cite check
+```
+
+### Migrating from assimilai
+
+citation-cli is the successor to the earlier **assimilai** project.
+The schema and vocabulary map one-to-one
+(`verbatim`/`adapted`/`dissolved` → `quote`/`paraphrase`/`synthesize`).
+To migrate an existing manifest:
+
+```bash
+cite migrate             # rewrite pyproject.toml or package.json in place
+cite migrate --dry-run   # preview the translation
+```
+
+See [Migration]({{ '/migration/' | relative_url }}) for a full
+before/after walkthrough.
+
+### Learn more
+
+- [The Concept]({{ '/concept/' | relative_url }}) — why cite beats
+  import, and how the three levels of engagement work
+- [Python CLI]({{ '/python/' | relative_url }}) — install, commands,
+  flags, and `pyproject.toml` schema
+- [npm CLI]({{ '/npm/' | relative_url }}) — install, commands,
+  flags, and `package.json` schema
+- [When Not to Use]({{ '/when-not-to-use/' | relative_url }}) —
+  compliance, provenance, and cases where traditional packages are
+  the right choice
+- [Migration]({{ '/migration/' | relative_url }}) — from assimilai
+  v1 to citation-cli v2
+- [Specification]({{ '/spec/' | relative_url }}) — formal schema
+  definition, field reference, propagation rules
+
+### Origin
+
+citation-cli was developed as part of
+[Culture](https://culture.dev), where multiple AI agent backends
+(Claude, Codex, and others) need to share infrastructure code while
+maintaining full independence in their agent-specific integration
+layers. Claude's backend synthesized `config.py` into its own
+`settings.py`, while Codex kept it as a quote — same reference,
+different engagement strategies.

--- a/docs/citation-cli/migration.md
+++ b/docs/citation-cli/migration.md
@@ -1,0 +1,119 @@
+---
+title: Migration
+nav_order: 5
+permalink: /migration/
+sites: [citation-cli]
+---
+
+## Migration from Assimilai v1
+
+citation-cli supersedes the earlier **assimilai** project. The
+schema and vocabulary map one-to-one:
+
+| Assimilai v1 | Citation CLI v1 |
+| ------------ | --------------- |
+| `[tool.assimilai]` | `[tool.citation]` |
+| `"assimilai"` (package.json) | `"citation"` (package.json) |
+| `assimilated` field | `cited` field |
+| status `verbatim` | status `quote` |
+| status `adapted` | status `paraphrase` |
+| status `dissolved` | status `synthesize` |
+| (no `schema` field) | `schema = 2` |
+
+### Run the migration
+
+From the root of any project that has a legacy manifest:
+
+```bash
+cite migrate             # rewrite pyproject.toml or package.json in place
+cite migrate --dry-run   # preview the translation
+```
+
+`cite migrate` refuses to run if a `[tool.citation]` / `"citation"`
+block already exists, and errors on any unrecognized file status.
+
+### Before / after (Python)
+
+Legacy `pyproject.toml`:
+
+```toml
+[tool.assimilai.packages.harness-claude]
+source = "../packages/agent-harness"
+version = "0.6.0"
+target = "src/clients/claude"
+assimilated = "2026-03-24"
+
+[tool.assimilai.packages.harness-claude.files]
+"daemon.py" = { status = "adapted" }
+"irc_transport.py" = { status = "verbatim", sha256 = "e3b0c44..." }
+"config.py" = { status = "dissolved", into = "src/clients/claude/settings.py" }
+```
+
+After `cite migrate`:
+
+```toml
+[tool.citation.packages.harness-claude]
+schema = 2
+source = "../packages/agent-harness"
+version = "0.6.0"
+target = "src/clients/claude"
+cited = "2026-03-24"
+
+[tool.citation.packages.harness-claude.files]
+"daemon.py" = { status = "paraphrase" }
+"irc_transport.py" = { status = "quote", sha256 = "e3b0c44..." }
+"config.py" = { status = "synthesize", into = "src/clients/claude/settings.py" }
+```
+
+### Before / after (npm)
+
+Legacy `package.json`:
+
+```json
+{
+  "assimilai": {
+    "packages": {
+      "harness-claude": {
+        "source": "../packages/agent-harness",
+        "version": "0.6.0",
+        "target": "src/clients/claude",
+        "assimilated": "2026-03-24",
+        "files": {
+          "daemon.js": { "status": "adapted" },
+          "transport.js": { "status": "verbatim", "sha256": "e3b0c44..." },
+          "config.js": { "status": "dissolved", "into": "src/clients/claude/settings.js" }
+        }
+      }
+    }
+  }
+}
+```
+
+After `cite migrate`:
+
+```json
+{
+  "citation": {
+    "packages": {
+      "harness-claude": {
+        "schema": 2,
+        "source": "../packages/agent-harness",
+        "version": "0.6.0",
+        "target": "src/clients/claude",
+        "cited": "2026-03-24",
+        "files": {
+          "daemon.js": { "status": "paraphrase" },
+          "transport.js": { "status": "quote", "sha256": "e3b0c44..." },
+          "config.js": { "status": "synthesize", "into": "src/clients/claude/settings.js" }
+        }
+      }
+    }
+  }
+}
+```
+
+### The old packages
+
+The `assimilai` package is frozen at `0.1.1` on both PyPI and npm,
+with a deprecation notice pointing at `citation-cli`. There is no
+shim or forwarding — install `citation-cli` directly.

--- a/docs/citation-cli/npm.md
+++ b/docs/citation-cli/npm.md
@@ -1,0 +1,168 @@
+---
+title: npm CLI
+nav_order: 3
+permalink: /npm/
+sites: [citation-cli]
+---
+
+## npm CLI
+
+The `citation-cli` npm package tracks cited code in `package.json`
+under the `"citation"` key.
+
+### Install
+
+```bash
+npm install -g citation-cli
+```
+
+Or as a dev dependency:
+
+```bash
+npm install --save-dev citation-cli
+```
+
+Or run without installing:
+
+```bash
+npx citation-cli --help
+```
+
+### Commands
+
+#### `cite add`
+
+Record a citation. Scans files in the target directory and records
+each as a quote with its sha256 hash.
+
+```bash
+cite add <name> \
+  --source <path-or-url> \
+  --version <semver> \
+  --target <local-dir>
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `<name>` | yes | Entry name (e.g. `agent-harness`) |
+| `--source` | yes | Path or URL to the reference package |
+| `--version` | yes | Semver of the reference at citation time |
+| `--target` | yes | Local directory where files were placed |
+| `--package-json` | no | Path to package.json (default: `package.json`) |
+
+**What it does:**
+
+1. Reads the existing `package.json`.
+2. Scans all files in `--target` (skipping hidden directories).
+3. Computes sha256 for each file.
+4. Records everything as `"status": "quote"` under
+   `"citation.packages.<name>"`.
+5. Sets `"cited"` to today's date.
+6. Writes `"schema": 2` on the package entry.
+
+#### `cite check`
+
+Verify integrity of cited files.
+
+```bash
+cite check [name]
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `[name]` | no | Check a specific package (omit to check all) |
+| `--package-json` | no | Path to package.json (default: `package.json`) |
+
+**What it reports:**
+
+- **OK** — file hash matches the recorded sha256.
+- **DRIFT** — file was modified (hash mismatch).
+- **MISSING** — file was deleted.
+- **SKIP** — file is a `paraphrase` or `synthesize` (expected to
+  differ).
+
+#### `cite migrate`
+
+Migrate a legacy `"assimilai"` key in `package.json` to the v2
+`"citation"` schema.
+
+```bash
+cite migrate [--dry-run]
+```
+
+Refuses to run if `"citation"` already exists and errors on any
+unknown file status.
+
+#### `cite sync`
+
+Reserved for 0.2.0 — will update quoted files from the source,
+following the propagation rules in the
+[Specification]({{ '/spec/#propagation' | relative_url }}).
+
+### package.json schema
+
+```json
+{
+  "citation": {
+    "packages": {
+      "harness-claude": {
+        "schema": 2,
+        "source": "../packages/agent-harness",
+        "version": "0.6.0",
+        "target": "src/clients/claude",
+        "cited": "2026-04-13",
+        "files": {
+          "daemon.js": { "status": "paraphrase" },
+          "transport.js": {
+            "status": "quote",
+            "sha256": "e3b0c44..."
+          },
+          "config.js": {
+            "status": "synthesize",
+            "into": "src/clients/claude/settings.js"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### File status
+
+After `cite add`, all files start as `quote`. To reclassify a file
+as a paraphrase or synthesis, edit `package.json` directly:
+
+```json
+{
+  "daemon.js": { "status": "paraphrase" },
+  "config.js": {
+    "status": "synthesize",
+    "into": "src/settings.js"
+  }
+}
+```
+
+`cite check` will then skip these files.
+
+### Walkthrough
+
+```bash
+# 1. Copy reference files into your project
+cp -r ../packages/agent-harness/ ./src/clients/claude/
+
+# 2. Record the citation
+cite add harness-claude \
+  --source ../packages/agent-harness \
+  --version 0.6.0 \
+  --target ./src/clients/claude
+
+# 3. Engage with the files
+# Rewrite daemon.js → mark it "status": "paraphrase"
+# Absorb config.js into settings.js → mark it "status": "synthesize"
+
+# 4. Update package.json to reflect those decisions
+
+# 5. Check integrity of the remaining quotes
+cite check harness-claude
+```

--- a/docs/citation-cli/python.md
+++ b/docs/citation-cli/python.md
@@ -1,0 +1,156 @@
+---
+title: Python CLI
+nav_order: 2
+permalink: /python/
+sites: [citation-cli]
+---
+
+## Python CLI
+
+The `citation-cli` Python package tracks cited code in
+`pyproject.toml` under the `[tool.citation]` section.
+
+### Install
+
+```bash
+uv tool install citation-cli
+```
+
+Or with pip:
+
+```bash
+pip install citation-cli
+```
+
+### Commands
+
+#### `cite add`
+
+Record a citation. Scans files in the target directory and records
+each as a quote with its sha256 hash.
+
+```bash
+cite add <name> \
+  --source <path-or-url> \
+  --version <semver> \
+  --target <local-dir>
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `<name>` | yes | Entry name (e.g. `agent-harness`) |
+| `--source` | yes | Path or URL to the reference package |
+| `--version` | yes | Semver of the reference at citation time |
+| `--target` | yes | Local directory where files were placed |
+| `--pyproject` | no | Path to pyproject.toml (default: `pyproject.toml`) |
+
+**What it does:**
+
+1. Reads the existing `pyproject.toml`.
+2. Scans all files in `--target` (skipping hidden directories).
+3. Computes sha256 for each file.
+4. Records everything as `status = "quote"` under
+   `[tool.citation.packages.<name>]`.
+5. Sets `cited` to today's date.
+6. Writes `schema = 2` on the package entry.
+
+#### `cite check`
+
+Verify integrity of cited files.
+
+```bash
+cite check [name]
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `[name]` | no | Check a specific package (omit to check all) |
+| `--pyproject` | no | Path to pyproject.toml (default: `pyproject.toml`) |
+
+**What it reports:**
+
+- **OK** — file hash matches the recorded sha256.
+- **DRIFT** — file was modified (hash mismatch).
+- **MISSING** — file was deleted.
+- **SKIP** — file is a `paraphrase` or `synthesize` (expected to
+  differ).
+
+Exit code 0 if all quoted files match; non-zero if any drift or
+missing files are detected, or if a requested package name is not
+found.
+
+#### `cite migrate`
+
+Migrate a legacy `[tool.assimilai]` manifest to the v2
+`[tool.citation]` schema.
+
+```bash
+cite migrate [--dry-run]
+```
+
+| Flag | Required | Description |
+| ---- | -------- | ----------- |
+| `--pyproject` | no | Path to pyproject.toml (default: `pyproject.toml`) |
+| `--dry-run` | no | Preview the translation without writing |
+
+Refuses to run if `[tool.citation]` already exists, and errors on
+any unknown file status.
+
+#### `cite sync`
+
+Reserved for the 0.2.0 release — will update quoted files from
+the source reference, following the propagation rules in the
+[Specification]({{ '/spec/#propagation' | relative_url }}).
+
+### pyproject.toml schema
+
+```toml
+[tool.citation.packages.harness-claude]
+schema = 2
+source = "../packages/agent-harness"
+version = "0.6.0"
+target = "src/clients/claude"
+cited = "2026-04-13"
+
+[tool.citation.packages.harness-claude.files]
+"daemon.py" = { status = "paraphrase" }
+"irc_transport.py" = { status = "quote", sha256 = "e3b0c44..." }
+"config.py" = { status = "synthesize", into = "src/clients/claude/settings.py" }
+```
+
+### File status
+
+After `cite add`, all files start as `quote`. To reclassify a file
+as a paraphrase or synthesis, edit `pyproject.toml` directly:
+
+```toml
+# Rewrote this file to fit our backend
+"daemon.py" = { status = "paraphrase" }
+
+# Absorbed into our existing settings module
+"config.py" = { status = "synthesize", into = "src/settings.py" }
+```
+
+`cite check` will then skip these files.
+
+### Walkthrough
+
+```bash
+# 1. Copy reference files into your project
+cp -r ../packages/agent-harness/ ./src/clients/claude/
+
+# 2. Record the citation
+cite add harness-claude \
+  --source ../packages/agent-harness \
+  --version 0.6.0 \
+  --target ./src/clients/claude
+
+# 3. Engage with the files
+# Rewrite daemon.py → mark it status = "paraphrase"
+# Absorb config.py into settings.py → mark it status = "synthesize"
+
+# 4. Update pyproject.toml to reflect those decisions
+
+# 5. Check integrity of the remaining quotes
+cite check harness-claude
+```

--- a/docs/citation-cli/spec.md
+++ b/docs/citation-cli/spec.md
@@ -1,0 +1,218 @@
+---
+title: Specification
+nav_order: 6
+permalink: /spec/
+sites: [citation-cli]
+---
+
+# Citation CLI Specification v1
+
+Version: 1.0.0
+Schema version: 2
+Date: 2026-04-13
+
+## Overview
+
+Citation CLI is a code distribution pattern where reference
+implementations are **cited into consumer projects as organic
+code** rather than imported as dependencies. This specification
+defines the metadata schema that tracks which code was cited,
+from where, and at what level of engagement — **Quote**,
+**Paraphrase**, or **Synthesize**.
+
+The citation metaphor is literal. In any academic or intellectual
+discipline, there are exactly three ways to use a source:
+
+- **Quote** — take it as-is. You are citing the text verbatim
+  because you need exactly what it is.
+- **Paraphrase** — rewrite it in your terms. The logic stays but
+  you have adapted it to fit your codebase, your language, your
+  style.
+- **Synthesize** — absorb it into your own work. The idea informed
+  your thinking, but the code is yours now. The boundary is gone.
+
+Each level implies deeper introspection, which is exactly what
+the pattern encodes.
+
+## Design Principles
+
+1. **Cite, don't import** — no shared runtime dependencies between
+   consumers.
+2. **Own your copy** — each consumer can modify cited code freely.
+3. **Organic placement** — code goes where it naturally belongs in
+   the consumer, not where it lived in the reference.
+4. **Trackable provenance** — metadata records what came from
+   where, enabling drift detection and informed updates.
+
+## Schema
+
+### Python (`pyproject.toml`)
+
+Citation metadata lives under `[tool.citation]` following
+[PEP 518](https://peps.python.org/pep-0518/) conventions.
+
+```toml
+[tool.citation.packages.<entry-name>]
+schema = 2
+source = "<path-or-url>"
+version = "<semver>"
+target = "<local-path>"
+cited = "<YYYY-MM-DD>"
+
+[tool.citation.packages.<entry-name>.files]
+"<filename>" = { status = "quote", sha256 = "<hash>" }
+"<filename>" = { status = "paraphrase" }
+"<filename>" = { status = "synthesize", into = "<consumer-file>" }
+```
+
+### Node.js (`package.json`)
+
+Citation metadata lives under the `"citation"` top-level key.
+
+```json
+{
+  "citation": {
+    "packages": {
+      "<entry-name>": {
+        "schema": 2,
+        "source": "<path-or-url>",
+        "version": "<semver>",
+        "target": "<local-path>",
+        "cited": "<YYYY-MM-DD>",
+        "files": {
+          "<filename>": { "status": "quote", "sha256": "<hash>" },
+          "<filename>": { "status": "paraphrase" },
+          "<filename>": { "status": "synthesize", "into": "<consumer-file>" }
+        }
+      }
+    }
+  }
+}
+```
+
+## Field Reference
+
+### Package-level fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `schema` | integer | yes | Schema version (currently `2`) |
+| `source` | string | yes | Path or URL to the reference |
+| `version` | string | yes | Semver of the reference at citation time |
+| `target` | string | yes | Local directory where files were placed |
+| `cited` | string | yes | ISO date (YYYY-MM-DD) of citation |
+
+### File-level fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `status` | string | yes | One of: `quote`, `paraphrase`, `synthesize` |
+| `sha256` | string | `quote` only | Hash of the file at citation time |
+| `into` | string | `synthesize` only | Consumer file where code was absorbed |
+
+## File Status
+
+### `quote`
+
+The file was copied without modification — a verbatim citation.
+The `sha256` field records the hash at citation time, enabling
+integrity checks: if the local file's hash differs from the
+recorded hash, it was modified outside the citation workflow.
+
+A quote is a conscious choice. You are saying: *this code,
+exactly as it is, is what I need.*
+
+### `paraphrase`
+
+The file was copied and then intentionally rewritten in the
+consumer's terms. The logic stays, but the code has been adapted
+to fit the consumer's style, idioms, or surrounding architecture.
+No hash is recorded because divergence is the point.
+
+A paraphrase means you understood the source well enough to
+restate it.
+
+### `synthesize`
+
+The file's contents were absorbed into an existing consumer file.
+There is no standalone copy of the reference file. The `into`
+field records which consumer file absorbed the code.
+
+A synthesis means you internalized the source completely — the
+boundary is gone.
+
+## Propagation
+
+When the reference package is updated, consumers can propagate
+changes using these rules:
+
+| File status | Action on update |
+| ----------- | ---------------- |
+| `quote` | Replace file, update `sha256`, `version`, `cited` |
+| `paraphrase` | **Do not overwrite.** Flag for review |
+| `synthesize` | **Do not touch.** Flag for review |
+
+Additional rules:
+
+- **New files in reference:** Add as `quote` to the consumer.
+- **Deleted files in reference:** Flag for manual review — do not
+  auto-delete.
+
+Propagation can be performed by an AI coding agent reading the
+`[tool.citation]` metadata, or by the forthcoming `cite sync`
+command.
+
+## Example
+
+A monorepo with a reference package cited into two backends:
+
+```toml
+# pyproject.toml
+
+[tool.citation.packages.harness-claude]
+schema = 2
+source = "../packages/agent-harness"
+version = "0.6.0"
+target = "culture/clients/claude"
+cited = "2026-04-13"
+
+[tool.citation.packages.harness-claude.files]
+"daemon.py" = { status = "paraphrase" }
+"irc_transport.py" = { status = "quote", sha256 = "e3b0c44..." }
+"config.py" = { status = "synthesize", into = "culture/clients/claude/settings.py" }
+
+[tool.citation.packages.harness-codex]
+schema = 2
+source = "../packages/agent-harness"
+version = "0.6.0"
+target = "culture/clients/codex"
+cited = "2026-04-13"
+
+[tool.citation.packages.harness-codex.files]
+"daemon.py" = { status = "paraphrase" }
+"irc_transport.py" = { status = "quote", sha256 = "e3b0c44..." }
+"config.py" = { status = "quote", sha256 = "b5bb9d8..." }
+```
+
+Claude's backend synthesized `config.py` into its own
+`settings.py`, while Codex kept it as a quote — same reference,
+different engagement strategies.
+
+## For AI Coding Agents
+
+When you encounter `[tool.citation]` in a `pyproject.toml` or
+`"citation"` in a `package.json`:
+
+1. **Read it** to understand which files originated from a
+   reference and at what level they are engaged.
+2. **Check quotes** — hash should match; if not, the file was
+   changed outside the citation workflow.
+3. **Respect paraphrases and syntheses** — these are owned by the
+   consumer and should not be overwritten during propagation.
+4. **When citing new code**, update the metadata to reflect what
+   was copied and how it was placed.
+
+## Migration from Assimilai v1
+
+See the [Migration]({{ '/migration/' | relative_url }}) page for
+the mapping and `cite migrate` usage.

--- a/docs/citation-cli/when-not-to-use.md
+++ b/docs/citation-cli/when-not-to-use.md
@@ -1,0 +1,68 @@
+---
+title: When Not to Use
+nav_order: 4
+permalink: /when-not-to-use/
+sites: [citation-cli]
+---
+
+## When Not to Use Citation CLI
+
+Citation CLI is designed for a specific situation: multiple
+consumers that share infrastructure code but need to diverge
+independently. Outside that situation, traditional approaches are
+often better.
+
+### Compliance and provenance requirements
+
+If your environment requires traceability to a specific published
+artifact — compliance audits, regulated industries, SBOM
+requirements that trace back to an exact audited package version —
+traditional dependencies remain the right choice.
+
+Synthesizing code into your own files breaks the chain of custody
+by design. There is no published artifact to point to, no version
+to audit against. The code becomes yours, indistinguishable from
+code you wrote yourself.
+
+### Code that must stay identical
+
+If shared code **must** remain identical across all consumers —
+crypto primitives, protocol parsers, security-critical validation
+logic — citation-cli is the wrong tool. The entire point of the
+pattern is that consumers can modify their copies. Use a versioned
+package with pinned dependencies instead.
+
+### Few consumers, low divergence
+
+If you have two or three consumers that mostly use the shared code
+as-is with minimal engagement, the overhead of tracking citation
+metadata may not be worth it. A shared internal package with
+well-defined extension points might serve you better.
+
+Citation CLI's value scales with divergence. If consumers barely
+diverge, the pattern adds complexity without adding freedom.
+
+### When vendoring is sufficient
+
+If you want to copy code but don't need organic placement
+(synthesis) or metadata tracking, plain vendoring works fine.
+Copy the files into a `vendor/` directory, leave them untouched,
+and update manually when needed.
+
+Citation CLI adds value over vendoring when you need to:
+
+- Track which files were quoted, paraphrased, or synthesized.
+- Absorb code into existing files.
+- Detect drift in quoted files.
+- Inform future updates with provenance metadata.
+
+### Summary
+
+| Situation | Use |
+| --------- | --- |
+| Consumers expected to diverge | citation-cli |
+| Monorepo, skip the publish step | citation-cli |
+| Compliance/provenance required | Traditional packages |
+| Code must stay identical | Pinned dependencies |
+| Few consumers, low divergence | Shared internal package |
+| Copy but don't modify | Plain vendoring |


### PR DESCRIPTION
## Summary

- Add a new Jekyll subdomain site for Citation CLI (the successor to assimilai), served at `citation-cli.culture.dev`.
- Extends the existing multi-site build (`_config.base.yml` + per-site configs + `sites:` front-matter filtering) with a third target, alongside `culture.dev` and `agentirc.dev`.
- Full docs tree under `docs/citation-cli/`: landing page, concept, Python CLI reference, npm CLI reference, when-not-to-use, migration walkthrough (assimilai v1 → citation-cli v2), and the full v1 spec.

## Pairs with

OriNachum/assimilai#5 — the code rename from `assimilai` to `citation-cli`. The `sync`/`migrate`/`cite` semantics described here match that branch.

## What's included

- `_config.citation-cli.yml` — mirrors the shape of `_config.agentirc.yml` / `_config.culture.yml` (title, url, build_site, aux_links, footer).
- `_data/sites.yml` — new `citation-cli: https://citation-cli.culture.dev` entry.
- `docs/citation-cli/` — 7 pages, each with `sites: [citation-cli]` front-matter so the existing `site_filter.rb` plugin picks them up only for the new build.
- `.github/workflows/docs-check.yml` — new build step `Build Citation CLI docs` runs alongside the AgentIRC + Culture builds.

## Test plan

- [x] Local build: `bundle exec jekyll build --config _config.base.yml,_config.citation-cli.yml -d _site_citation_cli` — succeeds, 6 pages (concept, python, npm, spec, when-not-to-use, migration) plus index.
- [x] `site_filter.rb` correctly drops agentirc/ and culture/ pages from the citation-cli build (verified `_site_citation_cli/` contents).
- [ ] After merge: Cloudflare Pages project for `citation-cli.culture.dev` pointing at this repo, build command `bundle exec jekyll build --config _config.base.yml,_config.citation-cli.yml -d _site_citation_cli`, output directory `_site_citation_cli`.
- [ ] After CF is wired: `curl -sI https://citation-cli.culture.dev/` returns 200.

- Claude