### PR TITLE
feat(events): SEVENT federation relay + server.link/unlink (Task 12 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.6.0] - 2026-04-17
+
+
+### Added
+
+- SEVENT generic S2S federation relay — lifecycle events (agent.connect, server.wake, room.create, etc.) now federate across linked servers
+- server.link and server.unlink events emitted at link handshake completion and link teardown
+- Generic fallback in relay_event() for event types not covered by typed relays
+
 ## [6.5.0] - 2026-04-16
 
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -584,13 +584,28 @@ class IRCd:
             self._notify_local_quit(rc, quit_msg, notified)
             del self.remote_clients[nick]
 
-    def _remove_link(self, link: ServerLink, *, squit: bool = False) -> None:
+    async def _remove_link(self, link: ServerLink, *, squit: bool = False) -> None:
         """Remove a S2S link and all its remote clients."""
         peer_name = link.peer_name
         if peer_name and peer_name in self.links:
+            # Remove peer FIRST so server.unlink relays only to remaining peers
             del self.links[peer_name]
             # Persist our current seq -- peer saw everything up to here via real-time relay
             self._peer_acked_seq[peer_name] = self._seq
+
+            # Emit server.unlink after removing the peer from self.links so the
+            # event does NOT relay back to the peer that just dropped.
+            try:
+                await self.emit_event(
+                    Event(
+                        type=EventType.SERVER_UNLINK,
+                        channel=None,
+                        nick=f"{SYSTEM_USER_PREFIX}{self.config.name}",
+                        data={"peer": peer_name},
+                    )
+                )
+            except Exception:
+                logger.exception("Failed to emit server.unlink for %s", peer_name)
 
         self._disconnect_remote_clients(link)
 

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -740,8 +741,12 @@ class ServerLink:
 
         try:
             data = json.loads(base64.b64decode(b64))
-        except (json.JSONDecodeError, ValueError) as exc:
+        except (ValueError, binascii.Error) as exc:
             logger.warning("SEVENT bad payload from %s: %s", self.peer_name, exc)
+            return
+
+        if not isinstance(data, dict):
+            logger.warning("SEVENT non-dict payload from %s", self.peer_name)
             return
 
         # Re-attach _origin so _surface_event_privmsg uses the correct federated prefix
@@ -827,10 +832,8 @@ class ServerLink:
         # If no typed relay exists, fall back to generic SEVENT.
         # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
         type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
-        payload = {k: v for k, v in event.data.items() if not k.startswith("_")}
-        encoded = base64.b64encode(
-            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
-        ).decode("ascii")
+        payload = self.server._build_event_payload(event)
+        encoded = self.server._encode_event_data(payload, type_str)
         target = event.channel or "*"
         # Egress trust check: channel-scoped events respect should_relay; global events always relay
         if event.channel is not None and not self.should_relay(event.channel):

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import binascii
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -741,7 +740,7 @@ class ServerLink:
 
         try:
             data = json.loads(base64.b64decode(b64))
-        except (ValueError, binascii.Error) as exc:
+        except ValueError as exc:
             logger.warning("SEVENT bad payload from %s: %s", self.peer_name, exc)
             return
 

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -104,7 +106,7 @@ class ServerLink:
         except (ConnectionError, asyncio.IncompleteReadError):
             pass
         finally:
-            self.server._remove_link(self, squit=self._squit_received)
+            await self.server._remove_link(self, squit=self._squit_received)
             self.writer.close()
             try:
                 await self.writer.wait_closed()
@@ -198,6 +200,17 @@ class ServerLink:
 
         await self.send_burst()
         await self._send_backfill_request()
+
+        # Emit server.link so the mesh knows this link is established.
+        # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
+        await self.server.emit_event(
+            Event(
+                type=EventType.SERVER_LINK,
+                channel=None,
+                nick=f"{SYSTEM_USER_PREFIX}{self.server.config.name}",
+                data={"peer": self.peer_name, "trust": self.trust},
+            )
+        )
 
     # --- Burst handlers ---
 
@@ -704,6 +717,50 @@ class ServerLink:
             )
         )
 
+    # --- Generic SEVENT federation ---
+
+    async def _handle_sevent(self, msg: Message) -> None:
+        """Ingest a generic federated event from a peer.
+
+        Wire format: SEVENT <origin-server> <seq> <type> <channel_or_*> :<b64-json-data>
+        """
+        if len(msg.params) < 5:
+            return
+        origin, _seq, type_str, target, b64 = msg.params[:5]
+        channel = None if target == "*" else target
+
+        # v1: direct-peer topology only — origin should match peer_name.
+        # Multi-hop mesh would need origin validation against known servers.
+        if origin != self.peer_name:
+            logger.warning("SEVENT origin %s != peer %s", origin, self.peer_name)
+
+        # Trust check: if channel-scoped, verify we should accept it
+        if channel is not None and not self._check_incoming_trust(channel):
+            return
+
+        try:
+            data = json.loads(base64.b64decode(b64))
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning("SEVENT bad payload from %s: %s", self.peer_name, exc)
+            return
+
+        # Re-attach _origin so _surface_event_privmsg uses the correct federated prefix
+        data["_origin"] = origin
+
+        # Map the type string back to an EventType if known; keep as string otherwise
+        try:
+            type_enum = EventType(type_str)
+        except ValueError:
+            type_enum = type_str  # custom event; stays as string for future bot events
+
+        ev = Event(
+            type=type_enum,
+            channel=channel,
+            nick=data.get("nick", f"{SYSTEM_USER_PREFIX}{origin}"),
+            data=data,
+        )
+        await self.server.emit_event(ev)
+
     # --- Backfill ---
 
     async def _send_backfill_request(self) -> None:
@@ -765,6 +822,21 @@ class ServerLink:
         handler = self._RELAY_DISPATCH.get(event.type)
         if handler:
             await maybe_await(handler(self, event, origin))
+            return
+
+        # If no typed relay exists, fall back to generic SEVENT.
+        # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
+        type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
+        payload = {k: v for k, v in event.data.items() if not k.startswith("_")}
+        encoded = base64.b64encode(
+            json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        ).decode("ascii")
+        target = event.channel or "*"
+        # Egress trust check: channel-scoped events respect should_relay; global events always relay
+        if event.channel is not None and not self.should_relay(event.channel):
+            return
+        seq = self.server._seq  # current local seq; peer stores but doesn't re-sequence
+        await self.send_raw(f":{origin} SEVENT {origin} {seq} {type_str} {target} :{encoded}")
 
     async def _relay_message(self, event: Event, origin: str) -> None:
         target = event.channel or event.data.get("target", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.5.0"
+version = "6.6.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,18 @@ class IRCTestClient:
             pass
         return "\r\n".join(collected)
 
+    async def count_until_idle(self, marker: str, seconds: float = 1.0) -> int:
+        """Read lines until timeout; return count of lines containing marker."""
+        count = 0
+        try:
+            while True:
+                line = await self.recv(timeout=seconds)
+                if marker in line:
+                    count += 1
+        except (asyncio.TimeoutError, ConnectionError):
+            pass
+        return count
+
     async def close(self) -> None:
         self.writer.close()
         try:

--- a/tests/test_events_federation.py
+++ b/tests/test_events_federation.py
@@ -10,7 +10,7 @@ from culture.agentirc.skill import Event, EventType
 @pytest.mark.asyncio
 async def test_event_federates_to_peer(linked_servers, make_client_b):
     """An event on server A is surfaced on server B's #system."""
-    alpha, beta = linked_servers
+    alpha, _ = linked_servers
 
     b = await make_client_b("beta-bob", "bob")
     await b.send("CAP REQ :message-tags")
@@ -36,7 +36,7 @@ async def test_event_federates_to_peer(linked_servers, make_client_b):
 @pytest.mark.asyncio
 async def test_federated_event_does_not_loop(linked_servers, make_client_a, make_client_b):
     """A federated event surfaces once on each side — no loop."""
-    alpha, beta = linked_servers
+    alpha, _ = linked_servers
 
     a = await make_client_a("alpha-alice", "alice")
     await a.send("CAP REQ :message-tags")
@@ -89,7 +89,7 @@ async def test_server_link_in_event_log(linked_servers):
 @pytest.mark.asyncio
 async def test_server_unlink_on_disconnect(linked_servers):
     """server.unlink is emitted when a peer link drops."""
-    alpha, beta = linked_servers
+    alpha, _ = linked_servers
 
     # Grab the link object and close it from alpha's side
     link = alpha.links["beta"]

--- a/tests/test_events_federation.py
+++ b/tests/test_events_federation.py
@@ -1,0 +1,110 @@
+"""Events federate across linked servers via SEVENT."""
+
+import asyncio
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_event_federates_to_peer(linked_servers, make_client_b):
+    """An event on server A is surfaced on server B's #system."""
+    alpha, beta = linked_servers
+
+    b = await make_client_b("beta-bob", "bob")
+    await b.send("CAP REQ :message-tags")
+    await b.recv_until("CAP")
+    await b.send("JOIN #system")
+    await b.recv_until("JOIN")
+
+    # Emit on alpha.
+    ev = Event(
+        type=EventType.AGENT_CONNECT,
+        channel=None,
+        nick="system-alpha",
+        data={"nick": "alpha-claude"},
+    )
+    await alpha.emit_event(ev)
+
+    line = await b.recv_until("event=agent.connect")
+    # Origin in the nick is alpha, not beta.
+    assert ":system-alpha!" in line
+    assert "alpha-claude connected" in line
+
+
+@pytest.mark.asyncio
+async def test_federated_event_does_not_loop(linked_servers, make_client_a, make_client_b):
+    """A federated event surfaces once on each side — no loop."""
+    alpha, beta = linked_servers
+
+    a = await make_client_a("alpha-alice", "alice")
+    await a.send("CAP REQ :message-tags")
+    await a.recv_until("CAP")
+    await a.send("JOIN #system")
+    await a.recv_until("JOIN")
+
+    b = await make_client_b("beta-bob", "bob")
+    await b.send("CAP REQ :message-tags")
+    await b.recv_until("CAP")
+    await b.send("JOIN #system")
+    await b.recv_until("JOIN")
+
+    await alpha.emit_event(
+        Event(
+            type=EventType.AGENT_CONNECT,
+            channel=None,
+            nick="system-alpha",
+            data={"nick": "alpha-claude"},
+        )
+    )
+
+    # Each side sees exactly one PRIVMSG line mentioning the event.
+    a_count = await a.count_until_idle("event=agent.connect", seconds=1.0)
+    b_count = await b.count_until_idle("event=agent.connect", seconds=1.0)
+    assert a_count == 1
+    assert b_count == 1
+
+
+@pytest.mark.asyncio
+async def test_server_link_in_event_log(linked_servers):
+    """server.link events land in both servers' _event_log after handshake."""
+    alpha, beta = linked_servers
+
+    alpha_link_events = [e for (_, e) in alpha._event_log if e.type == EventType.SERVER_LINK]
+    beta_link_events = [e for (_, e) in beta._event_log if e.type == EventType.SERVER_LINK]
+
+    assert len(alpha_link_events) >= 1, "alpha should have at least one server.link event"
+    assert len(beta_link_events) >= 1, "beta should have at least one server.link event"
+
+    # The event on alpha should mention beta as peer
+    alpha_peers = {e.data.get("peer") for e in alpha_link_events}
+    assert "beta" in alpha_peers
+
+    # The event on beta should mention alpha as peer
+    beta_peers = {e.data.get("peer") for e in beta_link_events}
+    assert "alpha" in beta_peers
+
+
+@pytest.mark.asyncio
+async def test_server_unlink_on_disconnect(linked_servers):
+    """server.unlink is emitted when a peer link drops."""
+    alpha, beta = linked_servers
+
+    # Grab the link object and close it from alpha's side
+    link = alpha.links["beta"]
+    link.writer.close()
+    try:
+        await link.writer.wait_closed()
+    except ConnectionError:
+        pass
+
+    # Wait for cleanup to propagate
+    for _ in range(50):
+        if "beta" not in alpha.links:
+            break
+        await asyncio.sleep(0.05)
+
+    unlink_events = [e for (_, e) in alpha._event_log if e.type == EventType.SERVER_UNLINK]
+    assert len(unlink_events) >= 1, "Expected server.unlink in alpha's event log"
+    assert unlink_events[0].data.get("peer") == "beta"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.5.0"
+version = "6.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **SEVENT generic S2S federation relay** — lifecycle events (`agent.connect`, `server.wake`, `room.create`, `console.open`, etc.) now federate across linked servers via a new generic fallback in `relay_event()`. Typed relays (`SMSG`/`SJOIN`/`SPART`/etc.) remain in place for their 10 event types; the generic SEVENT fallback handles everything else.
- **`server.link` and `server.unlink` events** — emitted at handshake completion and link teardown respectively. `_remove_link` made async to support `server.unlink` emission.
- **Wire format:** `:<origin> SEVENT <origin> <seq> <type> <channel_or_*> :<b64-json-data>`
- **Trust policy:** channel-scoped events respect `should_relay`/`_check_incoming_trust`; global events (`*`) always relay.
- **Loop prevention:** already handled at `ircd.emit_event()` — events with `_origin` skip re-relay. `_handle_sevent` re-attaches `_origin` on ingest.
- **`events/1` capability negotiation deferred** — v1 assumes all peers support SEVENT. This is intentional: Task 12 is the introducing change, no older peers exist. A future cap gate can slot in at the generic fallback branch.

### Files changed

| File | Change |
|---|---|
| `culture/agentirc/server_link.py` | `_handle_sevent` handler, generic fallback in `relay_event()`, `server.link` emission |
| `culture/agentirc/ircd.py` | `_remove_link` async + `server.unlink` emission |
| `tests/conftest.py` | `count_until_idle()` helper on `IRCTestClient` |
| `tests/test_events_federation.py` | 4 new tests |

### Review focus

- **Origin mismatch warning** — `_handle_sevent` logs a warning if the wire `origin` differs from `self.peer_name`. v1 direct-peer mode accepts it; multi-hop mesh would need stricter validation.
- **Backfill gap** — `_replay_event` only handles `MESSAGE` type. Non-MESSAGE events won't replay on reconnect. This is explicitly deferred to Task 13.

## Test plan

- [x] `test_event_federates_to_peer` — alpha emits AGENT_CONNECT, beta client in `#system` sees `system-alpha!` prefixed PRIVMSG
- [x] `test_federated_event_does_not_loop` — emit once on alpha, count exactly 1 on each side
- [x] `test_server_link_in_event_log` — both servers record SERVER_LINK with correct peer names post-handshake
- [x] `test_server_unlink_on_disconnect` — closing a link writer triggers SERVER_UNLINK in alpha's event log
- [x] `test_federated_event_uses_origin_prefix` (existing locked contract) — still passes
- [x] Full suite: 840 passed in 48.88s

Closes part of #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude