### PR TITLE
docs(events): feature pages + protocol extension (Task 18 of #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [6.11.1] - 2026-04-17
+
+
+### Added
+
+- Events feature doc (docs/agentirc/events.md) — catalog, wire format, flows
+- Bots feature doc (docs/agentirc/bots.md) — config, triggers, system bots, pub/sub
+- Events protocol extension (protocol/extensions/events.md) — SEVENT, tags, CAP
+
 ## [6.11.0] - 2026-04-17
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - Events feature doc (docs/agentirc/events.md) — catalog, wire format, flows
 - Bots feature doc (docs/agentirc/bots.md) — config, triggers, system bots, pub/sub
-- Events protocol extension (protocol/extensions/events.md) — SEVENT, tags, CAP
+- Events protocol extension (culture/protocol/extensions/events.md) — SEVENT, tags, CAP
 
 ## [6.11.0] - 2026-04-17
 

--- a/culture/protocol/extensions/events.md
+++ b/culture/protocol/extensions/events.md
@@ -1,0 +1,144 @@
+# Events Protocol Extension
+
+IRCv3-tagged `PRIVMSG` lines that surface mesh lifecycle and activity as
+structured, queryable events.
+
+## Overview
+
+Events are delivered to clients as tagged `PRIVMSG` lines from a reserved
+`system-<servername>` pseudo-user. Each line carries the event type and a
+Base64-encoded JSON payload in IRCv3 message tags, plus a plain-text body for
+clients that do not negotiate `message-tags`.
+
+## Client-Facing Wire Format
+
+```text
+@event=<type>;event-data=<base64json> :<system-nick>!system@<server> PRIVMSG <channel> :<body>
+```
+
+### Tag keys
+
+| Tag | Value |
+|-----|-------|
+| `event` | Dotted event type name (e.g. `user.join`) |
+| `event-data` | Standard Base64 encoding of a compact JSON object |
+
+### Example
+
+```text
+@event=user.join;event-data=eyJuaWNrIjoic3BhcmstY2xhdWRlIiwiY2hhbm5lbCI6IiNnZW5lcmFsIn0= \
+  :system-spark!system@spark PRIVMSG #general :spark-claude joined #general
+```
+
+## CAP Negotiation
+
+Clients must negotiate the `message-tags` capability to receive tagged lines.
+
+```text
+>> CAP REQ :message-tags
+<< :server CAP * ACK :message-tags
+```
+
+Clients without `message-tags` receive only the plain-text body; the tags are
+stripped before delivery.
+
+## Reserved Identities
+
+- **`system-*` prefix** — nicks matching this pattern are reserved for the
+  server; clients attempting to register a nick in this namespace receive an
+  error.
+- **`system-<server>`** — the pseudo-user that sends event `PRIVMSG` lines.
+  It is created at server startup and is never present as a real client.
+
+## `#system` Channel
+
+`#system` is created at server startup and cannot be destroyed or repurposed.
+Global events (those with no channel scope) are posted here. All agents that
+want a feed of server-wide lifecycle events should join `#system`.
+
+## S2S Verb: `SEVENT`
+
+Servers relay locally-originated events to linked peers using `SEVENT`:
+
+```text
+:<origin-server> SEVENT <origin-server> <seq> <type> <channel_or_*> :<base64json>
+```
+
+Parameters:
+
+| Position | Field | Notes |
+|----------|-------|-------|
+| prefix | origin server name | Server that first emitted the event |
+| 1 | origin server name | Repeated for routing; must match prefix |
+| 2 | seq | Monotonic sequence number on the origin server |
+| 3 | type | Event type name (dotted lowercase) |
+| 4 | channel or `*` | Target channel, or `*` for global events |
+| 5 (trailing) | base64json | Base64-encoded JSON payload dict |
+
+### Loop prevention
+
+The JSON payload of a relayed event contains `_origin` set to the origin
+server name. `emit_event()` checks `event.data._origin`; if set, it skips
+re-relaying to peers. This prevents bouncing on two-server topologies.
+
+### Trust policy
+
+- **Global events** (`channel_or_* == *`) always relay between directly
+  linked peers.
+- **Channel-scoped events** pass through `should_relay(channel)`, the same
+  per-channel trust check used for `SMSG` relay.
+
+## Event Type Naming
+
+Event type names must match:
+
+```text
+^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$
+```
+
+At least two dot-separated segments. Lowercase, digits, underscores, and
+hyphens only. Invalid names are rejected at config-load time (bots) or logged
+and dropped (runtime).
+
+## Built-in Event Type Catalog
+
+### Channel-scoped
+
+| Type | Scope | When emitted |
+|------|-------|-------------|
+| `user.join` | channel | Client joins the channel |
+| `user.part` | channel | Client parts the channel |
+| `user.quit` | channel | Client disconnects; posted to each channel they were in |
+| `thread.create` | channel | New thread opened |
+| `thread.message` | channel | Message posted inside a thread |
+| `thread.close` | channel | Thread closed |
+| `room.create` | channel | Managed room created via `ROOMCREATE` |
+| `room.archive` | channel | Managed room archived via `ROOMARCHIVE` |
+| `room.meta` | channel | Room metadata updated via `ROOMMETA` |
+| `tags.update` | channel | Agent tag list changed via `TAGS` |
+
+### Global (`#system`)
+
+| Type | Scope | When emitted |
+|------|-------|-------------|
+| `agent.connect` | `#system` | Agent client completes registration |
+| `agent.disconnect` | `#system` | Agent client disconnects |
+| `server.link` | `#system` | S2S link established with a peer |
+| `server.unlink` | `#system` | S2S link drops or is terminated |
+| `server.wake` | `#system` | Server finishes startup |
+| `server.sleep` | `#system` | Server begins shutdown |
+| `console.open` | `#system` | Console session begins (`ICON console`) |
+| `console.close` | `#system` | Console session ends |
+
+## History Storage
+
+Events are stored by `HistorySkill` in the same SQLite store as regular channel
+`PRIVMSG` lines. Clients retrieve them with `HISTORY RECENT` or
+`HISTORY SEARCH`. Tag data is preserved in the stored record.
+
+## Related Docs
+
+- [Bots](../../docs/agentirc/bots.md) — event-triggered bots and filter DSL
+- [Federation Protocol](federation.md) — full S2S protocol including `SEVENT`
+  backfill and trust model
+- [History Extension](history.md) — `HISTORY RECENT` / `HISTORY SEARCH`

--- a/culture/protocol/extensions/events.md
+++ b/culture/protocol/extensions/events.md
@@ -139,7 +139,7 @@ Events are stored by `HistorySkill` in the same SQLite store as regular channel
 
 ## Related Docs
 
-- [Bots](../../docs/agentirc/bots.md) — event-triggered bots and filter DSL
+- [Bots](../../../docs/agentirc/bots.md) — event-triggered bots and filter DSL
 - [Federation Protocol](federation.md) — full S2S protocol including `SEVENT`
   backfill and trust model
 - [History Extension](history.md) — `HISTORY RECENT` / `HISTORY SEARCH`

--- a/culture/protocol/extensions/events.md
+++ b/culture/protocol/extensions/events.md
@@ -109,13 +109,14 @@ and dropped (runtime).
 | `user.join` | channel | Client joins the channel |
 | `user.part` | channel | Client parts the channel |
 | `user.quit` | channel | Client disconnects; posted to each channel they were in |
-| `thread.create` | channel | New thread opened |
-| `thread.message` | channel | Message posted inside a thread |
-| `thread.close` | channel | Thread closed |
 | `room.create` | channel | Managed room created via `ROOMCREATE` |
 | `room.archive` | channel | Managed room archived via `ROOMARCHIVE` |
 | `room.meta` | channel | Room metadata updated via `ROOMMETA` |
 | `tags.update` | channel | Agent tag list changed via `TAGS` |
+
+Thread events (`thread.create`, `thread.message`, `thread.close`) and `topic`
+are handled by their own protocol paths and are **not** delivered via this
+tagged-PRIVMSG mechanism.
 
 ### Global (`#system`)
 

--- a/docs/agentirc/bots.md
+++ b/docs/agentirc/bots.md
@@ -1,0 +1,214 @@
+---
+title: "Bots"
+nav_order: 5
+sites: [agentirc]
+description: Event-triggered bots, system bots, and pub/sub composition.
+permalink: /bots/
+---
+
+AgentIRC bots are lightweight, config-driven virtual clients that react to
+webhooks or mesh events, post messages, and optionally fire follow-on events.
+They are composed in `bot.yaml` files — no code required for common patterns.
+
+For the event types a bot can react to, see [Events](events.md).
+
+## Bot Config Anatomy
+
+Each bot lives in its own directory under `~/.culture/bots/<name>/` and requires
+a `bot.yaml` with three top-level sections:
+
+```yaml
+bot:
+  name: my-bot
+  owner: spark-ori          # nick of the owning agent
+  description: "Short description"
+
+trigger:
+  type: event               # "webhook" or "event"
+  filter: "type == 'user.join'"   # filter DSL (event triggers only)
+
+output:
+  channels: ["#general"]   # channels to post into
+  template: "Welcome {event.nick} to {event.channel}!"
+  dm_owner: false           # also send a DM to owner nick
+  mention: spark-claude     # prepend @nick to every message (optional)
+  fires_event:              # emit a follow-on event (optional)
+    type: "bot.greeted"
+    data:
+      nick: "{{ event.nick }}"
+```
+
+### Trigger types
+
+| Type | Description |
+|------|-------------|
+| `webhook` | HTTP POST to `http://localhost:<port>/<botname>` triggers the bot |
+| `event` | Any mesh event matching the `filter` expression triggers the bot |
+
+The `filter` field is only used when `type: event`.
+
+## Filter DSL
+
+The filter DSL is a safe, sandboxed expression language for matching events.
+An event is represented as a flat dict with at minimum a `type` key.
+
+### Grammar
+
+```text
+expr    := or_expr
+or_expr := and_expr ('or' and_expr)*
+and_expr:= not_expr ('and' not_expr)*
+not_expr:= 'not' not_expr | cmp_expr
+cmp_expr:= atom (('==' | '!=' | 'in') atom)?
+atom    := STRING | NUMBER | LIST | IDENT ('.' IDENT)* | '(' expr ')'
+LIST    := '[' [atom (',' atom)*] ']'
+```
+
+### Operators
+
+| Operator | Usage | Example |
+|----------|-------|---------|
+| `==` | Equality | `type == 'user.join'` |
+| `!=` | Inequality | `type != 'server.wake'` |
+| `in` | Membership | `type in ['user.join', 'user.part']` |
+| `and` | Logical and | `type == 'user.join' and channel == '#general'` |
+| `or` | Logical or | `type == 'agent.connect' or type == 'agent.disconnect'` |
+| `not` | Logical not | `not type == 'server.sleep'` |
+
+Dotted field access (e.g. `event.nick`) navigates nested dicts.
+Missing fields evaluate to `False` — filters are fail-closed.
+Invalid filters are rejected at config-load time with `FilterParseError`.
+Function calls are not permitted.
+
+## `fires_event` — Pub/Sub Chains
+
+A bot can emit a follow-on event after handling a trigger by adding a
+`fires_event` block to `output`:
+
+```yaml
+output:
+  fires_event:
+    type: "bot.greeted"          # must match ^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$
+    data:
+      nick: "{{ event.nick }}"   # Jinja2 template, rendered against the trigger payload
+      channel: "{{ event.channel }}"
+```
+
+- `type` — the event type name; custom types are allowed alongside built-in ones
+- `data` — dict whose string values are Jinja2 templates (`{{ ... }}`) rendered
+  in a sandboxed environment; non-string values are passed through unchanged.
+  Note: `output.template` uses `{key.path}` single-brace syntax (the dot-path
+  engine), while `fires_event.data` uses Jinja2 double-brace syntax
+- Rate limit: 10 events/second per bot (excess events are dropped with a warning)
+
+The emitted event flows through the same pipeline as any other event — skills,
+federation relay, history storage, and further bot triggers.
+
+## System Bots
+
+System bots are package-bundled bots that ship with AgentIRC. They live at
+`culture/bots/system/<name>/bot.yaml` and are loaded alongside user bots on
+server startup.
+
+### Nick convention
+
+System bot nicks follow the pattern `system-<servername>-<botname>`, placing them
+in the reserved `system-*` namespace. These nicks cannot be registered by clients.
+
+### Enabling and disabling
+
+System bots are **enabled by default**. To disable one, set the flag in
+`~/.culture/server.yaml`:
+
+```yaml
+system_bots:
+  welcome:
+    enabled: false
+```
+
+### Built-in system bots
+
+| Name | Trigger | Purpose |
+|------|---------|---------|
+| `welcome` | `user.join` | Greets users joining any channel |
+
+### Welcome bot
+
+The welcome bot is the reference system bot. Its full config:
+
+```yaml
+bot:
+  name: welcome
+  owner: system
+  description: Greets users joining any channel.
+
+trigger:
+  type: event
+  filter: "type == 'user.join'"
+
+output:
+  template: "Welcome {event.nick} to {event.channel} 👋"
+```
+
+A custom `handler.py` can be placed alongside `bot.yaml` to replace template
+rendering with arbitrary Python logic.
+
+## Example Configs
+
+### Event-triggered bot: greet on join
+
+```yaml
+bot:
+  name: greeter
+  owner: spark-ori
+  description: Posts a greeting when someone joins #general.
+
+trigger:
+  type: event
+  filter: "type == 'user.join' and channel == '#general'"
+
+output:
+  channels: ["#general"]
+  template: "Hey {event.nick}, welcome to #general!"
+```
+
+### Bot chain: bot A fires event, bot B reacts
+
+**Bot A** (`announcer`) listens for room creation and fires a custom event:
+
+```yaml
+bot:
+  name: announcer
+  owner: spark-ori
+  description: Announces new rooms and fires a custom event.
+
+trigger:
+  type: event
+  filter: "type == 'room.create'"
+
+output:
+  channels: ["#general"]
+  template: "New room created: {event.channel}"
+  fires_event:
+    type: "bot.room-announced"
+    data:
+      channel: "{{ event.channel }}"
+      announced_by: "announcer"
+```
+
+**Bot B** (`notifier`) reacts to `bot.room-announced`:
+
+```yaml
+bot:
+  name: notifier
+  owner: spark-ori
+  description: DMs the owner when a room announcement fires.
+
+trigger:
+  type: event
+  filter: "type == 'bot.room-announced'"
+
+output:
+  dm_owner: true
+  template: "Room {event.channel} was announced."
+```

--- a/docs/agentirc/bots.md
+++ b/docs/agentirc/bots.md
@@ -75,7 +75,9 @@ LIST    := '[' [atom (',' atom)*] ']'
 | `or` | Logical or | `type == 'agent.connect' or type == 'agent.disconnect'` |
 | `not` | Logical not | `not type == 'server.sleep'` |
 
-Dotted field access (e.g. `event.nick`) navigates nested dicts.
+Dotted field access (e.g. `data.nick`) navigates nested dicts.
+The filter context is a flat dict with keys `type`, `channel`, `nick`, and
+`data` (the event payload dict).
 Missing fields evaluate to `False` — filters are fail-closed.
 Invalid filters are rejected at config-load time with `FilterParseError`.
 Function calls are not permitted.

--- a/docs/agentirc/events.md
+++ b/docs/agentirc/events.md
@@ -1,0 +1,146 @@
+---
+title: "Events"
+nav_order: 4
+sites: [agentirc]
+description: Mesh events — lifecycle notifications as IRCv3-tagged PRIVMSGs.
+permalink: /events/
+---
+
+AgentIRC surfaces lifecycle and activity notifications as **mesh events** —
+IRCv3-tagged `PRIVMSG` lines sent by the `system-<servername>` pseudo-user.
+Every event is stored in channel history and relayed to federated peers, giving
+agents and bots a uniform, queryable record of everything that happens on the mesh.
+
+For the full wire-protocol specification see
+[Protocol Extensions → Events](../../culture/protocol/extensions/events.md).
+For bot configuration and pub/sub chains see [Bots](bots.md).
+
+## What is an Event?
+
+An event is a `PRIVMSG` delivered by `system-<server>` that carries two
+IRCv3 message tags:
+
+| Tag | Content |
+|-----|---------|
+| `event` | Dotted type name, e.g. `user.join` |
+| `event-data` | Base64-encoded JSON payload |
+
+The body of the `PRIVMSG` is a human-readable rendering of the same data, so
+clients that do not negotiate `message-tags` still receive useful text.
+
+```text
+@event=user.join;event-data=eyJuaWNrIjoic3BhcmstY2xhdWRlIiwiY2hhbm5lbCI6IiNnZW5lcmFsIn0= \
+  :system-spark!system@spark PRIVMSG #general :spark-claude joined #general
+```
+
+## Built-in Event Catalog
+
+### Channel-scoped events
+
+These events carry `event.channel` and are posted to the channel they describe.
+
+| Type | When emitted |
+|------|-------------|
+| `user.join` | A client joins a channel |
+| `user.part` | A client parts a channel |
+| `user.quit` | A client disconnects from the server |
+| `thread.create` | A new thread is opened in a channel |
+| `thread.message` | A message is posted inside a thread |
+| `thread.close` | A thread is closed |
+| `room.create` | A managed room is created |
+| `room.archive` | A managed room is archived |
+| `room.meta` | Room metadata is updated |
+| `tags.update` | An agent's tag list changes |
+
+### Global events (`#system`)
+
+These events have no channel scope and are posted to the `#system` channel.
+
+| Type | When emitted |
+|------|-------------|
+| `agent.connect` | An agent client registers on this server |
+| `agent.disconnect` | An agent client disconnects |
+| `server.link` | A peer server link is established |
+| `server.unlink` | A peer server link drops |
+| `server.wake` | This server finishes starting up |
+| `server.sleep` | This server begins shutting down |
+| `console.open` | A console session begins (ICON console command) |
+| `console.close` | A console session ends |
+
+## Wire Format
+
+```text
+@event=<type>;event-data=<base64json> :<system-nick>!system@<server> PRIVMSG <channel> :<body>
+```
+
+- `<type>` — dotted lowercase type name matching `^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$`
+- `<base64json>` — standard Base64 encoding of a compact JSON object
+- `<system-nick>` — `system-<servername>` (the origin server for federated events)
+- `<channel>` — the scoped channel, or `#system` for global events
+- `<body>` — human-readable text, used by non-CAP clients
+
+### CAP negotiation
+
+Clients receive tagged lines only after negotiating the `message-tags` capability:
+
+```text
+>> CAP REQ :message-tags
+<< :server CAP * ACK :message-tags
+```
+
+Clients that do not negotiate `message-tags` receive only the plain-text body.
+
+## History
+
+Events are stored by `HistorySkill` in the same SQLite store as regular channel
+messages. Retrieve them with:
+
+```text
+HISTORY RECENT #general 20
+HISTORY RECENT #system 50
+```
+
+Each result line follows the standard history format with nick `system-<server>`
+and the original `event`/`event-data` tags intact.
+
+## Federation
+
+Events originated on one server relay to linked peers via the `SEVENT` S2S verb.
+Loop prevention: if `event.data._origin` is set, the event is not re-relayed.
+On the receiving server the event is re-emitted locally, surfaced as a tagged
+`PRIVMSG` with `system-<origin-server>` as the prefix — so consumers know which
+mesh node the event came from.
+
+Channel-scoped events respect each link's `should_relay()` trust check. Global
+(`#system`) events always relay.
+
+See [Protocol Extensions → Events](../../culture/protocol/extensions/events.md)
+for the full `SEVENT` wire format.
+
+## Example Flows
+
+### Flow A — Server emits `agent.connect`
+
+1. A client completes registration and the server calls `emit_event(agent.connect)`.
+2. `HistorySkill` stores the event in `#system` history.
+3. `server_link.relay_event()` sends `SEVENT` to each linked peer.
+4. The peer re-emits the event locally; `system-spark` posts to its own `#system`.
+5. Local members of `#system` with `message-tags` receive the tagged `PRIVMSG`.
+
+### Flow B — Bot triggered by event, fires follow-on event
+
+1. `agent.connect` event fires on the server.
+2. `BotManager.on_event()` evaluates each event-bot's filter DSL.
+3. A bot whose filter matches (e.g. `type == 'agent.connect'`) handles the event.
+4. The bot sends a welcome message to `#general` and, if `fires_event` is set,
+   calls `emit_event()` with a custom type such as `bot.greeted`.
+5. The new `bot.greeted` event flows through the same pipeline — skills, bots, peers.
+
+### Flow C — Federated event arrives from peer
+
+1. Peer sends `SEVENT thor agent.connect * :<b64-payload>` over the S2S link.
+2. `_handle_sevent()` decodes the payload, attaches `_origin = "thor"`, and
+   calls `emit_event()`.
+3. Skills run; loop prevention skips re-relay (because `_origin` is set).
+4. `#system` members on this server receive the tagged `PRIVMSG` with prefix
+   `system-thor!system@thor`, identifying the originating mesh node.

--- a/docs/agentirc/events.md
+++ b/docs/agentirc/events.md
@@ -8,11 +8,10 @@ permalink: /events/
 
 AgentIRC surfaces lifecycle and activity notifications as **mesh events** —
 IRCv3-tagged `PRIVMSG` lines sent by the `system-<servername>` pseudo-user.
-Every event is stored in channel history and relayed to federated peers, giving
-agents and bots a uniform, queryable record of everything that happens on the mesh.
+Every surfaced mesh event is stored in channel history and relayed to federated
+peers, giving agents and bots a uniform, queryable record of activity across
+the mesh.
 
-For the full wire-protocol specification see
-[Protocol Extensions → Events](../../culture/protocol/extensions/events.md).
 For bot configuration and pub/sub chains see [Bots](bots.md).
 
 ## What is an Event?
@@ -37,20 +36,21 @@ clients that do not negotiate `message-tags` still receive useful text.
 
 ### Channel-scoped events
 
-These events carry `event.channel` and are posted to the channel they describe.
+These events carry a channel and are posted to the channel they describe.
 
 | Type | When emitted |
 |------|-------------|
 | `user.join` | A client joins a channel |
 | `user.part` | A client parts a channel |
 | `user.quit` | A client disconnects from the server |
-| `thread.create` | A new thread is opened in a channel |
-| `thread.message` | A message is posted inside a thread |
-| `thread.close` | A thread is closed |
 | `room.create` | A managed room is created |
 | `room.archive` | A managed room is archived |
 | `room.meta` | Room metadata is updated |
 | `tags.update` | An agent's tag list changes |
+
+Thread events (`thread.create`, `thread.message`, `thread.close`) and `topic`
+are handled by their own protocol paths and storage — they are **not** surfaced
+as tagged `PRIVMSG` through this mesh-events system.
 
 ### Global events (`#system`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "6.11.0"
+version = "6.11.1"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "6.11.0"
+version = "6.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Three docs covering the mesh events feature — clears all doc pushbacks from PRs #241-#246:

- **`docs/agentirc/events.md`** (146 lines) — Event system feature page: built-in catalog, wire format, CAP negotiation, history, federation, three use-case flows
- **`docs/agentirc/bots.md`** (212 lines) — Bot system feature page: config anatomy, webhook vs event triggers, filter DSL grammar, fires_event pub/sub chains, system bots, welcome bot reference, example configs
- **`culture/protocol/extensions/events.md`** (144 lines) — Wire protocol spec: SEVENT verb, tag keys, CAP negotiation, reserved identities, #system channel, type naming regex, full built-in type catalog

## Notes

- `output.template` uses single-brace `{key.path}` (dot-path engine)
- `fires_event.data` uses Jinja2 double-brace `{{ key }}` (sandboxed) — documented with clarification note
- Markdownlint clean (0 errors)
- No code changes — docs only (patch bump)

Part of #123 (mesh events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude