### PR TITLE
feat(docs): add citation-cli to culture.dev navigation

### DIFF
--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -36,6 +36,8 @@ aux_links:
     - "/agentirc/"
   "Agent Experience":
     - "https://culture.dev/agex/"
+  "Citation CLI":
+    - "/citation-cli/"
   "GitHub":
     - "https://github.com/OriNachum/culture"
 
@@ -45,4 +47,5 @@ footer_content: >-
   Culture — human-agent collaboration built around
   <a href="/agentirc/">AgentIRC</a>.
   Agent Experience via <a href="https://culture.dev/agex/">agex-cli</a>.
+  Code distribution via <a href="/citation-cli/">Citation CLI</a>.
   Source on <a href="https://github.com/OriNachum/culture">GitHub</a>.

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,4 @@
 agentirc: https://culture.dev/agentirc/
 agex: https://culture.dev/agex/
+citation-cli: https://culture.dev/citation-cli/
 culture: https://culture.dev

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,4 +1,4 @@
 agentirc: https://culture.dev/agentirc/
 agex: https://culture.dev/agex/
-citation-cli: https://culture.dev/citation-cli/
+citation_cli: https://culture.dev/citation-cli/
 culture: https://culture.dev

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -4,3 +4,4 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
 <link rel="related" href="{{ site.data.sites.agex }}" title="Agent Experience">
+<link rel="related" href="{{ site.data.sites.citation-cli }}" title="Citation CLI">

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -4,4 +4,4 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
 <link rel="related" href="{{ site.data.sites.agex }}" title="Agent Experience">
-<link rel="related" href="{{ site.data.sites.citation-cli }}" title="Citation CLI">
+<link rel="related" href="{{ site.data.sites.citation_cli }}" title="Citation CLI">


### PR DESCRIPTION
## Summary

- Adds `citation-cli: https://culture.dev/citation-cli/` to `_data/sites.yml`
- Adds Citation CLI to `aux_links` in `_config.culture.yml` (relative `/citation-cli/` — same-origin)
- Adds Citation CLI to `footer_content`
- Adds `<link rel="related">` for citation-cli in `head_custom.html` via `site.data.sites.citation-cli`

Follows the merge of [citation-cli PR #11](https://github.com/OriNachum/citation-cli/pull/11) and CF Worker + 301 go-live. Same pattern as the agex retarget in culture PR #278.

## Verification

```
$ curl -sI https://culture.dev/citation-cli/ | head -1
HTTP/2 200

$ curl -sI https://citation-cli.culture.dev/ | head -2
HTTP/2 301
location: https://culture.dev/citation-cli/
```

## Test plan

- [ ] `bundle exec jekyll build --config _config.base.yml,_config.culture.yml` — verify citation-cli appears in nav, footer, and `<head>` rel=related
- [ ] Click Citation CLI nav link on culture.dev — navigates in same tab to /citation-cli/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude