### PR TITLE
feat(events): system bots + welcome bot (Task 16 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.10.0] - 2026-04-17
+
+
+### Added
+
+- System bot infrastructure — discover and register package-bundled bots at startup
+- Welcome bot — greets users on channel join, disabled via server config
+
 ## [6.9.0] - 2026-04-17
 
 

--- a/culture/agentirc/config.py
+++ b/culture/agentirc/config.py
@@ -22,3 +22,4 @@ class ServerConfig:
     webhook_port: int = 7680
     data_dir: str = ""
     links: list[LinkConfig] = field(default_factory=list)
+    system_bots: dict = field(default_factory=dict)

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -81,7 +81,7 @@ class IRCd:
         logger.info("Loading bots...")
         self.bot_manager = BotManager(self)
         await self.bot_manager.load_bots()
-        await self.bot_manager.load_system_bots()
+        self.bot_manager.load_system_bots()
 
         logger.info(
             "Binding IRC socket on %s:%d...",

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -81,6 +81,7 @@ class IRCd:
         logger.info("Loading bots...")
         self.bot_manager = BotManager(self)
         await self.bot_manager.load_bots()
+        await self.bot_manager.load_system_bots()
 
         logger.info(
             "Binding IRC socket on %s:%d...",

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -128,52 +128,49 @@ class Bot:
         if not self.active or not self.virtual_client:
             raise RuntimeError(f"Bot {self.config.name} is not active")
 
-        # Try custom handler first
-        handler_path = BOTS_DIR / self.config.name / "handler.py"
-        if handler_path.is_file():
-            message = await self._run_custom_handler(handler_path, payload)
-            if message is None:
-                return ""  # Handler chose to drop this event
-        else:
-            message = self._render_message(payload)
-
+        message = await self._resolve_message(payload)
         if not message:
             return ""
 
-        # Prepend @mention if configured
         if self.config.mention:
             message = f"@{self.config.mention} {message}"
 
-        # Determine target channels: use configured channels, or fall back to
-        # the event's channel for event-triggered bots with no pre-configured channels.
-        target_channels = list(self.config.channels)
-        dynamic_broadcast = False
-        if not target_channels and self.config.trigger_type == "event":
-            event_ctx = payload.get("event", {})
-            event_channel = event_ctx.get("channel") if isinstance(event_ctx, dict) else None
-            if event_channel:
-                target_channels = [event_channel]
-                dynamic_broadcast = True
+        await self._deliver(message, payload)
+        await self._maybe_fire_event(payload)
+        return message
 
+    async def _resolve_message(self, payload: dict) -> str:
+        """Render the message from custom handler or template."""
+        handler_path = BOTS_DIR / self.config.name / "handler.py"
+        if handler_path.is_file():
+            result = await self._run_custom_handler(handler_path, payload)
+            return "" if result is None else result
+        return self._render_message(payload)
+
+    async def _deliver(self, message: str, payload: dict) -> None:
+        """Send message to channels and optionally DM the owner."""
+        target_channels, dynamic = self._resolve_channels(payload)
         for channel in target_channels:
-            if dynamic_broadcast:
-                # Broadcast directly without joining — avoids persistent channel
-                # presence and spurious user.join events for the bot itself.
+            if dynamic:
                 await self.virtual_client.broadcast_to_channel(channel, message)
             else:
                 ch_obj = self.server.channels.get(channel)
                 if ch_obj is None or self.virtual_client not in ch_obj.members:
                     await self.virtual_client.join_channel(channel)
                 await self.virtual_client.send_to_channel(channel, message)
-
-        # DM the owner if configured
         if self.config.dm_owner and self.config.owner:
             await self.virtual_client.send_dm(self.config.owner, message)
 
-        # Fire follow-on event if configured
-        await self._maybe_fire_event(payload)
-
-        return message
+    def _resolve_channels(self, payload: dict) -> tuple[list[str], bool]:
+        """Return (channels, is_dynamic) for message delivery."""
+        channels = list(self.config.channels)
+        if channels or self.config.trigger_type != "event":
+            return channels, False
+        event_ctx = payload.get("event", {})
+        event_channel = event_ctx.get("channel") if isinstance(event_ctx, dict) else None
+        if event_channel:
+            return [event_channel], True
+        return [], False
 
     async def _maybe_fire_event(self, payload: dict) -> None:
         """Emit a follow-on event if fires_event is configured on this bot."""

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -144,9 +144,27 @@ class Bot:
         if self.config.mention:
             message = f"@{self.config.mention} {message}"
 
-        # Send to configured channels
-        for channel in self.config.channels:
-            await self.virtual_client.send_to_channel(channel, message)
+        # Determine target channels: use configured channels, or fall back to
+        # the event's channel for event-triggered bots with no pre-configured channels.
+        target_channels = list(self.config.channels)
+        dynamic_broadcast = False
+        if not target_channels and self.config.trigger_type == "event":
+            event_ctx = payload.get("event", {})
+            event_channel = event_ctx.get("channel") if isinstance(event_ctx, dict) else None
+            if event_channel:
+                target_channels = [event_channel]
+                dynamic_broadcast = True
+
+        for channel in target_channels:
+            if dynamic_broadcast:
+                # Broadcast directly without joining — avoids persistent channel
+                # presence and spurious user.join events for the bot itself.
+                await self.virtual_client.broadcast_to_channel(channel, message)
+            else:
+                ch_obj = self.server.channels.get(channel)
+                if ch_obj is None or self.virtual_client not in ch_obj.members:
+                    await self.virtual_client.join_channel(channel)
+                await self.virtual_client.send_to_channel(channel, message)
 
         # DM the owner if configured
         if self.config.dm_owner and self.config.owner:

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -115,7 +115,7 @@ class BotManager:
             except Exception:
                 logger.exception("Bot %s handle() failed for event %s", cfg.name, event.type)
 
-    async def load_system_bots(self) -> None:
+    def load_system_bots(self) -> None:
         """Discover and register system bots from the package."""
         from culture.bots.system import discover_system_bots
 

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -126,6 +126,9 @@ class BotManager:
             if raw:
                 server_config = {"system_bots": raw}
         for cfg in discover_system_bots(server_name, server_config):
+            if cfg.name in self.bots:
+                logger.info("Skipping system bot %s — name already registered", cfg.name)
+                continue
             try:
                 self.register_bot(cfg)
             except Exception:

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -115,6 +115,22 @@ class BotManager:
             except Exception:
                 logger.exception("Bot %s handle() failed for event %s", cfg.name, event.type)
 
+    async def load_system_bots(self) -> None:
+        """Discover and register system bots from the package."""
+        from culture.bots.system import discover_system_bots
+
+        server_name = self.server.config.name if self.server else "unknown"
+        server_config = {}
+        if self.server:
+            raw = getattr(self.server.config, "system_bots", None)
+            if raw:
+                server_config = {"system_bots": raw}
+        for cfg in discover_system_bots(server_name, server_config):
+            try:
+                self.register_bot(cfg)
+            except Exception:
+                logger.exception("Failed to register system bot %s", cfg.name)
+
     async def create_bot(self, config: BotConfig) -> Bot:
         """Create a new bot: write config to disk and start it."""
         bot_dir = BOTS_DIR / config.name

--- a/culture/bots/system/__init__.py
+++ b/culture/bots/system/__init__.py
@@ -1,0 +1,36 @@
+"""System bot loader."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from culture.bots.config import load_bot_config
+from culture.constants import SYSTEM_USER_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+def discover_system_bots(server_name: str, config: dict | None = None) -> list:
+    """Return BotConfigs for enabled system bots."""
+    root = Path(__file__).parent
+    found = []
+    sb_config = (config or {}).get("system_bots", {})
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("_"):
+            continue
+        yaml_path = entry / "bot.yaml"
+        if not yaml_path.is_file():
+            continue
+        enabled = sb_config.get(entry.name, {}).get("enabled", True)
+        if not enabled:
+            continue
+        try:
+            cfg = load_bot_config(yaml_path)
+        except Exception:
+            logger.warning("Failed to load system bot %s", entry.name, exc_info=True)
+            continue
+        cfg.name = f"{SYSTEM_USER_PREFIX}{server_name}-{entry.name}"
+        cfg.owner = "system"
+        found.append(cfg)
+    return found

--- a/culture/bots/system/welcome/__init__.py
+++ b/culture/bots/system/welcome/__init__.py
@@ -1,0 +1,1 @@
+"""Welcome system bot."""

--- a/culture/bots/system/welcome/bot.yaml
+++ b/culture/bots/system/welcome/bot.yaml
@@ -1,0 +1,11 @@
+bot:
+  name: welcome
+  owner: system
+  description: Greets users joining any channel.
+
+trigger:
+  type: event
+  filter: "type == 'user.join'"
+
+output:
+  template: "Welcome {event.nick} to {event.channel}"

--- a/culture/bots/system/welcome/handler.py
+++ b/culture/bots/system/welcome/handler.py
@@ -1,0 +1,1 @@
+"""Welcome handler — template-only bot, no custom logic needed."""

--- a/culture/bots/virtual_client.py
+++ b/culture/bots/virtual_client.py
@@ -113,7 +113,6 @@ class VirtualClient:
 
         Unlike ``send_to_channel``, this method does not require the bot to be
         a member of the channel — it delivers directly to current members.
-        No MESSAGE event is emitted and no mention-notifications fire.
         Used by event-triggered bots with no pre-configured channels (e.g.
         the welcome bot) so they can respond to events without persistently
         occupying a channel.
@@ -132,6 +131,11 @@ class VirtualClient:
         for member in list(channel.members):
             if member is not self:
                 await member.send(relay)
+
+        await self.server.emit_event(
+            Event(type=EventType.MESSAGE, channel=channel_name, nick=self.nick, data={"text": text})
+        )
+        await self._notify_mentions(channel_name, text)
 
     async def send_to_channel(self, channel_name: str, text: str) -> None:
         """Post a PRIVMSG to a channel as this bot."""

--- a/culture/bots/virtual_client.py
+++ b/culture/bots/virtual_client.py
@@ -128,7 +128,8 @@ class VirtualClient:
             command="PRIVMSG",
             params=[channel_name, text],
         )
-        for member in list(channel.members):
+        members_snapshot = list(channel.members)
+        for member in members_snapshot:
             if member is not self:
                 await member.send(relay)
 

--- a/culture/bots/virtual_client.py
+++ b/culture/bots/virtual_client.py
@@ -44,8 +44,15 @@ class VirtualClient:
     async def send(self, message: Message) -> None:
         """No-op — bots don't receive messages from others."""
 
-    async def join_channel(self, channel_name: str) -> None:
-        """Join a channel, notify members, and emit events."""
+    async def join_channel(self, channel_name: str, *, emit_event: bool = True) -> None:
+        """Join a channel, notify members, and optionally emit events.
+
+        Args:
+            channel_name: The channel to join.
+            emit_event: If False, skip emitting a user.join event (e.g. for
+                silent dynamic joins by event-triggered bots to avoid
+                triggering other bots that filter on user.join).
+        """
         channel = self.server.get_or_create_channel(channel_name)
         if self in channel.members:
             return
@@ -65,9 +72,10 @@ class VirtualClient:
             if member is not self:
                 await member.send(join_msg)
 
-        await self.server.emit_event(
-            Event(type=EventType.JOIN, channel=channel_name, nick=self.nick)
-        )
+        if emit_event:
+            await self.server.emit_event(
+                Event(type=EventType.JOIN, channel=channel_name, nick=self.nick)
+            )
 
     async def part_channel(self, channel_name: str) -> None:
         """Leave a channel, notify members, and emit events."""
@@ -99,6 +107,31 @@ class VirtualClient:
 
         if not channel.members and not channel.persistent:
             del self.server.channels[channel_name]
+
+    async def broadcast_to_channel(self, channel_name: str, text: str) -> None:
+        """Post a PRIVMSG to a channel without joining it first.
+
+        Unlike ``send_to_channel``, this method does not require the bot to be
+        a member of the channel — it delivers directly to current members.
+        No MESSAGE event is emitted and no mention-notifications fire.
+        Used by event-triggered bots with no pre-configured channels (e.g.
+        the welcome bot) so they can respond to events without persistently
+        occupying a channel.
+        """
+        text = _sanitize_irc_text(text)
+        channel = self.server.channels.get(channel_name)
+        if channel is None:
+            logger.warning("Bot %s: channel %s not found for broadcast", self.nick, channel_name)
+            return
+
+        relay = Message(
+            prefix=self.prefix,
+            command="PRIVMSG",
+            params=[channel_name, text],
+        )
+        for member in list(channel.members):
+            if member is not self:
+                await member.send(relay)
 
     async def send_to_channel(self, channel_name: str, text: str) -> None:
         """Post a PRIVMSG to a channel as this bot."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ packages = ["culture"]
 "culture/clients/acp/skill/SKILL.md" = "culture/clients/acp/skill/SKILL.md"
 "culture/skills/culture/SKILL.md" = "culture/skills/culture/SKILL.md"
 "culture/overview/web/style.css" = "culture/overview/web/style.css"
+"culture/bots/system/welcome/bot.yaml" = "culture/bots/system/welcome/bot.yaml"
 
 [project.optional-dependencies]
 copilot = ["github-copilot-sdk"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.9.0"
+version = "6.10.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ TEST_LINK_PASSWORD = "testlink123"
 # call rather than passing a parameter (per python:S7483).
 RECV_TIMEOUT_SECONDS = 2.0
 
+_BOTS_DIR_MANAGER = "culture.bots.bot_manager.BOTS_DIR"
+_BOTS_DIR_CONFIG = "culture.bots.config.BOTS_DIR"
+_BOTS_DIR_BOT = "culture.bots.bot.BOTS_DIR"
+
 
 class IRCTestClient:
     """A minimal IRC test client over raw TCP."""
@@ -92,9 +96,9 @@ async def server(tmp_path):
     empty_bots.mkdir()
     config = ServerConfig(name="testserv", host="127.0.0.1", port=0, webhook_port=0)
     with (
-        patch("culture.bots.bot_manager.BOTS_DIR", empty_bots),
-        patch("culture.bots.config.BOTS_DIR", empty_bots),
-        patch("culture.bots.bot.BOTS_DIR", empty_bots),
+        patch(_BOTS_DIR_MANAGER, empty_bots),
+        patch(_BOTS_DIR_CONFIG, empty_bots),
+        patch(_BOTS_DIR_BOT, empty_bots),
     ):
         ircd = IRCd(config)
         await ircd.start()
@@ -156,9 +160,9 @@ async def linked_servers(tmp_path):
     server_b = IRCd(config_b)
 
     with (
-        patch("culture.bots.bot_manager.BOTS_DIR", empty_bots),
-        patch("culture.bots.config.BOTS_DIR", empty_bots),
-        patch("culture.bots.bot.BOTS_DIR", empty_bots),
+        patch(_BOTS_DIR_MANAGER, empty_bots),
+        patch(_BOTS_DIR_CONFIG, empty_bots),
+        patch(_BOTS_DIR_BOT, empty_bots),
     ):
         await server_a.start()
         await server_b.start()
@@ -251,9 +255,9 @@ async def server_welcome_disabled(tmp_path):
         system_bots={"welcome": {"enabled": False}},
     )
     with (
-        patch("culture.bots.bot_manager.BOTS_DIR", empty_bots),
-        patch("culture.bots.config.BOTS_DIR", empty_bots),
-        patch("culture.bots.bot.BOTS_DIR", empty_bots),
+        patch(_BOTS_DIR_MANAGER, empty_bots),
+        patch(_BOTS_DIR_CONFIG, empty_bots),
+        patch(_BOTS_DIR_BOT, empty_bots),
     ):
         ircd = IRCd(config)
         await ircd.start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,6 +239,30 @@ async def make_client_b(linked_servers):
 
 
 @pytest_asyncio.fixture
+async def server_welcome_disabled(tmp_path):
+    """Server instance with the welcome system bot disabled via config."""
+    empty_bots = tmp_path / "_bots"
+    empty_bots.mkdir()
+    config = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        webhook_port=0,
+        system_bots={"welcome": {"enabled": False}},
+    )
+    with (
+        patch("culture.bots.bot_manager.BOTS_DIR", empty_bots),
+        patch("culture.bots.config.BOTS_DIR", empty_bots),
+        patch("culture.bots.bot.BOTS_DIR", empty_bots),
+    ):
+        ircd = IRCd(config)
+        await ircd.start()
+        ircd.config.port = ircd._server.sockets[0].getsockname()[1]
+        yield ircd
+        await ircd.stop()
+
+
+@pytest_asyncio.fixture
 async def server_with_bot(server):
     from culture.bots.bot_manager import BotManager
     from culture.bots.config import BotConfig

--- a/tests/test_events_basic.py
+++ b/tests/test_events_basic.py
@@ -33,13 +33,17 @@ async def test_event_nick_from_event_field_populates_payload(server, make_client
     )
     await server.emit_event(ev)
 
-    line = await c.recv_until("event=user.join")
-    assert "testserv-bob joined" in line  # template rendered actor
-    # Decode payload and confirm 'nick' was populated from Event.nick
-    at_idx = line.find("@")
-    space_idx = line.find(" ", at_idx)
-    tag_blob = line[at_idx + 1 : space_idx]
-    data_piece = [p for p in tag_blob.split(";") if p.startswith("event-data=")][0]
+    collected = await c.recv_until("event=user.join")
+    assert "testserv-bob joined" in collected  # template rendered actor
+    # Find the tagged system PRIVMSG line among potentially multiple received lines.
+    # Bots may also send untagged PRIVMSGs to the channel around the same time.
+    tagged_line = next(
+        (ln for ln in collected.split("\r\n") if ln.startswith("@") and "event=user.join" in ln),
+        None,
+    )
+    assert tagged_line is not None, f"Could not find tagged event line in: {collected!r}"
+    tags = tagged_line.split(" ", 1)[0][1:]  # strip leading @
+    data_piece = [p for p in tags.split(";") if p.startswith("event-data=")][0]
     decoded = json.loads(base64.b64decode(data_piece.split("=", 1)[1]))
     assert decoded["nick"] == "testserv-bob"
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -50,10 +50,14 @@ async def test_skill_receives_message_event(server, make_client):
     await bob.recv()  # get the message
     await asyncio.sleep(0.05)
 
-    msg_events = [e for e in skill.events if e.type == EventType.MESSAGE]
+    # Filter to the specific message alice sent (system bots may also emit
+    # MESSAGE events for welcome messages when users join).
+    msg_events = [
+        e
+        for e in skill.events
+        if e.type == EventType.MESSAGE and e.nick == "testserv-alice" and e.channel == "#test"
+    ]
     assert len(msg_events) == 1
-    assert msg_events[0].channel == "#test"
-    assert msg_events[0].nick == "testserv-alice"
     assert msg_events[0].data["text"] == "hello world"
 
 

--- a/tests/test_welcome_bot.py
+++ b/tests/test_welcome_bot.py
@@ -1,0 +1,87 @@
+"""Tests for the welcome system bot."""
+
+import asyncio
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+from tests.conftest import IRCTestClient
+
+# ---------------------------------------------------------------------------
+# test_welcome_bot_greets_on_join
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_welcome_bot_greets_on_join(server, make_client):
+    """Welcome bot greets a user when they join a channel."""
+    # Ensure the server has a welcome system bot loaded
+    welcome_nick = f"system-{server.config.name}-welcome"
+    bot = server.bot_manager.bots.get(welcome_nick)
+    assert bot is not None, (
+        f"Expected system bot {welcome_nick!r} to be registered. "
+        f"Registered bots: {list(server.bot_manager.bots)}"
+    )
+
+    # Connect a watcher who will receive the greeting
+    watcher = await make_client("testserv-watcher", "watcher")
+    await watcher.send("JOIN #lobby")
+    await watcher.recv_all(timeout=0.5)  # drain welcome/JOIN messages
+
+    # Emit a user.join event for the channel
+    await server.emit_event(
+        Event(
+            type=EventType.JOIN,
+            channel="#lobby",
+            nick="testserv-newbie",
+            data={"nick": "testserv-newbie"},
+        )
+    )
+
+    lines = await watcher.recv_all(timeout=1.0)
+    greeting = "Welcome testserv-newbie to #lobby"
+    assert any(
+        greeting in line for line in lines
+    ), f"Expected greeting {greeting!r} not found in lines: {lines}"
+
+
+# ---------------------------------------------------------------------------
+# test_welcome_bot_disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_welcome_bot_disabled(server_welcome_disabled):
+    """When welcome bot is disabled via config, it is not registered."""
+    server = server_welcome_disabled
+    welcome_nick = f"system-{server.config.name}-welcome"
+    bot = server.bot_manager.bots.get(welcome_nick)
+    assert (
+        bot is None
+    ), f"Expected welcome bot to be absent when disabled, but found: {welcome_nick!r}"
+
+    # Connect a watcher directly to this server, emit a join — no greeting should arrive
+    reader, writer = await asyncio.open_connection("127.0.0.1", server.config.port)
+    watcher = IRCTestClient(reader, writer)
+    try:
+        await watcher.send("NICK testserv-watcher2")
+        await watcher.send("USER watcher2 0 * :watcher2")
+        await watcher.recv_all(timeout=0.5)  # drain welcome messages
+        await watcher.send("JOIN #lobby")
+        await watcher.recv_all(timeout=0.5)
+
+        await server.emit_event(
+            Event(
+                type=EventType.JOIN,
+                channel="#lobby",
+                nick="testserv-ghost",
+                data={"nick": "testserv-ghost"},
+            )
+        )
+
+        lines = await watcher.recv_all(timeout=0.5)
+        assert not any(
+            "Welcome testserv-ghost" in line for line in lines
+        ), f"Greeting should not appear when bot is disabled. Lines: {lines}"
+    finally:
+        await watcher.close()

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.9.0"
+version = "6.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- System bot infrastructure: package-bundled bots discovered at startup from `culture/bots/system/<name>/bot.yaml`
- Welcome bot reference implementation: greets users on `user.join` with `broadcast_to_channel()` (no persistent channel presence)
- System bots enabled by default, disabled via `server.config.system_bots.<name>.enabled: false`
- Nick convention: `system-<servername>-<botname>` (e.g., `system-spark-welcome`)

## Changes

- **`culture/bots/system/__init__.py`** — `discover_system_bots()` loader
- **`culture/bots/system/welcome/`** — bot.yaml + handler.py (template-only)
- **`culture/bots/bot_manager.py`** — `load_system_bots()` method
- **`culture/agentirc/ircd.py`** — calls `load_system_bots()` after `load_bots()`
- **`culture/agentirc/config.py`** — `system_bots: dict` field on `ServerConfig`
- **`culture/bots/bot.py`** — event-triggered bots with no channels use `broadcast_to_channel()`
- **`culture/bots/virtual_client.py`** — `broadcast_to_channel()` + `emit_event` param on `join_channel()`

## Test plan

- [x] `test_welcome_bot_greets_on_join` — welcome bot greets on user.join
- [x] `test_welcome_bot_disabled` — no greeting when disabled via config
- [x] Full suite (861 tests) passes with zero regressions
- [x] Pre-commit hooks clean

Part of #123 (mesh events). Depends on Task 15 (PR #244).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude