### PR TITLE
feat(events): emit room.create on ROOMCREATE (Task 11 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.5.0] - 2026-04-16
+
+
+### Added
+
+- events: emit room.create on ROOMCREATE, before the existing room.meta emission. room.create signals room birth as a distinct lifecycle event; downstream consumers can distinguish creation from subsequent metadata updates.
+
 ## [6.4.0] - 2026-04-16
 
 

--- a/culture/agentirc/skills/rooms.py
+++ b/culture/agentirc/skills/rooms.py
@@ -120,6 +120,21 @@ class RoomsSkill(Skill):
             )
         )
         self._persist_room(channel)
+        # Emit room.create (new room lifecycle event) BEFORE room.meta so
+        # downstream consumers see creation as a distinct signal, then the
+        # initial metadata snapshot as a follow-up.
+        await self.server.emit_event(
+            Event(
+                type=EventType.ROOM_CREATE,
+                channel=channel_name,
+                nick=client.nick,
+                data={
+                    "nick": client.nick,
+                    "room_id": channel.room_id,
+                    "purpose": channel.purpose,
+                },
+            )
+        )
         await self.server.emit_event(
             Event(
                 type=EventType.ROOMMETA,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.4.0"
+version = "6.5.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_events_lifecycle.py
+++ b/tests/test_events_lifecycle.py
@@ -256,3 +256,45 @@ async def test_mode_before_registration_does_not_emit_events(server, make_client
     ), f"agent.connect fired pre-registration (security bug). Got: {tail_joined!r}"
 
     await bob_raw.close()
+
+
+@pytest.mark.asyncio
+async def test_room_create_emitted_on_roomcreate(server, make_client):
+    """ROOMCREATE emits a distinct `room.create` event, separate from room.meta.
+
+    room.create signals the room's birth (a lifecycle moment); the follow-up
+    room.meta carries the initial metadata snapshot. Downstream consumers
+    (bots, history, federation peers) see both and can pick whichever semantic
+    fits their logic.
+    """
+    creator = await make_client("testserv-creator", "creator")
+    await creator.send("CAP REQ :message-tags")
+    await creator.recv_until("ACK")
+
+    # Create a managed room. The channel-scoped room.create surfaces on the
+    # new channel itself — creator is auto-joined, so they receive it.
+    await creator.send("ROOMCREATE #research :purpose=AI research;tags=ai;persistent=true")
+
+    line = await creator.recv_until("event=room.create")
+    assert "event=room.create" in line, f"Expected room.create tag, got: {line!r}"
+    assert "testserv-creator created room #research" in line
+
+
+@pytest.mark.asyncio
+async def test_room_create_precedes_room_meta(server, make_client):
+    """room.create must precede room.meta on the wire so downstream consumers
+    can distinguish creation from subsequent metadata updates."""
+    creator = await make_client("testserv-creator", "creator")
+    await creator.send("CAP REQ :message-tags")
+    await creator.recv_until("ACK")
+
+    await creator.send("ROOMCREATE #ordering :purpose=Test;persistent=true")
+    collected = await creator.recv_until("event=room.meta")
+    create_idx = collected.find("event=room.create")
+    meta_idx = collected.find("event=room.meta")
+    assert create_idx != -1, f"room.create not found in: {collected!r}"
+    assert meta_idx != -1, f"room.meta not found in: {collected!r}"
+    assert create_idx < meta_idx, (
+        f"room.create must precede room.meta (create@{create_idx}, meta@{meta_idx}) "
+        f"in: {collected!r}"
+    )

--- a/tests/test_events_lifecycle.py
+++ b/tests/test_events_lifecycle.py
@@ -13,10 +13,32 @@ Event emission contract:
 """
 
 import asyncio
+import base64
+import json
 
 import pytest
 
 from tests.conftest import IRCTestClient
+
+
+def _decode_event_payload(lines: str) -> dict:
+    """Extract and decode the IRCv3 `event-data=<b64-json>` tag.
+
+    ``lines`` is multi-line text as returned by ``recv_until``; scan each
+    line for the ``@event=...`` tag blob and decode the matching
+    ``event-data=`` value. Only tagged PRIVMSG-style lines start with ``@``.
+    """
+    for raw in lines.split("\r\n"):
+        if not raw.startswith("@"):
+            continue
+        space_idx = raw.find(" ")
+        if space_idx == -1:
+            continue
+        tag_blob = raw[1:space_idx]
+        for piece in tag_blob.split(";"):
+            if piece.startswith("event-data="):
+                return json.loads(base64.b64decode(piece.split("=", 1)[1]))
+    raise AssertionError(f"No event-data tag found in lines: {lines!r}")
 
 
 async def _setup_observer(make_client) -> IRCTestClient:
@@ -278,6 +300,18 @@ async def test_room_create_emitted_on_roomcreate(server, make_client):
     line = await creator.recv_until("event=room.create")
     assert "event=room.create" in line, f"Expected room.create tag, got: {line!r}"
     assert "testserv-creator created room #research" in line
+
+    # Lock the structured payload fields downstream consumers rely on.
+    payload = _decode_event_payload(line)
+    assert payload["nick"] == "testserv-creator"
+    assert payload["purpose"] == "AI research"
+    # room_id is generated server-side — shape check only (starts with "R").
+    assert payload["room_id"].startswith(
+        "R"
+    ), f"Expected room_id to start with R, got: {payload['room_id']!r}"
+    # The server enriches the payload with the channel when the event is
+    # channel-scoped (see IRCd._build_event_payload).
+    assert payload["channel"] == "#research"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.4.0"
+version = "6.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Task 11 of the mesh-events rollout (issue #123). `RoomsSkill._handle_roomcreate` now emits a distinct `room.create` event before the existing `room.meta` emission.
- `room.create` is the lifecycle signal (a room was born); the follow-up `room.meta` carries the initial metadata snapshot. Downstream consumers (bots, HISTORY, federation peers) can subscribe to whichever semantic fits — creation vs. metadata update.
- Channel-scoped: the event surfaces into the newly-created channel itself via the Task 7 surfacing path. The creator is auto-joined, so they receive both events on the channel.
- No federation changes required — the existing `IRCd.emit_event` path relays `room.create` to peers automatically alongside every other event type.

## Design

The render template already exists (`events.py:81` — `"room.create": lambda d, c: f"{d.get('nick', '<unknown>')} created room {c}"`), as does `EventType.ROOM_CREATE` (shipped in Task 6). This PR wires the final piece — emission.

Payload:
```json
{"nick": "testserv-alice", "room_id": "R...", "purpose": "AI research"}
```

## Test plan

Two new tests appended to `tests/test_events_lifecycle.py`:

- [x] `test_room_create_emitted_on_roomcreate` — sends `ROOMCREATE #research :purpose=AI research;tags=ai;persistent=true`, verifies the creator receives a tagged PRIVMSG with `event=room.create` and body `"testserv-creator created room #research"`.
- [x] `test_room_create_precedes_room_meta` — asserts ordering on the wire (`create_idx < meta_idx`). Pins the contract so a future refactor can't silently reverse them; downstream consumers rely on seeing creation before the first meta snapshot.
- [x] Full parallel suite: **836/836 pass** (834 baseline + 2 new), zero regressions.
- [x] Pre-commit: black, isort, flake8, pylint, bandit all clean.

## Scope

Tight: one 15-line change to `skills/rooms.py` plus two tests. No protocol changes, no new verbs, no backend touches.

Refs: #123, follows #234, #238, #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)