### PR TITLE
[codex] Add citation-cli sitemap entry

### DIFF
--- a/sitemap-main.html
+++ b/sitemap-main.html
@@ -11,6 +11,7 @@ sitemap: false
   {%- unless page.url -%}{%- continue -%}{%- endunless -%}
   {%- if page.url contains "/agentirc/" -%}{%- continue -%}{%- endif -%}
   {%- if page.url contains "/agex/" -%}{%- continue -%}{%- endif -%}
+  {%- if page.url contains "/citation-cli/" -%}{%- continue -%}{%- endif -%}
   {%- assign ext = page.url | split: "." | last -%}
   {%- if page.url contains "." and ext != "html" -%}{%- continue -%}{%- endif -%}
   <url><loc>{{ page.url | absolute_url | xml_escape }}</loc></url>

--- a/sitemap.html
+++ b/sitemap.html
@@ -8,4 +8,5 @@ sitemap: false
   <sitemap><loc>{{ '/sitemap-main.xml' | absolute_url }}</loc></sitemap>
   <sitemap><loc>{{ '/agentirc/sitemap.xml' | absolute_url }}</loc></sitemap>
   <sitemap><loc>{{ '/agex/sitemap.xml' | absolute_url }}</loc></sitemap>
+  <sitemap><loc>{{ '/citation-cli/sitemap.xml' | absolute_url }}</loc></sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Summary

Adds Citation CLI to the Culture sitemap index and keeps `/citation-cli/` out of the main sitemap, matching the existing split-sitemap setup used for `/agex/` and `/agentirc/`.

## Impact

Search crawlers can discover `https://culture.dev/citation-cli/sitemap.xml` from the root sitemap index once the Citation CLI subtree is published.

## Validation

- `bundle exec jekyll build --config _config.base.yml,_config.culture.yml`
- Pre-commit hooks from `git commit` passed

Note: the Jekyll build still emits existing Liquid/Sass deprecation warnings unrelated to this change.