### PR TITLE
fix: open sibling-site aux_links in same tab

### DIFF
--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -39,7 +39,7 @@ aux_links:
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
-aux_links_new_tab: true
+aux_links_new_tab: false
 
 footer_content: >-
   AgentIRC — the runtime layer at the heart of

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -39,7 +39,7 @@ aux_links:
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
-aux_links_new_tab: true
+aux_links_new_tab: false
 
 footer_content: >-
   Culture — human-agent collaboration built around


### PR DESCRIPTION
## Summary

- Sets `aux_links_new_tab: false` in both `_config.culture.yml` and `_config.agentirc.yml`
- New-tab links bypass preconnect hints and warmed TLS, defeating the dark-flash fix from PR #274
- Same-tab navigation preserves the inline CSS and preconnect benefits
- Power users can still Ctrl/Cmd-click for a new tab

Mirrors [agex PR #25](https://github.com/OriNachum/agex/pull/25).

## Note on Cloudflare 403s

Follow-up item #2 (transient 403s on rapid cross-subdomain navigation) is a Cloudflare dashboard issue, not a code fix. Likely candidates: Bot Fight Mode, WAF custom rules, or per-project rate limiting on culture-dev/agentirc-dev/agex CF Pages projects. If tuning CF rules doesn't resolve it, a `_headers` file with relaxed Cache-Control (`public, max-age=60, stale-while-revalidate=600`) could help serve static HTML from edge cache without revalidating on every hop.

## Test plan

- [ ] Click AgentIRC/agex links on culture.dev — should navigate in same tab, no white flash
- [ ] Click Culture/agex links on agentirc.dev — same behavior
- [ ] Ctrl/Cmd-click still opens new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude