### PR TITLE
docs(sites): expand agex shorthand to "Agent Experience" in site chrome

### DIFF
--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -34,7 +34,7 @@ defaults:
 aux_links:
   "Culture":
     - "https://culture.dev"
-  "agex":
+  "Agent Experience":
     - "https://culture.dev/agex/"
   "GitHub":
     - "https://github.com/OriNachum/culture"
@@ -44,5 +44,5 @@ aux_links_new_tab: false
 footer_content: >-
   AgentIRC — the runtime layer at the heart of
   <a href="https://culture.dev">Culture</a>.
-  Agent execution via <a href="https://culture.dev/agex/">agex</a>.
+  Agent execution via <a href="https://culture.dev/agex/">Agent Experience</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.agentirc.yml
+++ b/_config.agentirc.yml
@@ -44,5 +44,5 @@ aux_links_new_tab: false
 footer_content: >-
   AgentIRC — the runtime layer at the heart of
   <a href="https://culture.dev">Culture</a>.
-  Agent execution via <a href="https://culture.dev/agex/">Agent Experience</a>.
+  Agent Experience via <a href="https://culture.dev/agex/">agex-cli</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -44,5 +44,5 @@ aux_links_new_tab: false
 footer_content: >-
   Culture — human-agent collaboration built around
   <a href="https://agentirc.dev">AgentIRC</a>.
-  Agent execution via <a href="https://culture.dev/agex/">Agent Experience</a>.
+  Agent Experience via <a href="https://culture.dev/agex/">agex-cli</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -34,7 +34,7 @@ defaults:
 aux_links:
   "AgentIRC":
     - "https://agentirc.dev"
-  "agex":
+  "Agent Experience":
     - "https://culture.dev/agex/"
   "GitHub":
     - "https://github.com/OriNachum/culture"
@@ -44,5 +44,5 @@ aux_links_new_tab: false
 footer_content: >-
   Culture — human-agent collaboration built around
   <a href="https://agentirc.dev">AgentIRC</a>.
-  Agent execution via <a href="https://culture.dev/agex/">agex</a>.
+  Agent execution via <a href="https://culture.dev/agex/">Agent Experience</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -5,8 +5,8 @@
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
 {% if site.build_site == "culture" %}
 <link rel="related" href="{{ site.data.sites.agentirc }}" title="AgentIRC">
-<link rel="related" href="{{ site.data.sites.agex }}" title="agex">
+<link rel="related" href="{{ site.data.sites.agex }}" title="Agent Experience">
 {% elsif site.build_site == "agentirc" %}
 <link rel="related" href="{{ site.data.sites.culture }}" title="Culture">
-<link rel="related" href="{{ site.data.sites.agex }}" title="agex">
+<link rel="related" href="{{ site.data.sites.agex }}" title="Agent Experience">
 {% endif %}


### PR DESCRIPTION
Update user-facing labels on the Jekyll-built sites so the product name reads
as "Agent Experience" rather than the internal "agex" shorthand. URL paths
(/agex/) and the internal sites.yml key are unchanged.

- _config.culture.yml + _config.agentirc.yml: aux_links key and footer
  anchor text now read "Agent Experience"
- _includes/head_custom.html: <link rel="related"> title now reads
  "Agent Experience"

https://claude.ai/code/session_01UW9vo3PpMtnunb4v5MkZQj