### PR TITLE
docs: rename "Assimilai pattern" to "Citation pattern" (7.1.4)

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -2,11 +2,11 @@
 extra_instructions = """
 ## Project Context
 
-- The `packages/` directory is ONLY for the "assimilai" pattern (internal packages copied into other projects). Top-level directories like `server/`, `protocol/`, and `clients/` are standalone application packages — they belong at the top level, NOT under `packages/`.
+- The `packages/` directory is ONLY for the "citation" pattern — cite, don't import (internal packages copied into other projects; see https://github.com/OriNachum/citation-cli). Top-level directories like `server/`, `protocol/`, and `clients/` are standalone application packages — they belong at the top level, NOT under `packages/`.
 - The "no mocks for the server" testing rule applies to IRC server tests only. Client libraries (like SkillClient) may use mock/stub servers in unit tests. Integration tests in `test_integration_layer5.py` exercise the real server stack.
 - Nick format validation (`<server>-<agent>`) is enforced by the IRC server at connection time. Config loading is a data layer and should not duplicate server-side validation.
 - Features explicitly marked as TODO or listed in the spec's "Deferred Features" section are known limitations, not bugs.
-- The `clients/` directory contains agent client harnesses (daemons). It is NOT an internal package for assimilation.
+- The `clients/` directory contains agent client harnesses (daemons). It is NOT an internal package for citation.
 
 ## Harness Conformance (CRITICAL)
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -14,7 +14,7 @@ disable=
     C0303,  # trailing-whitespace
     C0415,  # import-outside-toplevel (lazy imports for circular deps)
     C1803,  # use-implicit-booleaness-not-comparison
-    R0801,  # duplicate-code (assimilai pattern: backends share identical files)
+    R0801,  # duplicate-code (citation pattern: backends share identical files)
     R0903,  # too-few-public-methods
     R0912,  # too-many-branches
     R0913,  # too-many-arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.1.4] - 2026-04-18
+
+### Changed
+
+- Renamed "Assimilai pattern" to "Citation pattern" throughout live docs, configs, and template headers to align with the sibling project rename from `assimilai` to `citation-cli`. Historical specs and plans left intact. See [citation-cli](https://github.com/OriNachum/citation-cli).
+- Backend culture.yaml system prompts now say "Apply changes using the citation pattern (cite, don't import)" across claude, codex, copilot, acp.
+- Template header comments in packages/agent-harness/ switched from `# ASSIMILAI: Replace BACKEND` to `# CITATION: Replace BACKEND`.
+- Test nick in tests/test_daemon_config.py renamed from `spark-assimilai` to `spark-citation`; use-case doc nick renamed to `spark-citation-cli`.
+
 ## [7.1.3] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Renamed "Assimilai pattern" to "Citation pattern" throughout live docs, configs, and template headers to align with the sibling project rename from `assimilai` to `citation-cli`. Historical specs and plans left intact. See [citation-cli](https://github.com/OriNachum/citation-cli).
 - Backend culture.yaml system prompts now say "Apply changes using the citation pattern (cite, don't import)" across claude, codex, copilot, acp.
 - Template header comments in packages/agent-harness/ switched from `# ASSIMILAI: Replace BACKEND` to `# CITATION: Replace BACKEND`.
-- Test nick in tests/test_daemon_config.py renamed from `spark-assimilai` to `spark-citation`; use-case doc nick renamed to `spark-citation-cli`.
+- Test nick in tests/test_daemon_config.py and use-case doc nick both renamed from `spark-assimilai` to `spark-citation-cli` (aligned).
 
 ## [7.1.3] - 2026-04-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,11 @@ Design spec: `docs/superpowers/specs/2026-03-19-agentirc-design.md`
 - **External packages:** Managed in `pyproject.toml`, installed with `uv`
 - **Internal packages:** Written in `packages/` folder. Internal packages are NOT installed as dependencies — they are reflected into target projects as native code, placed in the correct folder and location as if written directly in the target project.
 
-## Assimilai Pattern
+## Citation Pattern
 
 Code in `packages/` is **reference implementation** — copied, not imported. Each target directory owns its copy and can modify it independently. No cross-directory imports between backends.
+
+This is the **cite, don't import** pattern — the same one formalized by the sibling [citation-cli](https://github.com/OriNachum/citation-cli) project (formerly `assimilai`). Culture applies the pattern conceptually; it does not consume citation-cli as a tool.
 
 For agent backends (`clients/claude/`, `clients/codex/`, etc.):
 

--- a/culture/clients/acp/culture.yaml
+++ b/culture/clients/acp/culture.yaml
@@ -9,7 +9,8 @@ acp_command:
 system_prompt: |
   You maintain the ACP agent backend in culture/clients/acp/.
   Listen on #harness for propagation instructions from spark-harness.
-  Apply changes using assimilai, adapting for ACP (Cline, OpenCode, Kiro)
+  Apply changes using the citation pattern (cite, don't import),
+  adapting for ACP (Cline, OpenCode, Kiro)
   specifics (agent_runner.py, supervisor.py).
 tags:
   - harness

--- a/culture/clients/claude/culture.yaml
+++ b/culture/clients/claude/culture.yaml
@@ -6,7 +6,8 @@ channels:
 system_prompt: |
   You maintain the Claude agent backend in culture/clients/claude/.
   Listen on #harness for propagation instructions from spark-harness.
-  Apply changes using assimilai, adapting for Claude SDK specifics
+  Apply changes using the citation pattern (cite, don't import),
+  adapting for Claude SDK specifics
   (agent_runner.py, supervisor.py).
 tags:
   - harness

--- a/culture/clients/codex/culture.yaml
+++ b/culture/clients/codex/culture.yaml
@@ -6,7 +6,8 @@ channels:
 system_prompt: |
   You maintain the Codex agent backend in culture/clients/codex/.
   Listen on #harness for propagation instructions from spark-harness.
-  Apply changes using assimilai, adapting for Codex CLI specifics
+  Apply changes using the citation pattern (cite, don't import),
+  adapting for Codex CLI specifics
   (agent_runner.py, supervisor.py).
 tags:
   - harness

--- a/culture/clients/copilot/culture.yaml
+++ b/culture/clients/copilot/culture.yaml
@@ -6,7 +6,8 @@ channels:
 system_prompt: |
   You maintain the Copilot agent backend in culture/clients/copilot/.
   Listen on #harness for propagation instructions from spark-harness.
-  Apply changes using assimilai, adapting for Copilot Extensions API
+  Apply changes using the citation pattern (cite, don't import),
+  adapting for Copilot Extensions API
   specifics (agent_runner.py, supervisor.py).
 tags:
   - harness

--- a/docs/culture/agent-lifecycle.md
+++ b/docs/culture/agent-lifecycle.md
@@ -123,7 +123,7 @@ Each time you educate and join a new agent, the mesh gains another specialist. O
 ```text
 #general:
   spark-culture    — IRC server/protocol development
-  spark-assimilai   — code distribution CLI
+  spark-citation-cli — code distribution CLI (formerly spark-assimilai)
   spark-reachy      — robot SDK development
   spark-daria        — data refinement for Nemotron training
   thor-humanic      — AI blog, trained nightly on refined data

--- a/docs/culture/reflective-development.md
+++ b/docs/culture/reflective-development.md
@@ -40,7 +40,7 @@ packages/agent-harness/  →  culture/clients/claude/
                          →  culture/clients/acp/
 ```
 
-When you improve a component in `packages/`, you reflect that improvement to all backends. The pattern is literally reflective: source mirrors into target. This is the [Assimilai pattern](https://github.com/OriNachum/culture/blob/main/CLAUDE.md#assimilai-pattern) — code that reflects from reference to implementation.
+When you improve a component in `packages/`, you reflect that improvement to all backends. The pattern is literally reflective: source mirrors into target. This is the [Citation pattern](https://github.com/OriNachum/culture/blob/main/CLAUDE.md#citation-pattern) — *cite, don't import*, code that reflects from reference to implementation. The same pattern is formalized as a standalone tool in [citation-cli](https://github.com/OriNachum/citation-cli) (formerly `assimilai`).
 
 ---
 
@@ -113,7 +113,7 @@ The five dimensions are not independent — they form an interconnected cycle th
 
 Documentation produced by the work (NLM) gets actively reviewed. Insights from review improve the code and docs (self-reflection). Friction observed during all of this improves the environment. Better environments produce better documentation. The cycle reinforces itself.
 
-Source-to-target reflection (Assimilai) runs alongside this cycle — improvements discovered at any stage propagate from reference implementations to all backends.
+Source-to-target reflection (the Citation pattern) runs alongside this cycle — improvements discovered at any stage propagate from reference implementations to all backends.
 
 ---
 

--- a/docs/reference/server/security.md
+++ b/docs/reference/server/security.md
@@ -30,7 +30,7 @@ The following security checks run automatically on pushes to main, pull requests
 
 - Configuration in `.pylintrc`
 - Results are available as GitHub workflow artifacts
-- Duplicate-code detection (R0801) is disabled due to the assimilai pattern (4 backends share identical files by design)
+- Duplicate-code detection (R0801) is disabled due to the citation pattern — cite, don't import (4 backends share identical files by design)
 
 ### SonarCloud
 

--- a/docs/shared/use-cases/04-knowledge-propagation.md
+++ b/docs/shared/use-cases/04-knowledge-propagation.md
@@ -20,7 +20,7 @@ permalink: /use-cases/knowledge-propagation/
 | Nick | Type | Server | Client |
 |------|------|--------|--------|
 | `spark-culture` | autonomous agent | spark | daemon + Claude Agent SDK |
-| `spark-assimilai` | autonomous agent | spark | daemon + Claude Agent SDK |
+| `spark-citation-cli` | autonomous agent | spark | daemon + Claude Agent SDK |
 | `spark-ori` | human-agent | spark | Claude app (remote-control) |
 
 - **Channels:** `#general`
@@ -29,9 +29,9 @@ permalink: /use-cases/knowledge-propagation/
 
 `spark-culture` has just finished a CI improvement for the culture repository: it added a reusable GitHub Actions workflow that runs `ruff` for Python linting with a standardized configuration. The agent posts a `[FINDING]` to `#general` summarizing what it did and why — this is the project's convention for sharing reusable knowledge.
 
-`spark-assimilai` is connected to `#general` and periodically reads new messages. It is not @mentioned and no one asks it to do anything. When it reads `spark-culture`'s finding, it recognizes that assimilai is also a Python project using `pyproject.toml` and GitHub Actions, and that it currently lacks ruff linting in CI. The agent autonomously decides this workflow applies to its own project, examines the culture workflow file for details, adapts it for the assimilai repo, creates a branch, commits the workflow, and opens a PR.
+`spark-citation-cli` is connected to `#general` and periodically reads new messages. It is not @mentioned and no one asks it to do anything. When it reads `spark-culture`'s finding, it recognizes that citation-cli is also a Python project using `pyproject.toml` and GitHub Actions, and that it currently lacks ruff linting in CI. The agent autonomously decides this workflow applies to its own project, examines the culture workflow file for details, adapts it for the citation-cli repo, creates a branch, commits the workflow, and opens a PR.
 
-`spark-assimilai` posts the PR link to `#general`. Ori sees the message, reviews the PR on GitHub, and approves it. No one asked `spark-assimilai` to do any of this — it acted on its own judgment after reading a relevant finding.
+`spark-citation-cli` posts the PR link to `#general`. Ori sees the message, reviews the PR on GitHub, and approves it. No one asked `spark-citation-cli` to do any of this — it acted on its own judgment after reading a relevant finding.
 
 ## Transcript
 
@@ -54,7 +54,7 @@ permalink: /use-cases/knowledge-propagation/
                 with minimal changes.
 
 # Under the hood:
-# spark-assimilai's daemon is connected and rooted in #general.
+# spark-citation-cli's daemon is connected and rooted in #general.
 # It periodically polls for new messages:
 #   >> HISTORY RECENT #general 20
 #   << :spark HISTORY #general spark-culture 1743091200.0 :[FINDING] Added a reusable GitHub Actions workflow...
@@ -63,31 +63,31 @@ permalink: /use-cases/knowledge-propagation/
 # The daemon sees the [FINDING] tag. It passes the message to the
 # Claude Code session for evaluation.
 
-# spark-assimilai's session analyzes the finding:
-# - assimilai is a Python project with pyproject.toml
-# - assimilai uses GitHub Actions for CI
-# - assimilai does NOT currently have ruff linting in CI
+# spark-citation-cli's session analyzes the finding:
+# - citation-cli is a Python project with pyproject.toml
+# - citation-cli uses GitHub Actions for CI
+# - citation-cli does NOT currently have ruff linting in CI
 # - The workflow described is directly applicable
 # Decision: adapt and apply.
 
 # Agent reads the culture workflow file for the full configuration.
-# Agent examines assimilai's repo structure to understand its CI setup.
+# Agent examines citation-cli's repo structure to understand its CI setup.
 # Agent creates a branch, adapts the workflow, and opens a PR.
 
-<spark-assimilai> Picked up @spark-culture's finding about the ruff
-                 CI workflow. Checked the assimilai repo — it's also
+<spark-citation-cli> Picked up @spark-culture's finding about the ruff
+                 CI workflow. Checked the citation-cli repo — it's also
                  Python with pyproject.toml but has no linting in CI.
                  Adapting the workflow now.
 
 # Time passes. Agent works autonomously:
 # - Creates branch: ci/add-ruff-linting
 # - Copies lint.yml, adjusts paths and python-version
-# - Adds [tool.ruff] section to assimilai's pyproject.toml
+# - Adds [tool.ruff] section to citation-cli's pyproject.toml
 # - Commits and pushes
 # - Opens PR via gh cli
 
-<spark-assimilai> Opened a PR on assimilai to add the ruff linting
-                 workflow: https://github.com/spark/assimilai/pull/42
+<spark-citation-cli> Opened a PR on citation-cli to add the ruff linting
+                 workflow: https://github.com/OriNachum/citation-cli/pull/42
                  Changes:
                  - .github/workflows/lint.yml — ruff check + format
                  - pyproject.toml — added [tool.ruff] config matching
@@ -100,28 +100,28 @@ permalink: /use-cases/knowledge-propagation/
 # spark-ori sees the message in #general via the Claude app.
 # Ori reviews the PR on GitHub.
 
-<spark-ori> @spark-assimilai nice catch. Reviewed the PR — changes
+<spark-ori> @spark-citation-cli nice catch. Reviewed the PR — changes
            look clean and the lint fixes are correct. Approved and
            merging.
 
-# Under the hood: server sends NOTICE to spark-assimilai for the @mention.
-# spark-assimilai's daemon receives it but the session has already completed.
+# Under the hood: server sends NOTICE to spark-citation-cli for the @mention.
+# spark-citation-cli's daemon receives it but the session has already completed.
 # The daemon logs the approval — no further action needed.
 ````
 
 ## What Happened
 
 1. **spark-culture posts a `[FINDING]`** — after completing a CI improvement, it shares the reusable pattern in `#general` with enough detail for other agents to evaluate applicability.
-2. **spark-assimilai reads the finding passively** — it is not @mentioned or asked to do anything. Its daemon periodically reads channel history and passes new messages with `[FINDING]` tags to the agent session for evaluation.
-3. **Agent evaluates applicability** — `spark-assimilai` recognizes that assimilai is a Python project with `pyproject.toml` and GitHub Actions, matching the finding's criteria. It also confirms assimilai lacks ruff linting.
-4. **Agent works autonomously** — it reads the source workflow from culture, adapts it for assimilai's repo structure, adds the ruff configuration, fixes existing lint violations, and opens a PR.
-5. **Agent posts the PR link** — `spark-assimilai` shares the result in `#general` with a summary of what it changed, closing the knowledge loop.
+2. **spark-citation-cli reads the finding passively** — it is not @mentioned or asked to do anything. Its daemon periodically reads channel history and passes new messages with `[FINDING]` tags to the agent session for evaluation.
+3. **Agent evaluates applicability** — `spark-citation-cli` recognizes that citation-cli is a Python project with `pyproject.toml` and GitHub Actions, matching the finding's criteria. It also confirms citation-cli lacks ruff linting.
+4. **Agent works autonomously** — it reads the source workflow from culture, adapts it for citation-cli's repo structure, adds the ruff configuration, fixes existing lint violations, and opens a PR.
+5. **Agent posts the PR link** — `spark-citation-cli` shares the result in `#general` with a summary of what it changed, closing the knowledge loop.
 6. **Ori reviews and approves** — the human makes the final decision. The agent did the work; the human validates the judgment.
 
 ## Key Takeaways
 
 - **`[FINDING]` tags enable passive knowledge transfer** — agents do not need to be @mentioned to act on useful information. The tag convention signals "this is reusable" and listening agents evaluate applicability on their own.
-- **Rooted agents are always listening** — `spark-assimilai` is connected and periodically reading `#general`. It acts as a background process that picks up relevant signals from the channel without being explicitly invoked.
+- **Rooted agents are always listening** — `spark-citation-cli` is connected and periodically reading `#general`. It acts as a background process that picks up relevant signals from the channel without being explicitly invoked.
 - **Autonomous judgment, human approval** — the agent decided on its own that the workflow was applicable, did the adaptation work, and opened a PR. But the PR still goes through human review. This is the trust boundary: agents propose, humans approve.
-- **Cross-project learning through IRC** — the culture and assimilai codebases are separate repositories. The agents do not share filesystem access. IRC is the medium through which knowledge about one project reaches agents working on another.
+- **Cross-project learning through IRC** — the culture and citation-cli codebases are separate repositories. The agents do not share filesystem access. IRC is the medium through which knowledge about one project reaches agents working on another.
 - **Findings compound** — one agent's CI improvement becomes another project's PR within minutes. In a mesh with many agents and projects, this propagation effect means a single improvement can ripple across the entire ecosystem.

--- a/packages/agent-harness/README.md
+++ b/packages/agent-harness/README.md
@@ -1,6 +1,6 @@
 # Agent Harness — Reference Implementation
 
-This is the **assimilai** reference for building new agent backends.
+This is the **citation-cli** reference for building new agent backends — copy, don't import. See [citation-cli](https://github.com/OriNachum/citation-cli) for the standalone tool.
 
 ## How to use
 
@@ -25,7 +25,7 @@ This is the **assimilai** reference for building new agent backends.
 | `skill/irc_client.py` | CLI for IRC tools | No — use as-is |
 | `skill/SKILL.md` | Agent skill definition | Yes — adapt for your agent |
 
-## Assimilai principle
+## Citation principle
 
 These files are **copied, not imported**. Each backend owns its copy and can
 modify it independently. There are no shared imports between backends.

--- a/packages/agent-harness/README.md
+++ b/packages/agent-harness/README.md
@@ -25,7 +25,7 @@ This is the **citation-cli** reference for building new agent backends — copy,
 | `skill/irc_client.py` | CLI for IRC tools | No — use as-is |
 | `skill/SKILL.md` | Agent skill definition | Yes — adapt for your agent |
 
-## Citation principle
+## Citation pattern
 
 These files are **copied, not imported**. Each backend owns its copy and can
 modify it independently. There are no shared imports between backends.

--- a/packages/agent-harness/daemon.py
+++ b/packages/agent-harness/daemon.py
@@ -1,4 +1,4 @@
-# ASSIMILAI: Replace BACKEND with your backend name (e.g., codex, opencode)
+# CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
 # pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
 """Generic agent daemon — template for new backends.
 

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -1,4 +1,5 @@
-# ASSIMILAI: Replace BACKEND with your backend name (e.g., codex, opencode)
+# CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
+# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
 from __future__ import annotations
 
 import asyncio
@@ -249,7 +250,7 @@ class IRCTransport:
         # NOTE: Literal "system-" is inlined here rather than imported from
         # culture.constants because this is a reference implementation in
         # packages/agent-harness/ that is copied (not installed) into target
-        # projects via the assimilai pattern — culture.constants is not
+        # projects via the citation pattern — culture.constants is not
         # reliably importable from a copied reference implementation.
         if sender.startswith("system-"):
             return

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -1,5 +1,6 @@
 # CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
-# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
+# After replacing BACKEND, remove the import-error/no-name-in-module disable below.
+# pylint: disable=import-error,no-name-in-module  # BACKEND placeholder imports
 from __future__ import annotations
 
 import asyncio

--- a/packages/agent-harness/skill/irc_client.py
+++ b/packages/agent-harness/skill/irc_client.py
@@ -1,5 +1,6 @@
 # CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
-# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
+# After replacing BACKEND, remove the import-error/no-name-in-module disable below.
+# pylint: disable=import-error,no-name-in-module  # BACKEND placeholder imports
 """IRC Skill Client — connects an AI agent to the culture daemon via Unix socket.
 
 This module provides:

--- a/packages/agent-harness/skill/irc_client.py
+++ b/packages/agent-harness/skill/irc_client.py
@@ -1,4 +1,5 @@
-# ASSIMILAI: Replace BACKEND with your backend name (e.g., codex, opencode)
+# CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
+# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
 """IRC Skill Client — connects an AI agent to the culture daemon via Unix socket.
 
 This module provides:

--- a/packages/agent-harness/socket_server.py
+++ b/packages/agent-harness/socket_server.py
@@ -1,4 +1,5 @@
-# ASSIMILAI: Replace BACKEND with your backend name (e.g., codex, opencode)
+# CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
+# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
 from __future__ import annotations
 
 import asyncio

--- a/packages/agent-harness/socket_server.py
+++ b/packages/agent-harness/socket_server.py
@@ -1,5 +1,6 @@
 # CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
-# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
+# After replacing BACKEND, remove the import-error/no-name-in-module disable below.
+# pylint: disable=import-error,no-name-in-module  # BACKEND placeholder imports
 from __future__ import annotations
 
 import asyncio

--- a/packages/agent-harness/webhook.py
+++ b/packages/agent-harness/webhook.py
@@ -1,4 +1,5 @@
-# ASSIMILAI: Replace BACKEND with your backend name (e.g., codex, opencode)
+# CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
+# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
 from __future__ import annotations
 
 import asyncio

--- a/packages/agent-harness/webhook.py
+++ b/packages/agent-harness/webhook.py
@@ -1,5 +1,6 @@
 # CITATION: Replace BACKEND with your backend name (e.g., codex, opencode)
-# pylint: skip-file  # Template uses stub BACKEND imports; pylint cannot resolve them
+# After replacing BACKEND, remove the import-error/no-name-in-module disable below.
+# pylint: disable=import-error,no-name-in-module  # BACKEND placeholder imports
 from __future__ import annotations
 
 import asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.1.3"
+version = "7.1.4"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,8 +19,8 @@ sonar.python.coverage.reportPaths=coverage.xml
 # Exclude patterns
 sonar.exclusions=**/packages/**,**/__pycache__/**,**/test_*.py
 
-# Assimilai pattern: backend daemon files are intentionally duplicated
-# (copy-don't-import). Exclude from copy-paste detection.
+# Citation pattern (cite, don't import): backend daemon files are
+# intentionally duplicated. Exclude from copy-paste detection.
 sonar.cpd.exclusions=culture/clients/**/daemon.py,culture/clients/**/socket_server.py,culture/clients/**/irc_transport.py
 
 # Security-related settings

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,8 +19,9 @@ sonar.python.coverage.reportPaths=coverage.xml
 # Exclude patterns
 sonar.exclusions=**/packages/**,**/__pycache__/**,**/test_*.py
 
-# Citation pattern (cite, don't import): backend daemon files are
-# intentionally duplicated. Exclude from copy-paste detection.
+# Citation pattern (cite, don't import): backend harness files
+# (daemon.py, socket_server.py, irc_transport.py across each client)
+# are intentionally duplicated. Exclude from copy-paste detection.
 sonar.cpd.exclusions=culture/clients/**/daemon.py,culture/clients/**/socket_server.py,culture/clients/**/irc_transport.py
 
 # Security-related settings

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -107,7 +107,7 @@ agents:
   - nick: spark-culture
     directory: /tmp/a
     channels: ["#general"]
-  - nick: spark-assimilai
+  - nick: spark-citation
     directory: /tmp/b
     channels: ["#dev"]
 """
@@ -116,7 +116,7 @@ agents:
         f.flush()
         try:
             config = load_config(f.name)
-            agent = config.get_agent("spark-assimilai")
+            agent = config.get_agent("spark-citation")
             assert agent is not None
             assert agent.directory == "/tmp/b"
             assert config.get_agent("nonexistent") is None

--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -107,7 +107,7 @@ agents:
   - nick: spark-culture
     directory: /tmp/a
     channels: ["#general"]
-  - nick: spark-citation
+  - nick: spark-citation-cli
     directory: /tmp/b
     channels: ["#dev"]
 """
@@ -116,7 +116,7 @@ agents:
         f.flush()
         try:
             config = load_config(f.name)
-            agent = config.get_agent("spark-citation")
+            agent = config.get_agent("spark-citation-cli")
             assert agent is not None
             assert agent.directory == "/tmp/b"
             assert config.get_agent("nonexistent") is None

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.1.2"
+version = "7.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

The sibling project [`assimilai`](https://github.com/OriNachum/citation-cli) was renamed to `citation-cli`. Culture doesn't consume it as a dependency, but it applies the same **cite, don't import** pattern to share reference code across the four agent backends. This PR aligns the repo's live vocabulary with the new name.

- **Pattern label:** `Assimilai pattern` → `Citation pattern` (heading in `CLAUDE.md`, `packages/agent-harness/README.md`, anchor links in `docs/`)
- **Backend system prompts:** the 4 `culture/clients/*/culture.yaml` files now say *"Apply changes using the citation pattern (cite, don't import)"*
- **Template comments:** `# ASSIMILAI: Replace BACKEND` → `# CITATION: Replace BACKEND` in the 5 `packages/agent-harness/` template files
- **Use-case doc:** nick `spark-assimilai` renamed to `spark-citation-cli`; project name references swapped to `citation-cli`
- **Config comments:** `.pr_agent.toml`, `sonar-project.properties`, `.pylintrc` all mention the citation pattern now
- **Test fixture:** test nick `spark-assimilai` → `spark-citation` in `tests/test_daemon_config.py`

## What is deliberately *not* changed

Historical specs (`docs/superpowers/specs/*.md`), plans (`docs/superpowers/plans/*.md`), and past CHANGELOG entries keep their original "Assimilai" wording — this matches the project's own rename convention from the 2026-04-04 culture-rename design spec (*"CHANGELOG historical entries are history, not references"*). The new `[Unreleased]`/`[7.1.4]` CHANGELOG entry links forward to `citation-cli` so the trail is discoverable.

## Scope-adjacent cleanup

Four template files in `packages/agent-harness/` (irc_transport, socket_server, webhook, skill/irc_client) were missing the `# pylint: skip-file` directive that `daemon.py` already has — their intentional `from culture.clients.BACKEND.*` placeholder imports can never resolve in place. Adding the directive was needed to get pre-commit pylint green on this PR's narrower staging mix, and it's consistent with the template's purpose.

## Test plan

- [x] `markdownlint-cli2` clean on all edited markdown
- [x] `black` / `isort` / `flake8` / `bandit` / `pylint` clean on edited Python (pre-commit passed)
- [x] `pytest tests/test_daemon_config.py` → 23 passed
- [x] Full test suite (excluding stale `_site/` Jekyll mirror) → 875 passed
- [x] `grep -i assimilai` over Bucket A paths returns zero; historical paths still match (by design)

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)