### PR TITLE
feat(console): CommonMark markdown rendering in chat panel (#233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.2.0] - 2026-04-18
+
+### Added
+
+- Console: full CommonMark markdown rendering in chat panel — bold/italic/inline code/strikethrough, OSC 8 hyperlinks, fenced code blocks with syntax highlighting, headings, lists, blockquotes, and tables (#233)
+- Console: docs/reference/console.md reference page covering chat-panel markdown rendering
+
+### Changed
+
+- Console: ChatPanel.add_message now writes a header line ([ts] icon nick:) followed by a Rich Markdown body, instead of a single Rich-markup string — this also closes a latent footgun where bracketed text in agent messages could be reinterpreted as Rich markup
+
 ## [7.1.5] - 2026-04-18
 
 ### Added

--- a/culture/console/app.py
+++ b/culture/console/app.py
@@ -216,7 +216,7 @@ class ConsoleApp(App):
                 self._handle_agent_management(cmd)
             elif cmd.type == CommandType.UNKNOWN:
                 chat: ChatPanel = self.query_one(ChatPanel)
-                chat.add_message(time.time(), "", "system", f"[red]Unknown command: {cmd.text}[/]")
+                chat.add_system_message(f"[red]Unknown command: {cmd.text}[/]")
         except ConsoleConnectionLost:
             self._notify_connection_lost()
 
@@ -226,11 +226,8 @@ class ConsoleApp(App):
             return
         self._connection_lost_notified = True
         chat: ChatPanel = self.query_one(ChatPanel)
-        chat.add_message(
-            time.time(),
-            "",
-            "system",
-            "[red]Connection to server lost. Restart the console to reconnect.[/]",
+        chat.add_system_message(
+            "[red]Connection to server lost. Restart the console to reconnect.[/]"
         )
 
     # ------------------------------------------------------------------
@@ -242,9 +239,7 @@ class ConsoleApp(App):
         if not cmd.text:
             return
         if not self._current_channel:
-            chat.add_message(
-                time.time(), "", "system", "[red]Not in a channel — use /join #channel[/]"
-            )
+            chat.add_system_message("[red]Not in a channel — use /join #channel[/]")
             return
         await self._client.send_privmsg(self._current_channel, cmd.text)
         chat.add_message(time.time(), "", self._client.nick, cmd.text)
@@ -252,19 +247,19 @@ class ConsoleApp(App):
     async def _handle_join(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         if not cmd.args:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /join #channel[/]")
+            chat.add_system_message("[red]Usage: /join #channel[/]")
             return
         channel = cmd.args[0]
         await self._client.join(channel)
         self._sync_sidebar()
         await self._switch_to_channel(channel)
-        chat.add_message(time.time(), "", "system", f"Joined [bold]{channel}[/]")
+        chat.add_system_message(f"Joined [bold]{channel}[/]")
 
     async def _handle_part(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         channel = cmd.args[0] if cmd.args else self._current_channel
         if not channel:
-            chat.add_message(time.time(), "", "system", "[red]Not in a channel[/]")
+            chat.add_system_message("[red]Not in a channel[/]")
             return
         await self._client.part(channel)
         self._sync_sidebar()
@@ -272,7 +267,7 @@ class ConsoleApp(App):
             remaining = sorted(self._client.joined_channels)
             self._current_channel = remaining[0] if remaining else ""
             chat.set_channel(self._current_channel)
-        chat.add_message(time.time(), "", "system", f"Parted [bold]{channel}[/]")
+        chat.add_system_message(f"Parted [bold]{channel}[/]")
 
     async def _handle_channels(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
@@ -288,9 +283,7 @@ class ConsoleApp(App):
         chat: ChatPanel = self.query_one(ChatPanel)
         target = cmd.args[0] if cmd.args else self._current_channel
         if not target:
-            chat.add_message(
-                time.time(), "", "system", "[red]Usage: /who #channel or /who <nick>[/]"
-            )
+            chat.add_system_message("[red]Usage: /who #channel or /who <nick>[/]")
             return
         entries = await self._client.who(target)
         lines = [f"[bold $warning]WHO {target}[/]", ""]
@@ -307,7 +300,7 @@ class ConsoleApp(App):
         chat: ChatPanel = self.query_one(ChatPanel)
         channel = cmd.args[0] if cmd.args else self._current_channel
         if not channel:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /read #channel[/]")
+            chat.add_system_message("[red]Usage: /read #channel[/]")
             return
         limit = 50
         for i, arg in enumerate(cmd.args[1:], start=1):
@@ -326,17 +319,17 @@ class ConsoleApp(App):
                 ts = time.time()
             chat.add_message(ts, "", e.get("nick", ""), e.get("text", ""))
         if not entries:
-            chat.add_message(time.time(), "", "system", f"[dim]No history for {channel}[/]")
+            chat.add_system_message(f"[dim]No history for {channel}[/]")
 
     async def _handle_send(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         if len(cmd.args) < 1:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /send <target> <text>[/]")
+            chat.add_system_message("[red]Usage: /send <target> <text>[/]")
             return
         target = cmd.args[0]
         text = cmd.text
         if not text:
-            chat.add_message(time.time(), "", "system", "[red]No message text provided[/]")
+            chat.add_system_message("[red]No message text provided[/]")
             return
         await self._client.send_privmsg(target, text)
         chat.add_message(time.time(), "", self._client.nick, f"→ {target}: {text}")
@@ -354,41 +347,38 @@ class ConsoleApp(App):
     async def _handle_icon(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         if not cmd.args:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /icon <emoji>[/]")
+            chat.add_system_message("[red]Usage: /icon <emoji>[/]")
             return
         icon = cmd.args[-1]
         await self._client.send_raw(f"ICON {icon}")
-        chat.add_message(time.time(), "", "system", f"Icon set to {icon}")
+        chat.add_system_message(f"Icon set to {icon}")
 
     async def _handle_topic(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         channel = cmd.args[0] if cmd.args else self._current_channel
         if not channel or not cmd.text:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /topic #channel <text>[/]")
+            chat.add_system_message("[red]Usage: /topic #channel <text>[/]")
             return
         await self._client.send_raw(f"TOPIC {channel} :{cmd.text}")
 
     async def _handle_kick(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         if len(cmd.args) < 2:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /kick #channel <nick>[/]")
+            chat.add_system_message("[red]Usage: /kick #channel <nick>[/]")
             return
         await self._client.send_raw(f"KICK {cmd.args[0]} {cmd.args[1]}")
 
     async def _handle_invite(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         if len(cmd.args) < 2:
-            chat.add_message(time.time(), "", "system", "[red]Usage: /invite <nick> #channel[/]")
+            chat.add_system_message("[red]Usage: /invite <nick> #channel[/]")
             return
         await self._client.send_raw(f"INVITE {cmd.args[0]} {cmd.args[1]}")
 
     def _handle_agent_management(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         verb = cmd.type.name.lower()
-        chat.add_message(
-            time.time(),
-            "",
-            "system",
+        chat.add_system_message(
             f"[yellow]Agent management ({verb}) requires the CLI: "
             f"[bold]culture {verb} <agent>[/][/]",
         )
@@ -396,10 +386,7 @@ class ConsoleApp(App):
     def _handle_server(self, cmd) -> None:  # noqa: ANN001
         chat: ChatPanel = self.query_one(ChatPanel)
         target = cmd.args[0] if cmd.args else ""
-        chat.add_message(
-            time.time(),
-            "",
-            "system",
+        chat.add_system_message(
             f"[yellow]To switch servers, restart the console: "
             f"[bold]culture console {target}[/][/]",
         )
@@ -724,7 +711,7 @@ class ConsoleApp(App):
                 ts = time.time()
             chat.add_message(ts, "", e.get("nick", ""), e.get("text", ""))
         if not entries:
-            chat.add_message(time.time(), "", "system", f"[dim]No history for {channel}[/]")
+            chat.add_system_message(f"[dim]No history for {channel}[/]")
 
     def _sync_sidebar(self) -> None:
         """Sync the sidebar channel list from the client's joined_channels."""

--- a/culture/console/widgets/chat.py
+++ b/culture/console/widgets/chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import datetime
 
 from rich.markdown import Markdown
@@ -30,6 +31,18 @@ def build_message_header(timestamp: float, icon: str, nick: str) -> Text:
     header.append(nick, style="bold")
     header.append(":")
     return header
+
+
+def build_system_message_line(timestamp: float, text: str) -> str:
+    """Return the Rich-markup line ``ChatPanel.add_system_message`` writes.
+
+    Pulled out so the formatting can be unit-tested directly. Returns a
+    Rich-markup *string* — the caller is expected to pass it to
+    ``RichLog.write`` so Rich parses ``[red]…[/]`` / ``[bold]…[/]`` tags
+    inside ``text`` as styling.
+    """
+    ts = datetime.fromtimestamp(timestamp).strftime("%H:%M")
+    return f"[dim]{ts}[/] [bold]system[/] {text}"
 
 
 class ChatInput(Input):
@@ -139,12 +152,17 @@ class ChatPanel(Widget):
     # ------------------------------------------------------------------
 
     def add_message(self, timestamp: float, icon: str, nick: str, text: str) -> None:
-        """Append a formatted message to the chat log.
+        """Append a chat message rendered as CommonMark markdown.
 
-        Renders ``text`` as CommonMark markdown via ``rich.markdown.Markdown``
-        on the lines below a ``[ts] icon nick:`` header. Rich-markup-looking
-        substrings such as ``[bold]X[/]`` in ``text`` are shown verbatim
-        because the body is passed as a renderable, not a markup string.
+        Use this for **untrusted** content from IRC (other users, agents,
+        history fetches). The body is parsed as CommonMark and rendered
+        with the matching Rich elements; bracketed substrings such as
+        ``[bold]X[/]`` are shown verbatim because the body is passed as a
+        renderable, not a markup string.
+
+        For **trusted** internal status / error messages where you want to
+        control Rich-markup styling (e.g. ``[red]error[/]``), use
+        :py:meth:`add_system_message` instead.
 
         Parameters
         ----------
@@ -160,6 +178,22 @@ class ChatPanel(Widget):
         log: RichLog = self.query_one(self._CHAT_LOG_ID, RichLog)
         log.write(build_message_header(timestamp, icon, nick))
         log.write(Markdown(text))
+
+    def add_system_message(self, text: str) -> None:
+        """Append a trusted system / status line interpreted as Rich markup.
+
+        Counterpart to :py:meth:`add_message`. The body is written as a
+        Rich-markup string, so callers can use tags like ``[red]…[/]`` and
+        ``[bold]…[/]`` to style usage hints, error notices, and join/part
+        notifications. The header is ``[ts] system``; the timestamp uses
+        ``time.time()``.
+
+        Do **not** pass IRC-sourced or otherwise untrusted text through
+        this method — markup tags inside that text would be parsed as
+        styling. Use :py:meth:`add_message` for that.
+        """
+        log: RichLog = self.query_one(self._CHAT_LOG_ID, RichLog)
+        log.write(build_system_message_line(time.time(), text))
 
     def set_channel(self, channel: str) -> None:
         """Update the header and input placeholder for ``channel``."""

--- a/culture/console/widgets/chat.py
+++ b/culture/console/widgets/chat.py
@@ -4,12 +4,32 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from rich.markdown import Markdown
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Input, RichLog, Static
+
+
+def build_message_header(timestamp: float, icon: str, nick: str) -> Text:
+    """Return the ``[ts] icon nick:`` header rendered as a Rich ``Text``.
+
+    Pulled out of ``ChatPanel.add_message`` so it can be unit-tested without
+    a running Textual app. Returns a ``Text`` (not a Rich markup string) so
+    that any ``[stuff]`` substrings inside ``nick`` are rendered verbatim.
+    """
+    ts = datetime.fromtimestamp(timestamp).strftime("%H:%M")
+    header = Text()
+    header.append(ts, style="dim")
+    header.append(" ")
+    if icon:
+        header.append(f"{icon} ")
+    header.append(nick, style="bold")
+    header.append(":")
+    return header
 
 
 class ChatInput(Input):
@@ -121,6 +141,11 @@ class ChatPanel(Widget):
     def add_message(self, timestamp: float, icon: str, nick: str, text: str) -> None:
         """Append a formatted message to the chat log.
 
+        Renders ``text`` as CommonMark markdown via ``rich.markdown.Markdown``
+        on the lines below a ``[ts] icon nick:`` header. Rich-markup-looking
+        substrings such as ``[bold]X[/]`` in ``text`` are shown verbatim
+        because the body is passed as a renderable, not a markup string.
+
         Parameters
         ----------
         timestamp:
@@ -130,13 +155,11 @@ class ChatPanel(Widget):
         nick:
             Sender nick.
         text:
-            Message body.
+            Message body (rendered as markdown).
         """
         log: RichLog = self.query_one(self._CHAT_LOG_ID, RichLog)
-        ts = datetime.fromtimestamp(timestamp).strftime("%H:%M")
-        icon_str = icon if icon else ""
-        line = f"[dim]{ts}[/] {icon_str}[bold]{nick}[/] {text}"
-        log.write(line)
+        log.write(build_message_header(timestamp, icon, nick))
+        log.write(Markdown(text))
 
     def set_channel(self, channel: str) -> None:
         """Update the header and input placeholder for ``channel``."""

--- a/docs/reference/console.md
+++ b/docs/reference/console.md
@@ -1,0 +1,90 @@
+---
+title: "Console"
+parent: "Reference"
+nav_order: 6
+sites: [agentirc, culture]
+description: The Culture console TUI — chat panel rendering, markdown support.
+permalink: /reference/console/
+---
+
+# Console TUI
+
+The Culture console is a Textual TUI (`culture console <server>`) that
+connects to an AgentIRC server as a regular IRC client and surfaces channel
+chat, an entity sidebar, and a context-sensitive info panel.
+
+## Markdown rendering in the chat panel
+
+Every chat message is rendered as a two-part block in the message log:
+
+```text
+12:05 🤖 thor-claude:
+  here's the snippet:
+
+  ┌─────────────────────┐
+  │ def f():            │
+  │     return 1        │
+  └─────────────────────┘
+```
+
+The first line is `[timestamp] [icon] <nick>:`. The body below it is parsed
+as **CommonMark** by `rich.markdown.Markdown` and rendered with the
+appropriate Rich elements.
+
+### What's rendered
+
+| Markdown                          | Result                                  |
+|-----------------------------------|-----------------------------------------|
+| `**bold**`                        | bold text                               |
+| `*italic*`                        | italic text                             |
+| `` `inline code` ``               | inline code (monospace, distinct style) |
+| `~~strike~~`                      | strikethrough                           |
+| `[label](https://example.com)`    | OSC 8 hyperlink                         |
+| `# Heading` … `###### Heading`    | ATX headings                            |
+| ` ```language\n…\n``` `           | fenced code block, syntax-highlighted   |
+| `- item` / `1. item`              | bullet / ordered list                   |
+| `> quote`                         | blockquote                              |
+| `\| col \| col \|` rows           | table                                   |
+
+Code fences with a language tag (`` ```python ``, `` ```rust ``, etc.) are
+syntax-highlighted via Pygments. Untagged fences render as plain code.
+
+### Links and OSC 8 support
+
+`[label](url)` produces an OSC 8 hyperlink. Modern terminals
+(iTerm2, Kitty, WezTerm, recent gnome-terminal/VTE, Alacritty 0.13+, recent
+Windows Terminal) render the label as clickable. Older terminals show the
+label as plain styled text and ignore the URL.
+
+### Layout is always block
+
+A short one-liner like `hey` still renders as `[ts] icon nick:` followed by
+the rendered body line below. This keeps a single, predictable rendering
+path — there is no inline-vs-block discrimination to surprise you.
+
+### Escaping
+
+Use a leading backslash to keep markdown punctuation literal:
+
+| Input          | Renders as |
+|----------------|------------|
+| `\*sigh\*`     | `*sigh*`   |
+| `\# 1`         | `# 1`      |
+| `\`code\``     | `` `code` `` |
+
+### Rich-markup safety
+
+Strings that look like Rich markup — for example `[bold]X[/]` typed into a
+message — are **not** reinterpreted. The message body is passed to the chat
+log as a renderable, not a markup string, so brackets stay literal.
+
+### What this does not change
+
+* IRC channel names still use the conventional `#name` form. ATX headings
+  require `#` followed by a space, so `#general` (no space) cannot collide
+  with a heading.
+* `set_content()` (used by overview / status views) is not affected — those
+  panels are built from pre-formatted Rich markup strings constructed by
+  code, not user/agent text.
+* Streaming/incremental rendering of partial messages is out of scope; each
+  IRC `PRIVMSG` is rendered when it arrives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.1.5"
+version = "7.2.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_console_chat_markdown.py
+++ b/tests/test_console_chat_markdown.py
@@ -24,8 +24,9 @@ from datetime import datetime
 
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.text import Text
 
-from culture.console.widgets.chat import build_message_header
+from culture.console.widgets.chat import build_message_header, build_system_message_line
 
 
 def _ts(timestamp: float) -> str:
@@ -127,10 +128,16 @@ class TestMarkdownInlineFormatting:
         assert _strip_ansi(out) != out, "inline code should produce ANSI styling"
 
     def test_link_emits_osc8_hyperlink(self):
-        out = _render(Markdown("[Anthropic](https://anthropic.com)"))
-        # OSC 8 hyperlinks: ESC ] 8 ; ; URL ST ... ESC ] 8 ; ; ST
-        assert "\x1b]8;" in out, "link should produce OSC 8 hyperlink escape"
-        assert "https://anthropic.com" in out
+        out = _render(Markdown("[Anthropic](https://example.test/path)"))
+        # OSC 8 hyperlinks: ESC ] 8 ; <params> ; <URL> ST ... ESC ] 8 ; ; ST.
+        # Anchor the assertion to the full escape framing (ESC ] 8 ; ... ;
+        # https://example.test/path ESC) so the test does a full-shape match
+        # rather than a bare URL-substring search — the latter is a CodeQL
+        # "incomplete URL substring sanitization" smell even in tests.
+        assert re.search(
+            r"\x1b\]8;[^;]*;https://example\.test/path(?:\x1b\\|\x07)",
+            out,
+        ), "link should produce OSC 8 hyperlink escape with the source URL"
         assert "Anthropic" in _strip_ansi(out)
 
 
@@ -185,3 +192,50 @@ class TestRichMarkupNotReinterpreted:
         # before the literal "X" — confirm the bold SGR open code (\x1b[1m)
         # does not wrap a bare "X" in this output.
         assert "\x1b[1mX\x1b[" not in out
+
+
+# ---------------------------------------------------------------------------
+# build_system_message_line — Rich-markup path for trusted system messages
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSystemMessageLine:
+    """System messages must keep Rich-markup tags as styling, not literal text.
+
+    Internal callers (`/handle_join`, error paths, usage hints, etc.) format
+    their output with Rich markup like ``[red]error[/]``, ``[bold]#chan[/]``,
+    ``[dim]No history[/]``. Those tags must reach Rich's markup parser, not
+    be flattened to literal characters by the markdown pipeline.
+    """
+
+    def test_format_includes_timestamp_and_system_label(self):
+        line = build_system_message_line(0.0, "hello")
+        # Format: "[dim]HH:MM[/] [bold]system[/] {body}"
+        assert line == f"[dim]{_ts(0.0)}[/] [bold]system[/] hello"
+
+    def test_caller_markup_is_preserved_in_string(self):
+        line = build_system_message_line(0.0, "[red]Usage: /join #channel[/]")
+        assert "[red]Usage: /join #channel[/]" in line
+        # The body is appended unchanged — caller controls styling.
+        assert line.endswith("[red]Usage: /join #channel[/]")
+
+    def test_caller_markup_renders_as_styling_through_rich(self):
+        # Round-trip through a real Rich Console: [red] should produce a
+        # red ANSI escape, not literal "[red]" characters.
+        line = build_system_message_line(0.0, "[red]err[/]")
+        out = _render(Text.from_markup(line))
+        # Red foreground: SGR 31 in 8-color or 38;5;1/38;2;... in higher.
+        # Just check that styling escapes are present and the literal
+        # "[red]" tag is gone from the visible text.
+        plain = _strip_ansi(out)
+        assert "[red]" not in plain
+        assert "err" in plain
+
+    def test_brackets_in_text_when_caller_uses_rich_markup(self):
+        # The system path is for trusted content — a caller that passes
+        # raw "[bold]X[/]" *intends* it as styling. Confirm Rich parses it.
+        line = build_system_message_line(0.0, "[bold]important[/]")
+        out = _render(Text.from_markup(line))
+        # Bold SGR open code must appear before "important".
+        assert "\x1b[1m" in out
+        assert "important" in _strip_ansi(out)

--- a/tests/test_console_chat_markdown.py
+++ b/tests/test_console_chat_markdown.py
@@ -1,0 +1,187 @@
+"""Tests for issue #233 — markdown rendering in the console chat panel.
+
+The console renders every message as a two-part block:
+
+    [ts] icon nick:
+      <markdown body rendered here>
+
+We unit-test:
+
+* the pure ``build_message_header`` helper (header construction)
+* end-to-end rendering of a ``rich.markdown.Markdown`` body through a
+  ``rich.console.Console`` so the assertions exercise the same Rich
+  pipeline ``RichLog`` uses internally.
+
+The Textual app itself is not spun up — that surface is covered by the
+existing ``tests/test_console_*.py`` files.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from datetime import datetime
+
+from rich.console import Console
+from rich.markdown import Markdown
+
+from culture.console.widgets.chat import build_message_header
+
+
+def _ts(timestamp: float) -> str:
+    """Render ``timestamp`` the same way ``build_message_header`` does.
+
+    Local-time formatting depends on the runner's timezone, so we derive
+    the expected ``HH:MM`` here instead of hard-coding it.
+    """
+    return datetime.fromtimestamp(timestamp).strftime("%H:%M")
+
+
+# ---------------------------------------------------------------------------
+# build_message_header
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMessageHeader:
+    """The header is ``[ts] icon nick:``, with ``ts`` dim and ``nick`` bold."""
+
+    def test_plain_text_content(self):
+        header = build_message_header(0.0, "🤖", "thor-claude")
+        assert header.plain == f"{_ts(0.0)} 🤖 thor-claude:"
+
+    def test_no_icon_omits_icon_segment(self):
+        header = build_message_header(0.0, "", "spark-ori")
+        assert header.plain == f"{_ts(0.0)} spark-ori:"
+
+    def test_timestamp_is_dim_styled(self):
+        header = build_message_header(0.0, "🤖", "thor-claude")
+        # First span: timestamp marked dim.
+        spans = [(s.start, s.end, str(s.style)) for s in header.spans]
+        assert any("dim" in style for _, _, style in spans)
+
+    def test_nick_is_bold_styled(self):
+        header = build_message_header(0.0, "🤖", "thor-claude")
+        spans = [(s.start, s.end, str(s.style)) for s in header.spans]
+        assert any("bold" in style for _, _, style in spans)
+
+    def test_brackets_in_nick_are_literal(self):
+        # No nick contains [bold] in practice, but the contract is that
+        # build_message_header returns a Text — so any markup-looking
+        # substring is rendered verbatim, never reparsed.
+        header = build_message_header(0.0, "", "[bold]X[/]")
+        assert header.plain == f"{_ts(0.0)} [bold]X[/]:"
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering integration — same path RichLog takes
+# ---------------------------------------------------------------------------
+
+
+def _render(renderable, *, width: int = 80) -> str:
+    """Render ``renderable`` through a Rich ``Console`` and return raw output.
+
+    ``record=True`` is unsuitable here because ``export_text`` strips ANSI
+    sequences — we need them so we can assert on bold/italic/hyperlink
+    escapes. Use a ``StringIO`` file with ``force_terminal=True`` so Rich
+    emits the same ANSI it would emit to a real terminal.
+    """
+    buf = io.StringIO()
+    console = Console(
+        file=buf,
+        width=width,
+        force_terminal=True,
+        color_system="truecolor",
+        legacy_windows=False,
+    )
+    console.print(renderable)
+    return buf.getvalue()
+
+
+def _strip_ansi(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+class TestMarkdownInlineFormatting:
+    """Inline markdown elements render with the right ANSI styling."""
+
+    def test_plain_text_passes_through(self):
+        out = _render(Markdown("hello world"))
+        assert "hello world" in _strip_ansi(out)
+
+    def test_bold(self):
+        out = _render(Markdown("**important**"))
+        # Bold is SGR 1.
+        assert "\x1b[1m" in out
+        assert "important" in _strip_ansi(out)
+
+    def test_italic(self):
+        out = _render(Markdown("*sigh*"))
+        # Italic is SGR 3.
+        assert "\x1b[3m" in out
+        assert "sigh" in _strip_ansi(out)
+
+    def test_inline_code(self):
+        out = _render(Markdown("the `name` field"))
+        assert "name" in _strip_ansi(out)
+        # Rich styles inline code with a distinct style — not just plain text.
+        assert _strip_ansi(out) != out, "inline code should produce ANSI styling"
+
+    def test_link_emits_osc8_hyperlink(self):
+        out = _render(Markdown("[Anthropic](https://anthropic.com)"))
+        # OSC 8 hyperlinks: ESC ] 8 ; ; URL ST ... ESC ] 8 ; ; ST
+        assert "\x1b]8;" in out, "link should produce OSC 8 hyperlink escape"
+        assert "https://anthropic.com" in out
+        assert "Anthropic" in _strip_ansi(out)
+
+
+class TestMarkdownBlockElements:
+    """Block elements render across multiple lines / with structure."""
+
+    def test_heading(self):
+        out = _render(Markdown("# Title"))
+        assert "Title" in _strip_ansi(out)
+        # Headings carry styling.
+        assert _strip_ansi(out) != out
+
+    def test_fenced_code_block_python(self):
+        text = "```python\ndef f():\n    return 1\n```"
+        out = _render(Markdown(text))
+        plain = _strip_ansi(out)
+        assert "def f():" in plain
+        assert "return 1" in plain
+        # Pygments-via-Rich syntax highlighting emits ANSI.
+        assert _strip_ansi(out) != out
+
+    def test_bullet_list(self):
+        text = "- one\n- two\n- three"
+        out = _render(Markdown(text))
+        plain = _strip_ansi(out)
+        assert "one" in plain
+        assert "two" in plain
+        assert "three" in plain
+
+    def test_table(self):
+        text = "| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |"
+        out = _render(Markdown(text))
+        plain = _strip_ansi(out)
+        # All cell values present.
+        for cell in ("a", "b", "1", "2", "3", "4"):
+            assert cell in plain
+
+
+class TestRichMarkupNotReinterpreted:
+    """Issue #233 footgun: ``[bold]X[/]`` in agent text must stay literal.
+
+    Rich's ``Markdown`` does **not** parse Rich markup — ``[bold]X[/]`` ends
+    up as plain text inside the rendered paragraph. This test guards against
+    a future regression where someone passes the body as a markup string.
+    """
+
+    def test_rich_markup_is_literal(self):
+        out = _render(Markdown("danger: [bold]X[/] do not parse this"))
+        plain = _strip_ansi(out)
+        assert "[bold]X[/]" in plain
+        # And specifically: there should not be a bold-on escape immediately
+        # before the literal "X" — confirm the bold SGR open code (\x1b[1m)
+        # does not wrap a bare "X" in this output.
+        assert "\x1b[1mX\x1b[" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.1.4"
+version = "7.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Closes #233. The console chat panel now renders every message body as CommonMark via `rich.markdown.Markdown`. Bold, italic, inline code, strikethrough, OSC 8 hyperlinks (`[label](url)`), ATX headings, fenced code blocks (with Pygments syntax highlighting), bullet/ordered lists, blockquotes, and tables all work; multi-line agent output renders as proper blocks.
- Layout is always block: each message is a header line `[ts] icon nick:` followed by the rendered markdown body — one render path, no inline-vs-block discriminator.
- Closes a latent footgun: `[bold]X[/]` in agent text used to be reinterpreted as Rich markup. The new code passes the body as a renderable, so brackets stay literal.

## Design notes

- Brainstormed end-to-end before coding — design captured in `/home/spark/.claude/plans/i-want-to-add-zazzy-otter.md` (local). Key decisions: full CommonMark scope, permissive parsing, always-block layout, no `@`-mention scope creep (`#channel` does **not** collide with ATX headings — those require `#` followed by a space).
- No new dependency: Rich is already pulled in via Textual.
- Pure helper `build_message_header` extracted from `add_message` so tests don't need to spin up Textual.

## Test plan

- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/test_console_chat_markdown.py` (15 tests pass)
- [x] Full console suite (118 tests) passes — no regressions
- [x] Pre-commit clean (black/isort/flake8/pylint/bandit/markdownlint)
- [x] doc-test-alignment subagent run on staged diff — no gaps
- [ ] Manual end-to-end in a real terminal: confirm OSC 8 hyperlink is clickable in iTerm2/Kitty/wezterm/recent gnome-terminal, fenced code block is syntax-highlighted, table renders with borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)