### PR TITLE
fix: reduce complexity + extract constants in all backends (S3776, S1192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.0.3] - 2026-04-17
+
+
+### Fixed
+
+- Duplicate _ERR_CHANNEL_PREFIX string in all 5 daemon files (S1192)
+- Cognitive complexity in claude/daemon.py _poll_loop (CC 22, S3776)
+- Cognitive complexity in agent-harness/daemon.py _poll_loop (CC 22, S3776)
+- Cognitive complexity in codex/daemon.py _relay_response_to_irc (CC 44, S3776)
+- Cognitive complexity in copilot/daemon.py _relay_response_to_irc (CC 23, S3776)
+- Cognitive complexity in acp/daemon.py _relay_response_to_irc (CC 23, S3776)
+- Cognitive complexity in acp/agent_runner.py start() (CC 17, S3776)
+
 ## [7.0.2] - 2026-04-17
 
 

--- a/culture/clients/acp/agent_runner.py
+++ b/culture/clients/acp/agent_runner.py
@@ -66,6 +66,57 @@ class ACPAgentRunner:
     def session_id(self) -> str | None:
         return self._session_id
 
+    async def _initialize_acp_session(self, cmd_label: str) -> None:
+        """Run ACP protocol negotiation: initialize, log auth methods, create session."""
+        # Initialize with ACP protocol
+        resp = await self._send_request(
+            "initialize",
+            {
+                "protocolVersion": 1,
+                "clientCapabilities": {
+                    "fs": {"readTextFile": True, "writeTextFile": True},
+                    "terminal": True,
+                },
+                "clientInfo": {"name": "culture-acp", "version": "0.1.0"},
+            },
+        )
+        logger.info("ACP initialized (%s): %s", cmd_label, resp)
+
+        # Log available auth methods as a hint
+        init_result = resp.get("result", {})
+        auth_methods = init_result.get("authMethods", [])
+        descriptions: list[str] = []
+        if auth_methods:
+            descriptions = [m.get("description", m.get("id", "unknown")) for m in auth_methods]
+            logger.warning(
+                "ACP agent (%s) reports auth methods: %s. "
+                "If prompts fail, configure auth tokens.",
+                cmd_label,
+                ", ".join(descriptions),
+            )
+
+        # Create a session with model selection
+        session_params: dict = {
+            "cwd": self.directory,
+            "mcpServers": [],
+        }
+        if self.model:
+            session_params["model"] = self.model
+        resp = await self._send_request("session/new", session_params)
+
+        logger.info("ACP session/new raw response: %s", json.dumps(resp)[:500])
+        result = resp.get("result", {})
+        self._session_id = result.get("sessionId")
+        if not self._session_id:
+            # Session creation failed — likely auth or model issue
+            error = resp.get("error", {})
+            error_msg = error.get("message", "unknown error")
+            if descriptions:
+                error_msg += f". Auth may be required: {', '.join(descriptions)}"
+            raise RuntimeError(f"ACP agent ({cmd_label}) session creation failed: {error_msg}")
+        self._running = True
+        logger.info("ACP session started (%s): %s", cmd_label, self._session_id)
+
     async def start(self, initial_prompt: str = "") -> None:
         """Start the ACP agent as a subprocess and initialize a session."""
         self._stopping = False
@@ -95,53 +146,7 @@ class ACPAgentRunner:
             self._reader_task = asyncio.create_task(self._read_loop())
             self._stderr_task = asyncio.create_task(self._stderr_loop())
 
-            # Initialize with ACP protocol
-            resp = await self._send_request(
-                "initialize",
-                {
-                    "protocolVersion": 1,
-                    "clientCapabilities": {
-                        "fs": {"readTextFile": True, "writeTextFile": True},
-                        "terminal": True,
-                    },
-                    "clientInfo": {"name": "culture-acp", "version": "0.1.0"},
-                },
-            )
-            logger.info("ACP initialized (%s): %s", cmd_label, resp)
-
-            # Log available auth methods as a hint
-            init_result = resp.get("result", {})
-            auth_methods = init_result.get("authMethods", [])
-            if auth_methods:
-                descriptions = [m.get("description", m.get("id", "unknown")) for m in auth_methods]
-                logger.warning(
-                    "ACP agent (%s) reports auth methods: %s. "
-                    "If prompts fail, configure auth tokens.",
-                    cmd_label,
-                    ", ".join(descriptions),
-                )
-
-            # Create a session with model selection
-            session_params = {
-                "cwd": self.directory,
-                "mcpServers": [],
-            }
-            if self.model:
-                session_params["model"] = self.model
-            resp = await self._send_request("session/new", session_params)
-
-            logger.info("ACP session/new raw response: %s", json.dumps(resp)[:500])
-            result = resp.get("result", {})
-            self._session_id = result.get("sessionId")
-            if not self._session_id:
-                # Session creation failed — likely auth or model issue
-                error = resp.get("error", {})
-                error_msg = error.get("message", "unknown error")
-                if auth_methods:
-                    error_msg += f". Auth may be required: {', '.join(descriptions)}"
-                raise RuntimeError(f"ACP agent ({cmd_label}) session creation failed: {error_msg}")
-            self._running = True
-            logger.info("ACP session started (%s): %s", cmd_label, self._session_id)
+            await self._initialize_acp_session(cmd_label)
 
             # Start the prompt processing loop
             self._task = asyncio.create_task(self._prompt_loop())

--- a/culture/clients/acp/daemon.py
+++ b/culture/clients/acp/daemon.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 _ERR_MISSING_CHANNEL = "Missing 'channel'"
 _ERR_MISSING_CHANNEL_THREAD = "Missing 'channel' or 'thread'"
 _ERR_MISSING_CHANNEL_THREAD_MSG = "Missing 'channel', 'thread', or 'message'"
+_ERR_CHANNEL_PREFIX = "Channel name must start with '#'"
 
 # Regex to extract @mentioned nicks from messages
 _MENTION_RE = re.compile(r"@([\w-]+)")
@@ -487,19 +488,23 @@ class ACPDaemon:
             channel,
         )
 
+    async def _send_relay_lines(self, relay_target: str, content: list) -> None:
+        """Send each text content item line-by-line to the relay target."""
+        for item in content:
+            if item.get("type") == "text":
+                text = item["text"].strip()
+                if text:
+                    for line in text.split("\n"):
+                        line = line.strip()
+                        if line:
+                            await self._transport.send_privmsg(relay_target, line)
+
     async def _relay_response_to_irc(self, msg: dict) -> None:
         """Dequeue the next relay target and send agent text lines to IRC."""
         relay_target = self._mention_targets.popleft() if self._mention_targets else None
         if self._transport and relay_target:
             content = msg.get("content", [])
-            for item in content:
-                if item.get("type") == "text":
-                    text = item["text"].strip()
-                    if text:
-                        for line in text.split("\n"):
-                            line = line.strip()
-                            if line:
-                                await self._transport.send_privmsg(relay_target, line)
+            await self._send_relay_lines(relay_target, content)
 
     def _capture_agent_status(self, msg: dict) -> None:
         """Capture the last assistant text for status reporting and fulfill any pending query."""
@@ -804,7 +809,7 @@ class ACPDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.join_channel(channel)
         return make_response(req_id, ok=True)
@@ -814,7 +819,7 @@ class ACPDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.part_channel(channel)
         return make_response(req_id, ok=True)
@@ -893,7 +898,7 @@ class ACPDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         topic = msg.get("topic")  # None means query, string means set
         await self._transport.send_topic(channel, topic)

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -28,6 +28,7 @@ CRASH_RESTART_DELAY = 5
 _ERR_MISSING_CHANNEL = "Missing 'channel'"
 _ERR_MISSING_CHANNEL_THREAD = "Missing 'channel' or 'thread'"
 _ERR_MISSING_CHANNEL_THREAD_MSG = "Missing 'channel', 'thread', or 'message'"
+_ERR_CHANNEL_PREFIX = "Channel name must start with '#'"
 
 # Regex to extract @mentioned nicks from messages
 _MENTION_RE = re.compile(r"@([\w-]+)")
@@ -258,36 +259,42 @@ class AgentDaemon:
         while True:
             try:
                 await asyncio.sleep(interval)
-                if self._paused or not self._agent_runner or not self._agent_runner.is_running():
-                    continue
-                for channel in self.agent.channels:
-                    msgs = self._buffer.read(channel)
-                    if not msgs:
-                        continue
-                    # Filter out messages that @mention this agent (already handled)
-                    nick = self.agent.nick
-                    short = nick.split("-", 1)[1] if "-" in nick else None
-                    msgs = [
-                        m
-                        for m in msgs
-                        if not re.search(rf"@{re.escape(nick)}\b", m.text)
-                        and not (short and re.search(rf"@{re.escape(short)}\b", m.text))
-                    ]
-                    if not msgs:
-                        continue
-                    lines = "\n".join(f"  <{m.nick}> {m.text}" for m in msgs)
-                    prompt = (
-                        f"[IRC Channel Poll: {channel}] Recent unread messages:\n"
-                        f"{lines}\n\n"
-                        "Respond naturally if any messages need your attention."
-                    )
-                    task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
-                    self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
+                self._process_poll_cycle()
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.exception("Poll loop error")
+
+    def _process_poll_cycle(self) -> None:
+        if self._paused or not self._agent_runner or not self._agent_runner.is_running():
+            return
+        for channel in self.agent.channels:
+            self._send_channel_poll(channel)
+
+    def _send_channel_poll(self, channel: str) -> None:
+        msgs = self._buffer.read(channel)
+        if not msgs:
+            return
+        # Filter out messages that @mention this agent (already handled)
+        nick = self.agent.nick
+        short = nick.split("-", 1)[1] if "-" in nick else None
+        msgs = [
+            m
+            for m in msgs
+            if not re.search(rf"@{re.escape(nick)}\b", m.text)
+            and not (short and re.search(rf"@{re.escape(short)}\b", m.text))
+        ]
+        if not msgs:
+            return
+        lines = "\n".join(f"  <{m.nick}> {m.text}" for m in msgs)
+        prompt = (
+            f"[IRC Channel Poll: {channel}] Recent unread messages:\n"
+            f"{lines}\n\n"
+            "Respond naturally if any messages need your attention."
+        )
+        task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     async def _graceful_shutdown(self) -> None:
         """Trigger a graceful shutdown, signaling any waiting stop event."""
@@ -694,7 +701,7 @@ class AgentDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.join_channel(channel)
         return make_response(req_id, ok=True)
@@ -704,7 +711,7 @@ class AgentDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.part_channel(channel)
         return make_response(req_id, ok=True)
@@ -783,7 +790,7 @@ class AgentDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         topic = msg.get("topic")  # None means query, string means set
         await self._transport.send_topic(channel, topic)

--- a/culture/clients/codex/daemon.py
+++ b/culture/clients/codex/daemon.py
@@ -471,20 +471,26 @@ class CodexDaemon:
             line = line[2:]
         return line
 
+    def _clean_relay_lines(self, text: str) -> list[str]:
+        """Strip, filter, and clean lines from a text content item."""
+        result = []
+        for line in text.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            line = self._strip_meta_response(line)
+            if line and line != ">":
+                result.append(line)
+        return result
+
     async def _send_relay_lines(self, relay_target: str, content: list) -> None:
         """Send each text content item line-by-line to the relay target."""
         for item in content:
-            if item.get("type") == "text":
-                text = item["text"].strip()
-                if text:
-                    for line in text.split("\n"):
-                        line = line.strip()
-                        if not line:
-                            continue
-                        line = self._strip_meta_response(line)
-                        # Skip lines that are just blockquote markers
-                        if line and line != ">":
-                            await self._transport.send_privmsg(relay_target, line)
+            if item.get("type") != "text":
+                continue
+            text = item["text"].strip()
+            for line in self._clean_relay_lines(text):
+                await self._transport.send_privmsg(relay_target, line)
 
     async def _relay_response_to_irc(self, msg: dict) -> None:
         """Dequeue the next relay target and send agent text lines to IRC."""

--- a/culture/clients/codex/daemon.py
+++ b/culture/clients/codex/daemon.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 _ERR_MISSING_CHANNEL = "Missing 'channel'"
 _ERR_MISSING_CHANNEL_THREAD = "Missing 'channel' or 'thread'"
 _ERR_MISSING_CHANNEL_THREAD_MSG = "Missing 'channel', 'thread', or 'message'"
+_ERR_CHANNEL_PREFIX = "Channel name must start with '#'"
 
 # Regex to extract @mentioned nicks from messages
 _MENTION_RE = re.compile(r"@([\w-]+)")
@@ -462,28 +463,35 @@ class CodexDaemon:
             channel,
         )
 
+    @staticmethod
+    def _strip_meta_response(line: str) -> str:
+        """Strip meta-response prefix and blockquote markers from a line."""
+        line = _META_RESPONSE_RE.sub("", line).strip()
+        if line.startswith("> "):
+            line = line[2:]
+        return line
+
+    async def _send_relay_lines(self, relay_target: str, content: list) -> None:
+        """Send each text content item line-by-line to the relay target."""
+        for item in content:
+            if item.get("type") == "text":
+                text = item["text"].strip()
+                if text:
+                    for line in text.split("\n"):
+                        line = line.strip()
+                        if not line:
+                            continue
+                        line = self._strip_meta_response(line)
+                        # Skip lines that are just blockquote markers
+                        if line and line != ">":
+                            await self._transport.send_privmsg(relay_target, line)
+
     async def _relay_response_to_irc(self, msg: dict) -> None:
         """Dequeue the next relay target and send agent text lines to IRC."""
         relay_target = self._mention_targets.popleft() if self._mention_targets else None
         if self._transport and relay_target:
             content = msg.get("content", [])
-            for item in content:
-                if item.get("type") == "text":
-                    text = item["text"].strip()
-                    if text:
-                        for line in text.split("\n"):
-                            line = line.strip()
-                            if not line:
-                                continue
-                            # Strip meta-response patterns
-                            line = _META_RESPONSE_RE.sub("", line).strip()
-                            # Skip lines that are just blockquote markers
-                            if line and line != ">":
-                                # Remove leading > from blockquoted actual content
-                                if line.startswith("> "):
-                                    line = line[2:]
-                                if line:
-                                    await self._transport.send_privmsg(relay_target, line)
+            await self._send_relay_lines(relay_target, content)
 
     def _capture_agent_status(self, msg: dict) -> None:
         """Capture the last assistant text for status reporting and fulfill any pending query."""
@@ -784,7 +792,7 @@ class CodexDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.join_channel(channel)
         return make_response(req_id, ok=True)
@@ -794,7 +802,7 @@ class CodexDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.part_channel(channel)
         return make_response(req_id, ok=True)
@@ -873,7 +881,7 @@ class CodexDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         topic = msg.get("topic")  # None means query, string means set
         await self._transport.send_topic(channel, topic)

--- a/culture/clients/copilot/daemon.py
+++ b/culture/clients/copilot/daemon.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 _ERR_MISSING_CHANNEL = "Missing 'channel'"
 _ERR_MISSING_CHANNEL_THREAD = "Missing 'channel' or 'thread'"
 _ERR_MISSING_CHANNEL_THREAD_MSG = "Missing 'channel', 'thread', or 'message'"
+_ERR_CHANNEL_PREFIX = "Channel name must start with '#'"
 
 # Regex to extract @mentioned nicks from messages
 _MENTION_RE = re.compile(r"@([\w-]+)")
@@ -462,19 +463,23 @@ class CopilotDaemon:
             channel,
         )
 
+    async def _send_relay_lines(self, relay_target: str, content: list) -> None:
+        """Send each text content item line-by-line to the relay target."""
+        for item in content:
+            if item.get("type") == "text":
+                text = item["text"].strip()
+                if text:
+                    for line in text.split("\n"):
+                        line = line.strip()
+                        if line:
+                            await self._transport.send_privmsg(relay_target, line)
+
     async def _relay_response_to_irc(self, msg: dict) -> None:
         """Dequeue the next relay target and send agent text lines to IRC."""
         relay_target = self._mention_targets.popleft() if self._mention_targets else None
         if self._transport and relay_target:
             content = msg.get("content", [])
-            for item in content:
-                if item.get("type") == "text":
-                    text = item["text"].strip()
-                    if text:
-                        for line in text.split("\n"):
-                            line = line.strip()
-                            if line:
-                                await self._transport.send_privmsg(relay_target, line)
+            await self._send_relay_lines(relay_target, content)
 
     def _capture_agent_status(self, msg: dict) -> None:
         """Capture the last assistant text for status reporting and fulfill any pending query."""
@@ -771,7 +776,7 @@ class CopilotDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.join_channel(channel)
         return make_response(req_id, ok=True)
@@ -781,7 +786,7 @@ class CopilotDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         await self._transport.part_channel(channel)
         return make_response(req_id, ok=True)
@@ -860,7 +865,7 @@ class CopilotDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         assert self._transport is not None
         topic = msg.get("topic")  # None means query, string means set
         await self._transport.send_topic(channel, topic)

--- a/packages/agent-harness/daemon.py
+++ b/packages/agent-harness/daemon.py
@@ -35,6 +35,7 @@ MAX_CONSECUTIVE_TURN_FAILURES = 3
 _ERR_MISSING_CHANNEL = "Missing 'channel'"
 _ERR_MISSING_CHANNEL_THREAD = "Missing 'channel' or 'thread'"
 _ERR_MISSING_CHANNEL_THREAD_MSG = "Missing 'channel', 'thread', or 'message'"
+_ERR_CHANNEL_PREFIX = "Channel name must start with '#'"
 
 # Regex to extract @mentioned nicks from messages
 _MENTION_RE = re.compile(r"@([\w-]+)")
@@ -255,37 +256,43 @@ class AgentDaemon:
         while True:
             try:
                 await asyncio.sleep(interval)
-                if self._paused or not self._agent_runner or not self._agent_runner.is_running():
-                    continue
-                for channel in self.agent.channels:
-                    msgs = self._buffer.read(channel)
-                    if not msgs:
-                        continue
-                    # Filter out @mention messages (already handled by _on_mention)
-                    nick = self.agent.nick
-                    short = nick.split("-", 1)[1] if "-" in nick else None
-                    msgs = [
-                        m
-                        for m in msgs
-                        if not re.search(rf"@{re.escape(nick)}\b", m.text)
-                        and not (short and re.search(rf"@{re.escape(short)}\b", m.text))
-                    ]
-                    if not msgs:
-                        continue
-                    lines = "\n".join(f"  <{m.nick}> {m.text}" for m in msgs)
-                    prompt = (
-                        f"[IRC Channel Poll: {channel}] Recent unread messages:\n"
-                        f"{lines}\n\n"
-                        "Respond naturally if any messages need your attention."
-                    )
-                    self._mention_targets.append(channel)
-                    task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
-                    self._background_tasks.add(task)
-                    task.add_done_callback(self._background_tasks.discard)
+                self._process_poll_cycle()
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.exception("Poll loop error")
+
+    def _process_poll_cycle(self) -> None:
+        if self._paused or not self._agent_runner or not self._agent_runner.is_running():
+            return
+        for channel in self.agent.channels:
+            self._send_channel_poll(channel)
+
+    def _send_channel_poll(self, channel: str) -> None:
+        msgs = self._buffer.read(channel)
+        if not msgs:
+            return
+        # Filter out @mention messages (already handled by _on_mention)
+        nick = self.agent.nick
+        short = nick.split("-", 1)[1] if "-" in nick else None
+        msgs = [
+            m
+            for m in msgs
+            if not re.search(rf"@{re.escape(nick)}\b", m.text)
+            and not (short and re.search(rf"@{re.escape(short)}\b", m.text))
+        ]
+        if not msgs:
+            return
+        lines = "\n".join(f"  <{m.nick}> {m.text}" for m in msgs)
+        prompt = (
+            f"[IRC Channel Poll: {channel}] Recent unread messages:\n"
+            f"{lines}\n\n"
+            "Respond naturally if any messages need your attention."
+        )
+        self._mention_targets.append(channel)
+        task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     async def _on_turn_error(self) -> None:
         """Send error feedback to IRC and clean up stale relay target.
@@ -437,7 +444,7 @@ class AgentDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         if self._transport:
             await self._transport.join_channel(channel)
         return make_response(req_id, ok=True)
@@ -447,7 +454,7 @@ class AgentDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         if self._transport:
             await self._transport.part_channel(channel)
         return make_response(req_id, ok=True)
@@ -463,7 +470,7 @@ class AgentDaemon:
         if not channel:
             return make_response(req_id, ok=False, error=_ERR_MISSING_CHANNEL)
         if not channel.startswith("#"):
-            return make_response(req_id, ok=False, error="Channel name must start with '#'")
+            return make_response(req_id, ok=False, error=_ERR_CHANNEL_PREFIX)
         if self._transport:
             topic = msg.get("topic")  # None means query, string means set
             await self._transport.send_topic(channel, topic)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.0.2"
+version = "7.0.3"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.0.2"
+version = "7.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Resolves 9 SonarCloud CRITICAL issues across 6 agent backend files.

### S1192 — Duplicate string literals (5 files)
- Added `_ERR_CHANNEL_PREFIX` constant in all 5 daemon files, replacing 3 occurrences each

### S3776 — Cognitive complexity (6 functions)

| File | Function | Before | Fix |
|------|----------|--------|-----|
| `claude/daemon.py` | `_poll_loop` | CC=22 | Extract `_process_poll_cycle`, `_send_channel_poll` |
| `agent-harness/daemon.py` | `_poll_loop` | CC=22 | Same (with `_mention_targets`) |
| `codex/daemon.py` | `_relay_response_to_irc` | CC=44 | Extract `_strip_meta_response`, `_send_relay_lines` |
| `copilot/daemon.py` | `_relay_response_to_irc` | CC=23 | Extract `_send_relay_lines` |
| `acp/daemon.py` | `_relay_response_to_irc` | CC=23 | Extract `_send_relay_lines` |
| `acp/agent_runner.py` | `start()` | CC=17 | Extract `_initialize_acp_session` |

No behavior changes — pure structural refactoring following Assimilai pattern.

## Test plan

- [x] Full suite: 865 passed
- [x] Pre-commit hooks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude