### PR TITLE
fix(console): handle BrokenPipeError on send, notify UI (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.2.2] - 2026-04-14
+
+
+### Fixed
+
+- console: handle BrokenPipeError/ConnectionResetError in _send_raw; surface a red system notice in the chat panel instead of letting the asyncio task crash (#230)
+
 ## [6.2.1] - 2026-04-13
 
 

--- a/culture/console/app.py
+++ b/culture/console/app.py
@@ -74,6 +74,10 @@ class ConsoleApp(App):
         self._background_tasks: set[asyncio.Task] = set()
         self._status_poll_task: asyncio.Task | None = None
 
+        # Once the connection drops, show the "connection lost" notice exactly
+        # once — subsequent failing commands/channel-switches stay quiet.
+        self._connection_lost_notified: bool = False
+
         # Dispatch table for command execution
         self._command_handlers: dict[CommandType, Any] = {
             CommandType.CHAT: self._handle_chat,
@@ -214,13 +218,20 @@ class ConsoleApp(App):
                 chat: ChatPanel = self.query_one(ChatPanel)
                 chat.add_message(time.time(), "", "system", f"[red]Unknown command: {cmd.text}[/]")
         except ConsoleConnectionLost:
-            chat = self.query_one(ChatPanel)
-            chat.add_message(
-                time.time(),
-                "",
-                "system",
-                "[red]Connection to server lost. Restart the console to reconnect.[/]",
-            )
+            self._notify_connection_lost()
+
+    def _notify_connection_lost(self) -> None:
+        """Post the 'connection lost' notice once per disconnect."""
+        if self._connection_lost_notified:
+            return
+        self._connection_lost_notified = True
+        chat: ChatPanel = self.query_one(ChatPanel)
+        chat.add_message(
+            time.time(),
+            "",
+            "system",
+            "[red]Connection to server lost. Restart the console to reconnect.[/]",
+        )
 
     # ------------------------------------------------------------------
     # Command handlers
@@ -701,12 +712,7 @@ class ConsoleApp(App):
         try:
             entries = await self._client.history(channel, limit=20)
         except ConsoleConnectionLost:
-            chat.add_message(
-                time.time(),
-                "",
-                "system",
-                "[red]Connection to server lost. Restart the console to reconnect.[/]",
-            )
+            self._notify_connection_lost()
             return
         # Stale check: if user switched away during fetch, discard results
         if self._current_channel != channel:

--- a/culture/console/app.py
+++ b/culture/console/app.py
@@ -13,7 +13,7 @@ from textual.containers import Horizontal
 from textual.widgets import Footer, Header
 
 from culture.aio import maybe_await
-from culture.console.client import ConsoleIRCClient
+from culture.console.client import ConsoleConnectionLost, ConsoleIRCClient
 from culture.console.commands import CommandType, parse_command
 from culture.console.status import query_all_agents
 from culture.console.widgets.chat import ChatPanel
@@ -205,13 +205,22 @@ class ConsoleApp(App):
     async def _execute_command(self, cmd) -> None:  # noqa: ANN001
         """Dispatch a ParsedCommand to the appropriate handler."""
         handler = self._command_handlers.get(cmd.type)
-        if handler:
-            await maybe_await(handler(cmd))
-        elif cmd.type in (CommandType.START, CommandType.STOP, CommandType.RESTART):
-            self._handle_agent_management(cmd)
-        elif cmd.type == CommandType.UNKNOWN:
-            chat: ChatPanel = self.query_one(ChatPanel)
-            chat.add_message(time.time(), "", "system", f"[red]Unknown command: {cmd.text}[/]")
+        try:
+            if handler:
+                await maybe_await(handler(cmd))
+            elif cmd.type in (CommandType.START, CommandType.STOP, CommandType.RESTART):
+                self._handle_agent_management(cmd)
+            elif cmd.type == CommandType.UNKNOWN:
+                chat: ChatPanel = self.query_one(ChatPanel)
+                chat.add_message(time.time(), "", "system", f"[red]Unknown command: {cmd.text}[/]")
+        except ConsoleConnectionLost:
+            chat = self.query_one(ChatPanel)
+            chat.add_message(
+                time.time(),
+                "",
+                "system",
+                "[red]Connection to server lost. Restart the console to reconnect.[/]",
+            )
 
     # ------------------------------------------------------------------
     # Command handlers
@@ -689,7 +698,16 @@ class ConsoleApp(App):
             pass
 
         # Fetch recent history
-        entries = await self._client.history(channel, limit=20)
+        try:
+            entries = await self._client.history(channel, limit=20)
+        except ConsoleConnectionLost:
+            chat.add_message(
+                time.time(),
+                "",
+                "system",
+                "[red]Connection to server lost. Restart the console to reconnect.[/]",
+            )
+            return
         # Stale check: if user switched away during fetch, discard results
         if self._current_channel != channel:
             return

--- a/culture/console/client.py
+++ b/culture/console/client.py
@@ -104,35 +104,47 @@ class ConsoleIRCClient:
             timeout=REGISTER_TIMEOUT,
         )
 
-        await self._send_raw(f"NICK {self.nick}")
-        await self._send_raw(f"USER {self.nick} 0 * :{self.nick}")
-
-        # Wait for RPL_WELCOME (001) before proceeding
-        welcome_future: asyncio.Future[Message] = asyncio.get_running_loop().create_future()
-        self._pending["001"] = welcome_future
-
-        # Start the read loop so the future can be resolved
-        self._read_task = asyncio.create_task(self._read_loop())
-
         try:
-            await asyncio.wait_for(welcome_future, timeout=REGISTER_TIMEOUT)
-        except asyncio.TimeoutError:
-            self._pending.clear()
-            if self._read_task:
-                self._read_task.cancel()
-            if self._writer:
+            await self._send_raw(f"NICK {self.nick}")
+            await self._send_raw(f"USER {self.nick} 0 * :{self.nick}")
+
+            # Wait for RPL_WELCOME (001) before proceeding
+            welcome_future: asyncio.Future[Message] = asyncio.get_running_loop().create_future()
+            self._pending["001"] = welcome_future
+
+            # Start the read loop so the future can be resolved
+            self._read_task = asyncio.create_task(self._read_loop())
+
+            try:
+                await asyncio.wait_for(welcome_future, timeout=REGISTER_TIMEOUT)
+            except asyncio.TimeoutError as e:
+                raise ConnectionError("Timed out waiting for server welcome (001)") from e
+
+            # Set user mode
+            if self.mode:
+                await self._send_raw(f"MODE {self.nick} +{self.mode}")
+
+            # Send ICON if provided
+            if self.icon:
+                await self._send_raw(f"ICON {self.icon}")
+        except BaseException:
+            # Any failure after open_connection: tear down the half-open state.
+            await self._teardown_connection()
+            raise
+
+    async def _teardown_connection(self) -> None:
+        """Close writer, cancel reader, clear pending futures. Idempotent."""
+        self._pending.clear()
+        if self._read_task:
+            self._read_task.cancel()
+            self._read_task = None
+        if self._writer:
+            try:
                 self._writer.close()
-                self._writer = None
-                self._reader = None
-            raise ConnectionError("Timed out waiting for server welcome (001)")
-
-        # Set user mode
-        if self.mode:
-            await self._send_raw(f"MODE {self.nick} +{self.mode}")
-
-        # Send ICON if provided
-        if self.icon:
-            await self._send_raw(f"ICON {self.icon}")
+            except OSError:
+                pass
+        self._writer = None
+        self._reader = None
 
     async def disconnect(self) -> None:
         """Send QUIT and close the connection."""
@@ -190,18 +202,24 @@ class ConsoleIRCClient:
         Returns a sorted list of channel names.
         """
         key = "LIST"
+        pending_key = "323"
         self._collect_buffers[key] = []
         end_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        self._pending["323"] = end_future
+        self._pending[pending_key] = end_future
 
-        await self._send_raw("LIST")
+        try:
+            await self._send_raw("LIST")
+        except ConsoleConnectionLost:
+            self._pending.pop(pending_key, None)
+            self._collect_buffers.pop(key, None)
+            raise
 
         try:
             await asyncio.wait_for(end_future, timeout=QUERY_TIMEOUT)
         except asyncio.TimeoutError:
             pass
         finally:
-            self._pending.pop("323", None)
+            self._pending.pop(pending_key, None)
 
         channels = self._collect_buffers.pop(key, [])
         return sorted(channels)
@@ -212,18 +230,24 @@ class ConsoleIRCClient:
         Returns a list of dicts with nick, user, host, server, flags, realname.
         """
         key = f"WHO {target}"
+        pending_key = f"315:{target}"
         self._collect_buffers[key] = []
         end_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        self._pending[f"315:{target}"] = end_future
+        self._pending[pending_key] = end_future
 
-        await self._send_raw(f"WHO {target}")
+        try:
+            await self._send_raw(f"WHO {target}")
+        except ConsoleConnectionLost:
+            self._pending.pop(pending_key, None)
+            self._collect_buffers.pop(key, None)
+            raise
 
         try:
             await asyncio.wait_for(end_future, timeout=QUERY_TIMEOUT)
         except asyncio.TimeoutError:
             pass
         finally:
-            self._pending.pop(f"315:{target}", None)
+            self._pending.pop(pending_key, None)
 
         entries = self._collect_buffers.pop(key, [])
         return entries
@@ -234,18 +258,24 @@ class ConsoleIRCClient:
         Returns a list of dicts with channel, nick, timestamp, text.
         """
         key = f"HISTORY {channel}"
+        pending_key = f"HISTORYEND:{channel}"
         self._collect_buffers[key] = []
         end_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
-        self._pending[f"HISTORYEND:{channel}"] = end_future
+        self._pending[pending_key] = end_future
 
-        await self._send_raw(f"HISTORY RECENT {channel} {limit}")
+        try:
+            await self._send_raw(f"HISTORY RECENT {channel} {limit}")
+        except ConsoleConnectionLost:
+            self._pending.pop(pending_key, None)
+            self._collect_buffers.pop(key, None)
+            raise
 
         try:
             await asyncio.wait_for(end_future, timeout=QUERY_TIMEOUT)
         except asyncio.TimeoutError:
             pass
         finally:
-            self._pending.pop(f"HISTORYEND:{channel}", None)
+            self._pending.pop(pending_key, None)
 
         entries = self._collect_buffers.pop(key, [])
         return entries

--- a/culture/console/client.py
+++ b/culture/console/client.py
@@ -24,6 +24,10 @@ QUERY_TIMEOUT = 10.0
 REGISTER_TIMEOUT = 15.0
 
 
+class ConsoleConnectionLost(ConnectionError):
+    """Raised by ConsoleIRCClient when the underlying socket is broken mid-send."""
+
+
 @dataclass
 class ChatMessage:
     """A buffered chat message from a channel or DM."""
@@ -252,9 +256,15 @@ class ConsoleIRCClient:
 
     async def _send_raw(self, line: str) -> None:
         """Write a raw IRC line to the socket."""
-        if self._writer:
+        if not self._writer:
+            return
+        try:
             self._writer.write(f"{line}\r\n".encode())
             await self._writer.drain()
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError) as e:
+            self.connected = False
+            logger.warning("ConsoleIRCClient: send failed (%s)", e.__class__.__name__)
+            raise ConsoleConnectionLost(str(e)) from e
 
     async def _read_loop(self) -> None:
         """Background task: read lines from socket and dispatch to _handle."""

--- a/culture/console/client.py
+++ b/culture/console/client.py
@@ -137,10 +137,12 @@ class ConsoleIRCClient:
         self._pending.clear()
         if self._read_task:
             self._read_task.cancel()
+            await asyncio.gather(self._read_task, return_exceptions=True)
             self._read_task = None
         if self._writer:
             try:
                 self._writer.close()
+                await self._writer.wait_closed()
             except OSError:
                 pass
         self._writer = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.2.1"
+version = "6.2.2"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_console_client.py
+++ b/tests/test_console_client.py
@@ -10,7 +10,7 @@ import asyncio
 
 import pytest
 
-from culture.console.client import ChatMessage, ConsoleIRCClient
+from culture.console.client import ChatMessage, ConsoleConnectionLost, ConsoleIRCClient
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -295,4 +295,44 @@ async def test_history_returns_messages(server, make_client):
     assert isinstance(entries, list)
     assert any(e.get("text") == "history test message" for e in entries)
 
+    await client.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Broken-pipe handling (issue #230)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_raw_raises_console_connection_lost_when_socket_broken(server):
+    """Writes to a broken socket surface as ConsoleConnectionLost, not BrokenPipeError.
+
+    Reproduces issue #230: iTerm / idle disconnects caused asyncio's
+    `StreamWriter.drain()` to raise `BrokenPipeError` which was never caught,
+    crashing the console command task. The fix wraps the write in
+    `_send_raw` and re-raises a typed `ConsoleConnectionLost`.
+    """
+    nick = "testserv-pipetest"
+    client = make_console_client(server, nick=nick)
+    await client.connect()
+    assert client.connected is True
+
+    # Force-close the server side of this client's socket. The server
+    # retains the asyncio StreamWriter on its Client object; closing it
+    # sends FIN to the console client and the next drain() there fails.
+    server_client = server.clients[nick]
+    server_client.writer.close()
+    try:
+        await server_client.writer.wait_closed()
+    except (ConnectionError, OSError):
+        pass
+
+    # Repeated writes are required — the first drain() often succeeds because
+    # data lands in the local kernel buffer before the RST is observed.
+    with pytest.raises(ConsoleConnectionLost):
+        for _ in range(20):
+            await client.send_privmsg("#nowhere", "x" * 512)
+            await asyncio.sleep(0.02)
+
+    assert client.connected is False
     await client.disconnect()

--- a/tests/test_console_client.py
+++ b/tests/test_console_client.py
@@ -336,3 +336,61 @@ async def test_send_raw_raises_console_connection_lost_when_socket_broken(server
 
     assert client.connected is False
     await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_history_cleans_up_pending_buffers_on_connection_lost(server):
+    """A failed history() send must not leak _pending / _collect_buffers entries."""
+    nick = "testserv-histleak"
+    client = make_console_client(server, nick=nick)
+    await client.connect()
+
+    # Break the socket from the server side.
+    server.clients[nick].writer.close()
+    try:
+        await server.clients[nick].writer.wait_closed()
+    except (ConnectionError, OSError):
+        pass
+
+    # Drain writes until ConsoleConnectionLost is raised by history().
+    raised = False
+    for _ in range(20):
+        try:
+            await client.history("#ghost", limit=5)
+        except ConsoleConnectionLost:
+            raised = True
+            break
+        await asyncio.sleep(0.02)
+
+    assert raised, "history() should eventually raise ConsoleConnectionLost"
+    # No stale state left behind — would otherwise hang future queries / leak memory.
+    assert "HISTORYEND:#ghost" not in client._pending
+    assert "HISTORY #ghost" not in client._collect_buffers
+    await client.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_connect_cleans_up_on_registration_failure(monkeypatch, server):
+    """A ConsoleConnectionLost mid-registration must close the writer, not leak it."""
+    client = make_console_client(server, nick="testserv-leaktest")
+
+    # Simulate a server drop between open_connection and the first NICK write.
+    original_send_raw = client._send_raw
+    calls = {"n": 0}
+
+    async def failing_send_raw(line: str) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ConsoleConnectionLost("simulated drop during registration")
+        await original_send_raw(line)
+
+    monkeypatch.setattr(client, "_send_raw", failing_send_raw)
+
+    with pytest.raises(ConsoleConnectionLost):
+        await client.connect()
+
+    # After failure, no half-open socket or dangling state.
+    assert client._writer is None
+    assert client._reader is None
+    assert client._read_task is None
+    assert client._pending == {}

--- a/tests/test_console_client.py
+++ b/tests/test_console_client.py
@@ -324,7 +324,7 @@ async def test_send_raw_raises_console_connection_lost_when_socket_broken(server
     server_client.writer.close()
     try:
         await server_client.writer.wait_closed()
-    except (ConnectionError, OSError):
+    except OSError:
         pass
 
     # Repeated writes are required — the first drain() often succeeds because
@@ -349,7 +349,7 @@ async def test_history_cleans_up_pending_buffers_on_connection_lost(server):
     server.clients[nick].writer.close()
     try:
         await server.clients[nick].writer.wait_closed()
-    except (ConnectionError, OSError):
+    except OSError:
         pass
 
     # Drain writes until ConsoleConnectionLost is raised by history().

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.2.1"
+version = "6.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes #230.

- `ConsoleIRCClient._send_raw` now catches `BrokenPipeError` / `ConnectionResetError` / `ConnectionAbortedError` from `StreamWriter.drain()`, flips `connected` to `False` synchronously, and re-raises a typed `ConsoleConnectionLost`.
- The console app's `_execute_command` dispatcher and the `_switch_to_channel` history fetch translate that exception into a single red system notice in the chat panel (\"Connection to server lost. Restart the console to reconnect.\").
- Added a regression test that closes the server-side socket, repeatedly writes through the console client, and asserts `ConsoleConnectionLost` surfaces — previously this path raised bare `BrokenPipeError` and crashed the asyncio task with \"Task exception was never retrieved\".
- Patch bump 6.2.1 → 6.2.2, CHANGELOG updated, uv.lock updated.

## Test plan

- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/test_console_client.py -v` — 17/17 pass including new `test_send_raw_raises_console_connection_lost_when_socket_broken`
- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/test_console_integration.py tests/test_console_connection.py tests/test_console_commands.py tests/test_console_status.py tests/test_console_fixes_224_227.py tests/test_console_icons.py` — 84/84 pass (no regressions)
- [x] Pre-commit hooks (flake8, isort, black, bandit, pylint) all pass
- [ ] Manual: start console, kill server, send message — expect a single red notice, no traceback in stderr

## Out of scope (follow-ups)

- Auto-reconnect with backoff
- Connection-health status widget
- Applying the same pattern to `culture/clients/*/irc_transport.py` harnesses

- Claude