### PR TITLE
chore(docs): retarget agex links to culture.dev/agex/ (release 7.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- `_data/sites.yml`: agex URL → `https://culture.dev/agex` (was `https://agex.culture.dev`)
-- `_config.culture.yml` + `_config.agentirc.yml`: aux_links and footer_content agex links retargeted to `https://culture.dev/agex`
+- `_data/sites.yml`: agex URL → `https://culture.dev/agex/` (was `https://agex.culture.dev`)
+- `_config.culture.yml` + `_config.agentirc.yml`: aux_links and footer_content agex links retargeted to `https://culture.dev/agex/`
 
 ## [7.2.0] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.2.1] - 2026-04-21
+
+### Changed
+
+- `_data/sites.yml`: agex URL → `https://culture.dev/agex` (was `https://agex.culture.dev`)
+- `_config.culture.yml` + `_config.agentirc.yml`: aux_links and footer_content agex links retargeted to `https://culture.dev/agex`
+
 ## [7.2.0] - 2026-04-18
 
 ### Added

--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -35,7 +35,7 @@ aux_links:
   "Culture":
     - "https://culture.dev"
   "agex":
-    - "https://culture.dev/agex"
+    - "https://culture.dev/agex/"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -44,5 +44,5 @@ aux_links_new_tab: true
 footer_content: >-
   AgentIRC — the runtime layer at the heart of
   <a href="https://culture.dev">Culture</a>.
-  Agent execution via <a href="https://culture.dev/agex">agex</a>.
+  Agent execution via <a href="https://culture.dev/agex/">agex</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -35,7 +35,7 @@ aux_links:
   "Culture":
     - "https://culture.dev"
   "agex":
-    - "https://agex.culture.dev"
+    - "https://culture.dev/agex"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -44,5 +44,5 @@ aux_links_new_tab: true
 footer_content: >-
   AgentIRC — the runtime layer at the heart of
   <a href="https://culture.dev">Culture</a>.
-  Agent execution via <a href="https://agex.culture.dev">agex</a>.
+  Agent execution via <a href="https://culture.dev/agex">agex</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -35,7 +35,7 @@ aux_links:
   "AgentIRC":
     - "https://agentirc.dev"
   "agex":
-    - "https://culture.dev/agex"
+    - "https://culture.dev/agex/"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -44,5 +44,5 @@ aux_links_new_tab: true
 footer_content: >-
   Culture — human-agent collaboration built around
   <a href="https://agentirc.dev">AgentIRC</a>.
-  Agent execution via <a href="https://culture.dev/agex">agex</a>.
+  Agent execution via <a href="https://culture.dev/agex/">agex</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -35,7 +35,7 @@ aux_links:
   "AgentIRC":
     - "https://agentirc.dev"
   "agex":
-    - "https://agex.culture.dev"
+    - "https://culture.dev/agex"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -44,5 +44,5 @@ aux_links_new_tab: true
 footer_content: >-
   Culture — human-agent collaboration built around
   <a href="https://agentirc.dev">AgentIRC</a>.
-  Agent execution via <a href="https://agex.culture.dev">agex</a>.
+  Agent execution via <a href="https://culture.dev/agex">agex</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,3 @@
 agentirc: https://agentirc.dev
-agex: https://culture.dev/agex
+agex: https://culture.dev/agex/
 culture: https://culture.dev

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,3 @@
 agentirc: https://agentirc.dev
-agex: https://agex.culture.dev
+agex: https://culture.dev/agex
 culture: https://culture.dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.2.0"
+version = "7.2.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.2.0"
+version = "7.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Part of the one-origin ecosystem consolidation (see culture#277 and agex#26). Retargets every Culture-and-AgentIRC reference to agex from `https://agex.culture.dev` to `https://culture.dev/agex/` (trailing slash — canonical directory form). **Release 7.2.1** per the repo convention that every PR bumps the version.

- `_data/sites.yml` — `agex` URL. Cascades through `_includes/head_custom.html`'s `rel=related` Liquid automatically.
- `_config.culture.yml` — `aux_links.agex[0]` + footer_content `agex` link.
- `_config.agentirc.yml` — same two edits as culture.
- `pyproject.toml` / `uv.lock` / `CHANGELOG.md` — 7.2.1 release (required by `version-check` CI).

No infra or protocol changes here; this is purely the Jekyll-side URL retarget. The Worker at `culture.dev/agex/*` already proxies to `https://agex.pages.dev` for the HTML path, so every updated link resolves to live content today.

## Why trailing slash

`culture.dev/agex/` is the canonical directory URL — matches agex PR #26's `<link rel="canonical" href="https://culture.dev/agex/">` from `jekyll-seo-tag`. Without the trailing slash, CF Pages typically 301s the browser to add it (extra redirect hop) and relative URL resolution in proxied HTML can resolve against the parent path instead of `/agex/`. Landing on the slash avoids both.

Fixed in 70488c6 after Copilot review feedback.

## Safe to merge now?

Yes — `culture.dev/agex/` currently returns 200 (verified via curl). The hosting-side cutover (Cloudflare Redirect Rule from `agex.culture.dev/*` → `culture.dev/agex/$1` and custom-domain unbind) is tracked separately in culture#277 and owned by Ori from the dashboard; that work does not block merging this PR.

## What this does NOT touch, and why

- `aux_links_new_tab` — carried in #279 along with the dark-paint CSS (supersedes closed #274).
- Sitemap index rework — separate PR #280.
- Agentirc fold-in (`agentirc.dev` → `culture.dev/agentirc`) — PR-C, sequenced after this agex migration is verified in production.

## Test plan

- [x] `markdownlint-cli2` clean via pre-commit hook.
- [x] All 5 URL references carry trailing slash (Copilot review feedback).
- [ ] CF Pages preview for both sites shows the updated nav/footer.
- [ ] Grep the built `_site_culture/` for any remaining occurrence of `agex.culture.dev` (expected: zero).

- Claude