### PR TITLE
chore: housekeeping sweep (#258, #249)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - run: uv python install 3.12
 
@@ -37,9 +37,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - run: uv python install 3.12
 
@@ -89,9 +89,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - run: uv python install 3.12
 

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -16,9 +16,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - run: uv python install 3.12
 
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Security Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: security-results
           path: |
@@ -54,10 +54,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
 
@@ -68,12 +68,12 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - run: uv python install 3.12
 
@@ -26,13 +26,13 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - run: git fetch origin main
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.1.2] - 2026-04-17
+
+### Changed
+
+- Pin all GitHub Actions workflow uses: to full commit SHAs (SonarCloud minor, #258)
+- Document Python API for events.register/validate_event_type/render_event in docs/agentirc/events.md (#249)
+- Document Python API for bot filter DSL and template engine in docs/agentirc/bots.md (#249)
+- Note in ConsoleIRCClient docstring that it intentionally does not negotiate CAP message-tags (#249)
+
+### Fixed
+
+- Remove unused PEER_CAPABILITY_EVENTS constant from culture/constants.py (#249)
+
 ## [7.1.1] - 2026-04-17
 
 ### Changed

--- a/culture/console/client.py
+++ b/culture/console/client.py
@@ -47,6 +47,11 @@ class ConsoleIRCClient:
 
     Maintains a persistent connection, buffers incoming PRIVMSG messages,
     and provides query methods for channel listing, WHO, and history.
+
+    Does **not** negotiate ``CAP REQ :message-tags``. The TUI renders plain
+    body text for mesh events; IRCv3 tags carry structured payloads that the
+    console has no use for. Agent harness transports (see
+    ``packages/agent-harness/irc_transport.py``) do negotiate the cap.
     """
 
     def __init__(

--- a/culture/constants.py
+++ b/culture/constants.py
@@ -13,8 +13,5 @@ SYSTEM_USER_REALNAME = "Culture system messages"
 EVENT_TAG_TYPE = "event"
 EVENT_TAG_DATA = "event-data"
 
-# Peer link capability (server-to-server)
-PEER_CAPABILITY_EVENTS = "events/1"
-
 # Event-type name regex (dotted lowercase, ≥2 segments)
 EVENT_TYPE_RE = re.compile(r"^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$")

--- a/docs/agentirc/bots.md
+++ b/docs/agentirc/bots.md
@@ -82,6 +82,24 @@ Missing fields evaluate to `False` — filters are fail-closed.
 Invalid filters are rejected at config-load time with `FilterParseError`.
 Function calls are not permitted.
 
+### Python API
+
+The DSL grammar above is exposed by `culture/bots/filter_dsl.py`:
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `compile_filter` | `compile_filter(source: str)` → AST node | Parse a filter expression. Raises `FilterParseError` on invalid input. |
+| `evaluate` | `evaluate(node, event: dict)` → `Any` | Evaluate a compiled AST against an event payload. Used by `BotManager` to decide whether a bot's trigger matches. |
+
+## Template Engine (Python API)
+
+`output.template` rendering lives in `culture/bots/template_engine.py`:
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `render_template` | `render_template(template, payload)` → `str \| None` | Expand `{dot.path}` tokens against a payload dict. Returns `None` if any token cannot be resolved (caller should use the bot's `fallback` config). Payload fields are available at top level (`{event.nick}`) and via the `body` alias (`{body.event.nick}`). |
+| `render_fallback` | `render_fallback(payload, mode="json")` → `str` | Stringify a payload when template resolution fails. `mode="json"` uses compact JSON; any other value falls back to `str(payload)`. |
+
 ## `fires_event` — Pub/Sub Chains
 
 A bot can emit a follow-on event after handling a trigger by adding a

--- a/docs/agentirc/bots.md
+++ b/docs/agentirc/bots.md
@@ -97,7 +97,7 @@ The DSL grammar above is exposed by `culture/bots/filter_dsl.py`:
 
 | Function | Signature | Purpose |
 |----------|-----------|---------|
-| `render_template` | `render_template(template, payload)` → `str \| None` | Expand `{dot.path}` tokens against a payload dict. Returns `None` if any token cannot be resolved (caller should use the bot's `fallback` config). Payload fields are available at top level (`{event.nick}`) and via the `body` alias (`{body.event.nick}`). |
+| `render_template` | `render_template(template: str, payload: dict \| str)` → `str \| None` | Expand `{dot.path}` tokens against a payload. Returns `None` if any token cannot be resolved (caller should use the bot's `fallback` config). For dict payloads, fields are available at top level (`{event.nick}`); any payload (dict or str) is also exposed via the `body` alias (`{body.event.nick}`). |
 | `render_fallback` | `render_fallback(payload, mode="json")` → `str` | Stringify a payload when template resolution fails. `mode="json"` uses compact JSON; any other value falls back to `str(payload)`. |
 
 ## `fires_event` — Pub/Sub Chains

--- a/docs/agentirc/events.md
+++ b/docs/agentirc/events.md
@@ -117,6 +117,23 @@ Channel-scoped events respect each link's `should_relay()` trust check. Global
 See [Protocol Extensions → Events](../../culture/protocol/extensions/events.md)
 for the full `SEVENT` wire format.
 
+## Custom Event Types (Python API)
+
+AgentIRC renders every event body through a registry of template functions in
+`culture/agentirc/events.py`. Skills and in-tree bots can register additional
+event types at module import time.
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `register` | `register(event_type: str, fn: RenderFn) -> None` | Attach a render function to a dotted event type (e.g. `"mybot.alert"`). `RenderFn` is `(data: dict, channel: str \| None) -> str`. |
+| `validate_event_type` | `validate_event_type(name: str) -> bool` | Returns `True` if `name` matches the dotted-lowercase convention (`EVENT_TYPE_RE` in `culture.constants`). |
+| `render_event` | `render_event(event_type, data, channel) -> str` | Look up and invoke the render template; falls back to `f"{type} {data}"` on missing template or exception. |
+
+Templates are presentation-only — the structured payload is attached as IRCv3
+tags by the server's emit path regardless of what the template returns, so
+custom templates need only concern themselves with producing a readable body
+line for non-CAP clients.
+
 ## Example Flows
 
 ### Flow A — Server emits `agent.connect`

--- a/docs/agentirc/events.md
+++ b/docs/agentirc/events.md
@@ -127,7 +127,7 @@ event types at module import time.
 |----------|-----------|---------|
 | `register` | `register(event_type: str, fn: RenderFn) -> None` | Attach a render function to a dotted event type (e.g. `"mybot.alert"`). `RenderFn` is `(data: dict, channel: str \| None) -> str`. |
 | `validate_event_type` | `validate_event_type(name: str) -> bool` | Returns `True` if `name` matches the dotted-lowercase convention (`EVENT_TYPE_RE` in `culture.constants`). |
-| `render_event` | `render_event(event_type, data, channel) -> str` | Look up and invoke the render template; falls back to `f"{type} {data}"` on missing template or exception. |
+| `render_event` | `render_event(event_type, data, channel) -> str` | Look up and invoke the render template; falls back to `f"{event_type} {data}"` on missing template or exception. |
 
 Templates are presentation-only — the structured payload is attached as IRCv3
 tags by the server's emit path regardless of what the template returns, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.1.1"
+version = "7.1.2"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.1.1"
+version = "7.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Bundled housekeeping for four related issues. Single `patch` bump (7.1.1 → 7.1.2).

- **#258** — Pin every GitHub Actions `uses:` to a full commit SHA (SonarCloud "use full commit SHA hash" rule). 16 lines across `publish.yml`, `tests.yml`, `security-checks.yml`. `docs-check.yml` was already compliant. Each SHA is annotated with the source tag as a trailing `# vN` comment.
- **#249** — Doc/test-alignment gaps from the mesh-events audit:
  - Added **Custom Event Types (Python API)** section to `docs/agentirc/events.md` documenting `register`, `validate_event_type`, `render_event`.
  - Added **Python API** subsections to `docs/agentirc/bots.md` Filter DSL (`compile_filter`, `evaluate`) and a new **Template Engine (Python API)** section (`render_template`, `render_fallback`).
  - Noted in `ConsoleIRCClient` docstring that the console TUI deliberately does **not** negotiate `CAP REQ :message-tags` (it renders plain body text; agent harnesses opt in).
  - Removed the unused `PEER_CAPABILITY_EVENTS = "events/1"` constant from `culture/constants.py`. Zero references existed outside a historical plan doc.
- **#255** — Already done in PR #130 / commit `2a1d8e3` (the `culture/cli/_helpers.py` → `culture/cli/shared/` split). Will close with a pointer comment once this PR merges.
- **#236** — Cloudflare Pages build-watch gating is a **dashboard-only** setting (no code change). Exact watch-path lists to paste into the CF dashboard are documented in the plan at `/home/spark/.claude/plans/let-s-fix-minor-sonarcloud-fancy-lovelace.md` and will be applied manually after merge.

## Test plan

- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p -q tests/test_events_basic.py tests/test_events_catalog.py tests/test_filter_dsl.py tests/test_template_engine.py tests/test_console_client.py tests/test_console_commands.py` — 93 passed.
- [x] `rg 'uses:.*@v[0-9]+\$' .github/workflows/` returns nothing.
- [x] `rg PEER_CAPABILITY_EVENTS` returns only the historical mention in `docs/superpowers/plans/2026-04-15-mesh-events.md` (intentional — it's describing the original design).
- [x] `markdownlint-cli2 docs/agentirc/events.md docs/agentirc/bots.md` — clean.
- [x] `uv run black culture/constants.py culture/console/client.py` — no changes needed.
- [ ] CI (`Tests`, `Docs Check`, `Security Checks`, `Publish` test job) green on the pinned SHAs.
- [ ] SonarCloud re-scan on this branch shows #258 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude