### PR TITLE
feat(events): IRCv3 message-tags CAP in all backends (Task 17 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.11.0] - 2026-04-17
+
+
+### Added
+
+- IRCv3 message-tags CAP negotiation in all agent backends (claude, codex, copilot, acp, agent-harness)
+
 ## [6.10.0] - 2026-04-17
 
 

--- a/culture/clients/acp/irc_transport.py
+++ b/culture/clients/acp/irc_transport.py
@@ -69,8 +69,10 @@ class IRCTransport:
                 f"Cannot connect to IRC server at {self.host}:{self.port} "
                 f"- is the server running?"
             ) from exc
+        await self._send_raw("CAP REQ :message-tags")
         await self._send_raw(f"NICK {self.nick}")
         await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+        await self._send_raw("CAP END")
         self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:

--- a/culture/clients/claude/irc_transport.py
+++ b/culture/clients/claude/irc_transport.py
@@ -69,8 +69,10 @@ class IRCTransport:
                 f"Cannot connect to IRC server at {self.host}:{self.port} "
                 f"- is the server running?"
             ) from exc
+        await self._send_raw("CAP REQ :message-tags")
         await self._send_raw(f"NICK {self.nick}")
         await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+        await self._send_raw("CAP END")
         self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:

--- a/culture/clients/codex/irc_transport.py
+++ b/culture/clients/codex/irc_transport.py
@@ -69,8 +69,10 @@ class IRCTransport:
                 f"Cannot connect to IRC server at {self.host}:{self.port} "
                 f"- is the server running?"
             ) from exc
+        await self._send_raw("CAP REQ :message-tags")
         await self._send_raw(f"NICK {self.nick}")
         await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+        await self._send_raw("CAP END")
         self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:

--- a/culture/clients/copilot/irc_transport.py
+++ b/culture/clients/copilot/irc_transport.py
@@ -69,8 +69,10 @@ class IRCTransport:
                 f"Cannot connect to IRC server at {self.host}:{self.port} "
                 f"- is the server running?"
             ) from exc
+        await self._send_raw("CAP REQ :message-tags")
         await self._send_raw(f"NICK {self.nick}")
         await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+        await self._send_raw("CAP END")
         self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -69,8 +69,10 @@ class IRCTransport:
                 f"Cannot connect to IRC server at {self.host}:{self.port} "
                 f"- is the server running?"
             ) from exc
+        await self._send_raw("CAP REQ :message-tags")
         await self._send_raw(f"NICK {self.nick}")
         await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+        await self._send_raw("CAP END")
         self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.10.0"
+version = "6.11.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_irc_transport_tags.py
+++ b/tests/test_irc_transport_tags.py
@@ -26,12 +26,12 @@ def test_message_parse_no_tags():
 
 
 @pytest.mark.asyncio
-async def test_transport_cap_req_sent_before_nick(server, make_client):
-    """Transport sends CAP REQ :message-tags before NICK/USER so that the
-    server ACKs the capability and thereafter sends tagged lines.
+async def test_transport_negotiates_message_tags(server, make_client):
+    """Transport negotiates message-tags capability during connection.
 
-    We verify this indirectly: after a transport connects and joins, an
-    emitted event PRIVMSG must arrive with an @tag prefix.
+    After a real IRCTransport connects, the server-side client object
+    should have 'message-tags' in its caps set, proving the CAP handshake
+    completed successfully.
     """
     from culture.agentirc.skill import Event, EventType
     from culture.clients.claude.irc_transport import IRCTransport
@@ -85,6 +85,7 @@ async def test_transport_receives_tagged_events(server, make_client):
     # Connect a tag-capable client via the raw test helper
     agent = await make_client("testserv-tagrcv", "tagrcv")
     await agent.send("CAP REQ :message-tags")
+    await agent.send("CAP END")
     await agent.recv_all(timeout=0.5)
     await agent.send("JOIN #test-tags")
     await agent.recv_all(timeout=0.5)

--- a/tests/test_irc_transport_tags.py
+++ b/tests/test_irc_transport_tags.py
@@ -1,0 +1,104 @@
+"""All-backends IRCv3 tag parsing smoke test — Task 17."""
+
+import asyncio
+
+import pytest
+
+from culture.protocol.message import Message
+
+
+def test_message_parse_extracts_tags():
+    """Message.parse() correctly extracts IRCv3 tags — shared by all transports."""
+    line = "@event=user.join;event-data=eyJuaWNrIjoib3JpIn0= :system-spark!system@spark PRIVMSG #general :ori joined"
+    msg = Message.parse(line)
+    assert msg.tags.get("event") == "user.join"
+    assert "event-data" in msg.tags
+    assert msg.command == "PRIVMSG"
+    assert msg.params == ["#general", "ori joined"]
+
+
+def test_message_parse_no_tags():
+    """Lines without tags still parse correctly."""
+    line = ":nick!user@host PRIVMSG #channel :hello"
+    msg = Message.parse(line)
+    assert msg.tags == {}
+    assert msg.command == "PRIVMSG"
+
+
+@pytest.mark.asyncio
+async def test_transport_cap_req_sent_before_nick(server, make_client):
+    """Transport sends CAP REQ :message-tags before NICK/USER so that the
+    server ACKs the capability and thereafter sends tagged lines.
+
+    We verify this indirectly: after a transport connects and joins, an
+    emitted event PRIVMSG must arrive with an @tag prefix.
+    """
+    from culture.agentirc.skill import Event, EventType
+    from culture.clients.claude.irc_transport import IRCTransport
+    from culture.clients.claude.message_buffer import MessageBuffer
+
+    buf = MessageBuffer()
+    transport = IRCTransport(
+        host="127.0.0.1",
+        port=server.config.port,
+        nick="testserv-tagtest",
+        user="tagtest",
+        channels=["#test-tags"],
+        buffer=buf,
+    )
+    await transport.connect()
+    try:
+        # Give the transport time to finish the welcome sequence and join
+        await asyncio.sleep(0.4)
+        assert transport.connected, "Transport did not connect"
+        assert "testserv-tagtest" in server.clients
+
+        # Emit an event that the server will surface as a tagged PRIVMSG
+        ev = Event(
+            type=EventType.JOIN,
+            channel="#test-tags",
+            nick="testserv-visitor",
+            data={"nick": "testserv-visitor"},
+        )
+        await server.emit_event(ev)
+
+        # Give the transport time to receive the event line
+        await asyncio.sleep(0.3)
+
+        # The server should have sent tagged lines to this client because it
+        # negotiated CAP REQ :message-tags during _do_connect()
+        server_client = server.clients.get("testserv-tagtest")
+        assert server_client is not None
+        assert "message-tags" in server_client.caps, (
+            "Transport did not negotiate message-tags CAP — "
+            "CAP REQ :message-tags was not sent before NICK/USER"
+        )
+    finally:
+        await transport.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_transport_receives_tagged_events(server, make_client):
+    """A raw IRCTestClient that REQs message-tags receives tagged event PRIVMSGs."""
+    from culture.agentirc.skill import Event, EventType
+
+    # Connect a tag-capable client via the raw test helper
+    agent = await make_client("testserv-tagrcv", "tagrcv")
+    await agent.send("CAP REQ :message-tags")
+    await agent.recv_all(timeout=0.5)
+    await agent.send("JOIN #test-tags")
+    await agent.recv_all(timeout=0.5)
+
+    # Emit an event that surfaces as tagged PRIVMSG
+    ev = Event(
+        type=EventType.JOIN,
+        channel="#test-tags",
+        nick="testserv-visitor",
+        data={"nick": "testserv-visitor"},
+    )
+    await server.emit_event(ev)
+
+    lines = await agent.recv_all(timeout=0.5)
+    tagged = [line for line in lines if line.startswith("@")]
+    assert tagged, f"Expected tagged line but got: {lines}"
+    assert "event=user.join" in tagged[0]

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.10.0"
+version = "6.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- All 5 agent transports now negotiate `CAP REQ :message-tags` during connection
- Server sends IRCv3-tagged lines to tag-capable clients (event type + base64 payload)
- `Message.parse()` already extracts tags (Task 2) — this completes the all-backends rule

## Changes

Identical 2-line change across all 5 transports (`_do_connect()`):
- `packages/agent-harness/irc_transport.py` (reference)
- `culture/clients/claude/irc_transport.py`
- `culture/clients/codex/irc_transport.py`
- `culture/clients/copilot/irc_transport.py`
- `culture/clients/acp/irc_transport.py`

## Test plan

- [x] `test_message_parse_extracts_tags` — IRCv3 tags parsed correctly
- [x] `test_message_parse_no_tags` — tagless lines still parse
- [x] `test_cap_client_receives_tagged_events` — tag-capable client sees `@event=` prefix
- [x] `test_non_cap_client_gets_plain_privmsg` — non-CAP client gets clean body
- [x] Full suite (865 tests) passes with zero regressions

Part of #123 (mesh events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude