### PR TITLE
feat(cli): culture afi passthrough + shared _passthrough helper (8.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.1.0] - 2026-04-23
+
+### Added
+
+- `culture afi` namespace — passthrough to the standalone `afi-cli` (Agent First Interface scaffolder) with argparse-REMAINDER argument forwarding, parallel to `culture devex`.
+- Universal verbs (`explain` / `overview` / `learn`) now register the `afi` topic; `culture explain` no longer marks `culture afi` as coming-soon. `culture overview afi` currently surfaces an upstream error because `afi overview` lands in `afi-cli` 0.3 (tracking: agentculture/afi-cli#5).
+- `afi-cli>=0.2,<1.0` as a library dependency.
+- `culture/cli/_passthrough.py` — shared plumbing for `culture <ext>` subcommands that embed a sibling CLI. Supplies `run()`, `capture()`, and `register_topic()` so each passthrough module stays a thin adapter.
+
+### Changed
+
+- `culture/cli/devex.py` refactored onto the new shared passthrough helper. Behaviour is preserved (explain/overview/learn argv and typer app invocation unchanged); the module shrinks to a package-specific entry adapter and a single `register_topic` call. When agex-cli adopts the agent-first CLI contract (`main(argv) -> int`, tracking: agentculture/agex-cli#30), the adapter collapses to a direct delegation.
+
 ## [8.0.0] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - `culture afi` namespace — passthrough to the standalone `afi-cli` (Agent First Interface scaffolder) with argparse-REMAINDER argument forwarding, parallel to `culture devex`.
-- Universal verbs (`explain` / `overview` / `learn`) now register the `afi` topic; `culture explain` no longer marks `culture afi` as coming-soon. `culture overview afi` currently surfaces an upstream error because `afi overview` lands in `afi-cli` 0.3 (tracking: agentculture/afi-cli#5).
-- `afi-cli>=0.2,<1.0` as a library dependency.
+- Universal verbs register the `afi` topic; `culture explain afi` / `culture overview afi` / `culture learn afi` all route through `afi-cli` 0.3+ and `culture explain` no longer marks `culture afi` as coming-soon.
+- `afi-cli>=0.3,<1.0` as a library dependency (0.3 added the `overview` verb + sixth rubric bundle per agentculture/afi-cli#5).
 - `culture/cli/_passthrough.py` — shared plumbing for `culture <ext>` subcommands that embed a sibling CLI. Supplies `run()`, `capture()`, and `register_topic()` so each passthrough module stays a thin adapter.
 
 ### Changed

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -8,6 +8,7 @@ Commands are organized into noun-based groups:
     culture bot      {create,start,stop,list,inspect,archive,unarchive}
     culture skills   {install}
     culture devex    {...developer-experience passthrough (powered by agex-cli)...}
+    culture afi      {...agent-first interface passthrough (powered by afi-cli)...}
 
 Universal verbs (available at the root):
     culture explain [topic]    full description of topic (default: culture)
@@ -22,9 +23,9 @@ import logging
 import sys
 
 from culture import __version__
-from culture.cli import agent, bot, channel, devex, introspect, mesh, server, skills
+from culture.cli import afi, agent, bot, channel, devex, introspect, mesh, server, skills
 
-GROUPS = [agent, server, mesh, channel, bot, skills, devex, introspect]
+GROUPS = [agent, server, mesh, channel, bot, skills, devex, afi, introspect]
 
 
 def _names_of(group) -> set[str]:

--- a/culture/cli/_passthrough.py
+++ b/culture/cli/_passthrough.py
@@ -37,12 +37,19 @@ from culture.cli import introspect
 Entry = Callable[[list[str]], "int | None"]
 
 
-def _translate_exit(code: "int | str | None") -> int:
+def _translate_exit(code: "int | str | None") -> "tuple[int, str | None]":
+    """Map a ``SystemExit.code`` to ``(rc, message)``.
+
+    Python's ``sys.exit`` accepts ``None`` (rc 0), an ``int`` (rc = int), or
+    anything else (rc 1 with the stringified value printed to stderr). We
+    mirror all three so an embedded CLI using any ``sys.exit`` form is
+    surfaced to culture's caller the way a bare invocation would be.
+    """
     if code is None:
-        return 0
+        return 0, None
     if isinstance(code, int):
-        return code
-    return 1
+        return code, None
+    return 1, str(code)
 
 
 def run(entry: Entry, argv: list[str]) -> None:
@@ -50,14 +57,17 @@ def run(entry: Entry, argv: list[str]) -> None:
 
     Used by a group module's ``dispatch()`` to forward arguments verbatim to
     the embedded CLI. ``SystemExit`` raised inside the entry (typer's
-    hard-exit, argparse's ``--help`` / ``--version`` / error path) is caught
-    and its code re-emitted via ``sys.exit`` so the behaviour matches a
-    bare invocation of the embedded CLI.
+    hard-exit, argparse's ``--help`` / ``--version`` / error path, or
+    ``sys.exit("msg")``) is caught, its message (if any) forwarded to
+    stderr, and its code re-emitted via ``sys.exit`` so the behaviour
+    matches a bare invocation of the embedded CLI.
     """
     try:
         rc = entry(argv) or 0
-    except SystemExit as exc:
-        rc = _translate_exit(exc.code)
+    except SystemExit as exc:  # NOSONAR S5754 — SystemExit is re-emitted via sys.exit below
+        rc, message = _translate_exit(exc.code)
+        if message is not None:
+            print(message, file=sys.stderr)
     sys.exit(rc)
 
 
@@ -66,15 +76,22 @@ def capture(entry: Entry, argv: list[str]) -> tuple[str, int]:
 
     Used by universal-verb handlers (``explain`` / ``overview`` / ``learn``),
     which must return a value rather than exit. ``SystemExit`` raised inside
-    the entry is translated into the ``rc`` half of the return tuple.
+    the entry is translated into the ``rc`` half of the return tuple; any
+    string-valued ``exc.code`` is appended to the captured buffer so the
+    embedded CLI's error text reaches the caller the way a bare invocation
+    would emit it on stderr.
     """
     buf = io.StringIO()
     rc = 0
     try:
         with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
             rc = entry(argv) or 0
-    except SystemExit as exc:
-        rc = _translate_exit(exc.code)
+    except SystemExit as exc:  # NOSONAR S5754 — code is surfaced as rc; behaviour documented above
+        rc, message = _translate_exit(exc.code)
+        if message is not None:
+            buf.write(message)
+            if not message.endswith("\n"):
+                buf.write("\n")
     return buf.getvalue(), rc
 
 

--- a/culture/cli/_passthrough.py
+++ b/culture/cli/_passthrough.py
@@ -1,0 +1,99 @@
+"""Shared plumbing for `culture <ext>` passthrough subcommands.
+
+A passthrough module (e.g. ``culture devex``, ``culture afi``) embeds a
+sibling CLI in-process: arguments after the namespace token are forwarded
+verbatim to the external CLI's entry callable, and the three universal
+verbs (``explain`` / ``overview`` / ``learn``) capture the external CLI's
+output and route it through :mod:`culture.cli.introspect`.
+
+Each passthrough module supplies a package-specific ``Entry`` callable
+with signature ``(argv: list[str]) -> int | None``. The callable may:
+
+* return ``None`` or ``0`` for success,
+* return a non-zero ``int`` for a handled error,
+* raise ``SystemExit`` for argparse ``--help`` / ``--version`` / errors
+  or typer's standalone-mode hard-exit on completion.
+
+:func:`run` propagates via ``sys.exit`` (for the ``dispatch()`` path).
+:func:`capture` collects stdout+stderr and translates ``SystemExit`` into
+an ``int`` return code (for the universal-verb handlers, which must
+return ``(stdout, rc)``).
+
+The long-term target is every embedded CLI exposing a clean
+``main(argv) -> int`` (agent-first CLI contract owned by afi-cli). Until
+then, typer-backed CLIs like agex-cli can be wrapped in a small entry
+adapter that calls the typer ``app`` — the plumbing here stays unchanged.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+from typing import Callable
+
+from culture.cli import introspect
+
+Entry = Callable[[list[str]], "int | None"]
+
+
+def _translate_exit(code: "int | str | None") -> int:
+    if code is None:
+        return 0
+    if isinstance(code, int):
+        return code
+    return 1
+
+
+def run(entry: Entry, argv: list[str]) -> None:
+    """Invoke ``entry(argv)`` and ``sys.exit`` with its return code.
+
+    Used by a group module's ``dispatch()`` to forward arguments verbatim to
+    the embedded CLI. ``SystemExit`` raised inside the entry (typer's
+    hard-exit, argparse's ``--help`` / ``--version`` / error path) is caught
+    and its code re-emitted via ``sys.exit`` so the behaviour matches a
+    bare invocation of the embedded CLI.
+    """
+    try:
+        rc = entry(argv) or 0
+    except SystemExit as exc:
+        rc = _translate_exit(exc.code)
+    sys.exit(rc)
+
+
+def capture(entry: Entry, argv: list[str]) -> tuple[str, int]:
+    """Invoke ``entry(argv)`` with stdout+stderr captured; return ``(out, rc)``.
+
+    Used by universal-verb handlers (``explain`` / ``overview`` / ``learn``),
+    which must return a value rather than exit. ``SystemExit`` raised inside
+    the entry is translated into the ``rc`` half of the return tuple.
+    """
+    buf = io.StringIO()
+    rc = 0
+    try:
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+            rc = entry(argv) or 0
+    except SystemExit as exc:
+        rc = _translate_exit(exc.code)
+    return buf.getvalue(), rc
+
+
+def register_topic(
+    topic: str,
+    entry: Entry,
+    *,
+    explain_argv: list[str],
+    overview_argv: list[str],
+    learn_argv: list[str],
+) -> None:
+    """Register ``explain`` / ``overview`` / ``learn`` handlers for ``topic``.
+
+    Each handler captures the output of ``entry(<verb_argv>)`` and returns
+    ``(stdout, rc)`` per the :mod:`culture.cli.introspect` handler protocol.
+    """
+    introspect.register_topic(
+        topic,
+        explain=lambda _t: capture(entry, explain_argv),
+        overview=lambda _t: capture(entry, overview_argv),
+        learn=lambda _t: capture(entry, learn_argv),
+    )

--- a/culture/cli/afi.py
+++ b/culture/cli/afi.py
@@ -1,0 +1,71 @@
+"""`culture afi` — passthrough to the standalone afi CLI.
+
+afi (Agent First Interface) scaffolds and audits agent-first CLIs, MCP
+servers, and HTTP sites. Culture embeds it as a first-class namespace so
+the culture CLI exposes the same agent-first affordances afi enforces.
+
+This module is a thin adapter: it supplies a package-specific ``Entry``
+callable and wires the three universal verbs
+(``explain`` / ``overview`` / ``learn``) through
+:mod:`culture.cli._passthrough`. afi already implements the agent-first
+CLI contract (``main(argv) -> int``), so the entry is a direct
+delegation — no typer adapter needed.
+
+``afi-cli`` owns the rubric the contract is measured against. See
+`agentculture/afi-cli#5 <https://github.com/agentculture/afi-cli/issues/5>`_
+for the tracking issue that adds an ``overview`` verb + rubric bundle so
+afi models every check it enforces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from culture.cli import _passthrough
+
+NAME = "afi"
+
+
+def _entry(argv: list[str]) -> "int | None":
+    """In-process call into ``afi.cli.main(argv)``.
+
+    afi's ``main`` returns an ``int`` on normal completion and raises
+    ``SystemExit`` only for argparse-level exits (``--help``, ``--version``,
+    unknown flag). Both paths are handled by :mod:`culture.cli._passthrough`.
+    """
+    try:
+        from afi.cli import main
+    except ImportError as exc:  # pragma: no cover — declared dep
+        print(f"afi-cli is not installed: {exc}", file=sys.stderr)
+        sys.exit(2)
+    return main(argv)
+
+
+_passthrough.register_topic(
+    "afi",
+    _entry,
+    explain_argv=["explain"],
+    overview_argv=["overview"],
+    learn_argv=["learn"],
+)
+
+
+# --- CLI group protocol ---------------------------------------------------
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    # prefix_chars=chr(0): every token (including --help, --version) is
+    # treated as positional and captured in afi_args for the underlying
+    # afi argparse parser to handle.
+    p = subparsers.add_parser(
+        NAME,
+        help="Run the afi agent-first CLI via passthrough",
+        add_help=False,
+        prefix_chars=chr(0),
+    )
+    p.add_argument("afi_args", nargs=argparse.REMAINDER, help="Arguments passed to afi")
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    _passthrough.run(_entry, list(getattr(args, "afi_args", []) or []))

--- a/culture/cli/devex.py
+++ b/culture/cli/devex.py
@@ -1,36 +1,36 @@
 """`culture devex` — passthrough to the standalone agex CLI.
 
-Also registers universal-verb handlers for the ``devex`` topic so
-``culture explain devex`` / ``culture overview devex`` /
-``culture learn devex`` route through culture's universal-verb path.
-
 Under the hood, ``devex`` is powered by the standalone ``agex-cli``
-(``agent_experience`` package). The command name differs for
-familiarity with the developer-experience vocabulary; the underlying
-tool is the same.
+(``agent_experience`` package). The command name differs for familiarity
+with the developer-experience vocabulary; the underlying tool is the
+same.
+
+This module is a thin adapter: it supplies a package-specific ``Entry``
+callable and wires the three universal verbs
+(``explain`` / ``overview`` / ``learn``) through
+:mod:`culture.cli._passthrough`. When agex-cli migrates to the
+agent-first CLI contract (``main(argv) -> int``), the adapter becomes a
+one-line ``return main(argv)`` without touching the shared plumbing.
 """
 
 from __future__ import annotations
 
 import argparse
-import contextlib
-import io
 import sys
 
-from culture.cli import introspect
+from culture.cli import _passthrough
 
 NAME = "devex"
 
 
-def _run_devex(argv: list[str]) -> None:
-    """Invoke the underlying agex typer app in-process.
+def _entry(argv: list[str]) -> None:
+    """In-process call into the agex typer ``app``.
 
-    Uses standalone_mode=True (the typer default) so typer's own --help,
-    --version, and Exit handling work unchanged. Typer calls ``sys.exit``
-    when done, raising ``SystemExit``; this function lets that propagate
-    so the caller (the ``culture devex`` passthrough) exits with the code
-    the user expects. Callers that need to capture output and translate
-    the exit into a return value should use :func:`_capture_devex` instead.
+    Typer's default ``standalone_mode=True`` makes ``app`` call ``sys.exit``
+    when it finishes — so this function naturally raises ``SystemExit``,
+    which :mod:`culture.cli._passthrough` translates into an ``int`` for the
+    universal-verb handlers and re-emits via ``sys.exit`` for the direct
+    passthrough path.
     """
     try:
         from agent_experience.cli import app
@@ -40,53 +40,14 @@ def _run_devex(argv: list[str]) -> None:
     app(args=argv)
 
 
-def _capture_devex(argv: list[str]) -> tuple[str, int]:
-    """Run devex with stdout + stderr captured, translating SystemExit.
-
-    The universal-verb handlers need ``(output, exit_code)`` rather than a
-    process-level exit, so we deliberately catch ``SystemExit`` here and
-    translate it into a return value. The :func:`_run_devex` variant is for
-    the passthrough path where the exit must propagate.
-    """
-    buf = io.StringIO()
-    try:
-        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
-            _run_devex(argv)
-    except SystemExit as exc:  # NOSONAR S5754 — see docstring
-        # typer calls sys.exit() on completion even for success, so this
-        # is the normal exit path; the trailing `return ... 0` only runs
-        # if _run_devex somehow returns without raising (defensive).
-        code = exc.code
-        if code is None:
-            return buf.getvalue(), 0
-        if isinstance(code, int):
-            return buf.getvalue(), code
-        return buf.getvalue() + str(code), 1
-    return buf.getvalue(), 0
-
-
-# --- universal-verb topic handlers for ``devex`` ---------------------------
-
-
-def _devex_explain(_topic: str | None) -> tuple[str, int]:
-    # The underlying agex library refers to itself as "agex"; that's what
-    # we pass to its own explain verb. The culture-facing name is devex.
-    return _capture_devex(["explain", "agex"])
-
-
-def _devex_overview(_topic: str | None) -> tuple[str, int]:
-    return _capture_devex(["overview", "--agent", "claude-code"])
-
-
-def _devex_learn(_topic: str | None) -> tuple[str, int]:
-    return _capture_devex(["learn", "--agent", "claude-code"])
-
-
-introspect.register_topic(
+# The underlying agex library refers to itself as "agex"; we pass that to
+# its own explain verb. The culture-facing name is devex.
+_passthrough.register_topic(
     "devex",
-    explain=_devex_explain,
-    overview=_devex_overview,
-    learn=_devex_learn,
+    _entry,
+    explain_argv=["explain", "agex"],
+    overview_argv=["overview", "--agent", "claude-code"],
+    learn_argv=["learn", "--agent", "claude-code"],
 )
 
 
@@ -107,5 +68,4 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
 
 
 def dispatch(args: argparse.Namespace) -> None:
-    rest = list(getattr(args, "devex_args", []) or [])
-    _run_devex(rest)
+    _passthrough.run(_entry, list(getattr(args, "devex_args", []) or []))

--- a/docs/culture/features.md
+++ b/docs/culture/features.md
@@ -79,7 +79,7 @@ description: Everything in the workspace — grouped by who it's for.
   <div class="feature-group-items">
     <div>culture explain / overview / learn</div>
     <div>culture devex (powered by agex-cli)</div>
-    <div>culture afi (coming soon)</div>
+    <div>culture afi (powered by afi-cli)</div>
     <div>culture identity / secret (coming soon)</div>
   </div>
   <a class="feature-group-deep" href="{{ '/reference/cli/devex/' | relative_url }}">Read the contract →</a>

--- a/docs/culture/vision.md
+++ b/docs/culture/vision.md
@@ -64,14 +64,14 @@ management — but the foundation is standard IRC.
 ## Upcoming
 
 Culture is the framework of agreements that makes agent behavior portable,
-inspectable, and effective. Beyond the workspace runtime and the
-[`culture devex`]({{ '/reference/cli/devex/' | relative_url }}) namespace
-(powered by the standalone `agex-cli`) that already ship, three more
-first-class namespaces are next:
+inspectable, and effective. Beyond the workspace runtime and the two
+first-class passthrough namespaces that already ship —
+[`culture devex`]({{ '/reference/cli/devex/' | relative_url }}) (powered
+by `agex-cli`) and
+[`culture afi`]({{ '/reference/cli/afi/' | relative_url }}) (powered by
+the standalone `afi-cli`, the Agent First Interface scaffolder) — two
+more first-class namespaces are next:
 
-- **`culture afi`** — Agent First Interface. Standards and scaffolding
-  for tools whose primary consumer is an AI agent (CLI / MCP / HTTP).
-  Wraps the standalone `afi-cli`.
 - **`culture identity`** — Identity management across the mesh. Wraps a
   standalone `zehut-cli` (Hebrew: "identity"). The command you'll reach
   for to name agents, issue keys, and federate trust between servers.

--- a/docs/culture/what-is-culture.md
+++ b/docs/culture/what-is-culture.md
@@ -62,10 +62,11 @@ to that node and its descendants:
 
 Each namespace owns its own handlers — culture is pure plumbing. Today
 the [`culture devex`]({{ '/reference/cli/devex/' | relative_url }})
-namespace (powered by the standalone `agex-cli`) is registered;
-`culture afi`, `culture identity`, and `culture secret` are surfaced as
-`(coming soon)` and will be added in future releases following the same
-pattern.
+namespace (powered by `agex-cli`) and the
+[`culture afi`]({{ '/reference/cli/afi/' | relative_url }}) namespace
+(powered by `afi-cli`) are registered; `culture identity` and
+`culture secret` remain `(coming soon)` and will be added in future
+releases following the same pattern.
 
 ## Reference points
 

--- a/docs/reference/cli/afi.md
+++ b/docs/reference/cli/afi.md
@@ -49,19 +49,18 @@ optional `topic`; when omitted, the topic defaults to `culture`.
 | Verb | Meaning |
 |------|---------|
 | `explain afi` | Full markdown description of afi (routes to `afi explain`) |
-| `overview afi` | Shallow map of afi (routes to `afi overview`, available in `afi-cli` 0.3+) |
+| `overview afi` | Shallow map of afi (routes to `afi overview`) |
 | `learn afi` | Agent-facing onboarding prompt for operating afi |
 
 ```bash
 culture explain afi    # markdown docs for afi root
+culture overview afi   # shallow map
 culture learn afi      # agent onboarding prompt for afi
 ```
 
-`overview afi` requires `afi-cli` 0.3+; the tracking issue is
+All three verbs are live from culture 8.1.0 + `afi-cli` 0.3.0 onward;
+the `overview` verb and its rubric bundle were added in
 [agentculture/afi-cli#5](https://github.com/agentculture/afi-cli/issues/5).
-Until that release lands, `culture overview afi` surfaces afi's own
-argparse error verbatim — an honest signal of the upstream gap rather
-than a synthetic placeholder.
 
 ## Each namespace owns its own
 

--- a/docs/reference/cli/afi.md
+++ b/docs/reference/cli/afi.md
@@ -1,0 +1,96 @@
+---
+title: "culture afi"
+parent: "CLI"
+grand_parent: "Reference"
+nav_order: 11
+sites: [agentirc, culture]
+description: "Agent First Interface passthrough and universal introspection verbs."
+permalink: /reference/cli/afi/
+---
+
+# `culture afi` and universal verbs
+
+Culture ships the **Agent First Interface** (afi) as a first-class
+namespace. `culture afi` is powered by the standalone
+[`afi-cli`](https://github.com/agentculture/afi-cli) (Python package
+`afi`). afi generates and audits agent-first CLIs, MCP servers, and
+HTTP sites — and models, on itself, every pattern it enforces on
+others.
+
+Two affordances:
+
+## `culture afi <anything>`
+
+A full passthrough to the standalone `afi` CLI. Everything after
+`culture afi` is forwarded verbatim to the argparse app. Exit codes
+propagate.
+
+```bash
+culture afi --version
+culture afi explain
+culture afi learn
+culture afi cli verify .
+```
+
+`culture afi --help` shows the underlying afi argparse help, not
+culture's.
+
+afi itself is argparse-based and exposes a library-grade
+`afi.cli.main(argv) -> int` entry point. Culture embeds it in-process
+via the shared passthrough helper at `culture/cli/_passthrough.py`;
+stdout and stderr from afi are captured cleanly and exit codes are
+preserved.
+
+## Universal verbs: `explain` / `overview` / `learn`
+
+Three verbs live at the root of the culture command tree. Each takes an
+optional `topic`; when omitted, the topic defaults to `culture`.
+
+| Verb | Meaning |
+|------|---------|
+| `explain afi` | Full markdown description of afi (routes to `afi explain`) |
+| `overview afi` | Shallow map of afi (routes to `afi overview`, available in `afi-cli` 0.3+) |
+| `learn afi` | Agent-facing onboarding prompt for operating afi |
+
+```bash
+culture explain afi    # markdown docs for afi root
+culture learn afi      # agent onboarding prompt for afi
+```
+
+`overview afi` requires `afi-cli` 0.3+; the tracking issue is
+[agentculture/afi-cli#5](https://github.com/agentculture/afi-cli/issues/5).
+Until that release lands, `culture overview afi` surfaces afi's own
+argparse error verbatim — an honest signal of the upstream gap rather
+than a synthetic placeholder.
+
+## Each namespace owns its own
+
+Culture is pure plumbing — the dispatcher at
+`culture/cli/introspect.py` maps topics to handlers, and the shared
+embedder at `culture/cli/_passthrough.py` provides the in-process
+call, output capture, and `SystemExit` translation. `afi.py` is a thin
+adapter: it supplies the package-specific entry callable and one call
+to `_passthrough.register_topic`. Adding another namespace that wraps
+a sibling CLI follows the same recipe.
+
+### Sibling namespaces
+
+| Namespace | Backing CLI | State |
+|-----------|-------------|-------|
+| `culture devex` | `agex-cli` (`agent_experience`) | Registered |
+| `culture afi` | `afi-cli` (`afi`) | Registered |
+| `culture identity` | future `zehut-cli` | Coming soon |
+| `culture secret` | future `shushu-cli` | Coming soon |
+
+Culture uses English for its first-class nouns; the underlying CLIs
+keep their brand names. `culture explain` is the always-current source
+of truth for which namespaces are ready vs. coming soon.
+
+## See also
+
+- [`culture devex` and universal verbs](./devex/) — the parallel
+  passthrough for the developer-experience CLI, and the full handler
+  protocol for namespace authors.
+- [afi-cli on GitHub](https://github.com/agentculture/afi-cli) — the
+  standalone tool, its rubric, and the spec for what makes a CLI
+  agent-first.

--- a/docs/reference/cli/devex.md
+++ b/docs/reference/cli/devex.md
@@ -70,14 +70,13 @@ that wants to participate registers its own handlers on import. For
 `devex`, the `agex-cli` library already implements the three verbs —
 culture just routes.
 
-### Upcoming namespaces
+### Sibling and upcoming namespaces
 
-Three more namespaces are registered as `(coming soon)` in
-`culture explain` output and will gain full handlers in future releases:
+[`culture afi`](./afi/) is registered as of culture 8.1, riding the
+same passthrough plumbing as devex. Two more namespaces are listed as
+`(coming soon)` in `culture explain` output and will gain full
+handlers in future releases:
 
-- **`culture afi`** — Agent First Interface. Scaffolding standards for
-  tools whose primary consumer is an AI agent. Wraps the standalone
-  [`afi-cli`](https://github.com/agentculture/afi-cli).
 - **`culture identity`** — Identity management across the mesh. Will
   wrap a standalone `zehut-cli` (Hebrew: "identity").
 - **`culture secret`** — Secret management. Will wrap a standalone

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -11,10 +11,12 @@ permalink: /reference/cli/
 # CLI Reference
 
 The `culture` command manages servers, agents, bots, channels, and the
-mesh, plus embeds the agex developer-experience CLI as `culture devex`.
-Every level of the command tree is inspectable via three universal
-verbs — `explain`, `overview`, `learn`. See
-[`culture devex` and universal verbs](./devex/) for the full contract.
+mesh, and embeds two sibling CLIs: the agex developer-experience CLI
+as [`culture devex`](./devex/) and the afi Agent-First-Interface CLI
+as [`culture afi`](./afi/). Every level of the command tree is
+inspectable via three universal verbs — `explain`, `overview`,
+`learn`. See [`culture devex` and universal verbs](./devex/) for the
+full contract.
 
 Install: `uv tool install culture` or `pip install culture`
 
@@ -407,6 +409,8 @@ registry of participating namespaces.
 - `culture learn [topic]` — agent onboarding prompt
 - `culture devex <anything>` — developer-experience passthrough
   (powered by `agex-cli`)
+- `culture afi <anything>` — Agent First Interface passthrough
+  (powered by `afi-cli`)
 
-`culture afi`, `culture identity`, and `culture secret` are upcoming
-and appear as `(coming soon)` in `culture explain` output.
+`culture identity` and `culture secret` are upcoming and appear as
+`(coming soon)` in `culture explain` output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "aiohttp>=3.9",
     "textual>=1.0",
     "agex-cli>=0.13,<1.0",
-    "afi-cli>=0.2,<1.0",
+    "afi-cli>=0.3,<1.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.0.0"
+version = "8.1.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -21,6 +21,7 @@ dependencies = [
     "aiohttp>=3.9",
     "textual>=1.0",
     "agex-cli>=0.13,<1.0",
+    "afi-cli>=0.2,<1.0",
 ]
 
 [project.urls]

--- a/tests/test_cli_afi.py
+++ b/tests/test_cli_afi.py
@@ -38,6 +38,18 @@ def test_culture_afi_learn_runs():
     assert result.stdout.strip()
 
 
+def test_culture_afi_overview_runs():
+    # afi-cli 0.3+ exposes `overview`; our pin guarantees it.
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "afi", "overview"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
 def test_culture_afi_help_shows_argparse_help():
     result = subprocess.run(
         [sys.executable, "-m", "culture", "afi", "--help"],
@@ -64,6 +76,17 @@ def test_culture_explain_afi_via_universal_verb():
 def test_culture_learn_afi_via_universal_verb():
     result = subprocess.run(
         [sys.executable, "-m", "culture", "learn", "afi"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_overview_afi_via_universal_verb():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "overview", "afi"],
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_cli_afi.py
+++ b/tests/test_cli_afi.py
@@ -1,0 +1,88 @@
+"""Tests for `culture afi` passthrough and `afi` universal topic."""
+
+import subprocess
+import sys
+
+
+def test_culture_afi_version_runs():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "afi", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    # afi --version prints "afi X.Y.Z"
+    assert result.stdout.strip().startswith("afi ")
+
+
+def test_culture_afi_explain_runs():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "afi", "explain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_afi_learn_runs():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "afi", "learn"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_afi_help_shows_argparse_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "afi", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    # afi uses argparse; help text contains the usage banner
+    assert "usage:" in result.stdout.lower()
+
+
+def test_culture_explain_afi_via_universal_verb():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "explain", "afi"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_learn_afi_via_universal_verb():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "learn", "afi"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_explain_lists_afi_as_registered():
+    # When afi registers handlers, `culture explain` should no longer show it
+    # as "(coming soon)".
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "explain"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    lines = [ln for ln in result.stdout.splitlines() if "`culture afi`" in ln]
+    assert lines, "afi line missing from `culture explain` namespaces list"
+    # The line must not carry the "(coming soon)" marker
+    assert "coming soon" not in lines[0], lines[0]

--- a/tests/test_cli_passthrough.py
+++ b/tests/test_cli_passthrough.py
@@ -38,8 +38,15 @@ def _error_entry(argv: list[str]) -> None:
 
 
 def _str_code_entry(argv: list[str]) -> None:
-    # Unusual SystemExit where code is a string: treated as rc=1.
+    # Unusual SystemExit where code is a string: treated as rc=1 and the
+    # message is forwarded to the caller (stderr for run, buf for capture).
     raise SystemExit("something went wrong")
+
+
+def _str_code_no_newline_entry(argv: list[str]) -> None:
+    # No trailing newline — capture() should append one to keep the buffer
+    # newline-terminated like a bare invocation's stderr stream.
+    raise SystemExit("boom")
 
 
 class TestCapture:
@@ -72,6 +79,16 @@ class TestCapture:
         out, rc = _passthrough.capture(_str_code_entry, [])
         # Stringly-typed exit codes are treated as generic failure (1).
         assert rc == 1
+        # The message must reach the caller — otherwise `culture overview <x>`
+        # would print nothing when the embedded CLI does `sys.exit("msg")`.
+        assert "something went wrong" in out
+
+    def test_capture_string_code_appends_newline(self):
+        out, rc = _passthrough.capture(_str_code_no_newline_entry, [])
+        assert rc == 1
+        # Even when the embedded CLI's message lacks a trailing newline, the
+        # buffer should end with one so introspect.dispatch prints cleanly.
+        assert out.endswith("boom\n")
 
 
 class TestRun:
@@ -94,6 +111,15 @@ class TestRun:
         with pytest.raises(SystemExit) as ei:
             _passthrough.run(_none_entry, [])
         assert ei.value.code == 0
+
+    def test_run_string_code_prints_and_exits_one(self, capsys):
+        with pytest.raises(SystemExit) as ei:
+            _passthrough.run(_str_code_entry, [])
+        assert ei.value.code == 1
+        # Python's default sys.exit("msg") prints the message to stderr
+        # before exiting 1; the passthrough must match that behaviour.
+        captured = capsys.readouterr()
+        assert "something went wrong" in captured.err
 
 
 class TestRegisterTopic:

--- a/tests/test_cli_passthrough.py
+++ b/tests/test_cli_passthrough.py
@@ -1,0 +1,120 @@
+"""Unit tests for `culture.cli._passthrough` — the shared embedding helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.cli import _passthrough
+
+
+def _ok_entry(argv: list[str]) -> int:
+    print(f"stdout:{' '.join(argv)}")
+    return 0
+
+
+def _nonzero_entry(argv: list[str]) -> int:
+    print("bad input", flush=True)
+    return 3
+
+
+def _none_entry(argv: list[str]) -> None:
+    # Exercises the "returns None → treated as 0" branch.
+    print("implicit success")
+    return None
+
+
+def _help_entry(argv: list[str]) -> None:
+    # Simulates argparse `--help`: writes to stdout, raises SystemExit(0).
+    print("usage: fake [-h]")
+    raise SystemExit(0)
+
+
+def _error_entry(argv: list[str]) -> None:
+    # Simulates argparse error: writes to stderr, raises SystemExit(2).
+    import sys as _sys
+
+    print("error: bad flag", file=_sys.stderr)
+    raise SystemExit(2)
+
+
+def _str_code_entry(argv: list[str]) -> None:
+    # Unusual SystemExit where code is a string: treated as rc=1.
+    raise SystemExit("something went wrong")
+
+
+class TestCapture:
+    def test_captures_stdout_and_returns_rc(self):
+        out, rc = _passthrough.capture(_ok_entry, ["a", "b"])
+        assert rc == 0
+        assert "stdout:a b" in out
+
+    def test_non_zero_return_passes_through(self):
+        out, rc = _passthrough.capture(_nonzero_entry, [])
+        assert rc == 3
+        assert "bad input" in out
+
+    def test_none_return_is_zero(self):
+        out, rc = _passthrough.capture(_none_entry, [])
+        assert rc == 0
+        assert "implicit success" in out
+
+    def test_systemexit_zero_is_captured_as_rc_zero(self):
+        out, rc = _passthrough.capture(_help_entry, ["--help"])
+        assert rc == 0
+        assert "usage:" in out
+
+    def test_systemexit_nonzero_is_captured_as_rc(self):
+        out, rc = _passthrough.capture(_error_entry, [])
+        assert rc == 2
+        assert "bad flag" in out
+
+    def test_systemexit_string_code_becomes_one(self):
+        out, rc = _passthrough.capture(_str_code_entry, [])
+        # Stringly-typed exit codes are treated as generic failure (1).
+        assert rc == 1
+
+
+class TestRun:
+    def test_run_zero_exits_zero(self):
+        with pytest.raises(SystemExit) as ei:
+            _passthrough.run(_ok_entry, [])
+        assert ei.value.code == 0
+
+    def test_run_nonzero_exits_with_code(self):
+        with pytest.raises(SystemExit) as ei:
+            _passthrough.run(_nonzero_entry, [])
+        assert ei.value.code == 3
+
+    def test_run_propagates_systemexit_code(self):
+        with pytest.raises(SystemExit) as ei:
+            _passthrough.run(_error_entry, [])
+        assert ei.value.code == 2
+
+    def test_run_none_becomes_zero(self):
+        with pytest.raises(SystemExit) as ei:
+            _passthrough.run(_none_entry, [])
+        assert ei.value.code == 0
+
+
+class TestRegisterTopic:
+    def test_register_wires_all_three_verbs(self):
+        # Use the real registry via a fresh topic name. Re-registering is
+        # last-write-wins with a warning in culture.cli.introspect.
+        from culture.cli import introspect
+
+        _passthrough.register_topic(
+            "__test_topic__",
+            _ok_entry,
+            explain_argv=["explain"],
+            overview_argv=["overview"],
+            learn_argv=["learn"],
+        )
+        out, rc = introspect.explain("__test_topic__")
+        assert rc == 0
+        assert "stdout:explain" in out
+        out, rc = introspect.overview("__test_topic__")
+        assert rc == 0
+        assert "stdout:overview" in out
+        out, rc = introspect.learn("__test_topic__")
+        assert rc == 0
+        assert "stdout:learn" in out

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "afi-cli"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/e8/08270fdf680908af68ed693f22132c12c8c506291dbfa61af84058be9c45/afi_cli-0.2.0.tar.gz", hash = "sha256:856b39d75e95e10e52279bef0e4bfe734eec76d33d6072b380a5ca1048c17b6d", size = 76668, upload-time = "2026-04-22T16:31:43.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/1a/dae889dc7c082657f84890399013bb2702ddc73491429facb9503dd0db6f/afi_cli-0.2.0-py3-none-any.whl", hash = "sha256:5711690e2bf74066c86f4712cac3fb15cb5870b779dd85823ea1c57367c0697f", size = 40436, upload-time = "2026-04-22T16:31:44.194Z" },
+]
+
+[[package]]
 name = "agex-cli"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -577,9 +586,10 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.0.0"
+version = "8.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "afi-cli" },
     { name = "agex-cli" },
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -614,6 +624,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "afi-cli", specifier = ">=0.2,<1.0" },
     { name = "agex-cli", specifier = ">=0.13,<1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", specifier = ">=0.40" },

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "afi-cli"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/e8/08270fdf680908af68ed693f22132c12c8c506291dbfa61af84058be9c45/afi_cli-0.2.0.tar.gz", hash = "sha256:856b39d75e95e10e52279bef0e4bfe734eec76d33d6072b380a5ca1048c17b6d", size = 76668, upload-time = "2026-04-22T16:31:43.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/20/c5172963bf440aba92b68a9d043151fb3dd543626fdad1cf846520d1e418/afi_cli-0.3.0.tar.gz", hash = "sha256:884aa1a5b539eedac8b38ea7c89f3c77f4ad1fe4e9d8c0659d306e45d16240ae", size = 92435, upload-time = "2026-04-23T14:55:41.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/1a/dae889dc7c082657f84890399013bb2702ddc73491429facb9503dd0db6f/afi_cli-0.2.0-py3-none-any.whl", hash = "sha256:5711690e2bf74066c86f4712cac3fb15cb5870b779dd85823ea1c57367c0697f", size = 40436, upload-time = "2026-04-22T16:31:44.194Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/af36f135cde37206333fd318bd92d49c4e2152d5122687653274fb54300e/afi_cli-0.3.0-py3-none-any.whl", hash = "sha256:f760a92bf1782fc470c3a1cdffef3c4f8014e749475332f45ce43811855ada7f", size = 54411, upload-time = "2026-04-23T14:55:42.662Z" },
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "afi-cli", specifier = ">=0.2,<1.0" },
+    { name = "afi-cli", specifier = ">=0.3,<1.0" },
     { name = "agex-cli", specifier = ">=0.13,<1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", specifier = ">=0.40" },


### PR DESCRIPTION
## Summary

- Adds `culture afi` as a first-class passthrough namespace to the standalone [afi-cli](https://github.com/agentculture/afi-cli) (Agent First Interface scaffolder). All args after `culture afi` forward verbatim to afi's argparse app.
- Extracts `culture/cli/_passthrough.py` — shared plumbing (`run()` / `capture()` / `register_topic()`) so every culture-embedded CLI (devex today, afi now, zehut/shushu later) uses the same embedding path.
- Refactors `culture/cli/devex.py` onto the shared helper; behaviour is preserved.
- Registers `afi` on the universal-verb dispatcher, so `culture explain` no longer marks it as coming-soon.
- Bumps culture to **8.1.0** and adds `afi-cli>=0.2,<1.0`.

## The better method

This PR is the culture-side slice of a broader agent-first CLI contract work. Every culture-embedded CLI is moving toward:

1. `main(argv: list[str] | None = None) -> int` — library-grade in-process entry, no `sys.exit` on normal paths.
2. Three universal verbs — `explain [path...]` / `overview [path...]` / `learn`.
3. `--json` everywhere; structured errors; stdout/stderr discipline.

afi-cli owns the rubric that enforces this; afi itself must also model it.

**Tracking issues**:
- [agentculture/afi-cli#5](https://github.com/agentculture/afi-cli/issues/5) — adds `overview` verb to afi + sixth rubric bundle + formalizes `main(argv) -> int` as a structural check. Ships as afi-cli 0.3.
- [agentculture/agex-cli#30](https://github.com/agentculture/agex-cli/issues/30) — adds `main(argv) -> int` to agex-cli (thin typer wrapper) and a path-arg `explain`. Ships as agex-cli 0.14.

Once both releases land, a follow-up PR bumps pins to `afi-cli>=0.3` + `agex-cli>=0.14`, removes the typer adapter in `devex.py` (it becomes a direct `main(argv)` delegation), and `culture overview afi` lights up automatically.

## Known intentional limitation

`culture overview afi` currently surfaces afi's own argparse error:

```
error: argument command: invalid choice: 'overview' (choose from 'learn', 'explain', 'cli')
```

This is honest — afi-cli 0.2 doesn't expose `overview` yet. Rather than masking the upstream gap with a synthetic placeholder, we route the real error. afi-cli 0.3 (tracking issue above) fixes it with no culture-side change needed beyond a pin bump.

## Test plan

- [x] `/run-tests` — 929 passed in 55.43s (full suite green).
- [x] New tests: `tests/test_cli_afi.py` (7 cases, subprocess-based integration), `tests/test_cli_passthrough.py` (11 unit cases covering every branch of `run` / `capture` / `register_topic` including all three `SystemExit.code` shapes).
- [x] Existing `tests/test_cli_devex.py` (4 cases) continues to pass — refactor is behaviour-preserving.
- [x] Manual smoke: `culture afi --version`, `culture afi explain`, `culture afi learn`, `culture afi --help`, `culture explain afi`, `culture learn afi`, `culture explain` (afi no longer shows "coming soon"), `culture devex --version`, `culture explain devex` (regression).
- [x] Pre-push reviewers: `doc-test-alignment` (one soft finding: `overview afi` routing not unit-tested — deliberate until afi 0.3) and `superpowers:code-reviewer` (approve; S2 changelog blank-line + S5 agex pin clarified inline and addressed).
- [x] Pre-commit hooks: flake8, isort, black, bandit, pylint, markdownlint-cli2 all passed.
- [ ] Qodo + Copilot review on this PR.
- [ ] `/sonarclaude` once CI completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)