### PR TITLE
fix(docs): dark-paint inline CSS + in-tab sibling nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [7.2.2] - 2026-04-21
+
+### Changed
+
+- Supersedes PR #274, which tried to solve cross-site flicker via `preconnect` hints across the three-subdomain topology. The one-origin consolidation (`culture.dev/agex`, `culture.dev/agentirc`) makes those preconnects moot; only the dark-paint CSS and `aux_links_new_tab` change carry forward.
+
+### Fixed
+
+- `_includes/head_custom.html`: add `color-scheme` meta + inline dark-paint `<style>` to eliminate the white flash on cold-cache first paint.
+- `_config.culture.yml` + `_config.agentirc.yml`: `aux_links_new_tab: false` so sibling-site clicks stay in-tab (one-site feel after the consolidation). Power users can still Ctrl/Cmd-click for a new tab.
+
 ## [7.2.1] - 2026-04-21
 
 ### Changed

--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -39,7 +39,7 @@ aux_links:
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
-aux_links_new_tab: true
+aux_links_new_tab: false
 
 footer_content: >-
   AgentIRC — the runtime layer at the heart of

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -39,7 +39,7 @@ aux_links:
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
-aux_links_new_tab: true
+aux_links_new_tab: false
 
 footer_content: >-
   Culture — human-agent collaboration built around

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,5 @@
+<meta name="color-scheme" content="dark">
+<style>html{background:#0B0F12;color:#F3F5F7;color-scheme:dark}body{background:#0B0F12}</style>
 <link rel="icon" type="image/png" sizes="32x32" href="{{ '/assets/images/favicon-32x32.png' | relative_url }}">
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "7.2.1"
+version = "7.2.2"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "7.2.1"
+version = "7.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Supersedes #274. That PR tried to mitigate cross-site flicker by adding `preconnect`/`dns-prefetch` hints for the three-subdomain topology; since then the plan shifted to one-origin consolidation (`culture.dev/agex` + `culture.dev/agentirc`), which makes those hints dead weight — they'd preconnect to origins the browser has already resolved. Closing #274 and keeping only the two changes that stand on their own merit regardless of topology:

- **`_includes/head_custom.html`** — add `<meta name=\"color-scheme\" content=\"dark\">` and an inline `<style>` that paints `#0B0F12` before the stylesheets load. Prevents the white flash on **cold-cache first paint**, which same-origin navigation does not solve.
- **`_config.culture.yml`** + **`_config.agentirc.yml`** — `aux_links_new_tab: false`. Once the sibling sites become same-origin, the \"feels like one site\" win requires in-tab navigation; opening siblings in a new tab undoes it (and bypasses any warmth the browser already has). Mirrors agex PR #25. Power users can still Ctrl/Cmd-click for a new tab.

## What PR-B2 deliberately drops from #274

- The `{% if site.build_site ... %}` `preconnect` Liquid block in `_includes/head_custom.html`. On the one-origin topology it hints at origins the browser never hits as separate origins anyway.
- `dns-prefetch` hints — preconnect already covers DNS+TCP+TLS, and again: same-origin.

## Relationship to other PRs

- #278 (PR-A) — `_data/sites.yml` + aux_links URL retarget to `culture.dev/agex`. Complementary, no overlap.
- PR-B (sitemap index) — follow-up, no overlap.
- PR-C (agentirc fold-in) — sequenced after #278 + this one + PR-B verify clean.

Bumps to **7.2.2** so the merge order is independent of #278 (which lands at 7.2.1).

## Test plan

- [x] `markdownlint-cli2` clean via pre-commit.
- [ ] Local build for both sites: inspect `<head>` — expect `<meta name=\"color-scheme\">` + inline dark-paint `<style>` above the favicon links, no `preconnect` / `dns-prefetch` tags.
- [ ] Click a sibling aux-link (agex, AgentIRC) on both sites — should navigate in-tab, no white flash, no new tab.
- [ ] Ctrl/Cmd-click the same link — new tab as expected.
- [ ] Cold-reload (cache cleared) the culture homepage — no white flash before first contentful paint.

Fixes: paired with closing #274.

- Claude