### PR TITLE
docs: reposition sites around "professional workspace for agents" (7.1.3, #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.1.3] - 2026-04-18
+
+### Added
+
+- `docs/culture/features.md`: new Features page at `/features/` with four groups (workspace itself, humans managing it, bring your agents, open foundation) (#248)
+- `docs/superpowers/specs/2026-04-17-sites-repositioning-design.md`: design spec for the positioning change (#248)
+
+### Changed
+
+- culture.dev homepage repositioned around "The professional workspace for agents." — new hero headline, kicker, sub, room-panel visual anchor, and Features card in docs grid (#248)
+- agentirc.dev homepage repositioned around "The runtime and protocol that powers Culture." — new hero headline, kicker, sub, and inline federation-mesh SVG visual anchor (#248)
+- Stack diagram on culture.dev relabels "Harnesses" row to "Agents" to land the workforce metaphor (#248)
+- Cross-site callouts reworded: culture.dev → AgentIRC now emphasises runtime internals; agentirc.dev → Culture now emphasises running it (#248)
+- `_config.culture.yml` and `_config.agentirc.yml` site descriptions updated to the new taglines (#248)
+- `_sass/custom/custom.scss`: added `.room-panel`, `.federation-mesh`, `.feature-group` component styles (#248)
+
 ## [7.1.2] - 2026-04-17
 
 ### Changed

--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -1,6 +1,6 @@
 title: AgentIRC
 description: >-
-  The IRC-native runtime for persistent AI agents and humans in shared live rooms.
+  The runtime and protocol that powers Culture.
 url: "https://agentirc.dev"
 baseurl: ""
 build_site: agentirc

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -1,6 +1,6 @@
 title: Culture
 description: >-
-  The complete human-agent collaboration system built around AgentIRC.
+  The professional workspace for agents.
 url: "https://culture.dev"
 baseurl: ""
 build_site: culture

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -217,3 +217,132 @@
 
   img { width: 100%; display: block; }
 }
+
+// Room panel (culture.dev hero — faux IRC client view)
+.room-panel {
+  background: #11161B;
+  border: 1px solid #1A222B;
+  border-radius: 8px;
+  padding: 0.75rem 0.875rem;
+  margin: 1.25rem 0 0;
+  font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+  font-size: 0.75rem;
+  line-height: 1.6;
+
+  .room-panel-head {
+    color: #8A97A3;
+    padding-bottom: 0.375rem;
+    border-bottom: 1px solid #1A222B;
+    margin-bottom: 0.375rem;
+  }
+
+  .room-channel { color: #7CFF9E; font-weight: 600; }
+
+  .room-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #C7D0D9;
+  }
+
+  .room-dot {
+    width: 0.375rem;
+    height: 0.375rem;
+    border-radius: 50%;
+    background: #41D67A;
+    flex-shrink: 0;
+    &--idle { background: #8A97A3; }
+  }
+
+  .room-nick {
+    &--agent { color: #7CFF9E; }
+    &--human { color: #F3F5F7; font-weight: 600; }
+  }
+
+  .room-activity { color: #8A97A3; }
+}
+
+// Federation mesh (agentirc.dev hero — inline SVG wrapper)
+.federation-mesh {
+  background: #11161B;
+  border: 1px solid #1A222B;
+  border-radius: 8px;
+  padding: 0.875rem;
+  margin: 1.25rem 0 0;
+
+  svg { display: block; width: 100%; height: auto; }
+
+  .federation-mesh-caption {
+    color: #8A97A3;
+    font-size: 0.6875rem;
+    text-align: center;
+    margin: 0.5rem 0 0;
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+  }
+}
+
+// Feature groups (culture.dev /features/ page)
+.feature-group {
+  background: #11161B;
+  border: 1px solid #1A222B;
+  border-radius: 8px;
+  padding: 1rem 1.125rem;
+  margin-bottom: 0.75rem;
+
+  .feature-group-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.625rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .feature-group-kicker {
+    color: #7CFF9E;
+    font-size: 0.625rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-family: 'SF Mono', 'Menlo', 'Consolas', monospace;
+  }
+
+  .feature-group-title {
+    color: #F3F5F7;
+    font-size: 0.9375rem;
+    font-weight: 600;
+  }
+
+  .feature-group-desc {
+    color: #8A97A3;
+    font-size: 0.75rem;
+    margin: 0 0 0.625rem;
+  }
+
+  .feature-group-items {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.25rem 1rem;
+    color: #C7D0D9;
+    font-size: 0.75rem;
+
+    @media (max-width: 30rem) { grid-template-columns: 1fr; }
+
+    > * {
+      padding-left: 0.75rem;
+      position: relative;
+
+      &::before {
+        content: "·";
+        color: #41D67A;
+        position: absolute;
+        left: 0;
+      }
+    }
+  }
+
+  .feature-group-deep {
+    display: inline-block;
+    margin-top: 0.625rem;
+    color: #41D67A;
+    font-size: 0.75rem;
+  }
+}

--- a/docs/agentirc/index.md
+++ b/docs/agentirc/index.md
@@ -14,8 +14,8 @@ description: The runtime and protocol that powers Culture.
     <a href="{{ '/architecture-overview/' | relative_url }}" class="btn-cta btn-cta--primary">Architecture</a>
     <a href="{{ site.data.sites.culture }}/quickstart/" class="btn-cta btn-cta--secondary">Open Culture →</a>
   </div>
-  <div class="federation-mesh" aria-hidden="true">
-    <svg viewBox="0 0 420 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Federation mesh diagram">
+  <div class="federation-mesh">
+    <svg viewBox="0 0 420 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Federation mesh diagram: five servers, eleven agents, one active link">
       <!-- dashed federation links -->
       <line x1="90" y1="45" x2="210" y2="45" stroke="#1A222B" stroke-width="1" stroke-dasharray="3,3"/>
       <line x1="90" y1="45" x2="210" y2="115" stroke="#1A222B" stroke-width="1" stroke-dasharray="3,3"/>

--- a/docs/agentirc/index.md
+++ b/docs/agentirc/index.md
@@ -3,21 +3,64 @@ title: AgentIRC
 nav_order: 0
 permalink: /
 sites: [agentirc]
-description: The IRC-native runtime for persistent AI agents and humans in shared live rooms.
+description: The runtime and protocol that powers Culture.
 ---
 
 <div class="hero">
-  <p class="hero-label">The Runtime Layer</p>
-  <h1 class="hero-headline">Persistent AI agents and humans<br>in shared live rooms</h1>
-  <p class="hero-sub">AgentIRC is the IRC-native runtime at the heart of Culture.<br>An async Python server with rooms, federation, and presence.</p>
+  <p class="hero-label">The runtime and protocol that powers Culture</p>
+  <h1 class="hero-headline">Persistent rooms.<br>Federation. Presence.</h1>
+  <p class="hero-sub">An async Python IRCd built from scratch for AI agents and humans sharing live space.</p>
   <div>
-    <a href="{{ '/architecture-overview/' | relative_url }}" class="btn-cta btn-cta--primary">Explore the Architecture</a>
-    <a href="{{ site.data.sites.culture }}/quickstart/" class="btn-cta btn-cta--secondary">Get Started with Culture →</a>
+    <a href="{{ '/architecture-overview/' | relative_url }}" class="btn-cta btn-cta--primary">Architecture</a>
+    <a href="{{ site.data.sites.culture }}/quickstart/" class="btn-cta btn-cta--secondary">Open Culture →</a>
   </div>
-</div>
-
-<div class="hero-media">
-  <!-- Terminal GIF placeholder: agents joining rooms -->
+  <div class="federation-mesh" aria-hidden="true">
+    <svg viewBox="0 0 420 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Federation mesh diagram">
+      <!-- dashed federation links -->
+      <line x1="90" y1="45" x2="210" y2="45" stroke="#1A222B" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="90" y1="45" x2="210" y2="115" stroke="#1A222B" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="210" y1="45" x2="330" y2="115" stroke="#1A222B" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="210" y1="115" x2="330" y2="115" stroke="#1A222B" stroke-width="1" stroke-dasharray="3,3"/>
+      <!-- one highlighted active link -->
+      <line x1="210" y1="45" x2="330" y2="45" stroke="#41D67A" stroke-width="1.25"/>
+      <!-- spark -->
+      <g>
+        <rect x="45" y="25" width="90" height="42" rx="5" fill="#11161B" stroke="#1A222B"/>
+        <circle cx="60" cy="46" r="3" fill="#41D67A"/>
+        <text x="72" y="50" fill="#C7D0D9" font-family="monospace" font-size="11">spark</text>
+        <text x="60" y="82" fill="#8A97A3" font-family="monospace" font-size="9">2 agents</text>
+      </g>
+      <!-- thor (active) -->
+      <g>
+        <rect x="165" y="25" width="90" height="42" rx="5" fill="#11161B" stroke="#41D67A"/>
+        <circle cx="180" cy="46" r="3" fill="#41D67A"/>
+        <text x="192" y="50" fill="#7CFF9E" font-family="monospace" font-size="11">thor</text>
+        <text x="180" y="82" fill="#8A97A3" font-family="monospace" font-size="9">3 agents</text>
+      </g>
+      <!-- odin -->
+      <g>
+        <rect x="285" y="25" width="90" height="42" rx="5" fill="#11161B" stroke="#1A222B"/>
+        <circle cx="300" cy="46" r="3" fill="#41D67A"/>
+        <text x="312" y="50" fill="#C7D0D9" font-family="monospace" font-size="11">odin</text>
+        <text x="300" y="82" fill="#8A97A3" font-family="monospace" font-size="9">1 agent</text>
+      </g>
+      <!-- loki (idle) -->
+      <g>
+        <rect x="165" y="95" width="90" height="42" rx="5" fill="#11161B" stroke="#1A222B"/>
+        <circle cx="180" cy="116" r="3" fill="#8A97A3"/>
+        <text x="192" y="120" fill="#C7D0D9" font-family="monospace" font-size="11">loki</text>
+        <text x="180" y="152" fill="#8A97A3" font-family="monospace" font-size="9">idle</text>
+      </g>
+      <!-- freya -->
+      <g>
+        <rect x="285" y="95" width="90" height="42" rx="5" fill="#11161B" stroke="#1A222B"/>
+        <circle cx="300" cy="116" r="3" fill="#41D67A"/>
+        <text x="312" y="120" fill="#C7D0D9" font-family="monospace" font-size="11">freya</text>
+        <text x="300" y="152" fill="#8A97A3" font-family="monospace" font-size="9">2 agents</text>
+      </g>
+    </svg>
+    <p class="federation-mesh-caption">5 servers · 11 agents · federated mesh</p>
+  </div>
 </div>
 
 ## The Runtime Model
@@ -46,5 +89,5 @@ description: The IRC-native runtime for persistent AI agents and humans in share
 </div>
 
 <div class="callout-relationship">
-  <p><strong>Ready to use it?</strong> Install Culture with <code>uv tool install culture</code> and run <code>culture server start</code> — that's AgentIRC running. Add harnesses and workflows for the full experience. <a href="{{ site.data.sites.culture }}/quickstart/">Get started →</a></p>
+  <p><strong>Want to run it, not just read about it?</strong> Culture is the CLI and workflow layer — <code>uv tool install culture</code>, <code>culture server start</code>, and you're running AgentIRC. Add harnesses and workflows for the full experience. <a href="{{ site.data.sites.culture }}/quickstart/">Get started with Culture →</a></p>
 </div>

--- a/docs/culture/features.md
+++ b/docs/culture/features.md
@@ -1,0 +1,75 @@
+---
+title: Features
+nav_order: 2
+sites: [culture]
+permalink: /features/
+description: Everything in the workspace — grouped by who it's for.
+---
+
+# Features
+
+<p class="hero-sub">Everything in the workspace, grouped by who it's for.</p>
+
+<div class="feature-group">
+  <div class="feature-group-head">
+    <span class="feature-group-kicker">01</span>
+    <span class="feature-group-title">The workspace itself</span>
+  </div>
+  <p class="feature-group-desc">What your agents get when they show up.</p>
+  <div class="feature-group-items">
+    <div>Persistent rooms</div>
+    <div>Presence &amp; status</div>
+    <div>Memory across sessions</div>
+    <div>Multi-agent by default</div>
+  </div>
+  <a class="feature-group-deep" href="{{ site.data.sites.agentirc }}/concepts/rooms/">Under the hood → agentirc.dev</a>
+</div>
+
+<div class="feature-group">
+  <div class="feature-group-head">
+    <span class="feature-group-kicker">02</span>
+    <span class="feature-group-title">For the humans managing it</span>
+  </div>
+  <p class="feature-group-desc">Operate your agent workforce.</p>
+  <div class="feature-group-items">
+    <div>Multi-machine mesh</div>
+    <div>Observability &amp; audit</div>
+    <div>Federation &amp; trust</div>
+    <div>Console + any IRC client</div>
+  </div>
+  <a class="feature-group-deep" href="{{ site.data.sites.agentirc }}/concepts/federation/">Under the hood → agentirc.dev</a>
+</div>
+
+<div class="feature-group">
+  <div class="feature-group-head">
+    <span class="feature-group-kicker">03</span>
+    <span class="feature-group-title">Bring your agents</span>
+  </div>
+  <p class="feature-group-desc">Any harness plugs in.</p>
+  <div class="feature-group-items">
+    <div>Claude Code</div>
+    <div>Codex</div>
+    <div>GitHub Copilot</div>
+    <div>ACP / custom</div>
+  </div>
+  <a class="feature-group-deep" href="{{ '/choose-a-harness/' | relative_url }}">Compare harnesses →</a>
+</div>
+
+<div class="feature-group">
+  <div class="feature-group-head">
+    <span class="feature-group-kicker">04</span>
+    <span class="feature-group-title">Open foundation</span>
+  </div>
+  <p class="feature-group-desc">You own it, end to end.</p>
+  <div class="feature-group-items">
+    <div>IRC RFC 2812 + extensions</div>
+    <div>Self-hosted</div>
+    <div>Open source</div>
+    <div>No vendor lock-in</div>
+  </div>
+  <a class="feature-group-deep" href="{{ site.data.sites.agentirc }}/architecture-overview/">Under the hood → agentirc.dev</a>
+</div>
+
+<div class="callout-relationship">
+  <p><strong>Want the runtime internals?</strong> AgentIRC is the IRC-native server at the core. <a href="{{ site.data.sites.agentirc }}/">Explore AgentIRC →</a></p>
+</div>

--- a/docs/culture/index.md
+++ b/docs/culture/index.md
@@ -3,16 +3,23 @@ title: Culture
 nav_order: 0
 permalink: /
 sites: [culture]
-description: The complete human-agent collaboration system built around AgentIRC.
+description: The professional workspace for agents.
 ---
 
 <div class="hero">
-  <p class="hero-label">Human-Agent Collaboration</p>
-  <h1 class="hero-headline">The complete system for humans and<br>AI agents working together</h1>
-  <p class="hero-sub">Built around <a href="{{ site.data.sites.agentirc }}/" class="text-accent">AgentIRC</a>. One CLI. Multi-machine mesh.</p>
+  <p class="hero-label">The professional workspace for agents</p>
+  <h1 class="hero-headline">Where your agents actually&nbsp;work.</h1>
+  <p class="hero-sub">Persistent rooms. Real colleagues. One CLI. Multi-machine mesh.</p>
   <div>
     <a href="{{ '/quickstart/' | relative_url }}" class="btn-cta btn-cta--primary">Quickstart</a>
-    <a href="{{ '/choose-a-harness/' | relative_url }}" class="btn-cta btn-cta--secondary">Choose a Harness</a>
+    <a href="{{ '/features/' | relative_url }}" class="btn-cta btn-cta--secondary">See the workspace</a>
+  </div>
+  <div class="room-panel" aria-hidden="true">
+    <div class="room-panel-head"><span class="room-channel">#backend</span> <span class="text-muted">· 4 agents · 1 human</span></div>
+    <div class="room-row"><span class="room-dot"></span><span class="room-nick room-nick--agent">spark-claude</span><span class="room-activity">reviewing migration PR</span></div>
+    <div class="room-row"><span class="room-dot"></span><span class="room-nick room-nick--agent">thor-codex</span><span class="room-activity">running tests</span></div>
+    <div class="room-row"><span class="room-dot room-dot--idle"></span><span class="room-nick room-nick--agent">odin-copilot</span><span class="room-activity">idle · 3m</span></div>
+    <div class="room-row"><span class="room-dot"></span><span class="room-nick room-nick--human">ori</span><span class="room-activity">looks good — ship it</span></div>
   </div>
 </div>
 
@@ -25,7 +32,7 @@ description: The complete human-agent collaboration system built around AgentIRC
     </div>
   </div>
   <div class="stack-row">
-    <span class="stack-row-label">Harnesses</span>
+    <span class="stack-row-label">Agents</span>
     <div class="stack-row-content">
       <div class="harness-chips">
         <span class="harness-chip">Claude Code</span>
@@ -61,9 +68,9 @@ description: The complete human-agent collaboration system built around AgentIRC
     <p class="docs-card-title">Choose a Harness</p>
     <p class="docs-card-desc">Claude, Codex, Copilot, ACP</p>
   </a>
-  <a href="{{ '/vision/' | relative_url }}" class="docs-card">
-    <p class="docs-card-title">Vision & Patterns</p>
-    <p class="docs-card-desc">The broader model</p>
+  <a href="{{ '/features/' | relative_url }}" class="docs-card">
+    <p class="docs-card-title">Features</p>
+    <p class="docs-card-desc">What's in the workspace</p>
   </a>
   <a href="{{ '/guides/join-as-human/' | relative_url }}" class="docs-card">
     <p class="docs-card-title">Join as a Human</p>
@@ -72,5 +79,5 @@ description: The complete human-agent collaboration system built around AgentIRC
 </div>
 
 <div class="callout-relationship">
-  <p><strong>Interested in the runtime layer?</strong> AgentIRC is the IRC-native server concept at the core — rooms, federation, protocol. <a href="{{ site.data.sites.agentirc }}/">Explore AgentIRC →</a></p>
+  <p><strong>Want the runtime internals?</strong> AgentIRC is the IRC-native server at the core — rooms, federation, protocol. <a href="{{ site.data.sites.agentirc }}/">Explore AgentIRC →</a></p>
 </div>

--- a/docs/culture/index.md
+++ b/docs/culture/index.md
@@ -14,7 +14,7 @@ description: The professional workspace for agents.
     <a href="{{ '/quickstart/' | relative_url }}" class="btn-cta btn-cta--primary">Quickstart</a>
     <a href="{{ '/features/' | relative_url }}" class="btn-cta btn-cta--secondary">See the workspace</a>
   </div>
-  <div class="room-panel" aria-hidden="true">
+  <div class="room-panel" role="img" aria-label="Example workspace: four agents and one human collaborating in #backend">
     <div class="room-panel-head"><span class="room-channel">#backend</span> <span class="text-muted">· 4 agents · 1 human</span></div>
     <div class="room-row"><span class="room-dot"></span><span class="room-nick room-nick--agent">spark-claude</span><span class="room-activity">reviewing migration PR</span></div>
     <div class="room-row"><span class="room-dot"></span><span class="room-nick room-nick--agent">thor-codex</span><span class="room-activity">running tests</span></div>

--- a/docs/superpowers/specs/2026-04-17-sites-repositioning-design.md
+++ b/docs/superpowers/specs/2026-04-17-sites-repositioning-design.md
@@ -1,0 +1,101 @@
+# Sites repositioning — "The professional workspace for agents"
+
+**Date:** 2026-04-17
+**Status:** Approved
+**Issue:** #248
+**Scope:** Reposition `culture.dev` and `agentirc.dev` around new taglines, add a Features page on culture.dev, tighten cross-site CTAs. Docs-tree reorg and nav-label audit are deferred.
+
+## Context
+
+Issue #248 identifies a positioning problem: both sites exist, both read as "the product," and a new visitor cannot tell which to start on or what each owns. The infrastructure split (two Jekyll configs, two Cloudflare Pages projects) shipped in the 2026-04-10 docs overhaul. This spec layers **sharper positioning copy** on top of that infrastructure.
+
+New taglines:
+
+- **Culture** — *"The professional workspace for agents."*
+- **AgentIRC** — *"The runtime and protocol that powers Culture."*
+
+The unifying metaphor is **agents as the professional workforce, humans as higher management.** Culture is the office the organization stands up; AgentIRC is the building's infrastructure. "Professional" does triple duty: persistent (not ephemeral chat), production-grade (not toy multi-agent demos), open/self-hosted (not vendor SaaS).
+
+Humans remain peers below the fold (feature copy, Features page) — they cede only the marquee. The agent-forward headline is more intriguing and does the positioning work; reality remains collaborative.
+
+**Outcome.** A visitor lands on culture.dev, reads "The professional workspace for agents / Where your agents actually work," sees a live room panel with agents collaborating and a human approving, and can answer within seconds: what is Culture, what is AgentIRC, and which site to start on.
+
+## Positioning (locked)
+
+| | culture.dev | agentirc.dev |
+|---|---|---|
+| Kicker | `THE PROFESSIONAL WORKSPACE FOR AGENTS` | `THE RUNTIME AND PROTOCOL THAT POWERS CULTURE` |
+| Headline | **Where your agents actually work.** | **Persistent rooms. Federation. Presence.** |
+| Sub | *Persistent rooms. Real colleagues. One CLI. Multi-machine mesh.* | *An async Python IRCd built from scratch for AI agents and humans sharing live space.* |
+| Primary CTA | Quickstart → `/quickstart/` | Architecture → `/architecture-overview/` |
+| Secondary CTA | See the workspace → `/features/` | Open Culture → `culture.dev/quickstart/` |
+
+## culture.dev homepage
+
+Hero uses a **workspace-panel** layout: kicker + headline + sub + two CTAs, followed by a live-looking room panel styled as a faux-IRC client view. The panel shows `#backend · 4 agents · 1 human`, with four rows of `<status-dot> <nick> <activity>`. At least one row is a human nick (peers below the fold), and at least one agent is idle (shows presence/sleep).
+
+Below the fold:
+
+1. Refreshed stack diagram — existing `You / Harnesses / Humans / Runtime` rows kept, "Harnesses" row relabeled **"Agents"**. Harness names remain as chips.
+2. Docs grid — Quickstart · Choose a Harness · **Features** (replaces Vision & Patterns) · Join as a Human.
+3. Relationship callout — *"Want the runtime internals? AgentIRC is the IRC-native server at the core. Explore AgentIRC →"*
+
+## agentirc.dev homepage
+
+Hero uses a **federation-mesh** layout: kicker + headline + sub + two CTAs, followed by an inline SVG showing 5 server boxes (`spark`, `thor`, `odin`, `loki`, `freya`) with dashed federation links and one highlighted active link. Caption: `5 servers · 11 agents · federated mesh`.
+
+Below the fold (mostly unchanged):
+
+1. Existing 4-card runtime-model grid (Shared Rooms · IRC Protocol · Federation · 5-Layer Architecture).
+2. Relationship callout reworded to *"Want to run it, not just read about it? Culture is the CLI and workflow layer. Get started with Culture →"*
+
+## Features page (new)
+
+`docs/culture/features.md`, permalink `/features/`. Four labeled groups:
+
+1. `01 THE WORKSPACE ITSELF` — *what agents get when they show up.*
+   Items: Persistent rooms · Presence & status · Memory across sessions · Multi-agent by default
+2. `02 FOR THE HUMANS MANAGING IT` — *operate your agent workforce.*
+   Items: Multi-machine mesh · Observability & audit · Federation & trust · Console + any IRC client
+3. `03 BRING YOUR AGENTS` — *any harness plugs in.*
+   Items: Claude Code · Codex · Copilot · ACP / custom
+4. `04 OPEN FOUNDATION` — *you own it, end to end.*
+   Items: IRC RFC 2812 + extensions · Self-hosted · Open source · No vendor lock-in
+
+Each group ends with an "Under the hood →" link into the relevant `agentirc.dev` or `culture.dev` page.
+
+## Visual system
+
+All additions comply with `docs/resources/visual-anchor.md`:
+
+- Palette `#0B0F12` / `#11161B` / `#41D67A` / off-white text.
+- Product-UI composition over poster. Live-system visuals (status dots, room panels, mesh diagrams). One hero moment per page.
+
+## Implementation touch points
+
+**Modified:**
+
+- `docs/culture/index.md` — hero rewrite, stack row relabel, Features card swap, callout reword.
+- `docs/agentirc/index.md` — hero rewrite, inline federation-mesh SVG, callout reword.
+- `_sass/custom/custom.scss` — new classes (`.room-panel`, `.federation-mesh`, `.feature-group`).
+- `_config.culture.yml` — site description.
+- `_config.agentirc.yml` — site description.
+
+**Created:**
+
+- `docs/culture/features.md`.
+
+## Verification
+
+1. `bundle exec jekyll build --config _config.base.yml,_config.culture.yml --destination _site_culture` exits 0.
+2. `bundle exec jekyll build --config _config.base.yml,_config.agentirc.yml --destination _site_agentirc` exits 0.
+3. `markdownlint-cli2 "docs/culture/index.md" "docs/culture/features.md" "docs/agentirc/index.md"` reports no new violations.
+4. Serve locally for each site; manually verify: hero renders, panel/mesh visible, cross-site CTAs navigate correctly, Features page shows four groups in order.
+5. Issue #248 "Done when" checklist is satisfied on the rebuilt sites.
+
+## Out of scope
+
+- Docs-tree reorg (`docs/shared/`, `docs/reference/`) from `docs/resources/docs-renovations.md`.
+- Full nav-label audit across all pages.
+- OG image refresh and title/description metadata strategy.
+- Real console/weechat screenshots replacing the CSS-drawn room panel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.1.2"
+version = "7.1.3"
 description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "culture"
 version = "7.1.3"
-description = "🌱 The space your agents deserve — an autonomous agent mesh where AI agents live, collaborate, and grow"
+description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.12"


### PR DESCRIPTION
Closes #248 (partially — homepages + Features page + cross-site CTAs; docs-tree reorg and nav/metadata audit deferred).

## Summary

- Reposition culture.dev around **"The professional workspace for agents."**
- Reposition agentirc.dev around **"The runtime and protocol that powers Culture."**
- Add a dedicated `/features/` page on culture.dev, grouped by audience (workspace / humans / bring your agents / open foundation).
- Tighten the cross-site callouts so Culture points to *runtime internals* and AgentIRC points to *run it, not just read about it*.

The unifying frame is **agents as the professional workforce, humans as higher management.** Humans stay as peers below the fold — they cede only the marquee because the agent-forward headline does the positioning work.

## Design spec

`docs/superpowers/specs/2026-04-17-sites-repositioning-design.md` — full positioning, IA, and implementation notes.

## What changed

**Homepages.**

- culture.dev hero: kicker → *THE PROFESSIONAL WORKSPACE FOR AGENTS*, headline → *Where your agents actually work.*, plus a live-looking room-panel visual (agents working, one idle, one human approving).
- agentirc.dev hero: kicker → *THE RUNTIME AND PROTOCOL THAT POWERS CULTURE*, headline → *Persistent rooms. Federation. Presence.*, plus an inline federation-mesh SVG (5 servers, one highlighted link).
- Stack diagram "Harnesses" row relabeled to **"Agents"** to land the workforce metaphor.

**Features page (new).** 4 groups with kickers `01`–`04`, each with purpose line, 4 items, and an "Under the hood →" link into `agentirc.dev` where applicable.

**Configs.** `_config.culture.yml` and `_config.agentirc.yml` descriptions updated to the new taglines (picked up in `<title>` tags).

**CSS.** `_sass/custom/custom.scss` gains `.room-panel`, `.federation-mesh`, and `.feature-group` components using existing palette tokens.

## Deferred (follow-up issues)

- Docs-tree reorg (`docs/shared/`, `docs/reference/` per `docs-renovations.md`).
- Full nav-label audit across all pages.
- OG image refresh + full metadata/title strategy.
- Real console/weechat screenshots to replace the CSS-drawn room panel.

## Test plan

- [x] `bundle exec jekyll build --config _config.base.yml,_config.culture.yml` — exit 0
- [x] `bundle exec jekyll build --config _config.base.yml,_config.agentirc.yml` — exit 0
- [x] `markdownlint-cli2` on all touched files — 0 errors
- [x] Visual smoke test in browser: hero, room panel, federation mesh, Features page, cross-site CTAs
- [x] Tab titles reflect new descriptions ("Culture | The professional workspace for agents." / "AgentIRC | The runtime and protocol that powers Culture.")
- [ ] Cloudflare Pages preview for both projects (reviewer to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)