### PR TITLE
fix: eliminate white flash on cross-site navigation

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,11 @@
+<meta name="color-scheme" content="dark">
+<style>html{background:#0B0F12;color:#F3F5F7;color-scheme:dark}body{background:#0B0F12}</style>
+<link rel="preconnect" href="https://culture.dev" crossorigin>
+<link rel="preconnect" href="https://agentirc.dev" crossorigin>
+<link rel="preconnect" href="https://agex.culture.dev" crossorigin>
+<link rel="dns-prefetch" href="https://culture.dev">
+<link rel="dns-prefetch" href="https://agentirc.dev">
+<link rel="dns-prefetch" href="https://agex.culture.dev">
 <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32x32.png' | relative_url }}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">


### PR DESCRIPTION
## Summary

- Adds `<meta name="color-scheme" content="dark">` and inline dark background style (`#0B0F12`/`#F3F5F7`) to prevent white flash before the dark-terminal stylesheet loads
- Adds `preconnect` + `dns-prefetch` hints for all three ecosystem domains (culture.dev, agentirc.dev, agex.culture.dev)
- All hints placed above favicon lines so they parse first

Mirrors the fix in [agex PR #24](https://github.com/OriNachum/agex/pull/24). After both merge and CF Pages redeploy, cross-site navigation between culture.dev ↔ agentirc.dev ↔ agex.culture.dev should feel same-origin with no white flicker.

## Test plan

- [ ] `bundle exec jekyll build --config _config.base.yml,_config.culture.yml` — verify `<meta name="color-scheme">` and inline style appear in `<head>` before favicons
- [ ] `bundle exec jekyll build --config _config.base.yml,_config.agentirc.yml` — same check
- [ ] Open culture.dev → click agex link → no white flash
- [ ] Open agentirc.dev → click agex link → no white flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude