### PR TITLE
feat(events): emit server.wake and server.sleep (Task 8 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.3.0] - 2026-04-16
+
+
+### Added
+
+- events: emit server.wake on IRCd start (after system identity bootstrap) and server.sleep at the top of IRCd stop, surfaced as IRCv3-tagged PRIVMSG into #system from system-<server>
+
 ## [6.2.3] - 2026-04-15
 
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -63,6 +63,15 @@ class IRCd:
         logger.info("Bootstrapping system identity...")
         self._bootstrap_system_identity()
 
+        await self.emit_event(
+            Event(
+                type=EventType.SERVER_WAKE,
+                channel=None,
+                nick=f"{SYSTEM_USER_PREFIX}{self.config.name}",
+                data={"server": self.config.name},
+            )
+        )
+
         # Initialize bot manager and webhook HTTP listener
         from culture.bots.bot_manager import BotManager
         from culture.bots.http_listener import HttpListener
@@ -300,7 +309,20 @@ class IRCd:
         return None
 
     async def stop(self) -> None:
+        if self._stopping:
+            return
         self._stopping = True
+        try:
+            await self.emit_event(
+                Event(
+                    type=EventType.SERVER_SLEEP,
+                    channel=None,
+                    nick=f"{SYSTEM_USER_PREFIX}{self.config.name}",
+                    data={"server": self.config.name},
+                )
+            )
+        except Exception:
+            logger.exception("failed to emit server.sleep")
         # Stop bots and HTTP listener
         if self.bot_manager:
             await self.bot_manager.stop_all()

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -48,6 +48,7 @@ class IRCd:
             {}
         )  # peer_name -> {"delay": float, "task": asyncio.Task}
         self._stopping = False
+        self._stopped = asyncio.Event()
         self._background_tasks: set[asyncio.Task] = set()
         # Bots
         self.bot_manager = None  # set in start() if webhook_port configured
@@ -71,6 +72,7 @@ class IRCd:
                 data={"server": self.config.name},
             )
         )
+        logger.info("Server awake on %s", self.config.name)
 
         # Initialize bot manager and webhook HTTP listener
         from culture.bots.bot_manager import BotManager
@@ -309,40 +311,52 @@ class IRCd:
         return None
 
     async def stop(self) -> None:
+        """Shut down the server. Concurrent callers await the same teardown.
+
+        The first caller runs the teardown path; subsequent callers block on
+        ``_stopped`` until teardown finishes (success *or* failure) so they
+        never return while shutdown is still in flight. The event is set in a
+        ``finally`` so an exception during teardown still unblocks waiters.
+        """
         if self._stopping:
+            await self._stopped.wait()
             return
         self._stopping = True
         try:
-            await self.emit_event(
-                Event(
-                    type=EventType.SERVER_SLEEP,
-                    channel=None,
-                    nick=f"{SYSTEM_USER_PREFIX}{self.config.name}",
-                    data={"server": self.config.name},
-                )
-            )
-        except Exception:
-            logger.exception("failed to emit server.sleep")
-        # Stop bots and HTTP listener
-        if self.bot_manager:
-            await self.bot_manager.stop_all()
-        if hasattr(self, "_http_listener") and self._http_listener:
-            await self._http_listener.stop()
-        for skill in self.skills:
-            await skill.stop()
-        # Cancel all pending retry tasks
-        for peer_name in list(self._link_retry_state):
-            self.cancel_link_retry(peer_name)
-        # Close all S2S links
-        for link in list(self.links.values()):
+            logger.info("Server going to sleep on %s", self.config.name)
             try:
-                link.writer.close()
+                await self.emit_event(
+                    Event(
+                        type=EventType.SERVER_SLEEP,
+                        channel=None,
+                        nick=f"{SYSTEM_USER_PREFIX}{self.config.name}",
+                        data={"server": self.config.name},
+                    )
+                )
             except Exception:
-                pass
-        self.links.clear()
-        if self._server:
-            self._server.close()
-            await self._server.wait_closed()
+                logger.exception("failed to emit server.sleep")
+            # Stop bots and HTTP listener
+            if self.bot_manager:
+                await self.bot_manager.stop_all()
+            if hasattr(self, "_http_listener") and self._http_listener:
+                await self._http_listener.stop()
+            for skill in self.skills:
+                await skill.stop()
+            # Cancel all pending retry tasks
+            for peer_name in list(self._link_retry_state):
+                self.cancel_link_retry(peer_name)
+            # Close all S2S links
+            for link in list(self.links.values()):
+                try:
+                    link.writer.close()
+                except Exception:
+                    pass
+            self.links.clear()
+            if self._server:
+                self._server.close()
+                await self._server.wait_closed()
+        finally:
+            self._stopped.set()
 
     async def connect_to_peer(
         self, host: str, port: int, password: str, trust: str = "full"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.2.3"
+version = "6.3.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_events_basic.py
+++ b/tests/test_events_basic.py
@@ -231,7 +231,7 @@ async def test_server_sleep_emitted_on_stop(tmp_path):
     """
     empty_bots = tmp_path / "_bots"
     empty_bots.mkdir()
-    config = ServerConfig(name="sleepserv", host="127.0.0.1", port=0, webhook_port=0)
+    config = ServerConfig(name="testserv", host="127.0.0.1", port=0, webhook_port=0)
 
     with (
         patch("culture.bots.bot_manager.BOTS_DIR", empty_bots),
@@ -247,7 +247,7 @@ async def test_server_sleep_emitted_on_stop(tmp_path):
         client = IRCTestClient(reader, writer)
         await client.send("CAP REQ :message-tags")
         await client.recv_until("CAP")
-        await client.send("NICK sleepserv-alice")
+        await client.send("NICK testserv-alice")
         await client.send("USER alice 0 * :alice")
         await client.recv_all(timeout=0.5)
         await client.send("JOIN #system")
@@ -285,4 +285,4 @@ async def test_server_sleep_emitted_on_stop(tmp_path):
         assert (
             "event=server.sleep" in line
         ), f"Expected server.sleep PRIVMSG before socket closed; got: {line!r}"
-        assert "sleepserv is shutting down" in line
+        assert "testserv is shutting down" in line

--- a/tests/test_events_basic.py
+++ b/tests/test_events_basic.py
@@ -193,3 +193,100 @@ async def test_federated_event_uses_origin_prefix(server, make_client):
     assert ":system-alpha!system@alpha" in line
     # Internal _-prefixed keys are NOT in the encoded payload
     assert "_origin" not in line
+
+
+@pytest.mark.asyncio
+async def test_server_wake_emitted_on_start(server):
+    """server.wake is emitted during IRCd.start() and recorded in _event_log.
+
+    We assert via _event_log introspection rather than HISTORY RECENT because
+    HistorySkill only stores MESSAGE events (Task 13 extends it to lifecycle
+    events). The _event_log is the canonical emission record: every event that
+    passes through emit_event() is appended here unconditionally.
+    """
+    wake_events = [ev for _seq, ev in server._event_log if ev.type == EventType.SERVER_WAKE]
+    assert wake_events, "Expected at least one SERVER_WAKE event in _event_log after start()"
+    ev = wake_events[0]
+    assert ev.channel is None
+    assert ev.data.get("server") == server.config.name
+
+
+@pytest.mark.asyncio
+async def test_server_sleep_emitted_on_stop(tmp_path):
+    """server.sleep surfaces as a tagged PRIVMSG to #system before teardown.
+
+    We construct a dedicated IRCd instance for this test rather than using the
+    shared `server` fixture because the test calls stop() itself — which would
+    leave the fixture's own teardown calling stop() a second time on an
+    already-stopped server. Using a fresh instance keeps fixture teardown
+    trivially safe and makes the test self-contained.
+
+    The test verifies both that the event is emitted AND that the surfacing
+    reaches connected clients before any socket teardown (i.e. stop() emits
+    server.sleep at the very top).
+    """
+    import asyncio
+    from unittest.mock import patch
+
+    from culture.agentirc.config import ServerConfig
+    from culture.agentirc.ircd import IRCd
+
+    empty_bots = tmp_path / "_bots"
+    empty_bots.mkdir()
+    config = ServerConfig(name="sleepserv", host="127.0.0.1", port=0, webhook_port=0)
+
+    with (
+        patch("culture.bots.bot_manager.BOTS_DIR", empty_bots),
+        patch("culture.bots.config.BOTS_DIR", empty_bots),
+        patch("culture.bots.bot.BOTS_DIR", empty_bots),
+    ):
+        ircd = IRCd(config)
+        await ircd.start()
+        ircd.config.port = ircd._server.sockets[0].getsockname()[1]
+
+        # Connect a tag-capable client and join #system before stopping.
+        reader, writer = await asyncio.open_connection("127.0.0.1", ircd.config.port)
+        from tests.conftest import IRCTestClient
+
+        client = IRCTestClient(reader, writer)
+        await client.send("CAP REQ :message-tags")
+        await client.recv_until("CAP")
+        await client.send("NICK sleepserv-alice")
+        await client.send("USER alice 0 * :alice")
+        await client.recv_all(timeout=0.5)
+        await client.send("JOIN #system")
+        await client.recv_until("366")
+        await asyncio.sleep(0.05)
+        await client.recv_all(timeout=0.2)  # flush any queued join-event PRIVMSG
+
+        # Start receiving concurrently before calling stop() so we capture the
+        # server.sleep PRIVMSG that must arrive at the top of stop() before any
+        # socket teardown. server.wait_closed() will not return until after we
+        # close the client connection.
+        recv_task = asyncio.create_task(client.recv_until("server.sleep"))
+
+        # Allow the event loop to schedule the recv task before we block in stop().
+        await asyncio.sleep(0)
+
+        # Trigger stop() — server.sleep must surface BEFORE sockets close.
+        # We close the client immediately after stop() emits the event so that
+        # server.wait_closed() can finish.
+        stop_task = asyncio.create_task(ircd.stop())
+
+        # Collect the sleep message — recv_until times out after 2s or on
+        # ConnectionError so this will not hang even if the event is never sent.
+        line = await recv_task
+
+        # Now close the client so server.wait_closed() can proceed.
+        try:
+            await client.close()
+        except Exception:
+            pass
+
+        # Wait for stop() to fully complete.
+        await stop_task
+
+        assert (
+            "event=server.sleep" in line
+        ), f"Expected server.sleep PRIVMSG before socket closed; got: {line!r}"
+        assert "sleepserv is shutting down" in line

--- a/tests/test_events_basic.py
+++ b/tests/test_events_basic.py
@@ -3,10 +3,14 @@
 import asyncio
 import base64
 import json
+from unittest.mock import patch
 
 import pytest
 
+from culture.agentirc.config import ServerConfig
+from culture.agentirc.ircd import IRCd
 from culture.agentirc.skill import Event, EventType
+from tests.conftest import IRCTestClient
 
 
 @pytest.mark.asyncio
@@ -225,12 +229,6 @@ async def test_server_sleep_emitted_on_stop(tmp_path):
     reaches connected clients before any socket teardown (i.e. stop() emits
     server.sleep at the very top).
     """
-    import asyncio
-    from unittest.mock import patch
-
-    from culture.agentirc.config import ServerConfig
-    from culture.agentirc.ircd import IRCd
-
     empty_bots = tmp_path / "_bots"
     empty_bots.mkdir()
     config = ServerConfig(name="sleepserv", host="127.0.0.1", port=0, webhook_port=0)
@@ -246,8 +244,6 @@ async def test_server_sleep_emitted_on_stop(tmp_path):
 
         # Connect a tag-capable client and join #system before stopping.
         reader, writer = await asyncio.open_connection("127.0.0.1", ircd.config.port)
-        from tests.conftest import IRCTestClient
-
         client = IRCTestClient(reader, writer)
         await client.send("CAP REQ :message-tags")
         await client.recv_until("CAP")

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.2.3"
+version = "6.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Task 8 of the mesh-events rollout (issue #123) — emits the first two lifecycle events so `#system` shows when each server comes up and goes down.
- `IRCd.start()` emits `server.wake` immediately after `_bootstrap_system_identity()`, before any client can connect.
- `IRCd.stop()` emits `server.sleep` at the very top, before bot manager / HTTP listener / skills / S2S links / socket teardown — so the surfaced IRCv3-tagged PRIVMSG actually reaches connected `#system` members before they're disconnected.
- `stop()` is now idempotent via an early-return on `_stopping` — the test calls `stop()` itself and fixture teardown would otherwise call it again.

Builds on Tasks 1–7 (merged in #234). No changes to the surfacing path, no new protocol wire, no backend touches.

## Test plan

- [x] New `test_server_wake_emitted_on_start` — asserts `server._event_log` contains a `SERVER_WAKE` event with `channel=None`, `data["server"] == "testserv"`. Uses `_event_log` introspection rather than `HISTORY RECENT` because `HistorySkill` doesn't yet store lifecycle events (Task 13).
- [x] New `test_server_sleep_emitted_on_stop` — builds a dedicated `IRCd` (name `sleepserv`), joins a tag-capable client to `#system`, schedules `recv_until("server.sleep")` concurrently with `stop()`, then asserts the `event=server.sleep` tagged PRIVMSG arrives before the socket closes. Verifies both the emission AND that it surfaces before teardown.
- [x] Full parallel suite: **824 passed in 70s**, no regressions.
- [x] Pre-commit: black, isort, flake8, pylint, bandit all clean.

## Why adapt the plan's test

The plan's original Task 8 test used `HISTORY RECENT #system 50` to verify `server.wake` was recorded. That path only works after Task 13 extends `HistorySkill` to store lifecycle events. The adapted tests directly verify Task 8's emission contract without coupling to future tasks. When Task 13 lands, the HISTORY replay becomes testable at that layer.

## Not in scope

- Task 9 (`agent.connect` / `agent.disconnect`) and Task 10 (`console.open` / `console.close`) — both depend on resolving an `ICON` semantics question (the current `ICON` is a free-form emoji, max 4 chars; the plan assumed it was a fixed enum of role tags). Deferred to a follow-up PR where the design choice — restrict ICON to an enum, add a new `+A/+C` user-mode, or co-exist — can be made deliberately.
- Task 11 (`room.create` emission) — independent of the ICON question but held back to land alongside 9–10 as "lifecycle emitters" once 9–10 are unblocked.

Refs: #123, follows #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)