### PR TITLE
feat(events): bot event-trigger + fires_event output (Task 15 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.9.0] - 2026-04-17
+
+
+### Added
+
+- Bot event-trigger type with filter DSL evaluation
+- fires_event output for pub/sub bot chains with rate limiting
+- EmitEventSpec config and _DynamicEventType for custom event types
+
 ## [6.8.0] - 2026-04-17
 
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -186,7 +186,14 @@ class IRCd:
                 except Exception:
                     logger.exception("Failed to relay event to %s", peer_name)
 
-        # 4) Surface as tagged PRIVMSG from system-<server>.
+        # 4) Dispatch to event-triggered bots.
+        if self.bot_manager is not None:
+            try:
+                await self.bot_manager.on_event(event)
+            except Exception:
+                logger.exception("bot_manager.on_event failed")
+
+        # 5) Surface as tagged PRIVMSG from system-<server>.
         await self._surface_event_privmsg(event)
 
     _NO_SURFACE_TYPES = NO_SURFACE_EVENT_TYPES

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -4,17 +4,67 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from culture.agentirc.skill import Event, EventType
 from culture.bots.config import BOTS_DIR, BotConfig
 from culture.bots.template_engine import render_fallback, render_template
 from culture.bots.virtual_client import VirtualClient
+from culture.constants import EVENT_TYPE_RE
 
 if TYPE_CHECKING:
     from culture.agentirc.ircd import IRCd
 
 logger = logging.getLogger(__name__)
+
+
+class _DynamicEventType:
+    """Lightweight stand-in for EventType when the event type is not in the enum."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:
+        return self.value
+
+
+# ---------------------------------------------------------------------------
+# Rate-limiter for fires_event — module-level state, 10 events/sec per bot
+# ---------------------------------------------------------------------------
+
+_RATE_MAX_PER_SEC = 10
+_rate_state: dict[str, list[float]] = {}
+
+
+def _check_rate(bot_name: str) -> bool:
+    """Return True if the bot may fire an event; False if rate-limited."""
+    now = time.monotonic()
+    window = _rate_state.setdefault(bot_name, [])
+    window[:] = [t for t in window if now - t < 1.0]
+    if len(window) >= _RATE_MAX_PER_SEC:
+        return False
+    window.append(now)
+    return True
+
+
+def _render_data_values(data: dict[str, Any], ctx: dict[str, Any]) -> dict[str, Any]:
+    """Render Jinja2 template strings inside an EmitEventSpec data dict."""
+    from jinja2 import Template
+
+    result = {}
+    for key, val in data.items():
+        if isinstance(val, str):
+            try:
+                result[key] = Template(val).render(ctx)
+            except Exception:
+                result[key] = val
+        else:
+            result[key] = val
+    return result
 
 
 class Bot:
@@ -101,7 +151,46 @@ class Bot:
         if self.config.dm_owner and self.config.owner:
             await self.virtual_client.send_dm(self.config.owner, message)
 
+        # Fire follow-on event if configured
+        await self._maybe_fire_event(payload)
+
         return message
+
+    async def _maybe_fire_event(self, payload: dict) -> None:
+        """Emit a follow-on event if fires_event is configured on this bot."""
+        spec = self.config.fires_event
+        if spec is None:
+            return
+
+        if not EVENT_TYPE_RE.match(spec.type):
+            logger.warning(
+                "Bot %s has invalid fires_event.type %r — skipping", self.config.name, spec.type
+            )
+            return
+
+        if not _check_rate(self.config.name):
+            logger.warning("Bot %s rate-limited on fires_event", self.config.name)
+            return
+
+        rendered_data = _render_data_values(spec.data, payload)
+
+        # Prefer a real EventType enum member; fall back to dynamic type for custom events.
+        try:
+            event_type = EventType(spec.type)
+        except ValueError:
+            event_type = _DynamicEventType(spec.type)
+
+        try:
+            await self.server.emit_event(
+                Event(
+                    type=event_type,
+                    channel=None,
+                    nick=self.config.name,
+                    data=rendered_data,
+                )
+            )
+        except Exception:
+            logger.exception("Bot %s failed to emit fires_event", self.config.name)
 
     def _render_message(self, payload: dict) -> str:
         """Render message using template or fallback."""

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -53,13 +53,14 @@ def _check_rate(bot_name: str) -> bool:
 
 def _render_data_values(data: dict[str, Any], ctx: dict[str, Any]) -> dict[str, Any]:
     """Render Jinja2 template strings inside an EmitEventSpec data dict."""
-    from jinja2 import Template
+    from jinja2.sandbox import SandboxedEnvironment
 
+    env = SandboxedEnvironment()
     result = {}
     for key, val in data.items():
         if isinstance(val, str):
             try:
-                result[key] = Template(val).render(ctx)
+                result[key] = env.from_string(val).render(ctx)
             except Exception:
                 result[key] = val
         else:

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -13,6 +13,7 @@ from culture.bots.config import (
     load_bot_config,
     save_bot_config,
 )
+from culture.bots.filter_dsl import FilterParseError, compile_filter, evaluate
 
 if TYPE_CHECKING:
     from culture.agentirc.ircd import IRCd
@@ -41,12 +42,70 @@ class BotManager:
                 if config.archived:
                     logger.info("Skipping archived bot %s", config.name)
                     continue
+                # Compile event filter at load time
+                if config.trigger_type == "event" and config.event_filter:
+                    try:
+                        config._compiled_filter = compile_filter(config.event_filter)
+                    except FilterParseError as exc:
+                        logger.error("Bot %s has invalid filter, skipping: %s", config.name, exc)
+                        continue
                 bot = Bot(config, self.server)
                 self.bots[config.name] = bot
                 await bot.start()
                 logger.info("Loaded bot %s", config.name)
             except Exception:
                 logger.exception("Failed to load bot from %s", bot_dir)
+
+    def register_bot(self, config: BotConfig) -> Bot:
+        """Register a bot from config (used by tests and system bot loader)."""
+        if config.trigger_type == "event" and config.event_filter:
+            try:
+                config._compiled_filter = compile_filter(config.event_filter)
+            except FilterParseError as exc:
+                raise ValueError(f"bot {config.name} has invalid filter: {exc}") from exc
+        bot = Bot(config, self.server)
+        self.bots[config.name] = bot
+        return bot
+
+    async def on_event(self, event) -> None:
+        """Evaluate event-triggered bots against an event and dispatch matches."""
+        for bot in list(self.bots.values()):
+            cfg = bot.config
+            if cfg.trigger_type != "event":
+                continue
+            compiled = getattr(cfg, "_compiled_filter", None)
+            if compiled is None:
+                continue
+            ctx = {
+                "type": event.type.value if hasattr(event.type, "value") else str(event.type),
+                "channel": event.channel,
+                "nick": event.nick,
+                "data": dict(event.data),
+            }
+            try:
+                if not evaluate(compiled, ctx):
+                    continue
+            except Exception:
+                logger.exception("Filter evaluation failed for bot %s", cfg.name)
+                continue
+            # Start the bot lazily if register_bot() was called without start().
+            # Guard against reentrant start() calls (e.g. the bot joining a channel
+            # emitting another event before start() completes).
+            if not bot.active:
+                if getattr(bot, "_starting", False):
+                    continue
+                bot._starting = True  # type: ignore[attr-defined]
+                try:
+                    await bot.start()
+                except Exception:
+                    logger.exception("Bot %s failed to start on first event", cfg.name)
+                    bot._starting = False  # type: ignore[attr-defined]
+                    continue
+                bot._starting = False  # type: ignore[attr-defined]
+            try:
+                await bot.handle({"event": ctx})
+            except Exception:
+                logger.exception("Bot %s handle() failed for event %s", cfg.name, event.type)
 
     async def create_bot(self, config: BotConfig) -> Bot:
         """Create a new bot: write config to disk and start it."""

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -87,8 +87,9 @@ class BotManager:
 
     async def on_event(self, event) -> None:
         """Evaluate event-triggered bots against an event and dispatch matches."""
-        # list() is required: handle() may call emit_event() which re-enters on_event().
-        for bot in list(self.bots.values()):
+        # Snapshot: handle() may call emit_event() which re-enters on_event().
+        bots_snapshot = list(self.bots.values())
+        for bot in bots_snapshot:
             cfg = bot.config
             if cfg.trigger_type != "event":
                 continue

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -15,6 +15,8 @@ from culture.bots.config import (
 )
 from culture.bots.filter_dsl import FilterParseError, compile_filter, evaluate
 
+_FILTER_ERRORS = (FilterParseError, TypeError)
+
 if TYPE_CHECKING:
     from culture.agentirc.ircd import IRCd
 
@@ -46,7 +48,7 @@ class BotManager:
                 if config.trigger_type == "event" and config.event_filter:
                     try:
                         config._compiled_filter = compile_filter(config.event_filter)
-                    except FilterParseError as exc:
+                    except _FILTER_ERRORS as exc:
                         logger.error("Bot %s has invalid filter, skipping: %s", config.name, exc)
                         continue
                 bot = Bot(config, self.server)
@@ -61,14 +63,31 @@ class BotManager:
         if config.trigger_type == "event" and config.event_filter:
             try:
                 config._compiled_filter = compile_filter(config.event_filter)
-            except FilterParseError as exc:
+            except _FILTER_ERRORS as exc:
                 raise ValueError(f"bot {config.name} has invalid filter: {exc}") from exc
         bot = Bot(config, self.server)
         self.bots[config.name] = bot
         return bot
 
+    async def _try_start_bot(self, bot: Bot) -> bool:
+        """Lazily start a bot on first matching event. Returns True if ready."""
+        if bot.active:
+            return True
+        if getattr(bot, "_starting", False):
+            return False
+        bot._starting = True  # type: ignore[attr-defined]
+        try:
+            await bot.start()
+            return True
+        except Exception:
+            logger.exception("Bot %s failed to start", bot.config.name)
+            return False
+        finally:
+            bot._starting = False  # type: ignore[attr-defined]
+
     async def on_event(self, event) -> None:
         """Evaluate event-triggered bots against an event and dispatch matches."""
+        # list() is required: handle() may call emit_event() which re-enters on_event().
         for bot in list(self.bots.values()):
             cfg = bot.config
             if cfg.trigger_type != "event":
@@ -88,20 +107,8 @@ class BotManager:
             except Exception:
                 logger.exception("Filter evaluation failed for bot %s", cfg.name)
                 continue
-            # Start the bot lazily if register_bot() was called without start().
-            # Guard against reentrant start() calls (e.g. the bot joining a channel
-            # emitting another event before start() completes).
-            if not bot.active:
-                if getattr(bot, "_starting", False):
-                    continue
-                bot._starting = True  # type: ignore[attr-defined]
-                try:
-                    await bot.start()
-                except Exception:
-                    logger.exception("Bot %s failed to start on first event", cfg.name)
-                    bot._starting = False  # type: ignore[attr-defined]
-                    continue
-                bot._starting = False  # type: ignore[attr-defined]
+            if not await self._try_start_bot(bot):
+                continue
             try:
                 await bot.handle({"event": ctx})
             except Exception:

--- a/culture/bots/config.py
+++ b/culture/bots/config.py
@@ -6,11 +6,20 @@ import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 BOTS_DIR = Path(os.path.expanduser("~/.culture/bots"))
 BOT_CONFIG_FILE = "bot.yaml"
+
+
+@dataclass
+class EmitEventSpec:
+    """Specification for an event emitted by a bot after handling a trigger."""
+
+    type: str = ""
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -30,6 +39,8 @@ class BotConfig:
     archived: bool = False
     archived_at: str = ""
     archived_reason: str = ""
+    event_filter: str | None = None
+    fires_event: EmitEventSpec | None = None
 
     @property
     def has_handler(self) -> bool:
@@ -47,6 +58,15 @@ def load_bot_config(path: Path) -> BotConfig:
     trigger_section = raw.get("trigger", {})
     output_section = raw.get("output", {})
 
+    # Parse optional fires_event block
+    fires_event_raw = output_section.get("fires_event")
+    fires_event: EmitEventSpec | None = None
+    if isinstance(fires_event_raw, dict):
+        fires_event = EmitEventSpec(
+            type=fires_event_raw.get("type", ""),
+            data=fires_event_raw.get("data", {}),
+        )
+
     return BotConfig(
         name=bot_section.get("name", ""),
         owner=bot_section.get("owner", ""),
@@ -61,6 +81,8 @@ def load_bot_config(path: Path) -> BotConfig:
         archived=bot_section.get("archived", False),
         archived_at=bot_section.get("archived_at", ""),
         archived_reason=bot_section.get("archived_reason", ""),
+        event_filter=trigger_section.get("filter"),
+        fires_event=fires_event,
     )
 
 
@@ -79,18 +101,27 @@ def save_bot_config(path: Path, config: BotConfig) -> None:
         bot_section["archived_at"] = config.archived_at
         bot_section["archived_reason"] = config.archived_reason
 
+    trigger_section: dict[str, Any] = {"type": config.trigger_type}
+    if config.event_filter:
+        trigger_section["filter"] = config.event_filter
+
+    output_section: dict[str, Any] = {
+        "channels": config.channels,
+        "dm_owner": config.dm_owner,
+        "mention": config.mention,
+        "template": config.template,
+        "fallback": config.fallback,
+    }
+    if config.fires_event:
+        output_section["fires_event"] = {
+            "type": config.fires_event.type,
+            "data": config.fires_event.data,
+        }
+
     data = {
         "bot": bot_section,
-        "trigger": {
-            "type": config.trigger_type,
-        },
-        "output": {
-            "channels": config.channels,
-            "dm_owner": config.dm_owner,
-            "mention": config.mention,
-            "template": config.template,
-            "fallback": config.fallback,
-        },
+        "trigger": trigger_section,
+        "output": output_section,
     }
 
     yaml_str = yaml.dump(data, default_flow_style=False)

--- a/culture/bots/config.py
+++ b/culture/bots/config.py
@@ -62,10 +62,13 @@ def load_bot_config(path: Path) -> BotConfig:
     fires_event_raw = output_section.get("fires_event")
     fires_event: EmitEventSpec | None = None
     if isinstance(fires_event_raw, dict):
-        fires_event = EmitEventSpec(
-            type=fires_event_raw.get("type", ""),
-            data=fires_event_raw.get("data", {}),
-        )
+        fe_type = fires_event_raw.get("type", "")
+        if not isinstance(fe_type, str):
+            fe_type = str(fe_type)
+        fe_data = fires_event_raw.get("data")
+        if not isinstance(fe_data, dict):
+            fe_data = {}
+        fires_event = EmitEventSpec(type=fe_type, data=fe_data)
 
     return BotConfig(
         name=bot_section.get("name", ""),

--- a/culture/bots/template_engine.py
+++ b/culture/bots/template_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 
-_TOKEN_RE = re.compile(r"\{(body(?:\.[^}]+)?)\}")
+_TOKEN_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*(?:\.[^}]+)?)\}")
 
 
 def _resolve_path(data: dict, path: str) -> str | None:
@@ -37,7 +37,10 @@ def render_template(template: str, payload: dict) -> str | None:
         The rendered string, or None if any token could not be resolved
         (caller should fall back based on the bot's ``fallback`` config).
     """
-    wrapper = {"body": payload}
+    # Build lookup context: payload keys are available directly AND via 'body'.
+    # 'body' always points to the entire payload for backward compatibility.
+    # When payload is not a dict (e.g. a raw string), skip the spread.
+    wrapper = {"body": payload, **(payload if isinstance(payload, dict) else {})}
 
     def _replace(match: re.Match) -> str:
         path = match.group(1)

--- a/culture/bots/template_engine.py
+++ b/culture/bots/template_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 
-_TOKEN_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*(?:\.[^}]+)?)\}")
+_TOKEN_RE = re.compile(r"\{(\w+(?:\.[^}]+)?)\}")
 
 
 def _resolve_path(data: dict, path: str) -> str | None:
@@ -27,20 +27,22 @@ def _resolve_path(data: dict, path: str) -> str | None:
 
 
 def render_template(template: str, payload: dict) -> str | None:
-    """Render a template string with {body.field.subfield} tokens.
+    """Render a template string with ``{key.field.subfield}`` tokens.
+
+    Payload keys are available directly (e.g. ``{event.nick}``) and
+    via the ``body`` alias (e.g. ``{body.event.nick}``).  ``body``
+    always points to the full payload for backward compatibility.
 
     Args:
-        template: Template string with {body.x.y} placeholders.
-        payload: The webhook JSON payload (accessible as ``body``).
+        template: Template string with ``{key.path}`` placeholders.
+        payload: The incoming payload dict.
 
     Returns:
         The rendered string, or None if any token could not be resolved
         (caller should fall back based on the bot's ``fallback`` config).
     """
-    # Build lookup context: payload keys are available directly AND via 'body'.
-    # 'body' always points to the entire payload for backward compatibility.
-    # When payload is not a dict (e.g. a raw string), skip the spread.
-    wrapper = {"body": payload, **(payload if isinstance(payload, dict) else {})}
+    # body last so it always wins even if payload contains a "body" key.
+    wrapper = {**(payload if isinstance(payload, dict) else {}), "body": payload}
 
     def _replace(match: re.Match) -> str:
         path = match.group(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.8.0"
+version = "6.9.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,3 +236,55 @@ async def make_client_b(linked_servers):
             await c.close()
         except Exception:
             pass
+
+
+@pytest_asyncio.fixture
+async def server_with_bot(server):
+    from culture.bots.bot_manager import BotManager
+    from culture.bots.config import BotConfig
+
+    def _make(**kwargs):
+        fires = kwargs.pop("fires_event", None)
+        filt = kwargs.pop("event_filter", None)
+        cfg = BotConfig(
+            name=kwargs.pop("bot_name"),
+            owner="testserv",
+            trigger_type=kwargs.pop("trigger_type", "event"),
+            event_filter=filt,
+            channels=kwargs.pop("channels", []),
+            template=kwargs.pop("template", None),
+            fires_event=fires,
+        )
+        if server.bot_manager is None:
+            server.bot_manager = BotManager(server=server)
+        server.bot_manager.register_bot(cfg)
+        return server, cfg
+
+    yield _make
+
+
+@pytest_asyncio.fixture
+async def server_with_bots(server):
+    from culture.bots.bot_manager import BotManager
+    from culture.bots.config import BotConfig
+
+    def _make(bot_kwargs_list):
+        if server.bot_manager is None:
+            server.bot_manager = BotManager(server=server)
+        cfgs = []
+        for kwargs in bot_kwargs_list:
+            fires = kwargs.pop("fires_event", None)
+            cfg = BotConfig(
+                name=kwargs.pop("bot_name"),
+                owner="testserv",
+                trigger_type=kwargs.pop("trigger_type", "event"),
+                event_filter=kwargs.pop("event_filter", None),
+                channels=kwargs.pop("channels", []),
+                template=kwargs.pop("template", None),
+                fires_event=fires,
+            )
+            server.bot_manager.register_bot(cfg)
+            cfgs.append(cfg)
+        return server, cfgs
+
+    yield _make

--- a/tests/test_events_bot_chain.py
+++ b/tests/test_events_bot_chain.py
@@ -1,0 +1,59 @@
+"""Tests for bot chain: bot A fires an event that triggers bot B."""
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+from culture.bots.config import EmitEventSpec
+
+
+@pytest.mark.asyncio
+async def test_bot_chain_fires_event(server_with_bots, make_client):
+    """Bot A fires on user.join, emits a custom event; bot B triggers on that event."""
+    # Bot A: triggered by user.join, fires custom.alert event
+    fires_a = EmitEventSpec(
+        type="custom.alert",
+        data={"source": "bot-a"},
+    )
+
+    # Bot B: triggered by custom.alert, posts to #alerts channel
+    server, cfgs = server_with_bots(
+        [
+            {
+                "bot_name": "testserv-bot-a",
+                "trigger_type": "event",
+                "event_filter": "type == 'user.join'",
+                "channels": [],
+                "template": None,
+                "fires_event": fires_a,
+            },
+            {
+                "bot_name": "testserv-bot-b",
+                "trigger_type": "event",
+                "event_filter": "type == 'custom.alert'",
+                "channels": ["#alerts"],
+                "template": "Chain alert: {event.data.source}",
+                "fires_event": None,
+            },
+        ]
+    )
+
+    # Agent subscribes to #alerts to observe bot B
+    agent = await make_client("testserv-chain-watcher", "watcher")
+    await agent.send("JOIN #alerts")
+    await agent.recv_all(timeout=0.5)
+
+    # Emit user.join — should chain: bot A fires custom.alert → bot B posts
+    await server.emit_event(
+        Event(
+            type=EventType.JOIN,
+            channel="#lobby",
+            nick="testserv-newbie",
+            data={"nick": "testserv-newbie"},
+        )
+    )
+
+    # Allow async chain to propagate
+    lines = await agent.recv_all(timeout=0.8)
+    assert any(
+        "Chain alert" in line for line in lines
+    ), f"Bot chain message not received. Lines: {lines}"

--- a/tests/test_events_bot_chain.py
+++ b/tests/test_events_bot_chain.py
@@ -16,7 +16,7 @@ async def test_bot_chain_fires_event(server_with_bots, make_client):
     )
 
     # Bot B: triggered by custom.alert, posts to #alerts channel
-    server, cfgs = server_with_bots(
+    server, _ = server_with_bots(
         [
             {
                 "bot_name": "testserv-bot-a",

--- a/tests/test_events_bot_trigger.py
+++ b/tests/test_events_bot_trigger.py
@@ -1,0 +1,101 @@
+"""Tests for event-triggered bots (trigger_type: event + filter DSL)."""
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+from culture.bots.bot_manager import BotManager
+from culture.bots.config import BotConfig
+
+# ---------------------------------------------------------------------------
+# test_event_triggered_bot_runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_triggered_bot_runs(server_with_bot, make_client):
+    """A bot with trigger_type=event fires on a matching event and posts to channels."""
+    server, cfg = server_with_bot(
+        bot_name="testserv-evt-bot",
+        trigger_type="event",
+        event_filter="type == 'user.join'",
+        channels=["#general"],
+        template="User joined: {event.nick}",
+    )
+
+    # Connect a real client so it can join and receive the bot message
+    agent = await make_client("testserv-watcher", "watcher")
+    await agent.send("JOIN #general")
+    await agent.recv_all(timeout=0.5)  # drain JOIN ack + bot JOIN
+
+    # Emit a matching event
+    await server.emit_event(
+        Event(
+            type=EventType.JOIN,
+            channel="#general",
+            nick="testserv-joiner",
+            data={"nick": "testserv-joiner"},
+        )
+    )
+
+    lines = await agent.recv_all(timeout=0.5)
+    assert any(
+        "User joined: testserv-joiner" in line for line in lines
+    ), f"Expected bot message not in lines: {lines}"
+
+
+# ---------------------------------------------------------------------------
+# test_filter_mismatch_does_not_fire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_mismatch_does_not_fire(server_with_bot, make_client):
+    """When the filter doesn't match, the bot must not post anything."""
+    server, cfg = server_with_bot(
+        bot_name="testserv-silent-bot",
+        trigger_type="event",
+        event_filter="channel == '#restricted'",
+        channels=["#general"],
+        template="Triggered: {event.nick}",
+    )
+
+    agent = await make_client("testserv-spy", "spy")
+    await agent.send("JOIN #general")
+    await agent.recv_all(timeout=0.5)
+
+    # Emit an event whose channel does NOT match the filter
+    await server.emit_event(
+        Event(
+            type=EventType.JOIN,
+            channel="#other",
+            nick="testserv-nobody",
+            data={"nick": "testserv-nobody"},
+        )
+    )
+
+    lines = await agent.recv_all(timeout=0.4)
+    assert not any("Triggered:" in line for line in lines), f"Bot fired unexpectedly: {lines}"
+
+
+# ---------------------------------------------------------------------------
+# test_bad_filter_rejected_at_load
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bad_filter_rejected_at_load(server):
+    """A malformed filter expression raises ValueError when the bot is registered."""
+    from culture.bots.bot_manager import BotManager
+    from culture.bots.config import BotConfig
+
+    mgr = BotManager(server=server)
+    cfg = BotConfig(
+        name="testserv-badfilter-bot",
+        owner="testserv",
+        trigger_type="event",
+        event_filter="type == (",  # deliberately malformed
+        channels=[],
+    )
+
+    with pytest.raises(ValueError, match="invalid filter"):
+        mgr.register_bot(cfg)

--- a/tests/test_events_bot_trigger.py
+++ b/tests/test_events_bot_trigger.py
@@ -3,8 +3,6 @@
 import pytest
 
 from culture.agentirc.skill import Event, EventType
-from culture.bots.bot_manager import BotManager
-from culture.bots.config import BotConfig
 
 # ---------------------------------------------------------------------------
 # test_event_triggered_bot_runs
@@ -14,7 +12,7 @@ from culture.bots.config import BotConfig
 @pytest.mark.asyncio
 async def test_event_triggered_bot_runs(server_with_bot, make_client):
     """A bot with trigger_type=event fires on a matching event and posts to channels."""
-    server, cfg = server_with_bot(
+    server, _ = server_with_bot(
         bot_name="testserv-evt-bot",
         trigger_type="event",
         event_filter="type == 'user.join'",
@@ -51,7 +49,7 @@ async def test_event_triggered_bot_runs(server_with_bot, make_client):
 @pytest.mark.asyncio
 async def test_filter_mismatch_does_not_fire(server_with_bot, make_client):
     """When the filter doesn't match, the bot must not post anything."""
-    server, cfg = server_with_bot(
+    server, _ = server_with_bot(
         bot_name="testserv-silent-bot",
         trigger_type="event",
         event_filter="channel == '#restricted'",

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.8.0"
+version = "6.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bots can now be triggered by mesh events via `trigger_type: event` with a filter DSL expression
- After handling, bots can emit follow-on events via `fires_event` for pub/sub composition chains
- Rate-limited to 10 events/sec per bot to prevent runaway loops
- `EmitEventSpec` dataclass for declarative event emission config
- `_DynamicEventType` wrapper for custom event types not in the EventType enum

## Changes

- **`culture/bots/config.py`** — Added `EmitEventSpec`, `event_filter` and `fires_event` fields to `BotConfig`, updated load/save
- **`culture/bots/bot_manager.py`** — Added `register_bot()` with filter compilation, `on_event()` dispatch with lazy bot start
- **`culture/bots/bot.py`** — Added `_maybe_fire_event()`, rate limiter, Jinja data value rendering
- **`culture/agentirc/ircd.py`** — Wired `bot_manager.on_event()` into `emit_event()` pipeline
- **`culture/bots/template_engine.py`** — Extended token regex to support `{event.nick}` patterns
- **`tests/conftest.py`** — Added `server_with_bot` and `server_with_bots` fixtures

## Test plan

- [x] `test_event_triggered_bot_runs` — bot fires on matching event
- [x] `test_filter_mismatch_does_not_fire` — wrong channel, bot stays silent
- [x] `test_bad_filter_rejected_at_load` — malformed filter raises ValueError
- [x] `test_bot_chain_fires_event` — bot A → custom event → bot B chain
- [x] Full suite (859 tests) passes with zero regressions

Part of #123 (mesh events). Depends on Task 14 (filter DSL, PR #243).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude