### PR TITLE
fix: CLI code quality — reduce complexity + extract constants (SonarCloud)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.0.4] - 2026-04-17
+
+
+### Fixed
+
+- Reduce cognitive complexity and fix code quality issues across CLI modules (SonarCloud S3776, S1192, S5886, S108)
+
 ## [7.0.3] - 2026-04-17
 
 

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -9,8 +9,14 @@ import os
 import signal
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
+
+if TYPE_CHECKING:
+    from culture.clients.acp.config import AgentConfig as ACPAgentConfig
+    from culture.clients.codex.config import AgentConfig as CodexAgentConfig
+    from culture.clients.copilot.config import AgentConfig as CopilotAgentConfig
 
 from culture.config import (
     AgentConfig,
@@ -239,7 +245,7 @@ def dispatch(args: argparse.Namespace) -> None:
 # -----------------------------------------------------------------------
 
 
-def _create_codex_config(full_nick: str) -> AgentConfig:
+def _create_codex_config(full_nick: str) -> CodexAgentConfig:
     """Build a CodexAgentConfig."""
     from culture.clients.codex.config import AgentConfig as CodexAgentConfig
 
@@ -251,7 +257,7 @@ def _create_codex_config(full_nick: str) -> AgentConfig:
     )
 
 
-def _create_copilot_config(full_nick: str) -> AgentConfig:
+def _create_copilot_config(full_nick: str) -> CopilotAgentConfig:
     """Build a CopilotAgentConfig."""
     from culture.clients.copilot.config import AgentConfig as CopilotAgentConfig
 
@@ -279,7 +285,7 @@ def _parse_acp_command(raw_command: str | None) -> list[str]:
     return acp_cmd
 
 
-def _create_acp_config(full_nick: str, args: argparse.Namespace) -> AgentConfig:
+def _create_acp_config(full_nick: str, args: argparse.Namespace) -> ACPAgentConfig:
     """Build an ACPAgentConfig."""
     from culture.clients.acp.config import AgentConfig as ACPAgentConfig
 
@@ -469,8 +475,8 @@ def _probe_server_connection(host: str, port: int, server_name: str) -> None:
     import socket as _socket
 
     try:
-        with _socket.create_connection((host, port), timeout=2):
-            pass
+        conn = _socket.create_connection((host, port), timeout=2)
+        conn.close()
     except OSError:
         hint = ""
         server_pid = read_pid(f"server-{server_name}")

--- a/culture/cli/channel.py
+++ b/culture/cli/channel.py
@@ -15,6 +15,7 @@ NAME = "channel"
 
 _ALL_CMDS = "list|read|message|who|join|part|ask|topic|compact|clear"
 _CHANNEL_HELP = "Channel (e.g. #general)"
+_ERR_EMPTY_CHANNEL = "Error: channel name cannot be empty"
 
 
 def _valid_nick(nick: str) -> bool:
@@ -110,6 +111,13 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     channel_sub.add_parser("clear", help="Clear the agent's context window")
 
 
+def _is_connection_error(msg: str) -> bool:
+    """Return True if the exception message indicates a connection failure."""
+    return (
+        "Timed out" in msg or "Connection refused" in msg or "Connect call failed" in msg or not msg
+    )
+
+
 def dispatch(args: argparse.Namespace) -> None:
     if not args.channel_command:
         print(f"Usage: culture channel {{{_ALL_CMDS}}}", file=sys.stderr)
@@ -134,13 +142,7 @@ def dispatch(args: argparse.Namespace) -> None:
     try:
         handler(args)
     except (TimeoutError, OSError) as exc:
-        msg = str(exc)
-        if (
-            "Timed out" in msg
-            or "Connection refused" in msg
-            or "Connect call failed" in msg
-            or not msg  # TimeoutError from asyncio often has empty message
-        ):
+        if _is_connection_error(str(exc)):
             print(
                 "Error: cannot connect to IRC server. Is the server running?\n"
                 "  Start it with: culture server start",
@@ -181,7 +183,7 @@ def _cmd_list(args: argparse.Namespace) -> None:
 
 def _cmd_read(args: argparse.Namespace) -> None:
     if not args.target.strip():
-        print("Error: channel name cannot be empty", file=sys.stderr)
+        print(_ERR_EMPTY_CHANNEL, file=sys.stderr)
         sys.exit(1)
     channel = args.target if args.target.startswith("#") else f"#{args.target}"
 
@@ -244,7 +246,7 @@ def _interpret_escapes(text: str) -> str:
 
 def _cmd_message(args: argparse.Namespace) -> None:
     if not args.target.strip():
-        print("Error: channel name cannot be empty", file=sys.stderr)
+        print(_ERR_EMPTY_CHANNEL, file=sys.stderr)
         sys.exit(1)
     if not args.text.strip():
         print("Error: message text cannot be empty", file=sys.stderr)
@@ -272,7 +274,7 @@ def _cmd_message(args: argparse.Namespace) -> None:
 
 def _cmd_who(args: argparse.Namespace) -> None:
     if not args.target.strip():
-        print("Error: channel name cannot be empty", file=sys.stderr)
+        print(_ERR_EMPTY_CHANNEL, file=sys.stderr)
         sys.exit(1)
     target = args.target
 
@@ -313,7 +315,7 @@ def _cmd_part(args: argparse.Namespace) -> None:
 
 def _cmd_ask(args: argparse.Namespace) -> None:
     if not args.target.strip():
-        print("Error: channel name cannot be empty", file=sys.stderr)
+        print(_ERR_EMPTY_CHANNEL, file=sys.stderr)
         sys.exit(1)
     if not args.text.strip():
         print("Error: question text cannot be empty", file=sys.stderr)
@@ -329,7 +331,7 @@ def _cmd_ask(args: argparse.Namespace) -> None:
 
 def _cmd_topic(args: argparse.Namespace) -> None:
     if not args.target.strip():
-        print("Error: channel name cannot be empty", file=sys.stderr)
+        print(_ERR_EMPTY_CHANNEL, file=sys.stderr)
         sys.exit(1)
     target = args.target if args.target.startswith("#") else f"#{args.target}"
 

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -13,7 +13,7 @@ import time
 
 from culture.config import ServerConfig, load_config, load_config_or_default
 
-from .shared.constants import AGENTS_YAML, CULTURE_DIR, DEFAULT_CONFIG
+from .shared.constants import _CONFIG_HELP, AGENTS_YAML, CULTURE_DIR, DEFAULT_CONFIG
 from .shared.mesh import build_server_start_cmd, generate_mesh_from_agents
 from .shared.process import server_stop_by_name, stop_agent
 
@@ -92,7 +92,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     console_parser.add_argument(
         "--config",
         default=DEFAULT_CONFIG,
-        help="Config file path",
+        help=_CONFIG_HELP,
     )
 
 
@@ -653,8 +653,39 @@ def _resolve_mesh_for_server(server_name: str, config_path: str):
     return None
 
 
-def _cmd_update(args: argparse.Namespace) -> None:
+def _restart_running_servers(running, args, culture_bin):
+    """Restart all running servers, returning names of any that failed."""
+    failed = []
+    for srv in running:
+        mesh = _resolve_mesh_for_server(srv["name"], args.config)
+        if mesh is None:
+            print(
+                f"  Warning: no config found for server '{srv['name']}', skipping",
+                file=sys.stderr,
+            )
+            continue
+        if not _restart_mesh_services(mesh, srv["name"], culture_bin, args.config, args.dry_run):
+            failed.append(srv["name"])
+    return failed
+
+
+def _restart_from_config(args, culture_bin):
+    """Start services from config when none are running, returning names of any that failed."""
     from culture.mesh_config import load_mesh_config
+
+    try:
+        mesh = load_mesh_config(args.config)
+    except FileNotFoundError:
+        mesh = generate_mesh_from_agents(args.config)
+        if mesh is None:
+            sys.exit(1)
+    failed = []
+    if not _restart_mesh_services(mesh, mesh.server.name, culture_bin, args.config, args.dry_run):
+        failed.append(mesh.server.name)
+    return failed
+
+
+def _cmd_update(args: argparse.Namespace) -> None:
     from culture.pidfile import list_servers
 
     if not _upgrade_culture_package(args):
@@ -663,32 +694,11 @@ def _cmd_update(args: argparse.Namespace) -> None:
     culture_bin = shutil.which("culture") or "culture"
 
     running = list_servers()
-    failed = []
-
-    if running:
-        for srv in running:
-            mesh = _resolve_mesh_for_server(srv["name"], args.config)
-            if mesh is None:
-                print(
-                    f"  Warning: no config found for server '{srv['name']}', skipping",
-                    file=sys.stderr,
-                )
-                continue
-            if not _restart_mesh_services(
-                mesh, srv["name"], culture_bin, args.config, args.dry_run
-            ):
-                failed.append(srv["name"])
-    else:
-        try:
-            mesh = load_mesh_config(args.config)
-        except FileNotFoundError:
-            mesh = generate_mesh_from_agents(args.config)
-            if mesh is None:
-                sys.exit(1)
-        if not _restart_mesh_services(
-            mesh, mesh.server.name, culture_bin, args.config, args.dry_run
-        ):
-            failed.append(mesh.server.name)
+    failed = (
+        _restart_running_servers(running, args, culture_bin)
+        if running
+        else _restart_from_config(args, culture_bin)
+    )
 
     if failed:
         print(

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -121,6 +121,45 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+def _cmd_default(args: argparse.Namespace) -> None:
+    """Set the default server name."""
+    from pathlib import Path
+
+    from culture.config import load_config_or_default
+    from culture.pidfile import PID_DIR, list_servers, write_default_server
+
+    from .shared.constants import DEFAULT_CONFIG
+
+    # Accept the name if: it matches a running server, has a PID file,
+    # or matches the configured server name.
+    known_running = {s["name"] for s in list_servers()}
+    pid_dir = Path(PID_DIR)
+    known_pids = set()
+    if pid_dir.exists():
+        prefix = "server-"
+        for p in pid_dir.glob(f"{prefix}*.pid"):
+            known_pids.add(p.stem[len(prefix) :])
+    known_names = known_running | known_pids
+
+    # Also accept the configured server name
+    try:
+        config = load_config_or_default(DEFAULT_CONFIG)
+        known_names.add(config.server.name)
+    except Exception:
+        pass
+
+    if args.name not in known_names:
+        print(f"Server '{args.name}' not found.", file=sys.stderr)
+        if known_names:
+            print(
+                f"Known servers: {', '.join(sorted(known_names))}",
+                file=sys.stderr,
+            )
+        sys.exit(1)
+    write_default_server(args.name)
+    print(f"Default server set to '{args.name}'")
+
+
 def dispatch(args: argparse.Namespace) -> None:
     if not args.server_command:
         print(
@@ -133,55 +172,18 @@ def dispatch(args: argparse.Namespace) -> None:
     if args.server_command not in ("default", "rename") and hasattr(args, "name"):
         args.name = _resolve_server_name(args)
 
-    if args.server_command == "start":
-        _server_start(args)
-    elif args.server_command == "stop":
-        _server_stop(args)
-    elif args.server_command == "status":
-        _server_status(args)
-    elif args.server_command == "default":
-        from pathlib import Path
-
-        from culture.pidfile import PID_DIR, list_servers, write_default_server
-
-        from .shared.constants import DEFAULT_CONFIG
-
-        # Accept the name if: it matches a running server, has a PID file,
-        # or matches the configured server name.
-        known_running = {s["name"] for s in list_servers()}
-        pid_dir = Path(PID_DIR)
-        known_pids = set()
-        if pid_dir.exists():
-            prefix = "server-"
-            for p in pid_dir.glob(f"{prefix}*.pid"):
-                known_pids.add(p.stem[len(prefix) :])
-        known_names = known_running | known_pids
-
-        # Also accept the configured server name
-        try:
-            from culture.config import load_config_or_default
-
-            config = load_config_or_default(DEFAULT_CONFIG)
-            known_names.add(config.server.name)
-        except Exception:
-            pass
-
-        if args.name not in known_names:
-            print(f"Server '{args.name}' not found.", file=sys.stderr)
-            if known_names:
-                print(
-                    f"Known servers: {', '.join(sorted(known_names))}",
-                    file=sys.stderr,
-                )
-            sys.exit(1)
-        write_default_server(args.name)
-        print(f"Default server set to '{args.name}'")
-    elif args.server_command == "rename":
-        _server_rename(args)
-    elif args.server_command == "archive":
-        _server_archive(args)
-    elif args.server_command == "unarchive":
-        _server_unarchive(args)
+    handlers = {
+        "start": _server_start,
+        "stop": _server_stop,
+        "status": _server_status,
+        "default": _cmd_default,
+        "rename": _server_rename,
+        "archive": _server_archive,
+        "unarchive": _server_unarchive,
+    }
+    handler = handlers.get(args.server_command)
+    if handler:
+        handler(args)
 
 
 # -----------------------------------------------------------------------

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -182,8 +182,10 @@ def dispatch(args: argparse.Namespace) -> None:
         "unarchive": _server_unarchive,
     }
     handler = handlers.get(args.server_command)
-    if handler:
-        handler(args)
+    if handler is None:
+        print(f"Unknown server command: {args.server_command}", file=sys.stderr)
+        sys.exit(1)
+    handler(args)
 
 
 # -----------------------------------------------------------------------

--- a/culture/cli/shared/display.py
+++ b/culture/cli/shared/display.py
@@ -29,32 +29,36 @@ def agent_process_status(agent) -> tuple[str, int | None]:
     return "stopped", None
 
 
+def _print_running_detail(agent, args, pid) -> None:
+    """Print status detail for a running agent with IPC data."""
+    query = getattr(args, "full", False)
+    resp = asyncio.run(ipc_request(agent_socket_path(agent.nick), "status", query=query))
+    if resp and resp.get("ok"):
+        data = resp.get("data", {})
+        status = "running"
+        if data.get("circuit_open"):
+            status = "circuit-open"
+        elif data.get("paused"):
+            status = "paused"
+        print(f"  Status:     {status}")
+        print(f"  PID:        {pid or '-'}")
+        print(f"  Activity:   {data.get('description', 'nothing')}")
+        print(f"  Turns:      {data.get('turn_count', 0)}")
+        print(f"  Paused:     {'yes' if data.get('paused') else 'no'}")
+        print(f"  Circuit:    {'OPEN (not restarting)' if data.get('circuit_open') else 'closed'}")
+    else:
+        print("  Status:     running")
+        print(f"  PID:        {pid or '-'}")
+        print("  Activity:   unknown (daemon may need restart)")
+
+
 def print_agent_detail(agent, config_path: str, args: argparse.Namespace) -> None:
     """Print detailed status for a single agent, including live IPC activity query."""
     status, pid = agent_process_status(agent)
     print(agent.nick)
 
     if status == "running":
-        query = getattr(args, "full", False)
-        resp = asyncio.run(ipc_request(agent_socket_path(agent.nick), "status", query=query))
-        if resp and resp.get("ok"):
-            data = resp.get("data", {})
-            if data.get("circuit_open"):
-                status = "circuit-open"
-            elif data.get("paused"):
-                status = "paused"
-            print(f"  Status:     {status}")
-            print(f"  PID:        {pid or '-'}")
-            print(f"  Activity:   {data.get('description', 'nothing')}")
-            print(f"  Turns:      {data.get('turn_count', 0)}")
-            print(f"  Paused:     {'yes' if data.get('paused') else 'no'}")
-            print(
-                f"  Circuit:    {'OPEN (not restarting)' if data.get('circuit_open') else 'closed'}"
-            )
-        else:
-            print(f"  Status:     {status}")
-            print(f"  PID:        {pid or '-'}")
-            print("  Activity:   unknown (daemon may need restart)")
+        _print_running_detail(agent, args, pid)
     else:
         print(f"  Status:     {status}")
         print(f"  PID:        {pid or '-'}")
@@ -87,6 +91,27 @@ def _fetch_ipc_data(agent) -> dict | None:
     return None
 
 
+def _agent_overview_row(
+    agent, show_activity: bool, show_archived_marker: bool
+) -> tuple[str, str, str, str]:
+    """Build (nick, status, pid_str, activity) for one agent row."""
+    base_status, pid = agent_process_status(agent)
+    activity = "-"
+    if base_status == "running":
+        ipc_data = _fetch_ipc_data(agent)
+        if ipc_data:
+            if ipc_data.get("circuit_open"):
+                base_status = "circuit-open"
+            elif ipc_data.get("paused"):
+                base_status = "paused"
+            if show_activity:
+                activity = ipc_data.get("description", "nothing")
+    status = _format_agent_status(
+        base_status, getattr(agent, "archived", False), show_archived_marker
+    )
+    return agent.nick, status, str(pid or "-"), activity
+
+
 def print_agents_overview(
     agents: list, show_activity: bool, show_archived_marker: bool = False
 ) -> None:
@@ -99,25 +124,13 @@ def print_agents_overview(
         print("-" * 52)
 
     for agent in agents:
-        base_status, pid = agent_process_status(agent)
-        activity = "-"
-        # Enrich status from IPC for running agents
-        if base_status == "running":
-            ipc_data = _fetch_ipc_data(agent)
-            if ipc_data:
-                if ipc_data.get("circuit_open"):
-                    base_status = "circuit-open"
-                elif ipc_data.get("paused"):
-                    base_status = "paused"
-                if show_activity:
-                    activity = ipc_data.get("description", "nothing")
-        status = _format_agent_status(
-            base_status, getattr(agent, "archived", False), show_archived_marker
+        nick, status, pid_str, activity = _agent_overview_row(
+            agent, show_activity, show_archived_marker
         )
         if show_activity:
-            print(f"{agent.nick:<30} {status:<12} {str(pid or '-'):<10} {activity}")
+            print(f"{nick:<30} {status:<12} {pid_str:<10} {activity}")
         else:
-            print(f"{agent.nick:<30} {status:<12} {str(pid or '-'):<10}")
+            print(f"{nick:<30} {status:<12} {pid_str:<10}")
 
 
 def _load_bot_configs() -> list:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.0.3"
+version = "7.0.4"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.0.3"
+version = "7.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- **display.py**: Extract `_print_running_detail()` and `_agent_overview_row()` from high-CC functions (CC 20→5, 22→6)
- **channel.py**: Extract `_is_connection_error()` predicate, add `_ERR_EMPTY_CHANNEL` constant
- **server.py**: Convert `dispatch()` elif chain to handler dict, extract `_cmd_default()` (CC 22→4)
- **mesh.py**: Extract `_restart_running_servers()` and `_restart_from_config()` from `_cmd_update()` (CC 22→6)
- **agent.py**: Fix return type annotations (S5886 ×3), replace empty with-block (S108)

SonarCloud rules addressed: S3776 (cognitive complexity), S1192 (duplicate literals), S5886 (return type mismatch), S108 (empty block).

## Test plan

- [x] `uv run pytest -n auto -q` — 865 tests pass
- [x] All pre-commit hooks pass (black, isort, flake8, pylint, bandit)
- [x] SonarCloud re-scan shows reduced CRITICAL count for CLI files
- [ ] Qodo/Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude