### PR TITLE
feat(events): HistorySkill stores lifecycle events (Task 13 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.7.0] - 2026-04-17
+
+
+### Added
+
+- HistorySkill stores lifecycle events — HISTORY RECENT now replays agent.connect, server.wake, room.create, etc.
+
 ## [6.6.0] - 2026-04-17
 
 

--- a/culture/agentirc/events.py
+++ b/culture/agentirc/events.py
@@ -13,9 +13,25 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
+from culture.agentirc.skill import EventType
 from culture.constants import EVENT_TYPE_RE
 
 logger = logging.getLogger(__name__)
+
+# Event types whose content is already delivered to clients via the normal
+# IRC path (PRIVMSG, NOTICE, TOPIC) or has dedicated storage (threads).
+# Used by both IRCd._surface_event_privmsg (to avoid double-delivery) and
+# HistorySkill (to avoid double-storage).  Keep this as the single source
+# of truth — do not duplicate.
+NO_SURFACE_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        EventType.MESSAGE.value,
+        EventType.THREAD_CREATE.value,
+        EventType.THREAD_MESSAGE.value,
+        EventType.THREAD_CLOSE.value,
+        EventType.TOPIC.value,
+    }
+)
 
 RenderFn = Callable[[dict[str, Any], str | None], str]
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from culture.agentirc.channel import Channel
 from culture.agentirc.config import ServerConfig
-from culture.agentirc.events import render_event
+from culture.agentirc.events import NO_SURFACE_EVENT_TYPES, render_event
 from culture.agentirc.skill import Event, EventType, Skill
 from culture.bots.virtual_client import VirtualClient
 from culture.constants import (
@@ -189,18 +189,7 @@ class IRCd:
         # 4) Surface as tagged PRIVMSG from system-<server>.
         await self._surface_event_privmsg(event)
 
-    # Event types whose content is already delivered to clients via the normal
-    # IRC path (PRIVMSG, NOTICE, TOPIC).  Surfacing these as additional system
-    # PRIVMSGs would double-deliver them and break echo-suppression tests.
-    _NO_SURFACE_TYPES = frozenset(
-        {
-            EventType.MESSAGE.value,
-            EventType.THREAD_CREATE.value,
-            EventType.THREAD_MESSAGE.value,
-            EventType.THREAD_CLOSE.value,
-            EventType.TOPIC.value,
-        }
-    )
+    _NO_SURFACE_TYPES = NO_SURFACE_EVENT_TYPES
 
     @staticmethod
     def _build_event_payload(event: Event) -> dict:

--- a/culture/agentirc/skills/history.py
+++ b/culture/agentirc/skills/history.py
@@ -6,7 +6,9 @@ from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from culture.agentirc.events import render_event
 from culture.agentirc.skill import Event, EventType, Skill
+from culture.constants import SYSTEM_CHANNEL, SYSTEM_USER_PREFIX
 from culture.protocol import replies
 from culture.protocol.message import Message
 
@@ -26,6 +28,20 @@ class HistoryEntry:
 class HistorySkill(Skill):
     name = "history"
     commands = {"HISTORY"}
+
+    # Event types that are NOT stored as lifecycle entries.  Must mirror
+    # IRCd._NO_SURFACE_TYPES exactly: these are either handled by the MESSAGE
+    # branch above (MESSAGE) or have their own dedicated storage (threads,
+    # topic).
+    _NO_STORE_TYPES = frozenset(
+        {
+            EventType.MESSAGE.value,
+            EventType.THREAD_CREATE.value,
+            EventType.THREAD_MESSAGE.value,
+            EventType.THREAD_CLOSE.value,
+            EventType.TOPIC.value,
+        }
+    )
 
     def __init__(self, maxlen: int = 10000, retention_days: int = 30):
         self.maxlen = maxlen
@@ -85,6 +101,30 @@ class HistorySkill(Skill):
             )
             if self._store is not None:
                 self._store.append(event.channel, event.nick, event.data["text"], event.timestamp)
+            return
+
+        # Skip event types that are delivered via their own IRC verbs
+        # (THREAD_*, TOPIC) — they have dedicated storage. MESSAGE was
+        # already handled above.
+        type_wire = event.type.value if hasattr(event.type, "value") else str(event.type)
+        if type_wire in self._NO_STORE_TYPES:
+            return
+
+        # Store lifecycle events (agent.connect, server.wake, etc.)
+        target = event.channel or SYSTEM_CHANNEL
+        origin = event.data.get("_origin") or self.server.config.name
+        nick = f"{SYSTEM_USER_PREFIX}{origin}"
+        payload = {k: v for k, v in event.data.items() if not k.startswith("_")}
+        if event.nick:
+            payload.setdefault("nick", event.nick)
+        if event.channel:
+            payload.setdefault("channel", event.channel)
+        body = event.data.get("_render") or render_event(type_wire, payload, event.channel)
+
+        buf = self._channels.setdefault(target, deque(maxlen=self.maxlen))
+        buf.append(HistoryEntry(nick=nick, text=body, timestamp=event.timestamp))
+        if self._store is not None:
+            self._store.append(target, nick, body, event.timestamp)
 
     def get_recent(self, channel: str, count: int) -> list[HistoryEntry]:
         if count <= 0:

--- a/culture/agentirc/skills/history.py
+++ b/culture/agentirc/skills/history.py
@@ -6,7 +6,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from culture.agentirc.events import render_event
+from culture.agentirc.events import NO_SURFACE_EVENT_TYPES, render_event
 from culture.agentirc.skill import Event, EventType, Skill
 from culture.constants import SYSTEM_CHANNEL, SYSTEM_USER_PREFIX
 from culture.protocol import replies
@@ -29,19 +29,7 @@ class HistorySkill(Skill):
     name = "history"
     commands = {"HISTORY"}
 
-    # Event types that are NOT stored as lifecycle entries.  Must mirror
-    # IRCd._NO_SURFACE_TYPES exactly: these are either handled by the MESSAGE
-    # branch above (MESSAGE) or have their own dedicated storage (threads,
-    # topic).
-    _NO_STORE_TYPES = frozenset(
-        {
-            EventType.MESSAGE.value,
-            EventType.THREAD_CREATE.value,
-            EventType.THREAD_MESSAGE.value,
-            EventType.THREAD_CLOSE.value,
-            EventType.TOPIC.value,
-        }
-    )
+    _NO_STORE_TYPES = NO_SURFACE_EVENT_TYPES
 
     def __init__(self, maxlen: int = 10000, retention_days: int = 30):
         self.maxlen = maxlen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.6.0"
+version = "6.7.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_events_history.py
+++ b/tests/test_events_history.py
@@ -1,0 +1,64 @@
+"""Events appear in HISTORY RECENT replays."""
+
+import asyncio
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_event_appears_in_history(server, make_client):
+    """A global event (agent.connect) appears in #system HISTORY RECENT."""
+    alice = await make_client("testserv-alice", "alice")
+    await alice.send("CAP REQ :message-tags")
+    await alice.recv_until("CAP")
+
+    # Emit an event before the client joins #system.
+    await server.emit_event(
+        Event(
+            type=EventType.AGENT_CONNECT,
+            channel=None,
+            nick="system-testserv",
+            data={"nick": "testserv-claude"},
+        )
+    )
+
+    await alice.send("JOIN #system")
+    await alice.recv_until("JOIN")
+    # Flush any surfaced PRIVMSGs from the join
+    await asyncio.sleep(0.05)
+    await alice.recv_all(timeout=0.2)
+
+    await alice.send("HISTORY RECENT #system 50")
+    history = await alice.recv_until("HISTORYEND")
+    assert "testserv-claude connected" in history
+
+
+@pytest.mark.asyncio
+async def test_channel_event_in_channel_history(server, make_client):
+    """A channel-scoped event (room.create) appears in that channel's history."""
+    alice = await make_client("testserv-alice", "alice")
+    await alice.send("CAP REQ :message-tags")
+    await alice.recv_until("CAP")
+    await alice.send("JOIN #room")
+    await alice.recv_until("JOIN")
+    # Flush join-related messages
+    await asyncio.sleep(0.05)
+    await alice.recv_all(timeout=0.2)
+
+    await server.emit_event(
+        Event(
+            type=EventType.ROOM_CREATE,
+            channel="#room",
+            nick="testserv-bob",
+            data={"nick": "testserv-bob", "room": "#room"},
+        )
+    )
+
+    # Wait for event to be processed
+    await asyncio.sleep(0.05)
+
+    await alice.send("HISTORY RECENT #room 50")
+    history = await alice.recv_until("HISTORYEND")
+    assert "created room #room" in history

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -29,10 +29,11 @@ async def test_history_records_channel_messages(server, make_client):
     await asyncio.sleep(0.05)
 
     entries = skill.get_recent("#test", 10)
-    assert len(entries) == 2
-    assert entries[0].nick == "testserv-alice"
-    assert entries[0].text == "first message"
-    assert entries[1].text == "second message"
+    # 2 join lifecycle events + 2 messages = 4+ entries; check messages are present.
+    message_entries = [e for e in entries if e.nick == "testserv-alice"]
+    assert len(message_entries) == 2
+    assert message_entries[0].text == "first message"
+    assert message_entries[1].text == "second message"
 
 
 @pytest.mark.asyncio
@@ -77,10 +78,11 @@ async def test_history_per_channel_isolation(server, make_client):
 
     chan1 = skill.get_recent("#chan1", 10)
     chan2 = skill.get_recent("#chan2", 10)
-    assert len(chan1) == 1
-    assert chan1[0].text == "msg for chan1"
-    assert len(chan2) == 1
-    assert chan2[0].text == "msg for chan2"
+    # Join lifecycle events are also stored; verify message isolation by nick/text.
+    assert any(e.text == "msg for chan1" for e in chan1)
+    assert not any(e.text == "msg for chan2" for e in chan1)
+    assert any(e.text == "msg for chan2" for e in chan2)
+    assert not any(e.text == "msg for chan1" for e in chan2)
 
 
 @pytest.mark.asyncio
@@ -229,8 +231,10 @@ async def test_history_recent_count_exceeds_stored(server, make_client):
     lines = await bob.recv_all(timeout=1.0)
 
     history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
-    assert len(history_lines) == 1
-    assert "only one" in history_lines[0]
+    # Join lifecycle events are also stored — at least 1 HISTORY line, and the
+    # message text appears somewhere among the entries.
+    assert len(history_lines) >= 1
+    assert any("only one" in l for l in history_lines)
 
 
 @pytest.mark.asyncio
@@ -370,8 +374,8 @@ async def test_history_auto_registered(server, make_client):
     lines = await bob.recv_all(timeout=1.0)
 
     history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
-    assert len(history_lines) == 1
-    assert "auto registered test" in history_lines[0]
+    # Join lifecycle events are also stored — verify the message appears.
+    assert any("auto registered test" in l for l in history_lines)
 
 
 # --- History store unit tests ---
@@ -516,13 +520,12 @@ async def test_history_persists_across_restart():
         await carol.send("USER carol 0 * :carol")
         await carol.recv_all(timeout=0.5)
 
-        # Query history — should still have the messages
+        # Query history — should still have the messages (plus persisted join events).
         await carol.send("HISTORY RECENT #test 10")
         lines = await carol.recv_all(timeout=1.0)
         history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
-        assert len(history_lines) == 2
-        assert "persisted message one" in history_lines[0]
-        assert "persisted message two" in history_lines[1]
+        assert any("persisted message one" in l for l in history_lines)
+        assert any("persisted message two" in l for l in history_lines)
 
         await carol.close()
         await ircd2.stop()
@@ -543,9 +546,8 @@ async def test_history_no_persistence_without_data_dir(server, make_client):
     await bob.recv()
     await asyncio.sleep(0.05)
 
-    # Should still work in-memory
+    # Should still work in-memory (join lifecycle events also stored).
     await bob.send("HISTORY RECENT #test 5")
     lines = await bob.recv_all(timeout=1.0)
     history_lines = [l for l in lines if "HISTORY" in l and "HISTORYEND" not in l]
-    assert len(history_lines) == 1
-    assert "ephemeral message" in history_lines[0]
+    assert any("ephemeral message" in l for l in history_lines)

--- a/tests/test_overview_collector.py
+++ b/tests/test_overview_collector.py
@@ -90,9 +90,10 @@ async def test_collect_sees_messages(server, make_client):
         message_limit=4,
     )
     testing_room = next(r for r in mesh.rooms if r.name == "#testing")
-    assert len(testing_room.messages) == 2
-    assert testing_room.messages[0].text == "test message one"
-    assert testing_room.messages[1].text == "test message two"
+    # Join lifecycle events are also stored in history; filter to PRIVMSG content.
+    texts = [m.text for m in testing_room.messages]
+    assert "test message one" in texts
+    assert "test message two" in texts
 
 
 @pytest.mark.asyncio

--- a/tests/test_overview_collector.py
+++ b/tests/test_overview_collector.py
@@ -90,7 +90,8 @@ async def test_collect_sees_messages(server, make_client):
         message_limit=4,
     )
     testing_room = next(r for r in mesh.rooms if r.name == "#testing")
-    # Join lifecycle events are also stored in history; filter to PRIVMSG content.
+    # History may also include lifecycle entries; assert that the sent PRIVMSG
+    # texts are present in the collected message texts.
     texts = [m.text for m in testing_room.messages]
     assert "test message one" in texts
     assert "test message two" in texts

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.6.0"
+version = "6.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **HistorySkill now stores lifecycle events** — `agent.connect`, `server.wake`, `room.create`, `user.join/part/quit`, and all other non-MESSAGE event types are stored in channel history so `HISTORY RECENT` replays them.
- Global events (no channel) → stored under `#system`. Channel-scoped events → stored under their channel.
- `_NO_STORE_TYPES` frozenset mirrors `IRCd._NO_SURFACE_TYPES` — events with dedicated storage (MESSAGE already handled, THREAD_*, TOPIC) are skipped.
- Rendered body text uses `render_event()` for human-readable history entries (e.g., "testserv-claude connected").
- Existing tests updated: `user.join` events now appear in channel history, so exact-count assertions changed to membership checks (`any(...)`) — no behavioral regression, just accounting for new entries.

### Files changed

| File | Change |
|---|---|
| `culture/agentirc/skills/history.py` | Extended `on_event()` + `_NO_STORE_TYPES` |
| `tests/test_events_history.py` | 2 new tests |
| `tests/test_history.py` | Updated 6 assertions for lifecycle entries |
| `tests/test_overview_collector.py` | Updated 1 assertion |

## Test plan

- [x] `test_event_appears_in_history` — global event in `#system` HISTORY RECENT
- [x] `test_channel_event_in_channel_history` — channel-scoped event in channel history
- [x] All existing history tests pass (updated for lifecycle entries)
- [x] Full suite: 842 passed in 45.53s

Closes part of #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude