### PR TITLE
feat(docs): add agex reciprocal navigation

### DIFF
--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -34,6 +34,8 @@ defaults:
 aux_links:
   "Culture":
     - "https://culture.dev"
+  "agex":
+    - "https://agex.culture.dev"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -42,4 +44,5 @@ aux_links_new_tab: true
 footer_content: >-
   AgentIRC — the runtime layer at the heart of
   <a href="https://culture.dev">Culture</a>.
+  Agent execution via <a href="https://agex.culture.dev">agex</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -34,6 +34,8 @@ defaults:
 aux_links:
   "AgentIRC":
     - "https://agentirc.dev"
+  "agex":
+    - "https://agex.culture.dev"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -42,4 +44,5 @@ aux_links_new_tab: true
 footer_content: >-
   Culture — human-agent collaboration built around
   <a href="https://agentirc.dev">AgentIRC</a>.
+  Agent execution via <a href="https://agex.culture.dev">agex</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,2 +1,3 @@
 agentirc: https://agentirc.dev
+agex: https://agex.culture.dev
 culture: https://culture.dev

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -3,6 +3,8 @@
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
 {% if site.build_site == "culture" %}
 <link rel="related" href="https://agentirc.dev" title="AgentIRC">
+<link rel="related" href="https://agex.culture.dev" title="agex">
 {% elsif site.build_site == "agentirc" %}
 <link rel="related" href="https://culture.dev" title="Culture">
+<link rel="related" href="https://agex.culture.dev" title="agex">
 {% endif %}

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -2,9 +2,9 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
 {% if site.build_site == "culture" %}
-<link rel="related" href="https://agentirc.dev" title="AgentIRC">
-<link rel="related" href="https://agex.culture.dev" title="agex">
+<link rel="related" href="{{ site.data.sites.agentirc }}" title="AgentIRC">
+<link rel="related" href="{{ site.data.sites.agex }}" title="agex">
 {% elsif site.build_site == "agentirc" %}
-<link rel="related" href="https://culture.dev" title="Culture">
-<link rel="related" href="https://agex.culture.dev" title="agex">
+<link rel="related" href="{{ site.data.sites.culture }}" title="Culture">
+<link rel="related" href="{{ site.data.sites.agex }}" title="agex">
 {% endif %}


### PR DESCRIPTION
## Summary

- Adds `agex: https://agex.culture.dev` to `_data/sites.yml`
- Extends `_includes/head_custom.html` so both culture and agentirc sites emit `<link rel="related">` for agex
- Adds agex to `aux_links` and `footer_content` in `_config.culture.yml` and `_config.agentirc.yml`

Closes the `rel=related` triangle between culture.dev, agentirc.dev, and agex.culture.dev. Follows the merge of [agex PR #23](https://github.com/OriNachum/agex/pull/23), which already advertises culture + agentirc from the agex side.

## Test plan

- [ ] `bundle exec jekyll build --config _config.base.yml,_config.culture.yml` — verify agex appears in nav and footer
- [ ] `bundle exec jekyll build --config _config.base.yml,_config.agentirc.yml` — same check
- [ ] Inspect generated `<head>` for `<link rel="related" href="https://agex.culture.dev">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude