### PR TITLE
docs: add afi-cli site to culture.dev navigation + sitemap

### DIFF
--- a/_config.culture.yml
+++ b/_config.culture.yml
@@ -36,6 +36,8 @@ aux_links:
     - "/agentirc/"
   "Agent Experience":
     - "https://culture.dev/agex/"
+  "Agent First Interop":
+    - "https://culture.dev/afi/"
   "Citation CLI":
     - "/citation-cli/"
   "GitHub":
@@ -49,5 +51,6 @@ footer_content: >-
   Inspectable CLI via <a href="/reference/cli/devex/">culture devex</a>
   (explain / overview / learn at every level).
   Agent Experience via <a href="https://culture.dev/agex/">agex-cli</a>.
+  Agent First Interop via <a href="https://culture.dev/afi/">afi-cli</a>.
   Code distribution via <a href="/citation-cli/">Citation CLI</a>.
   Source on <a href="https://github.com/agentculture/culture">GitHub</a>.

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -1,3 +1,4 @@
+afi: https://culture.dev/afi/
 agentirc: https://culture.dev/agentirc/
 agex: https://culture.dev/agex/
 citation_cli: https://culture.dev/citation-cli/

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -4,4 +4,5 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/images/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/images/apple-touch-icon.png' | relative_url }}">
 <link rel="related" href="{{ site.data.sites.agex }}" title="Agent Experience">
+<link rel="related" href="{{ site.data.sites.afi }}" title="Agent First Interop">
 <link rel="related" href="{{ site.data.sites.citation_cli }}" title="Citation CLI">

--- a/docs/reference/architecture/index.md
+++ b/docs/reference/architecture/index.md
@@ -10,4 +10,18 @@ permalink: /reference/architecture/
 
 # Architecture Reference
 
-Technical details of the 5-layer architecture, conversation threads, and harness specs.
+Technical details of the 5-layer architecture, conversation threads,
+harness specs, and the shared sub-site pattern for projects hosted
+under `culture.dev/*`.
+
+- [Layers]({{ '/reference/architecture/layers/' | relative_url }}) —
+  the 5-layer AgentIRC architecture (Core IRC, Attention, Skills,
+  Federation, Harness).
+- [Threads]({{ '/reference/architecture/threads/' | relative_url }}) —
+  conversation-thread model and how it maps onto IRC channels.
+- [Agent harness spec]({{ '/reference/architecture/agent-harness-spec/' | relative_url }}) —
+  the shared contract every backend harness implements.
+- [Sub-sites on culture.dev]({{ '/reference/architecture/subsites/' | relative_url }}) —
+  the reference pattern for hosting a project's docs at
+  `culture.dev/<project>/` (e.g. `/agex/`, `/afi/`); the exact file
+  edits on both the project side and the culture side.

--- a/docs/reference/architecture/subsites.md
+++ b/docs/reference/architecture/subsites.md
@@ -1,0 +1,111 @@
+---
+title: "Sub-sites on culture.dev"
+parent: "Architecture"
+grand_parent: "Reference"
+nav_order: 4
+sites: [agentirc, culture]
+description: The reference pattern for hosting an AgentCulture project's docs as a sub-site under culture.dev (e.g. /agex/, /afi/).
+permalink: /reference/architecture/subsites/
+---
+
+# Sub-sites on `culture.dev`
+
+AgentCulture projects whose primary docs site should live under the
+shared `culture.dev` origin — so navigation between them is same-origin,
+cache hits survive cross-project jumps, and external links live at one
+canonical host — follow a single reference pattern. `culture.dev/agex/`
+and `culture.dev/afi/` are the two current instances; `zehut` and
+`shushu` will follow.
+
+This page blesses that pattern as the reference scaffold and lists the
+exact edits a new sub-site needs on both the project side and the
+culture side.
+
+## When to make a project a sub-site
+
+- The project is an AgentCulture first-class namespace
+  (e.g. `culture afi`, `culture devex`) and wants a public docs home.
+- The project's docs are natural neighbours of the other
+  `culture.dev/*` sub-sites — agents and humans should be able to
+  navigate between them without leaving the origin.
+- The project is comfortable deploying via Cloudflare Pages with its
+  docs rooted at a path prefix (`baseurl: /<project>`), not a
+  subdomain.
+
+If any of those don't hold, keep the project's docs on its own origin
+and cross-link via `rel=related` only.
+
+## Reference scaffold (project side)
+
+Mirror the `afi-cli` scaffold ([agentculture/afi-cli#7](https://github.com/agentculture/afi-cli/pull/7))
+or the earlier `agex-cli` scaffold it was modeled on. Both are blessed;
+new sub-sites should start from the afi-cli version because it includes the later
+refinements.
+
+Required pieces in the project repo:
+
+- `docs/_config.yml` — Jekyll config with `url: https://culture.dev`
+  and `baseurl: /<project>`. Path-prefix hosting, not subdomain.
+- **Theme:** [`just-the-docs`](https://just-the-docs.com/) (matches
+  the rest of the culture.dev family).
+- **Plugin:** `jekyll-sitemap` so `/<project>/sitemap.xml` generates
+  automatically.
+- `docs/_includes/head_custom.html` — `rel=related` back-links to the
+  other culture.dev sub-sites (optional but recommended).
+- `.github/workflows/docs.yml` — builds `docs/` and deploys to a
+  Cloudflare Pages project named `<project>`. See the afi-cli workflow
+  for the canonical job shape.
+
+**Not in the project repo:**
+
+- The Cloudflare Pages project itself, custom-domain binding, DNS
+  records, Worker / Redirect Rule for path routing —
+  tracked in [agentculture/cloudflare](https://github.com/agentculture/cloudflare).
+
+## Reference scaffold (culture side)
+
+Every sub-site touches exactly five files in this repo. The diff for
+`culture.dev/afi/` is the canonical example (PR #289); the `agex`
+entries in the same files are the prior example.
+
+| File | Edit |
+|------|------|
+| `_data/sites.yml` | Add `<project>: https://culture.dev/<project>/`. Centralises every cross-site URL so links never hard-code the origin. |
+| `_config.culture.yml` (`aux_links:`) | Add `"Display Name": - "https://culture.dev/<project>/"` — shows up in the top nav bar. |
+| `_config.culture.yml` (`footer_content:`) | Add a one-line description + link, parallel to the agex / afi entries. |
+| `_includes/head_custom.html` | Add `<link rel="related" href="{{ site.data.sites.<project> }}" title="Display Name">` so cross-site discovery is declarative. |
+| `sitemap.html` | Add a `<sitemap>` entry pointing at `/<project>/sitemap.xml` (see the `afi` and `agex` lines in this file) so search engines see the sub-site. |
+
+That is the whole culture-side cost. No `_config.culture.yml` routing
+block is needed — the path prefix is served by Cloudflare, not Jekyll.
+
+## Required edits vs. optional
+
+All five culture-side edits above are **required** for a sub-site to be
+considered properly wired. A sub-site that skips `rel=related` or
+`sitemap.html` is "reachable but not discoverable" and should not ship.
+
+On the project side, `just-the-docs` and `jekyll-sitemap` are
+**required**; everything else (landing-page content, `rel=related`
+back-links, custom `head_custom.html` tweaks) is project-specific.
+
+## Checklist for a new sub-site
+
+1. Land the Jekyll scaffold in the project repo (model on `afi-cli`'s
+   `docs/` + `.github/workflows/docs.yml`).
+2. File the Cloudflare companion issue in
+   [agentculture/cloudflare](https://github.com/agentculture/cloudflare)
+   asking for the Pages project + path routing.
+3. Open a PR against this repo adding the five file edits above.
+   Reference the Cloudflare issue in the PR body so ordering is
+   explicit (the Pages project must exist before nav links go live,
+   otherwise the aux-link 404s).
+4. After merge, verify `https://culture.dev/<project>/` returns 200
+   and `curl -sI https://culture.dev/sitemap.xml | grep
+   <project>/sitemap.xml` finds the sub-sitemap entry.
+
+## See also
+
+- [`culture devex` and universal verbs]({{ '/reference/cli/devex/' | relative_url }}) — the CLI-side sibling pattern for embedding a project.
+- [`culture afi`]({{ '/reference/cli/afi/' | relative_url }}) — the second live sub-site; files in this PR are the canonical example.
+- [agentculture/cloudflare](https://github.com/agentculture/cloudflare) — DNS / Pages / redirect-rule configuration for culture.dev and its sub-sites.

--- a/sitemap.html
+++ b/sitemap.html
@@ -8,5 +8,6 @@ sitemap: false
   <sitemap><loc>{{ '/sitemap-main.xml' | absolute_url }}</loc></sitemap>
   <sitemap><loc>{{ '/agentirc/sitemap.xml' | absolute_url }}</loc></sitemap>
   <sitemap><loc>{{ '/agex/sitemap.xml' | absolute_url }}</loc></sitemap>
+  <sitemap><loc>{{ '/afi/sitemap.xml' | absolute_url }}</loc></sitemap>
   <sitemap><loc>{{ '/citation-cli/sitemap.xml' | absolute_url }}</loc></sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Summary

- Adds `afi: https://culture.dev/afi/` to `_data/sites.yml` (parallel to the existing agex entry)
- Adds "Agent First Interop" aux_link + footer link in `_config.culture.yml`
- Adds `<link rel="related">` for afi in `_includes/head_custom.html`
- Adds `/afi/sitemap.xml` to the sitemap index

This is the culture-side linkage for [agentculture/afi-cli#7](https://github.com/agentculture/afi-cli/pull/7) (Jekyll site scaffold). The Cloudflare Pages project + DNS routing is tracked separately in [agentculture/cloudflare#16](https://github.com/agentculture/cloudflare/issues/16).

Closes #288

## Test plan

- [ ] `bundle exec jekyll build` succeeds with the new config entries
- [ ] Sitemap index at `/sitemap.xml` includes `/afi/sitemap.xml`
- [ ] Aux links bar shows "Agent First Interop" linking to `culture.dev/afi/`
- [ ] Footer includes afi-cli link
- [ ] `<link rel="related">` present in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude