### PR TITLE
fix: mesh update hang, sonar high issues, fires_event chain (7.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.1.0] - 2026-04-17
+
+
+### Changed
+
+- Refactored _handle_channel_mode in culture/agentirc/client.py: extracted _apply_mode_char and _broadcast_mode_change helpers to drop cognitive complexity from 21 to ≤15 (SonarCloud S3776)
+- Background task GC safety in ircd.py _notify_local_quit: asyncio.ensure_future replaced with a tracked asyncio.create_task using the existing self._background_tasks set + add_done_callback(discard) pattern
+
+
+### Fixed
+
+- culture mesh update no longer hangs on broken/unresponsive systemd units — all subprocess calls in persistence.py and cli/mesh.py now have explicit timeouts (30s for service restarts, 30s for CLI fallbacks, 120s for package upgrade)
+- fires_event chain not triggering downstream bots (#260) — the bot.yaml loader now accepts fires_event at the top level as well as under output:, so configs that put the block at the top level emit events as expected
+- Daemon log flushing stops after startup — replaced logging.basicConfig's default StreamHandler (which inherits stderr buffering from interpreter startup) with an explicit logging.FileHandler so runtime log records flush per-record
+
 ## [7.0.4] - 2026-04-17
 
 

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -444,6 +444,56 @@ class Client:
         applied_modes.append(("+" if adding else "-") + ch)
         applied_params.append(target_nick)
 
+    _PARAM_MODES = frozenset({"o", "v", "S"})
+
+    async def _apply_mode_char(
+        self,
+        channel,
+        channel_name: str,
+        ch: str,
+        adding: bool,
+        param_queue: list[str],
+        applied_modes: list[str],
+        applied_params: list[str],
+    ) -> None:
+        """Apply a single mode character. Consumes one param from param_queue when needed."""
+        if ch == "R":
+            self._apply_mode_r(channel, adding, applied_modes)
+            return
+        if ch not in self._PARAM_MODES or not param_queue:
+            return
+        param_value = param_queue.pop(0)
+        if ch == "S":
+            self._apply_mode_s(channel, adding, param_value, applied_modes, applied_params)
+        else:
+            await self._apply_mode_membership(
+                channel,
+                channel_name,
+                ch,
+                adding,
+                param_value,
+                applied_modes,
+                applied_params,
+            )
+
+    async def _broadcast_mode_change(
+        self,
+        channel,
+        channel_name: str,
+        applied_modes: list[str],
+        applied_params: list[str],
+    ) -> None:
+        """Send the aggregated MODE message to all channel members."""
+        if not applied_modes:
+            return
+        mode_msg = Message(
+            prefix=self.prefix,
+            command="MODE",
+            params=[channel_name, "".join(applied_modes)] + applied_params,
+        )
+        for member in list(channel.members):
+            await member.send(mode_msg)
+
     async def _handle_channel_mode(self, msg: Message) -> None:
         channel_name = msg.params[0]
         channel = self.server.channels.get(channel_name)
@@ -457,7 +507,6 @@ class Client:
             await self.send_numeric(replies.RPL_CHANNELMODEIS, channel_name, "+")
             return
 
-        modestring = msg.params[1]
         if not channel.is_operator(self):
             await self.send_numeric(
                 replies.ERR_CHANOPRIVSNEEDED,
@@ -466,48 +515,32 @@ class Client:
             )
             return
 
+        modestring = msg.params[1]
         param_queue = list(msg.params[2:])
-        param_modes = {"o", "v", "S"}
-
         adding = True
-        applied_modes = []
+        applied_modes: list[str] = []
         applied_params: list[str] = []
         for ch in modestring:
             if ch == "+":
                 adding = True
             elif ch == "-":
                 adding = False
-            elif ch == "R":
-                self._apply_mode_r(channel, adding, applied_modes)
-            elif ch in param_modes:
-                if not param_queue:
-                    continue
-                param_value = param_queue.pop(0)
-                if ch == "S":
-                    self._apply_mode_s(channel, adding, param_value, applied_modes, applied_params)
-                else:
-                    await self._apply_mode_membership(
-                        channel,
-                        channel_name,
-                        ch,
-                        adding,
-                        param_value,
-                        applied_modes,
-                        applied_params,
-                    )
+            else:
+                await self._apply_mode_char(
+                    channel,
+                    channel_name,
+                    ch,
+                    adding,
+                    param_queue,
+                    applied_modes,
+                    applied_params,
+                )
 
         # Auto-promote if no operators remain
         if not channel.operators and channel.members:
             channel.operators.add(min(channel.members, key=lambda m: m.nick))
 
-        if applied_modes:
-            mode_msg = Message(
-                prefix=self.prefix,
-                command="MODE",
-                params=[channel_name, "".join(applied_modes)] + applied_params,
-            )
-            for member in list(channel.members):
-                await member.send(mode_msg)
+        await self._broadcast_mode_change(channel, channel_name, applied_modes, applied_params)
 
     _VALID_USER_MODE_CHARS = frozenset("HABC")
     _USER_MODE_EDGE_EVENTS: dict[tuple[str, bool], EventType] = {

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -562,7 +562,9 @@ class IRCd:
         for channel in list(rc.channels):
             for member in list(channel.members):
                 if not isinstance(member, RemoteClient) and member not in notified:
-                    asyncio.ensure_future(member.send(quit_msg))
+                    task = asyncio.create_task(member.send(quit_msg))
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
                     notified.add(member)
             channel.members.discard(rc)
             if not channel.members:

--- a/culture/bots/config.py
+++ b/culture/bots/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from dataclasses import dataclass, field
@@ -9,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 BOTS_DIR = Path(os.path.expanduser("~/.culture/bots"))
 BOT_CONFIG_FILE = "bot.yaml"
@@ -58,8 +61,16 @@ def load_bot_config(path: Path) -> BotConfig:
     trigger_section = raw.get("trigger", {})
     output_section = raw.get("output", {})
 
-    # Parse optional fires_event block
+    # Parse optional fires_event block. Canonical location is under `output:`;
+    # top-level `fires_event:` is also accepted so configs authored against the
+    # intuitive YAML shape still work (see issue #260).
     fires_event_raw = output_section.get("fires_event")
+    fires_event_from_top = False
+    if not isinstance(fires_event_raw, dict):
+        top_level = raw.get("fires_event")
+        if isinstance(top_level, dict):
+            fires_event_raw = top_level
+            fires_event_from_top = True
     fires_event: EmitEventSpec | None = None
     if isinstance(fires_event_raw, dict):
         fe_type = fires_event_raw.get("type", "")
@@ -69,6 +80,12 @@ def load_bot_config(path: Path) -> BotConfig:
         if not isinstance(fe_data, dict):
             fe_data = {}
         fires_event = EmitEventSpec(type=fe_type, data=fe_data)
+        if fires_event_from_top:
+            logger.info(
+                "Bot %s: top-level 'fires_event' accepted; "
+                "canonical location is under 'output:'",
+                bot_section.get("name", "<unknown>"),
+            )
 
     return BotConfig(
         name=bot_section.get("name", ""),

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -432,10 +432,24 @@ def _find_upgrade_tool() -> tuple[str, list[str]] | None:
     return None
 
 
+_UPGRADE_TIMEOUT_SECONDS = 120
+_FALLBACK_START_TIMEOUT_SECONDS = 30
+
+
 def _run_upgrade(tool_name: str, cmd: list[str]) -> None:
-    """Run the upgrade subprocess and exit on failure."""
+    """Run the upgrade subprocess and exit on failure or timeout."""
     print(f"Upgrading via {tool_name}...")
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_UPGRADE_TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            f"{tool_name} upgrade timed out after {_UPGRADE_TIMEOUT_SECONDS}s — "
+            "rerun with --skip-upgrade to proceed without upgrading",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if tool_name == "uv":
         print(result.stdout.strip() if result.stdout else "")
     if result.returncode != 0:
@@ -523,7 +537,14 @@ def _restart_single_service(svc_name: str, fallback_cmd: list[str], restart_serv
         )
     else:
         print("  No service file found, starting via CLI...")
-    subprocess.run(fallback_cmd, check=False)
+    try:
+        subprocess.run(fallback_cmd, check=False, timeout=_FALLBACK_START_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        print(
+            f"  Warning: startup command for {svc_name} timed out after "
+            f"{_FALLBACK_START_TIMEOUT_SECONDS}s — continuing",
+            file=sys.stderr,
+        )
 
 
 def _restart_mesh_services(

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -371,9 +371,14 @@ def _daemonize_server(args: argparse.Namespace, pid_name: str, links: list) -> N
     os.dup2(devnull, 0)
     os.close(devnull)
 
+    # Use an explicit FileHandler: logging.StreamHandler on sys.stderr
+    # inherits stderr's buffering from interpreter startup. After dup2'ing
+    # fd 2 to a log file, those writes can buffer indefinitely and make
+    # the daemon's runtime log appear frozen.
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        handlers=[logging.FileHandler(log_path)],
         force=True,
     )
 

--- a/culture/persistence.py
+++ b/culture/persistence.py
@@ -49,7 +49,8 @@ def _run_cmd(args: list[str], timeout: float = DEFAULT_CMD_TIMEOUT) -> bool:
         subprocess.run(args, check=False, capture_output=True, timeout=timeout)
         return True
     except subprocess.TimeoutExpired:
-        logger.warning("Command %r timed out after %.0fs", args[0], timeout)
+        command = shlex.join(args) if args else "<empty command>"
+        logger.warning("Command %s timed out after %.0fs", command, timeout)
         return False
 
 

--- a/culture/persistence.py
+++ b/culture/persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shlex
 import subprocess
@@ -10,6 +11,10 @@ from pathlib import Path
 from xml.sax.saxutils import escape as xml_escape
 
 LOG_DIR = os.path.expanduser("~/.culture/logs")
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CMD_TIMEOUT = 30.0
 
 
 def get_platform() -> str:
@@ -33,9 +38,19 @@ def _windows_service_dir() -> Path:
     return Path(os.path.expandvars(r"%USERPROFILE%\.culture\services"))
 
 
-def _run_cmd(args: list[str]) -> None:
-    """Run a command, suppressing output."""
-    subprocess.run(args, check=False, capture_output=True)
+def _run_cmd(args: list[str], timeout: float = DEFAULT_CMD_TIMEOUT) -> bool:
+    """Run a command, suppressing output.
+
+    Returns True if the command completed (regardless of exit code), False
+    if it timed out. A hung systemd unit can make ``systemctl restart``
+    block indefinitely, so every caller needs a bounded wait.
+    """
+    try:
+        subprocess.run(args, check=False, capture_output=True, timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("Command %r timed out after %.0fs", args[0], timeout)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -248,8 +263,7 @@ def _restart_linux_service(name: str) -> bool:
     path = _systemd_user_dir() / f"{name}.service"
     if not path.exists():
         return False
-    _run_cmd(["systemctl", "--user", "restart", name])
-    return True
+    return _run_cmd(["systemctl", "--user", "restart", name])
 
 
 def _restart_macos_service(name: str) -> bool:
@@ -257,21 +271,25 @@ def _restart_macos_service(name: str) -> bool:
     path = _launchd_dir() / f"{plist_name}.plist"
     if not path.exists():
         return False
-    _run_cmd(["launchctl", "unload", str(path)])
-    _run_cmd(["launchctl", "load", str(path)])
-    return True
+    if not _run_cmd(["launchctl", "unload", str(path)]):
+        return False
+    return _run_cmd(["launchctl", "load", str(path)])
 
 
 def _restart_windows_service(name: str) -> bool:
-    probe = subprocess.run(
-        ["schtasks", "/Query", "/TN", f"culture\\{name}"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        probe = subprocess.run(
+            ["schtasks", "/Query", "/TN", f"culture\\{name}"],
+            capture_output=True,
+            text=True,
+            timeout=DEFAULT_CMD_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("schtasks query for %s timed out", name)
+        return False
     if probe.returncode != 0:
         return False
-    _run_cmd(["schtasks", "/Run", "/TN", f"culture\\{name}"])
-    return True
+    return _run_cmd(["schtasks", "/Run", "/TN", f"culture\\{name}"])
 
 
 _PLATFORM_RESTARTERS = {

--- a/docs/agentirc/bots.md
+++ b/docs/agentirc/bots.md
@@ -106,6 +106,13 @@ output:
 The emitted event flows through the same pipeline as any other event — skills,
 federation relay, history storage, and further bot triggers.
 
+> **Location tolerance.** The canonical location for `fires_event` is under
+> `output:` as shown above. A top-level `fires_event:` block is also accepted
+> (the loader falls back to it if `output.fires_event` is missing) so configs
+> authored against the intuitive top-level shape still work. When the top-level
+> form is used, the server logs an INFO message pointing to the canonical
+> location; `save_bot_config` always writes the canonical form.
+
 ## System Bots
 
 System bots are package-bundled bots that ship with AgentIRC. They live at

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -363,6 +363,11 @@ culture mesh update --config /path/mesh.yaml
 | `--skip-upgrade` | off | Skip the package upgrade step; just restart services |
 | `--config PATH` | `~/.culture/mesh.yaml` | Path to `mesh.yaml` |
 
+Subprocess steps are bounded so a hung service unit cannot freeze the CLI: the
+package upgrade aborts after 120s, each service-restart command after 30s, and
+the fallback `culture server start` step after 30s. Timeouts are reported on
+stderr and the next step proceeds.
+
 ## Bots
 
 ### `culture bot archive`

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -364,9 +364,10 @@ culture mesh update --config /path/mesh.yaml
 | `--config PATH` | `~/.culture/mesh.yaml` | Path to `mesh.yaml` |
 
 Subprocess steps are bounded so a hung service unit cannot freeze the CLI: the
-package upgrade aborts after 120s, each service-restart command after 30s, and
-the fallback `culture server start` step after 30s. Timeouts are reported on
-stderr and the next step proceeds.
+package upgrade times out after 120s and aborts the command, while each
+service-restart command times out after 30s and the fallback
+`culture server start` step times out after 30s. Restart and fallback
+timeouts are reported on stderr, and the next step proceeds where applicable.
 
 ## Bots
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.0.4"
+version = "7.1.0"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_bot_config_fires_event_toplevel.py
+++ b/tests/test_bot_config_fires_event_toplevel.py
@@ -1,0 +1,114 @@
+"""Regression tests for issue #260: `fires_event` at the top level of bot.yaml.
+
+The canonical location for the block is under `output:`, but prior to the
+fix a top-level `fires_event:` block was silently ignored, producing a bot
+whose `fires_event` attribute was ``None`` — so chained events never fired.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from culture.bots.config import load_bot_config, save_bot_config
+
+
+def _write_yaml(tmp_path, data: dict):
+    path = tmp_path / "bot.yaml"
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def test_load_top_level_fires_event(tmp_path):
+    path = _write_yaml(
+        tmp_path,
+        {
+            "bot": {"name": "spark-greeter", "owner": "spark"},
+            "trigger": {"type": "event", "filter": "type == 'user.join'"},
+            "output": {"channels": ["#general"], "template": "hi {event.nick}"},
+            "fires_event": {
+                "type": "custom.greeted",
+                "data": {"nick": "{{ event.nick }}"},
+            },
+        },
+    )
+
+    cfg = load_bot_config(path)
+    assert cfg.fires_event is not None
+    assert cfg.fires_event.type == "custom.greeted"
+    assert cfg.fires_event.data == {"nick": "{{ event.nick }}"}
+
+
+def test_load_canonical_output_fires_event_still_works(tmp_path):
+    path = _write_yaml(
+        tmp_path,
+        {
+            "bot": {"name": "spark-greeter", "owner": "spark"},
+            "trigger": {"type": "event", "filter": "type == 'user.join'"},
+            "output": {
+                "channels": ["#general"],
+                "template": "hi {event.nick}",
+                "fires_event": {
+                    "type": "custom.greeted",
+                    "data": {"nick": "{{ event.nick }}"},
+                },
+            },
+        },
+    )
+
+    cfg = load_bot_config(path)
+    assert cfg.fires_event is not None
+    assert cfg.fires_event.type == "custom.greeted"
+
+
+def test_output_location_wins_over_top_level(tmp_path):
+    """If both are set, `output.fires_event` is canonical and wins."""
+    path = _write_yaml(
+        tmp_path,
+        {
+            "bot": {"name": "spark-greeter", "owner": "spark"},
+            "trigger": {"type": "event", "filter": "type == 'user.join'"},
+            "output": {
+                "channels": ["#general"],
+                "fires_event": {"type": "custom.canonical", "data": {}},
+            },
+            "fires_event": {"type": "custom.toplevel", "data": {}},
+        },
+    )
+
+    cfg = load_bot_config(path)
+    assert cfg.fires_event is not None
+    assert cfg.fires_event.type == "custom.canonical"
+
+
+def test_save_round_trip_writes_canonical_location(tmp_path):
+    """save_bot_config always emits the canonical output.fires_event form."""
+    src = _write_yaml(
+        tmp_path,
+        {
+            "bot": {"name": "spark-greeter", "owner": "spark"},
+            "trigger": {"type": "event", "filter": "type == 'user.join'"},
+            "output": {"channels": ["#general"], "template": "hi"},
+            "fires_event": {"type": "custom.greeted", "data": {"n": "x"}},
+        },
+    )
+
+    cfg = load_bot_config(src)
+    out_path = tmp_path / "saved.yaml"
+    save_bot_config(out_path, cfg)
+    data = yaml.safe_load(out_path.read_text())
+    assert "fires_event" not in data, "top-level fires_event must not be re-emitted"
+    assert data["output"]["fires_event"]["type"] == "custom.greeted"
+
+
+def test_missing_fires_event_still_loads(tmp_path):
+    path = _write_yaml(
+        tmp_path,
+        {
+            "bot": {"name": "spark-plain", "owner": "spark"},
+            "trigger": {"type": "webhook"},
+            "output": {"channels": ["#general"], "template": "hi"},
+        },
+    )
+
+    cfg = load_bot_config(path)
+    assert cfg.fires_event is None

--- a/tests/test_persistence_timeout.py
+++ b/tests/test_persistence_timeout.py
@@ -1,0 +1,59 @@
+"""Regression tests: subprocess timeout handling in persistence._run_cmd.
+
+Covers the hang reported for ``culture mesh update``: a broken/hung systemd
+unit caused ``systemctl --user restart`` to block indefinitely because the
+underlying subprocess call had no timeout.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from culture.persistence import (
+    DEFAULT_CMD_TIMEOUT,
+    _restart_linux_service,
+    _run_cmd,
+)
+
+
+def test_run_cmd_returns_true_on_success():
+    with patch("culture.persistence.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(args=["/bin/true"], returncode=0)
+        assert _run_cmd(["/bin/true"]) is True
+
+
+def test_run_cmd_returns_false_on_timeout():
+    """_run_cmd must not propagate TimeoutExpired — callers treat it as failure."""
+    with patch("culture.persistence.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["systemctl"], timeout=30)
+        assert _run_cmd(["systemctl", "restart", "x"]) is False
+
+
+def test_run_cmd_passes_timeout_to_subprocess():
+    with patch("culture.persistence.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        _run_cmd(["echo", "hi"], timeout=5)
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["timeout"] == 5
+
+
+def test_run_cmd_default_timeout_bounds_wait():
+    """A default timeout must be applied so hung services never hang the CLI."""
+    with patch("culture.persistence.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        _run_cmd(["systemctl", "restart", "x"])
+        assert mock_run.call_args.kwargs["timeout"] == DEFAULT_CMD_TIMEOUT
+
+
+def test_restart_linux_service_returns_false_on_timeout(tmp_path, monkeypatch):
+    """When the restart command times out, the restarter must report failure."""
+    svc_name = "culture-test-timeout"
+    unit_dir = tmp_path / "systemd-user"
+    unit_dir.mkdir()
+    (unit_dir / f"{svc_name}.service").write_text("[Service]\nExecStart=/bin/true\n")
+
+    monkeypatch.setattr("culture.persistence._systemd_user_dir", lambda: unit_dir)
+    with patch("culture.persistence.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["systemctl"], timeout=30)
+        assert _restart_linux_service(svc_name) is False

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.0.4"
+version = "7.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bundled 7.1.0 release covering four independent fixes reported together.

### Fixes

- **`culture mesh update` hangs indefinitely.** `persistence._run_cmd` and the two peer subprocess calls in `cli/mesh.py` now have explicit timeouts (30s for service restarts, 30s for CLI fallbacks, 120s for package upgrade). `_run_cmd` returns `bool`; `_restart_linux/macos/windows_service` propagate it.
- **`fires_event` chain never fires downstream bots (#260).** Root cause: `load_bot_config` only read `fires_event` from `output:`; the reporter's YAML put it at the top level, so parsing silently yielded `fires_event=None`. The loader now falls back to top-level `fires_event:` when `output.fires_event` is missing. Canonical location remains under `output:`; `save_bot_config` always emits the canonical form.
- **Daemon log flushing stops after startup.** `logging.basicConfig`'s default `StreamHandler` on `sys.stderr` inherits stderr's buffering mode from interpreter startup, so after `os.dup2(log_fd, 2)` writes can buffer indefinitely. Swapped to an explicit `logging.FileHandler(log_path)` so records flush per-record.

### Code quality

- **SonarCloud high S3776** — `_handle_channel_mode` cognitive complexity 21 → ≤15. Extracted `_apply_mode_char` and `_broadcast_mode_change` helpers. Semantics unchanged (verified against `tests/test_channel.py` + `tests/test_modes.py`).
- **SonarCloud high (asyncio task GC)** — `_notify_local_quit` replaced `asyncio.ensure_future(member.send(...))` with tracked `asyncio.create_task(...)` using the existing `self._background_tasks` set + `add_done_callback(discard)` pattern already used at `ircd.py:367-368`.

## Test plan

- [x] `/run-tests` — all 875 tests pass locally.
- [x] New regression tests:
  - `tests/test_persistence_timeout.py` — `TimeoutExpired` propagation, default timeout injection, `_restart_linux_service` returns `False` on timeout.
  - `tests/test_bot_config_fires_event_toplevel.py` — top-level accept, canonical precedence, round-trip strips to canonical, missing-block still loads.
- [x] Existing `tests/test_events_bot_chain.py` (bot chain happy path) still passes.
- [x] Pre-push `superpowers:code-reviewer` review — no blocking issues.
- [x] `doc-test-alignment` audit — surfaced the mesh-update timeout ceiling gap; added a note in `docs/reference/cli/index.md`.

## Closes

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude