### PR TITLE
feat(events): safe filter DSL for bot event triggers (Task 14 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.8.0] - 2026-04-17
+
+
+### Added
+
+- Safe filter DSL for bot event triggers — recursive-descent parser with ==, !=, in, and, or, not operators and dotted field access
+
 ## [6.7.0] - 2026-04-17
 
 

--- a/culture/bots/filter_dsl.py
+++ b/culture/bots/filter_dsl.py
@@ -1,0 +1,319 @@
+"""Safe expression DSL for bot event filters.
+
+Grammar (recursive descent):
+
+    expr       := or_expr
+    or_expr    := and_expr ('or' and_expr)*
+    and_expr   := not_expr ('and' not_expr)*
+    not_expr   := 'not' not_expr | cmp_expr
+    cmp_expr   := atom (('==' | '!=' | 'in') atom)?
+    atom       := STRING | NUMBER | LIST | IDENT ('.' IDENT)* | '(' expr ')'
+    LIST       := '[' [atom (',' atom)*] ']'
+
+Evaluates against a dict (the event). Missing fields short-circuit to
+`_MISSING`, which compares `False` to everything.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+_MISSING = object()
+
+
+class FilterParseError(Exception):
+    def __init__(self, message: str, column: int = 0, expected: str = "") -> None:
+        self.column = column
+        self.expected = expected
+        super().__init__(message, column, expected)
+
+
+# -------- AST nodes --------
+
+
+@dataclass
+class Literal:
+    value: Any
+
+
+@dataclass
+class FieldRef:
+    parts: tuple[str, ...]
+
+
+@dataclass
+class ListExpr:
+    items: list
+
+
+@dataclass
+class Compare:
+    op: str  # '==', '!=', 'in'
+    left: Any
+    right: Any
+
+
+@dataclass
+class And:
+    left: Any
+    right: Any
+
+
+@dataclass
+class Or:
+    left: Any
+    right: Any
+
+
+@dataclass
+class Not:
+    expr: Any
+
+
+# -------- tokenizer --------
+
+
+class _Tok:
+    STRING = "STRING"
+    NUMBER = "NUMBER"
+    IDENT = "IDENT"
+    OP = "OP"
+    KW = "KW"
+    LP = "LP"
+    RP = "RP"
+    LBR = "LBR"
+    RBR = "RBR"
+    COMMA = "COMMA"
+    DOT = "DOT"
+    END = "END"
+
+
+_KEYWORDS = {"and", "or", "not", "in"}
+
+
+def _tokenize(src: str) -> list[tuple]:
+    tokens = []
+    i = 0
+    n = len(src)
+    while i < n:
+        ch = src[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch == "'":
+            end = src.find("'", i + 1)
+            if end == -1:
+                raise FilterParseError("unterminated string", i, "closing quote")
+            tokens.append((_Tok.STRING, src[i + 1 : end], i))
+            i = end + 1
+            continue
+        if ch.isdigit():
+            j = i
+            while j < n and src[j].isdigit():
+                j += 1
+            tokens.append((_Tok.NUMBER, int(src[i:j]), i))
+            i = j
+            continue
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < n and (src[j].isalnum() or src[j] in "_-"):
+                j += 1
+            word = src[i:j]
+            if word in _KEYWORDS:
+                tokens.append((_Tok.KW, word, i))
+            else:
+                tokens.append((_Tok.IDENT, word, i))
+            i = j
+            continue
+        if ch == "=" and i + 1 < n and src[i + 1] == "=":
+            tokens.append((_Tok.OP, "==", i))
+            i += 2
+            continue
+        if ch == "!" and i + 1 < n and src[i + 1] == "=":
+            tokens.append((_Tok.OP, "!=", i))
+            i += 2
+            continue
+        if ch == "(":
+            tokens.append((_Tok.LP, "(", i))
+            i += 1
+            continue
+        if ch == ")":
+            tokens.append((_Tok.RP, ")", i))
+            i += 1
+            continue
+        if ch == "[":
+            tokens.append((_Tok.LBR, "[", i))
+            i += 1
+            continue
+        if ch == "]":
+            tokens.append((_Tok.RBR, "]", i))
+            i += 1
+            continue
+        if ch == ",":
+            tokens.append((_Tok.COMMA, ",", i))
+            i += 1
+            continue
+        if ch == ".":
+            tokens.append((_Tok.DOT, ".", i))
+            i += 1
+            continue
+        raise FilterParseError(f"unexpected character {ch!r}", i, "operator / identifier")
+    tokens.append((_Tok.END, "", n))
+    return tokens
+
+
+# -------- parser --------
+
+
+class _Parser:
+    def __init__(self, tokens):
+        self.tokens = tokens
+        self.pos = 0
+
+    def peek(self):
+        return self.tokens[self.pos]
+
+    def consume(self):
+        tok = self.tokens[self.pos]
+        self.pos += 1
+        return tok
+
+    def expect(self, kind, expected_label):
+        tok = self.peek()
+        if tok[0] != kind:
+            raise FilterParseError(f"unexpected {tok[1]!r}", tok[2], expected_label)
+        return self.consume()
+
+    def parse(self):
+        expr = self._or()
+        if self.peek()[0] != _Tok.END:
+            tok = self.peek()
+            raise FilterParseError(f"trailing {tok[1]!r}", tok[2], "end of expression")
+        return expr
+
+    def _or(self):
+        left = self._and()
+        while self.peek()[0] == _Tok.KW and self.peek()[1] == "or":
+            self.consume()
+            right = self._and()
+            left = Or(left, right)
+        return left
+
+    def _and(self):
+        left = self._not()
+        while self.peek()[0] == _Tok.KW and self.peek()[1] == "and":
+            self.consume()
+            right = self._not()
+            left = And(left, right)
+        return left
+
+    def _not(self):
+        if self.peek()[0] == _Tok.KW and self.peek()[1] == "not":
+            self.consume()
+            return Not(self._not())
+        return self._cmp()
+
+    def _cmp(self):
+        left = self._atom()
+        tok = self.peek()
+        if tok[0] == _Tok.OP and tok[1] in ("==", "!="):
+            self.consume()
+            right = self._atom()
+            return Compare(tok[1], left, right)
+        if tok[0] == _Tok.KW and tok[1] == "in":
+            self.consume()
+            right = self._atom()
+            return Compare("in", left, right)
+        return left
+
+    def _atom(self):
+        tok = self.peek()
+        if tok[0] == _Tok.STRING:
+            self.consume()
+            return Literal(tok[1])
+        if tok[0] == _Tok.NUMBER:
+            self.consume()
+            return Literal(tok[1])
+        if tok[0] == _Tok.LP:
+            self.consume()
+            inner = self._or()
+            self.expect(_Tok.RP, "')'")
+            return inner
+        if tok[0] == _Tok.LBR:
+            self.consume()
+            items = []
+            if self.peek()[0] != _Tok.RBR:
+                items.append(self._atom())
+                while self.peek()[0] == _Tok.COMMA:
+                    self.consume()
+                    items.append(self._atom())
+            self.expect(_Tok.RBR, "']'")
+            return ListExpr(items)
+        if tok[0] == _Tok.IDENT:
+            self.consume()
+            parts = [tok[1]]
+            while self.peek()[0] == _Tok.DOT:
+                self.consume()
+                ident = self.expect(_Tok.IDENT, "identifier after '.'")
+                parts.append(ident[1])
+            # Reject function calls: next token must not be LP
+            if self.peek()[0] == _Tok.LP:
+                raise FilterParseError(
+                    f"function calls not allowed: {tok[1]!r}",
+                    tok[2],
+                    "operator or end of expression",
+                )
+            return FieldRef(tuple(parts))
+        raise FilterParseError(f"unexpected {tok[1]!r}", tok[2], "value")
+
+
+def compile_filter(source: str):
+    """Parse *source* into an AST node ready for :func:`evaluate`."""
+    tokens = _tokenize(source)
+    return _Parser(tokens).parse()
+
+
+# -------- evaluator --------
+
+
+def _resolve(ref: FieldRef, event: dict) -> Any:
+    cur: Any = event
+    for part in ref.parts:
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return _MISSING
+    return cur
+
+
+def evaluate(node, event: dict) -> Any:
+    """Evaluate an AST *node* against *event* dict, returning a Python value."""
+    if isinstance(node, Literal):
+        return node.value
+    if isinstance(node, FieldRef):
+        return _resolve(node, event)
+    if isinstance(node, ListExpr):
+        return [evaluate(i, event) for i in node.items]
+    if isinstance(node, Compare):
+        left = evaluate(node.left, event)
+        right = evaluate(node.right, event)
+        if left is _MISSING or right is _MISSING:
+            return False
+        if node.op == "==":
+            return left == right
+        if node.op == "!=":
+            return left != right
+        if node.op == "in":
+            try:
+                return left in right
+            except TypeError:
+                return False
+        return False
+    if isinstance(node, And):
+        return bool(evaluate(node.left, event)) and bool(evaluate(node.right, event))
+    if isinstance(node, Or):
+        return bool(evaluate(node.left, event)) or bool(evaluate(node.right, event))
+    if isinstance(node, Not):
+        return not bool(evaluate(node.expr, event))
+    return False

--- a/culture/bots/filter_dsl.py
+++ b/culture/bots/filter_dsl.py
@@ -24,9 +24,15 @@ _MISSING = object()
 
 class FilterParseError(Exception):
     def __init__(self, message: str, column: int = 0, expected: str = "") -> None:
+        super().__init__(message, column, expected)  # noqa: B042
         self.column = column
         self.expected = expected
-        super().__init__(message, column, expected)
+
+    def __str__(self) -> str:
+        msg = self.args[0] if self.args else ""
+        if self.expected:
+            return f"{msg} at col {self.column} (expected {self.expected})"
+        return f"{msg} at col {self.column}"
 
 
 # -------- AST nodes --------
@@ -91,6 +97,45 @@ class _Tok:
 
 _KEYWORDS = {"and", "or", "not", "in"}
 
+_SIMPLE_CHARS = {
+    "(": _Tok.LP,
+    ")": _Tok.RP,
+    "[": _Tok.LBR,
+    "]": _Tok.RBR,
+    ",": _Tok.COMMA,
+    ".": _Tok.DOT,
+}
+
+
+def _tok_string(src, i, n):
+    end = src.find("'", i + 1)
+    if end == -1:
+        raise FilterParseError("unterminated string", i, "closing quote")
+    return (_Tok.STRING, src[i + 1 : end], i), end + 1
+
+
+def _tok_number(src, i, n):
+    j = i
+    while j < n and src[j].isdigit():
+        j += 1
+    return (_Tok.NUMBER, int(src[i:j]), i), j
+
+
+def _tok_word(src, i, n):
+    j = i
+    while j < n and (src[j].isalnum() or src[j] in "_-"):
+        j += 1
+    word = src[i:j]
+    kind = _Tok.KW if word in _KEYWORDS else _Tok.IDENT
+    return (kind, word, i), j
+
+
+def _tok_operator(src, i):
+    two = src[i : i + 2]
+    if two in ("==", "!="):
+        return (_Tok.OP, two, i), i + 2
+    return None, i
+
 
 def _tokenize(src: str) -> list[tuple]:
     tokens = []
@@ -102,60 +147,25 @@ def _tokenize(src: str) -> list[tuple]:
             i += 1
             continue
         if ch == "'":
-            end = src.find("'", i + 1)
-            if end == -1:
-                raise FilterParseError("unterminated string", i, "closing quote")
-            tokens.append((_Tok.STRING, src[i + 1 : end], i))
-            i = end + 1
+            tok, i = _tok_string(src, i, n)
+            tokens.append(tok)
             continue
         if ch.isdigit():
-            j = i
-            while j < n and src[j].isdigit():
-                j += 1
-            tokens.append((_Tok.NUMBER, int(src[i:j]), i))
-            i = j
+            tok, i = _tok_number(src, i, n)
+            tokens.append(tok)
             continue
         if ch.isalpha() or ch == "_":
-            j = i
-            while j < n and (src[j].isalnum() or src[j] in "_-"):
-                j += 1
-            word = src[i:j]
-            if word in _KEYWORDS:
-                tokens.append((_Tok.KW, word, i))
-            else:
-                tokens.append((_Tok.IDENT, word, i))
-            i = j
+            tok, i = _tok_word(src, i, n)
+            tokens.append(tok)
             continue
-        if ch == "=" and i + 1 < n and src[i + 1] == "=":
-            tokens.append((_Tok.OP, "==", i))
-            i += 2
+        tok, new_i = _tok_operator(src, i)
+        if tok is not None:
+            tokens.append(tok)
+            i = new_i
             continue
-        if ch == "!" and i + 1 < n and src[i + 1] == "=":
-            tokens.append((_Tok.OP, "!=", i))
-            i += 2
-            continue
-        if ch == "(":
-            tokens.append((_Tok.LP, "(", i))
-            i += 1
-            continue
-        if ch == ")":
-            tokens.append((_Tok.RP, ")", i))
-            i += 1
-            continue
-        if ch == "[":
-            tokens.append((_Tok.LBR, "[", i))
-            i += 1
-            continue
-        if ch == "]":
-            tokens.append((_Tok.RBR, "]", i))
-            i += 1
-            continue
-        if ch == ",":
-            tokens.append((_Tok.COMMA, ",", i))
-            i += 1
-            continue
-        if ch == ".":
-            tokens.append((_Tok.DOT, ".", i))
+        simple = _SIMPLE_CHARS.get(ch)
+        if simple is not None:
+            tokens.append((simple, ch, i))
             i += 1
             continue
         raise FilterParseError(f"unexpected character {ch!r}", i, "operator / identifier")
@@ -238,7 +248,7 @@ class _Parser:
         if tok[0] == _Tok.LP:
             self.consume()
             inner = self._or()
-            self.expect(_Tok.RP, "')'")
+            self.expect(_Tok.RP, ")")
             return inner
         if tok[0] == _Tok.LBR:
             self.consume()
@@ -248,7 +258,7 @@ class _Parser:
                 while self.peek()[0] == _Tok.COMMA:
                     self.consume()
                     items.append(self._atom())
-            self.expect(_Tok.RBR, "']'")
+            self.expect(_Tok.RBR, "]")
             return ListExpr(items)
         if tok[0] == _Tok.IDENT:
             self.consume()
@@ -287,6 +297,29 @@ def _resolve(ref: FieldRef, event: dict) -> Any:
     return cur
 
 
+def _to_bool(val) -> bool:
+    if val is _MISSING:
+        return False
+    return bool(val)
+
+
+def _eval_compare(node: Compare, event: dict) -> Any:
+    left = evaluate(node.left, event)
+    right = evaluate(node.right, event)
+    if left is _MISSING or right is _MISSING:
+        return False
+    if node.op == "==":
+        return left == right
+    if node.op == "!=":
+        return left != right
+    if node.op == "in":
+        try:
+            return left in right
+        except TypeError:
+            return False
+    return False
+
+
 def evaluate(node, event: dict) -> Any:
     """Evaluate an AST *node* against *event* dict, returning a Python value."""
     if isinstance(node, Literal):
@@ -296,24 +329,11 @@ def evaluate(node, event: dict) -> Any:
     if isinstance(node, ListExpr):
         return [evaluate(i, event) for i in node.items]
     if isinstance(node, Compare):
-        left = evaluate(node.left, event)
-        right = evaluate(node.right, event)
-        if left is _MISSING or right is _MISSING:
-            return False
-        if node.op == "==":
-            return left == right
-        if node.op == "!=":
-            return left != right
-        if node.op == "in":
-            try:
-                return left in right
-            except TypeError:
-                return False
-        return False
+        return _eval_compare(node, event)
     if isinstance(node, And):
-        return bool(evaluate(node.left, event)) and bool(evaluate(node.right, event))
+        return _to_bool(evaluate(node.left, event)) and _to_bool(evaluate(node.right, event))
     if isinstance(node, Or):
-        return bool(evaluate(node.left, event)) or bool(evaluate(node.right, event))
+        return _to_bool(evaluate(node.left, event)) or _to_bool(evaluate(node.right, event))
     if isinstance(node, Not):
-        return not bool(evaluate(node.expr, event))
+        return not _to_bool(evaluate(node.expr, event))
     return False

--- a/culture/bots/filter_dsl.py
+++ b/culture/bots/filter_dsl.py
@@ -107,7 +107,7 @@ _SIMPLE_CHARS = {
 }
 
 
-def _tok_string(src, i, n):
+def _tok_string(src, i):
     end = src.find("'", i + 1)
     if end == -1:
         raise FilterParseError("unterminated string", i, "closing quote")
@@ -147,7 +147,7 @@ def _tokenize(src: str) -> list[tuple]:
             i += 1
             continue
         if ch == "'":
-            tok, i = _tok_string(src, i, n)
+            tok, i = _tok_string(src, i)
             tokens.append(tok)
             continue
         if ch.isdigit():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.7.0"
+version = "6.8.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_filter_dsl.py
+++ b/tests/test_filter_dsl.py
@@ -1,0 +1,89 @@
+"""Bot filter DSL — safe expressions over event dicts."""
+
+import pytest
+
+from culture.bots.filter_dsl import (
+    FilterParseError,
+    compile_filter,
+    evaluate,
+)
+
+
+def event(**kw):
+    d = {"type": "user.join", "channel": "#general", "data": {"nick": "ori"}}
+    d.update(kw)
+    return d
+
+
+def test_equality():
+    f = compile_filter("type == 'user.join'")
+    assert evaluate(f, event()) is True
+    assert evaluate(f, event(type="user.part")) is False
+
+
+def test_and():
+    f = compile_filter("type == 'user.join' and channel == '#general'")
+    assert evaluate(f, event()) is True
+    assert evaluate(f, event(channel="#other")) is False
+
+
+def test_or():
+    f = compile_filter("type == 'user.join' or type == 'user.part'")
+    assert evaluate(f, event()) is True
+    assert evaluate(f, event(type="user.part")) is True
+    assert evaluate(f, event(type="server.link")) is False
+
+
+def test_not():
+    f = compile_filter("not (type == 'user.join')")
+    assert evaluate(f, event()) is False
+    assert evaluate(f, event(type="user.part")) is True
+
+
+def test_in_list():
+    f = compile_filter("type in ['server.link', 'server.unlink']")
+    assert evaluate(f, event(type="server.link")) is True
+    assert evaluate(f, event(type="user.join")) is False
+
+
+def test_dotted_field():
+    f = compile_filter("data.nick == 'ori'")
+    assert evaluate(f, event()) is True
+    assert evaluate(f, event(data={"nick": "bob"})) is False
+
+
+def test_missing_field_is_false():
+    f = compile_filter("data.missing == 'x'")
+    assert evaluate(f, event()) is False
+
+
+def test_in_string_membership():
+    f = compile_filter("'research' in data.tags")
+    ev = event(data={"tags": ["research", "ai"]})
+    assert evaluate(f, ev) is True
+    ev2 = event(data={"tags": ["games"]})
+    assert evaluate(f, ev2) is False
+
+
+def test_parens_for_precedence():
+    f = compile_filter("(type == 'a' or type == 'b') and channel == '#c'")
+    assert evaluate(f, event(type="a", channel="#c")) is True
+    assert evaluate(f, event(type="b", channel="#c")) is True
+    assert evaluate(f, event(type="a", channel="#other")) is False
+
+
+def test_parse_error_message():
+    with pytest.raises(FilterParseError) as exc:
+        compile_filter("type = 'x'")  # single '=' invalid
+    assert exc.value.column >= 0
+    assert exc.value.expected
+
+
+def test_parse_error_unclosed_string():
+    with pytest.raises(FilterParseError):
+        compile_filter("type == 'unclosed")
+
+
+def test_parse_error_no_function_calls():
+    with pytest.raises(FilterParseError):
+        compile_filter("exec('x')")

--- a/tests/test_filter_dsl.py
+++ b/tests/test_filter_dsl.py
@@ -3,6 +3,7 @@
 import pytest
 
 from culture.bots.filter_dsl import (
+    _MISSING,
     FilterParseError,
     compile_filter,
     evaluate,
@@ -70,6 +71,15 @@ def test_parens_for_precedence():
     assert evaluate(f, event(type="a", channel="#c")) is True
     assert evaluate(f, event(type="b", channel="#c")) is True
     assert evaluate(f, event(type="a", channel="#other")) is False
+
+
+def test_bare_missing_field_is_falsy():
+    f = compile_filter("data.missing")
+    assert evaluate(f, event()) is _MISSING
+    f2 = compile_filter("data.missing and type == 'user.join'")
+    assert evaluate(f2, event()) is False
+    f3 = compile_filter("not data.missing")
+    assert evaluate(f3, event()) is True
 
 
 def test_parse_error_message():

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.7.0"
+version = "6.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Adds `culture/bots/filter_dsl.py` — a safe recursive-descent expression parser and evaluator for bot event filters
- Supports `==`, `!=`, `in`, `and`, `or`, `not` operators with dotted field access (`data.nick`)
- Fail-closed semantics: missing fields evaluate to `False`, no function calls allowed
- `FilterParseError(message, column, expected)` for user-friendly parse errors

## Design

Grammar: `expr → or_expr → and_expr → not_expr → cmp_expr → atom`

Public API:
- `compile_filter(source)` — parse to AST (raises `FilterParseError` on bad syntax)
- `evaluate(node, event_dict)` — evaluate AST against an event dict

Used by Task 15 (bot event triggers) to evaluate `trigger.filter` expressions at runtime.

## Test plan

- [x] 12 unit tests in `tests/test_filter_dsl.py` covering all operators and error cases
- [x] Full suite (854 tests) passes with zero regressions
- [x] Pre-commit hooks clean (black, isort, flake8, pylint, bandit)

Part of #123 (mesh events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude