### PR TITLE
feat(telemetry): OTEL federation trace-context relay (8.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.3.0] - 2026-04-25
+
+### Added
+
+- `irc.s2s.session` span over ServerLink connection lifetime.
+- `irc.s2s.<VERB>` per-verb spans on inbound federation messages with traceparent extraction and the inbound mitigation rules from `culture/protocol/extensions/tracing.md`.
+- `irc.s2s.relay` span on outbound relay enforcing the re-sign-per-hop rule.
+- `irc.client.session` span over Client connection lifetime (#290).
+- `irc.join` and `irc.part` spans (#290).
+- Public `culture.telemetry.context_from_traceparent` and `current_traceparent` helpers.
+- Single traceparent injection choke point at `ServerLink.send_raw`.
+- End-to-end propagation tests proving one `trace_id` spans federated client → server → relay → server hops.
+
+### Changed
+
+- `Client._dispatch` span name and `irc.command` attribute now uppercase, matching `ServerLink._dispatch` convention.
+
+### Fixed
+
+- `_replay_event` uses the hasattr-guarded comparison so string-typed federated `event.type` no longer skips the typed fast path. (#291)
+
 ## [8.2.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `irc.s2s.relay` span on outbound relay enforcing the re-sign-per-hop rule.
 - `irc.client.session` span over Client connection lifetime (#290).
 - `irc.join` and `irc.part` spans (#290).
-- Public `culture.telemetry.context_from_traceparent` and `current_traceparent` helpers.
+- Public `culture.telemetry.context_from_traceparent` and `culture.telemetry.current_traceparent` helpers.
 - Single traceparent injection choke point at `ServerLink.send_raw`.
 - End-to-end propagation tests proving one `trace_id` spans federated client → server → relay → server hops.
 

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -151,21 +151,24 @@ class Client:
             attributes={"irc.client.remote_addr": remote_addr},
         ) as span:
             self._session_span = span
-            buffer = ""
-            if initial_msg:
-                buffer = initial_msg.replace("\r\n", "\n").replace("\r", "\n")
-                buffer = await self._process_buffer(buffer)
-            while True:
-                data = await self.reader.read(4096)
-                if not data:
-                    break
-                buffer += data.decode("utf-8", errors="replace")
-                # Cap buffer to prevent unbounded memory growth (512 bytes per RFC 2812)
-                if len(buffer) > 8192:
-                    buffer = buffer[-4096:]
-                # Normalize all line endings to \n for simpler parsing
-                buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
-                buffer = await self._process_buffer(buffer)
+            try:
+                buffer = ""
+                if initial_msg:
+                    buffer = initial_msg.replace("\r\n", "\n").replace("\r", "\n")
+                    buffer = await self._process_buffer(buffer)
+                while True:
+                    data = await self.reader.read(4096)
+                    if not data:
+                        break
+                    buffer += data.decode("utf-8", errors="replace")
+                    # Cap buffer to prevent unbounded memory growth (512 bytes per RFC 2812)
+                    if len(buffer) > 8192:
+                        buffer = buffer[-4096:]
+                    # Normalize all line endings to \n for simpler parsing
+                    buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
+                    buffer = await self._process_buffer(buffer)
+            except (ConnectionError, asyncio.IncompleteReadError):
+                pass
 
     async def _dispatch(self, msg: Message) -> None:
         extract = extract_traceparent_from_tags(msg, peer=None)
@@ -331,20 +334,17 @@ class Client:
         )
 
     async def _handle_join(self, msg: Message) -> None:
+        if not self._registered:
+            return
+        if not msg.params:
+            await self.send_numeric(replies.ERR_NEEDMOREPARAMS, "JOIN", replies.MSG_NEEDMOREPARAMS)
+            return
+
+        channel_name = msg.params[0]
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             "irc.join",
-            attributes={"irc.channel": "", "irc.client.nick": self.nick or ""},
-        ) as join_span:
-            if not self._registered:
-                return
-            if not msg.params:
-                await self.send_numeric(
-                    replies.ERR_NEEDMOREPARAMS, "JOIN", replies.MSG_NEEDMOREPARAMS
-                )
-                return
-
-            channel_name = msg.params[0]
-            join_span.set_attribute("irc.channel", channel_name)
+            attributes={"irc.channel": channel_name, "irc.client.nick": self.nick or ""},
+        ):
             if not channel_name.startswith("#"):
                 return
 
@@ -386,18 +386,15 @@ class Client:
             )
 
     async def _handle_part(self, msg: Message) -> None:
+        if not msg.params:
+            await self.send_numeric(replies.ERR_NEEDMOREPARAMS, "PART", replies.MSG_NEEDMOREPARAMS)
+            return
+
+        channel_name = msg.params[0]
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             "irc.part",
-            attributes={"irc.channel": "", "irc.client.nick": self.nick or ""},
-        ) as part_span:
-            if not msg.params:
-                await self.send_numeric(
-                    replies.ERR_NEEDMOREPARAMS, "PART", replies.MSG_NEEDMOREPARAMS
-                )
-                return
-
-            channel_name = msg.params[0]
-            part_span.set_attribute("irc.channel", channel_name)
+            attributes={"irc.channel": channel_name, "irc.client.nick": self.nick or ""},
+        ):
             reason = msg.params[1] if len(msg.params) > 1 else ""
 
             channel = self.server.channels.get(channel_name)

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -7,6 +7,7 @@ import re
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as _otel_trace
+from opentelemetry.trace import Span as _OtelSpan
 
 from culture.agentirc.channel import Channel
 from culture.agentirc.skill import Event, EventType
@@ -57,6 +58,7 @@ class Client:
         self.caps: set[str] = set()
         self.modes: set[str] = set()
         self.icon: str | None = None
+        self._session_span: _OtelSpan | None = None
 
     @property
     def prefix(self) -> str:
@@ -142,21 +144,28 @@ class Client:
             return buffer
 
     async def handle(self, initial_msg: str | None = None) -> None:
-        buffer = ""
-        if initial_msg:
-            buffer = initial_msg.replace("\r\n", "\n").replace("\r", "\n")
-            buffer = await self._process_buffer(buffer)
-        while True:
-            data = await self.reader.read(4096)
-            if not data:
-                break
-            buffer += data.decode("utf-8", errors="replace")
-            # Cap buffer to prevent unbounded memory growth (512 bytes per RFC 2812)
-            if len(buffer) > 8192:
-                buffer = buffer[-4096:]
-            # Normalize all line endings to \n for simpler parsing
-            buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
-            buffer = await self._process_buffer(buffer)
+        peer_info = self.writer.get_extra_info("peername")
+        remote_addr = f"{peer_info[0]}:{peer_info[1]}" if peer_info else ""
+        with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
+            "irc.client.session",
+            attributes={"irc.client.remote_addr": remote_addr},
+        ) as span:
+            self._session_span = span
+            buffer = ""
+            if initial_msg:
+                buffer = initial_msg.replace("\r\n", "\n").replace("\r", "\n")
+                buffer = await self._process_buffer(buffer)
+            while True:
+                data = await self.reader.read(4096)
+                if not data:
+                    break
+                buffer += data.decode("utf-8", errors="replace")
+                # Cap buffer to prevent unbounded memory growth (512 bytes per RFC 2812)
+                if len(buffer) > 8192:
+                    buffer = buffer[-4096:]
+                # Normalize all line endings to \n for simpler parsing
+                buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
+                buffer = await self._process_buffer(buffer)
 
     async def _dispatch(self, msg: Message) -> None:
         extract = extract_traceparent_from_tags(msg, peer=None)
@@ -164,8 +173,9 @@ class Client:
         if extract.status == "valid":
             parent_ctx = context_from_traceparent(extract.traceparent)
 
+        verb = msg.command.upper()
         attrs = {
-            "irc.command": msg.command,
+            "irc.command": verb,
             "irc.prefix_nick": (msg.prefix.split("!")[0] if msg.prefix else ""),
             "culture.trace.origin": "local" if extract.status == "missing" else "remote",
         }
@@ -174,7 +184,7 @@ class Client:
 
         # Per-call get_tracer: test fixture swaps provider between tests.
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
-            f"irc.command.{msg.command}",
+            f"irc.command.{verb}",
             context=parent_ctx,
             attributes=attrs,
         ):
@@ -275,6 +285,8 @@ class Client:
 
         self.nick = nick
         self.server.clients[nick] = self
+        if self._session_span is not None:
+            self._session_span.set_attribute("irc.client.nick", nick)
         await self._try_register()
 
     async def _handle_user(self, msg: Message) -> None:
@@ -319,89 +331,103 @@ class Client:
         )
 
     async def _handle_join(self, msg: Message) -> None:
-        if not self._registered:
-            return
-        if not msg.params:
-            await self.send_numeric(replies.ERR_NEEDMOREPARAMS, "JOIN", replies.MSG_NEEDMOREPARAMS)
-            return
-
-        channel_name = msg.params[0]
-        if not channel_name.startswith("#"):
-            return
-
-        # Block joins to archived rooms
-        existing = self.server.channels.get(channel_name)
-        if existing and existing.archived:
-            await self.send(
-                Message(
-                    prefix=self.server.config.name,
-                    command="NOTICE",
-                    params=[self.nick, f"{channel_name} is archived and cannot be joined"],
+        with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
+            "irc.join",
+            attributes={"irc.channel": "", "irc.client.nick": self.nick or ""},
+        ) as join_span:
+            if not self._registered:
+                return
+            if not msg.params:
+                await self.send_numeric(
+                    replies.ERR_NEEDMOREPARAMS, "JOIN", replies.MSG_NEEDMOREPARAMS
                 )
+                return
+
+            channel_name = msg.params[0]
+            join_span.set_attribute("irc.channel", channel_name)
+            if not channel_name.startswith("#"):
+                return
+
+            # Block joins to archived rooms
+            existing = self.server.channels.get(channel_name)
+            if existing and existing.archived:
+                await self.send(
+                    Message(
+                        prefix=self.server.config.name,
+                        command="NOTICE",
+                        params=[self.nick, f"{channel_name} is archived and cannot be joined"],
+                    )
+                )
+                return
+
+            channel = self.server.get_or_create_channel(channel_name)
+            if self in channel.members:
+                return
+
+            channel.add(self)
+            self.channels.add(channel)
+
+            # Notify all channel members (including self)
+            join_msg = Message(prefix=self.prefix, command="JOIN", params=[channel_name])
+            for member in list(channel.members):
+                await member.send(join_msg)
+
+            # Send topic if set
+            if channel.topic:
+                await self.send_numeric(replies.RPL_TOPIC, channel_name, channel.topic)
+
+            # Send names list
+            await self._send_names(channel)
+
+            # Emit event AFTER delivering all join-related numerics (topic, NAMES)
+            # so that the event PRIVMSG doesn't interleave with 353/366 in client buffers.
+            await self.server.emit_event(
+                Event(type=EventType.JOIN, channel=channel_name, nick=self.nick)
             )
-            return
-
-        channel = self.server.get_or_create_channel(channel_name)
-        if self in channel.members:
-            return
-
-        channel.add(self)
-        self.channels.add(channel)
-
-        # Notify all channel members (including self)
-        join_msg = Message(prefix=self.prefix, command="JOIN", params=[channel_name])
-        for member in list(channel.members):
-            await member.send(join_msg)
-
-        # Send topic if set
-        if channel.topic:
-            await self.send_numeric(replies.RPL_TOPIC, channel_name, channel.topic)
-
-        # Send names list
-        await self._send_names(channel)
-
-        # Emit event AFTER delivering all join-related numerics (topic, NAMES)
-        # so that the event PRIVMSG doesn't interleave with 353/366 in client buffers.
-        await self.server.emit_event(
-            Event(type=EventType.JOIN, channel=channel_name, nick=self.nick)
-        )
 
     async def _handle_part(self, msg: Message) -> None:
-        if not msg.params:
-            await self.send_numeric(replies.ERR_NEEDMOREPARAMS, "PART", replies.MSG_NEEDMOREPARAMS)
-            return
+        with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
+            "irc.part",
+            attributes={"irc.channel": "", "irc.client.nick": self.nick or ""},
+        ) as part_span:
+            if not msg.params:
+                await self.send_numeric(
+                    replies.ERR_NEEDMOREPARAMS, "PART", replies.MSG_NEEDMOREPARAMS
+                )
+                return
 
-        channel_name = msg.params[0]
-        reason = msg.params[1] if len(msg.params) > 1 else ""
+            channel_name = msg.params[0]
+            part_span.set_attribute("irc.channel", channel_name)
+            reason = msg.params[1] if len(msg.params) > 1 else ""
 
-        channel = self.server.channels.get(channel_name)
-        if not channel or self not in channel.members:
-            await self.send_numeric(
-                replies.ERR_NOTONCHANNEL,
-                channel_name,
-                replies.MSG_NOTONCHANNEL,
+            channel = self.server.channels.get(channel_name)
+            if not channel or self not in channel.members:
+                await self.send_numeric(
+                    replies.ERR_NOTONCHANNEL,
+                    channel_name,
+                    replies.MSG_NOTONCHANNEL,
+                )
+                return
+
+            part_params = [channel_name, reason] if reason else [channel_name]
+            part_msg = Message(prefix=self.prefix, command="PART", params=part_params)
+            for member in list(channel.members):
+                await member.send(part_msg)
+
+            await self.server.emit_event(
+                Event(
+                    type=EventType.PART,
+                    channel=channel_name,
+                    nick=self.nick,
+                    data={"reason": reason},
+                )
             )
-            return
 
-        part_params = [channel_name, reason] if reason else [channel_name]
-        part_msg = Message(prefix=self.prefix, command="PART", params=part_params)
-        for member in list(channel.members):
-            await member.send(part_msg)
+            channel.remove(self)
+            self.channels.discard(channel)
 
-        await self.server.emit_event(
-            Event(
-                type=EventType.PART,
-                channel=channel_name,
-                nick=self.nick,
-                data={"reason": reason},
-            )
-        )
-
-        channel.remove(self)
-        self.channels.discard(channel)
-
-        if not channel.members and not channel.persistent:
-            del self.server.channels[channel_name]
+            if not channel.members and not channel.persistent:
+                del self.server.channels[channel_name]
 
     async def _handle_topic(self, msg: Message) -> None:
         if not msg.params:

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -7,8 +7,6 @@ import re
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as _otel_trace
-from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
-from opentelemetry.trace.propagation import set_span_in_context
 
 from culture.agentirc.channel import Channel
 from culture.agentirc.skill import Event, EventType
@@ -18,6 +16,8 @@ from culture.protocol import replies
 from culture.protocol.message import Message
 from culture.telemetry.context import TRACEPARENT_TAG as _TP_TAG_NAME
 from culture.telemetry.context import (
+    context_from_traceparent,
+    current_traceparent,
     extract_traceparent_from_tags,
 )
 from culture.telemetry.context import inject_traceparent as _inject_traceparent
@@ -29,35 +29,6 @@ _TRACER_NAME = "culture.agentirc"
 # rename / sanitization layer has one edit point.
 _ATTR_BODY = "irc.message.body"
 _ATTR_SIZE = "irc.message.size"
-
-
-def _context_from_traceparent(tp: str):
-    """Build an OTEL context whose current span is a NonRecordingSpan
-    synthesized from a W3C traceparent string. The `_dispatch` span we
-    start next will be a child of this context."""
-    # Format: 00-<trace-id>-<parent-id>-<flags>
-    _, trace_hex, parent_hex, flags_hex = tp.split("-")
-    span_ctx = SpanContext(
-        trace_id=int(trace_hex, 16),
-        span_id=int(parent_hex, 16),
-        is_remote=True,
-        trace_flags=TraceFlags(int(flags_hex, 16)),
-    )
-    return set_span_in_context(NonRecordingSpan(span_ctx))
-
-
-def _current_traceparent() -> str | None:
-    """Return the W3C traceparent for the currently-active span, or None
-    if no span is recording (no-op tracer / sampler dropped).
-    """
-    span = _otel_trace.get_current_span()
-    ctx = span.get_span_context()
-    if not ctx.is_valid:
-        return None
-    return (
-        f"00-{format(ctx.trace_id, '032x')}-{format(ctx.span_id, '016x')}"
-        f"-{format(int(ctx.trace_flags), '02x')}"
-    )
 
 
 if TYPE_CHECKING:
@@ -97,7 +68,7 @@ class Client:
         # block and `send_tagged`'s tag-stripping for non-capable clients
         # would be undone here.
         if "message-tags" in self.caps:
-            tp = _current_traceparent()
+            tp = current_traceparent()
             if tp is not None:
                 _inject_traceparent(message, traceparent=tp, tracestate=None)
         try:
@@ -114,7 +85,7 @@ class Client:
         AND the client negotiated the `message-tags` capability.
         """
         if "message-tags" in self.caps:
-            tp = _current_traceparent()
+            tp = current_traceparent()
             if tp is not None:
                 # send_raw takes a pre-formatted line without an existing tag
                 # block; prefix a fresh @tag.
@@ -191,7 +162,7 @@ class Client:
         extract = extract_traceparent_from_tags(msg, peer=None)
         parent_ctx = None
         if extract.status == "valid":
-            parent_ctx = _context_from_traceparent(extract.traceparent)
+            parent_ctx = context_from_traceparent(extract.traceparent)
 
         attrs = {
             "irc.command": msg.command,

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -7,6 +7,7 @@ import re
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as _otel_trace
+from opentelemetry.context import Context as _OtelContext
 from opentelemetry.trace import Span as _OtelSpan
 
 from culture.agentirc.channel import Channel
@@ -26,10 +27,12 @@ from culture.telemetry.context import inject_traceparent as _inject_traceparent
 # OTEL instrumentation name (must match `_CULTURE_TRACER_NAME` in
 # culture/telemetry/tracing.py so trace consumers see one consistent value).
 _TRACER_NAME = "culture.agentirc"
-# Span attribute keys for PRIVMSG body capture, defined once so a future
-# rename / sanitization layer has one edit point.
+# Span attribute keys, defined once so a future rename / sanitization layer
+# has one edit point.
 _ATTR_BODY = "irc.message.body"
 _ATTR_SIZE = "irc.message.size"
+_ATTR_NICK = "irc.client.nick"
+_ATTR_CHANNEL = "irc.channel"
 
 
 if TYPE_CHECKING:
@@ -172,9 +175,10 @@ class Client:
 
     async def _dispatch(self, msg: Message) -> None:
         extract = extract_traceparent_from_tags(msg, peer=None)
-        parent_ctx = None
         if extract.status == "valid":
-            parent_ctx = context_from_traceparent(extract.traceparent)
+            parent_ctx: _OtelContext | None = context_from_traceparent(extract.traceparent)
+        else:
+            parent_ctx = _OtelContext()  # force root: detach from session span
 
         verb = msg.command.upper()
         attrs = {
@@ -289,7 +293,7 @@ class Client:
         self.nick = nick
         self.server.clients[nick] = self
         if self._session_span is not None:
-            self._session_span.set_attribute("irc.client.nick", nick)
+            self._session_span.set_attribute(_ATTR_NICK, nick)
         await self._try_register()
 
     async def _handle_user(self, msg: Message) -> None:
@@ -343,7 +347,7 @@ class Client:
         channel_name = msg.params[0]
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             "irc.join",
-            attributes={"irc.channel": channel_name, "irc.client.nick": self.nick or ""},
+            attributes={_ATTR_CHANNEL: channel_name, _ATTR_NICK: self.nick or ""},
         ):
             if not channel_name.startswith("#"):
                 return
@@ -393,7 +397,7 @@ class Client:
         channel_name = msg.params[0]
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             "irc.part",
-            attributes={"irc.channel": channel_name, "irc.client.nick": self.nick or ""},
+            attributes={_ATTR_CHANNEL: channel_name, _ATTR_NICK: self.nick or ""},
         ):
             reason = msg.params[1] if len(msg.params) > 1 else ""
 

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -920,7 +920,11 @@ class ServerLink:
     async def _replay_event(self, seq: int, event: Event) -> None:
         """Replay a single event to the peer as S2S wire format."""
         origin = self.server.config.name
-        if event.type == EventType.MESSAGE:
+        # Federated events arrive with event.type as either an EventType enum
+        # or a plain string (when _parse_event_type sees an unknown wire type).
+        # Compare against the .value to handle both shapes — see #291.
+        event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
+        if event_type_str == EventType.MESSAGE.value:
             target = event.channel or event.data.get("target", "")
             text = event.data.get("text", "")
             # Filter channel messages through trust check

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -935,23 +935,32 @@ class ServerLink:
 
     async def relay_event(self, event: Event) -> None:
         """Relay a local event to the peer in S2S wire format."""
-        origin = self.server.config.name
-        handler = self._RELAY_DISPATCH.get(event.type)
-        if handler:
-            await maybe_await(handler(self, event, origin))
-            return
+        event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
+        attrs = {
+            "event.type": event_type_str,
+            "s2s.peer": self.peer_name or "",
+        }
+        with otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
+            "irc.s2s.relay", attributes=attrs
+        ):
+            origin = self.server.config.name
+            handler = self._RELAY_DISPATCH.get(event.type)
+            if handler:
+                await maybe_await(handler(self, event, origin))
+                return
 
-        # If no typed relay exists, fall back to generic SEVENT.
-        # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
-        type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
-        payload = self.server._build_event_payload(event)
-        encoded = self.server._encode_event_data(payload, type_str)
-        target = event.channel or "*"
-        # Egress trust check: channel-scoped events respect should_relay; global events always relay
-        if event.channel is not None and not self.should_relay(event.channel):
-            return
-        seq = self.server._seq  # current local seq; peer stores but doesn't re-sequence
-        await self.send_raw(f":{origin} SEVENT {origin} {seq} {type_str} {target} :{encoded}")
+            # If no typed relay exists, fall back to generic SEVENT.
+            # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
+            payload = self.server._build_event_payload(event)
+            encoded = self.server._encode_event_data(payload, event_type_str)
+            target = event.channel or "*"
+            # Egress trust check: channel-scoped events respect should_relay; global events always relay
+            if event.channel is not None and not self.should_relay(event.channel):
+                return
+            seq = self.server._seq  # current local seq; peer stores but doesn't re-sequence
+            await self.send_raw(
+                f":{origin} SEVENT {origin} {seq} {event_type_str} {target} :{encoded}"
+            )
 
     async def _relay_message(self, event: Event, origin: str) -> None:
         target = event.channel or event.data.get("target", "")

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -15,8 +15,8 @@ from culture.aio import maybe_await
 from culture.bots.virtual_client import VirtualClient
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
-from culture.telemetry import current_traceparent
-from culture.telemetry.context import TRACEPARENT_TAG
+from culture.telemetry import context_from_traceparent, current_traceparent
+from culture.telemetry.context import TRACEPARENT_TAG, extract_traceparent_from_tags
 
 # OTEL instrumentation name (must match `_CULTURE_TRACER_NAME` in
 # culture/telemetry/tracing.py so all spans go through one tracer instance).
@@ -198,9 +198,29 @@ class ServerLink:
         await self.send_raw(f"SERVER {self.server.config.name} 1 :{self.server.config.name} IRC")
 
     async def _dispatch(self, msg: Message) -> None:
+        verb = msg.command.upper()
         handler = getattr(self, f"_handle_{msg.command.lower()}", None)
-        if handler:
-            await maybe_await(handler(msg))
+
+        extracted = extract_traceparent_from_tags(msg, peer=self.peer_name)
+        parent_ctx = None
+        if extracted.status == "valid":
+            parent_ctx = context_from_traceparent(extracted.traceparent)
+
+        attrs = {
+            "irc.command": verb,
+            "culture.trace.origin": "remote",
+            "culture.federation.peer": self.peer_name or "",
+        }
+        if extracted.status in ("malformed", "too_long"):
+            attrs["culture.trace.dropped_reason"] = extracted.status
+
+        with otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
+            f"irc.s2s.{verb}",
+            context=parent_ctx,
+            attributes=attrs,
+        ):
+            if handler:
+                await maybe_await(handler(msg))
 
     # --- Handshake handlers ---
 

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -113,7 +113,7 @@ class ServerLink:
         self._peer_pass: str | None = None
         self.last_seen_seq: int = 0
         self._squit_received: bool = False
-        self._session_span = None
+        self._session_span: otel_trace.Span | None = None
 
     def should_relay(self, channel_name: str) -> bool:
         """Check if a channel event should be relayed over this link."""

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -940,6 +940,8 @@ class ServerLink:
             "event.type": event_type_str,
             "s2s.peer": self.peer_name or "",
         }
+        # Single span name (no verb suffix): the wire verb is decided downstream
+        # by _RELAY_DISPATCH or the SEVENT fallback, after this span opens.
         with otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             "irc.s2s.relay", attributes=attrs
         ):

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -13,11 +13,61 @@ from culture.aio import maybe_await
 from culture.bots.virtual_client import VirtualClient
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
+from culture.telemetry import current_traceparent
+from culture.telemetry.context import TRACEPARENT_TAG
 
 if TYPE_CHECKING:
     from culture.agentirc.ircd import IRCd
 
 logger = logging.getLogger(__name__)
+
+
+def _prepend_trace_tags(line: str, tp: str) -> str:
+    """Inject *tp* as the ``culture.dev/traceparent`` IRCv3 tag on *line*.
+
+    - Empty line → returned unchanged (defensive no-op).
+    - Line with no existing tag block (does not start with ``@``) → prepend
+      ``@culture.dev/traceparent=<tp> `` before the rest of the line.
+    - Line that already has a tag block (starts with ``@``) → merge the tag
+      into the existing block.  If the block already contains
+      ``culture.dev/traceparent``, its value is replaced with *tp*; otherwise
+      the new tag is appended with a ``;`` separator.
+
+    The helper is intentionally lenient: if the tag block is somehow
+    ill-formed the existing text is preserved and the new tag is appended —
+    tagging is best-effort, never load-bearing.
+    """
+    if not line:
+        return line
+
+    if not line.startswith("@"):
+        return f"@{TRACEPARENT_TAG}={tp} {line}"
+
+    # Split off the tag block: everything up to the first space, then the rest.
+    space_idx = line.find(" ")
+    if space_idx == -1:
+        # Malformed: entire line is a tag block with no message body.
+        # Append the tag and move on.
+        return f"{line};{TRACEPARENT_TAG}={tp}"
+
+    tag_block = line[1:space_idx]  # strip leading '@'
+    rest = line[space_idx + 1 :]
+
+    # Split existing tags on ';', replace or append the traceparent tag.
+    tags = tag_block.split(";")
+    replaced = False
+    new_tags = []
+    for tag in tags:
+        key = tag.split("=", 1)[0]
+        if key == TRACEPARENT_TAG:
+            new_tags.append(f"{TRACEPARENT_TAG}={tp}")
+            replaced = True
+        else:
+            new_tags.append(tag)
+    if not replaced:
+        new_tags.append(f"{TRACEPARENT_TAG}={tp}")
+
+    return f"@{';'.join(new_tags)} {rest}"
 
 
 class ServerLink:
@@ -62,6 +112,9 @@ class ServerLink:
         return False
 
     async def send_raw(self, line: str) -> None:
+        tp = current_traceparent()
+        if tp:
+            line = _prepend_trace_tags(line, tp)
         try:
             self.writer.write(f"{line}\r\n".encode("utf-8"))
             await self.writer.drain()

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -7,6 +7,8 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+from opentelemetry import trace as otel_trace
+
 from culture.agentirc.remote_client import RemoteClient
 from culture.agentirc.skill import Event, EventType
 from culture.aio import maybe_await
@@ -15,6 +17,10 @@ from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
 from culture.telemetry import current_traceparent
 from culture.telemetry.context import TRACEPARENT_TAG
+
+# OTEL instrumentation name (must match `_CULTURE_TRACER_NAME` in
+# culture/telemetry/tracing.py so all spans go through one tracer instance).
+_TRACER_NAME = "culture.agentirc"
 
 if TYPE_CHECKING:
     from culture.agentirc.ircd import IRCd
@@ -107,6 +113,7 @@ class ServerLink:
         self._peer_pass: str | None = None
         self.last_seen_seq: int = 0
         self._squit_received: bool = False
+        self._session_span = None
 
     def should_relay(self, channel_name: str) -> bool:
         """Check if a channel event should be relayed over this link."""
@@ -153,31 +160,38 @@ class ServerLink:
 
     async def handle(self, initial_msg: str | None = None) -> None:
         """Main S2S connection loop."""
-        try:
-            if self.initiator:
-                await self._send_handshake()
-
-            buffer = ""
-            if initial_msg:
-                buffer = initial_msg + "\n"
-                buffer = await self._process_buffer(buffer)
-
-            while True:
-                data = await self.reader.read(4096)
-                if not data:
-                    break
-                buffer += data.decode("utf-8", errors="replace")
-                buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
-                buffer = await self._process_buffer(buffer)
-        except (ConnectionError, asyncio.IncompleteReadError):
-            pass
-        finally:
-            await self.server._remove_link(self, squit=self._squit_received)
-            self.writer.close()
+        tracer = otel_trace.get_tracer(_TRACER_NAME)
+        direction = "outbound" if self.initiator else "inbound"
+        with tracer.start_as_current_span(
+            "irc.s2s.session",
+            attributes={"s2s.direction": direction},
+        ) as span:
+            self._session_span = span
             try:
-                await self.writer.wait_closed()
-            except ConnectionError:
+                if self.initiator:
+                    await self._send_handshake()
+
+                buffer = ""
+                if initial_msg:
+                    buffer = initial_msg + "\n"
+                    buffer = await self._process_buffer(buffer)
+
+                while True:
+                    data = await self.reader.read(4096)
+                    if not data:
+                        break
+                    buffer += data.decode("utf-8", errors="replace")
+                    buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
+                    buffer = await self._process_buffer(buffer)
+            except (ConnectionError, asyncio.IncompleteReadError):
                 pass
+            finally:
+                await self.server._remove_link(self, squit=self._squit_received)
+                self.writer.close()
+                try:
+                    await self.writer.wait_closed()
+                except ConnectionError:
+                    pass
 
     async def _send_handshake(self) -> None:
         await self.send_raw(f"PASS {self.password}")
@@ -255,6 +269,8 @@ class ServerLink:
         await self._validate_peer_credentials()
 
         self._authenticated = True
+        if self._session_span is not None:
+            self._session_span.set_attribute("s2s.peer", self.peer_name)
         self.server.links[self.peer_name] = self
         self.server.cancel_link_retry(self.peer_name)
 

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -8,6 +8,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as otel_trace
+from opentelemetry.context import Context as _OtelContext
 
 from culture.agentirc.remote_client import RemoteClient
 from culture.agentirc.skill import Event, EventType
@@ -43,14 +44,14 @@ def _prepend_trace_tags(line: str, tp: str) -> str:
     ill-formed the existing text is preserved and the new tag is appended —
     tagging is best-effort, never load-bearing.
 
-    .. note:: IRCv3-escape limitation
+    .. note:: Parsing limitation
 
-        This helper assumes the existing tag block contains no IRCv3-escaped
-        ``;`` or ``=`` characters in tag *values* (RFC-compliant values use
-        ``\\:`` and ``\\=`` escapes rather than bare characters).  This
-        assumption is safe for all current ``send_raw`` callers, which today
-        emit no tags of their own.  Revisit if a caller begins authoring tags
-        whose values contain literal ``;`` or ``=`` sequences.
+        This helper does not fully parse or unescape IRCv3 tag values; it
+        simply splits the tag block on ``;`` and separates each tag's key from
+        its value on the first ``=``. This is safe for current ``send_raw``
+        callers, which today emit no tags of their own. Revisit if a caller
+        begins authoring tags whose values may contain IRCv3-escaped
+        semicolons.
     """
     if not line:
         return line
@@ -202,9 +203,10 @@ class ServerLink:
         handler = getattr(self, f"_handle_{msg.command.lower()}", None)
 
         extracted = extract_traceparent_from_tags(msg, peer=self.peer_name)
-        parent_ctx = None
         if extracted.status == "valid":
-            parent_ctx = context_from_traceparent(extracted.traceparent)
+            parent_ctx: _OtelContext | None = context_from_traceparent(extracted.traceparent)
+        else:
+            parent_ctx = _OtelContext()  # force root: detach from session span
 
         attrs = {
             "irc.command": verb,

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -36,6 +36,15 @@ def _prepend_trace_tags(line: str, tp: str) -> str:
     The helper is intentionally lenient: if the tag block is somehow
     ill-formed the existing text is preserved and the new tag is appended —
     tagging is best-effort, never load-bearing.
+
+    .. note:: IRCv3-escape limitation
+
+        This helper assumes the existing tag block contains no IRCv3-escaped
+        ``;`` or ``=`` characters in tag *values* (RFC-compliant values use
+        ``\\:`` and ``\\=`` escapes rather than bare characters).  This
+        assumption is safe for all current ``send_raw`` callers, which today
+        emit no tags of their own.  Revisit if a caller begins authoring tags
+        whose values contain literal ``;`` or ``=`` sequences.
     """
     if not line:
         return line
@@ -53,8 +62,9 @@ def _prepend_trace_tags(line: str, tp: str) -> str:
     tag_block = line[1:space_idx]  # strip leading '@'
     rest = line[space_idx + 1 :]
 
-    # Split existing tags on ';', replace or append the traceparent tag.
-    tags = tag_block.split(";")
+    # Split existing tags on ';', drop empty entries (e.g. from an empty tag
+    # block like "@ :rest"), then replace or append the traceparent tag.
+    tags = [t for t in tag_block.split(";") if t]
     replaced = False
     new_tags = []
     for tag in tags:
@@ -114,7 +124,10 @@ class ServerLink:
     async def send_raw(self, line: str) -> None:
         tp = current_traceparent()
         if tp:
-            line = _prepend_trace_tags(line, tp)
+            try:
+                line = _prepend_trace_tags(line, tp)
+            except Exception:  # noqa: BLE001 - telemetry must never break the link
+                logger.debug("traceparent injection failed; sending untagged", exc_info=True)
         try:
             self.writer.write(f"{line}\r\n".encode("utf-8"))
             await self.writer.drain()

--- a/culture/protocol/extensions/tracing.md
+++ b/culture/protocol/extensions/tracing.md
@@ -29,3 +29,9 @@ User on `spark` sends:
     @culture.dev/traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01 PRIVMSG #general :hi
 
 Server `spark` starts span `irc.command.PRIVMSG` as a child of the extracted context, relays the event via SEVENT to `thor`, re-injecting its own span's traceparent. Server `thor` sees trace ID `4bf92f35…4736` and starts another child span — the collector stitches both spans into one trace.
+
+**Re-sign per hop on the wire.** Concretely, the SEVENT line `spark` sends to `thor` looks like:
+
+    @culture.dev/traceparent=00-4bf92f3577b34da6a3ce929d0e0e4736-aaaaaaaaaaaaaaaa-01 :spark SEVENT spark 42 message #general :<base64>
+
+The trace-id (`4bf92f35…4736`) is preserved across the hop. The parent-id changes (`00f067aa…02b7` → `aaaaaaaa…aaaa`) because `spark` re-injects its own relay span's id, not the inbound parent-id verbatim. This produces a parent-per-hop span tree that mirrors the federation topology rather than collapsing every hop into one flat span.

--- a/culture/telemetry/__init__.py
+++ b/culture/telemetry/__init__.py
@@ -7,6 +7,8 @@ from culture.telemetry.context import (
     TRACEPARENT_TAG,
     TRACESTATE_TAG,
     ExtractResult,
+    context_from_traceparent,
+    current_traceparent,
     extract_traceparent_from_tags,
     inject_traceparent,
 )
@@ -16,6 +18,8 @@ __all__ = [
     "ExtractResult",
     "TRACEPARENT_TAG",
     "TRACESTATE_TAG",
+    "context_from_traceparent",
+    "current_traceparent",
     "extract_traceparent_from_tags",
     "init_telemetry",
     "inject_traceparent",

--- a/culture/telemetry/context.py
+++ b/culture/telemetry/context.py
@@ -6,6 +6,11 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
+from opentelemetry import trace as _otel_trace
+from opentelemetry.context import Context
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from opentelemetry.trace.propagation import set_span_in_context
+
 from culture.protocol.message import Message
 
 TRACEPARENT_TAG = "culture.dev/traceparent"
@@ -82,3 +87,35 @@ def inject_traceparent(msg: Message, traceparent: str, tracestate: str | None) -
         msg.tags[TRACESTATE_TAG] = tracestate
     else:
         msg.tags.pop(TRACESTATE_TAG, None)
+
+
+def context_from_traceparent(tp: str) -> Context:
+    """Build an OTEL context whose current span is a NonRecordingSpan
+    synthesized from a W3C traceparent string. A span started under this
+    context will be parented as a child of the remote trace.
+
+    Caller MUST have validated `tp` (e.g. via `extract_traceparent_from_tags`).
+    Format: `00-<32-hex trace-id>-<16-hex parent-id>-<2-hex flags>`.
+    """
+    _, trace_hex, parent_hex, flags_hex = tp.split("-")
+    span_ctx = SpanContext(
+        trace_id=int(trace_hex, 16),
+        span_id=int(parent_hex, 16),
+        is_remote=True,
+        trace_flags=TraceFlags(int(flags_hex, 16)),
+    )
+    return set_span_in_context(NonRecordingSpan(span_ctx))
+
+
+def current_traceparent() -> str | None:
+    """W3C traceparent string for the currently-active OTEL span, or None
+    if no span is recording (no-op tracer or sampler dropped).
+    """
+    span = _otel_trace.get_current_span()
+    ctx = span.get_span_context()
+    if not ctx.is_valid:
+        return None
+    return (
+        f"00-{format(ctx.trace_id, '032x')}-{format(ctx.span_id, '016x')}"
+        f"-{format(int(ctx.trace_flags), '02x')}"
+    )

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -9,7 +9,7 @@ nav_order: 90
 
 Culture ships with first-class OpenTelemetry support: traces for every IRC command and event, W3C trace context carried across federation via a new IRCv3 tag, and a local collector pattern that keeps Culture's surface small.
 
-This page covers the **Foundation + Server Tracing** release (culture 8.2.0). Metrics, audit, harness instrumentation, and bot instrumentation ship in subsequent releases.
+This page covers the **Foundation + Server Tracing** release (culture 8.2.0) plus **Federation Trace-Context Relay** (culture 8.3.0). Metrics, audit, harness instrumentation, and bot instrumentation ship in subsequent releases.
 
 ## What you get in 8.2.0
 
@@ -27,6 +27,27 @@ Every span is tagged with:
 
 - `service.name=culture.agentirc` (or your override)
 - `service.instance.id=<server_name>`
+
+## What you get in 8.3.0
+
+Federation trace-context relay: a single `trace_id` now spans every hop of a federated message — client → originating server → S2S relay → receiving server → bot/skill — with each hop contributing its own span.
+
+New spans added in 8.3.0:
+
+- `irc.client.session` — wraps `Client.handle()` for the connection lifetime. Attributes: `irc.client.remote_addr`, `irc.client.nick` (set after `NICK`).
+- `irc.join`, `irc.part` — wrap `_handle_join` / `_handle_part`. Attributes: `irc.channel`, `irc.client.nick`.
+- `irc.s2s.session` — wraps `ServerLink.handle()` for the link lifetime. Attributes: `s2s.direction` (`inbound`/`outbound`), `s2s.peer` (set once handshake completes).
+- `irc.s2s.<VERB>` — per-verb span on every inbound S2S message. Attributes: `irc.command`, `culture.trace.origin=remote`, `culture.federation.peer=<peer>`. On invalid traceparent: `culture.trace.dropped_reason` ∈ `{malformed, too_long}`.
+- `irc.s2s.relay` — wraps `ServerLink.relay_event` for outbound relay. Attributes: `event.type`, `s2s.peer`.
+
+The `irc.s2s.relay` span is the **per-hop re-sign anchor**: every outbound federation line carries this span's traceparent on the wire, never the inbound peer's traceparent verbatim. This produces a parent-per-hop span tree mirroring the federation topology. See [`tracing.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/tracing.md) for the wire-level example.
+
+New public helpers in `culture.telemetry`:
+
+- `context_from_traceparent(tp: str) -> Context` — build an OTEL context from a W3C traceparent string. Caller MUST validate `tp` first (e.g. via `extract_traceparent_from_tags`).
+- `current_traceparent() -> str | None` — W3C traceparent for the currently-active span, or `None` if no span is recording.
+
+These power the federation re-sign loop and are also useful for embedding Culture's tracer into other Python code that needs to bridge IRC trace context to non-IRC transports.
 
 ## Configuration
 
@@ -68,12 +89,11 @@ When telemetry is enabled and a span is active, outbound client messages carry t
 
 Protocol details, length caps, and inbound mitigation rules: see [`tracing.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/tracing.md) (lives under `culture/` in the repo; Jekyll excludes that path from the published site).
 
-## What's not in 8.2.0
+## What's not in 8.3.0
 
 The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces ship in later releases:
 
-- Federation trace-context relay across `ServerLink` (so a trace spans multiple servers).
-- Metrics pillar (message counters, histograms, federation health).
+- Metrics pillar (message counters, histograms, federation health, including `culture.trace.inbound{result, peer}` for the inbound mitigation states already attribute-tagged on `irc.s2s.<VERB>` spans).
 - Audit JSONL sink.
 - Harness-side tracing for `claude`/`codex`/`copilot`/`acp`.
 - Bot webhook HTTP instrumentation.

--- a/docs/superpowers/plans/2026-04-25-otel-federation.md
+++ b/docs/superpowers/plans/2026-04-25-otel-federation.md
@@ -1,0 +1,229 @@
+# OTEL Federation Trace-Context Relay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend Plan 1's trace context across the federation boundary so a single `trace_id` spans every hop of a federated message and produces a parent-per-hop span tree, while sweeping in two open issues (#290, #291) that naturally fall in the touched files.
+
+**Architecture:** Hoist trace-context helpers from `client.py` into the public `culture.telemetry.context` surface, instrument `culture/agentirc/server_link.py` at three points (`handle` session span, `_dispatch` per-verb spans with inbound mitigation, `relay_event` re-sign-per-hop span), and inject `culture.dev/traceparent` at the single send choke point (`ServerLink.send_raw`). Fold in #290 (client session + JOIN/PART spans) and #291 (`event.type` enum-vs-string fast-path bug).
+
+**Tech Stack:** OpenTelemetry SDK (`opentelemetry-api`, `opentelemetry-sdk`), pytest + pytest-asyncio + pytest-xdist, existing `linked_servers` + `tracing_exporter` test fixtures.
+
+---
+
+## Context
+
+Plan 1 (PR #292, merged as `9aea96a`) shipped server-side tracing on `IRCd.emit_event` and `Client._dispatch`, plus W3C trace-context extraction/injection on the **client-facing** boundary (`culture/agentirc/client.py` + helpers in `culture/telemetry/context.py`). The federation boundary (`culture/agentirc/server_link.py`) is currently **untouched** — when a PRIVMSG hops from `alpha` to `beta`, the trace breaks at the wire.
+
+Plan 2 closes that gap. After it ships, a single `trace_id` will span every hop of a federated message: client → originating server → S2S relay → receiving server → bot/skill, producing a parent-per-hop span tree as documented in `culture/protocol/extensions/tracing.md`.
+
+The same branch also sweeps in two open issues that naturally fall in `server_link.py` / `client.py`:
+
+- **#290** — `Client.handle` session span + `_handle_join`/`_handle_part` spans (deferred from Plan 1).
+- **#291** — `server_link.py:821` `EventType` comparison bug (string-typed federated events skip the typed fast path). One-line fix.
+
+`culture.trace.inbound{result, peer}` metric stays deferred to **Plan 3** (Metrics pillar) — instrument inbound mitigation only with span attributes here, not counters.
+
+## Critical files to read before implementing
+
+- `docs/superpowers/specs/2026-04-24-otel-observability-design.md` — sections "Protocol: IRCv3 trace-context tags", "Instrumentation points → server_link.py", "Metrics catalog → Trace-context hygiene".
+- `docs/superpowers/plans/2026-04-24-otel-foundation.md` — Plan 1 reference for tone, TDD discipline, task granularity.
+- `culture/protocol/extensions/tracing.md` — protocol contract Plan 2 must honor (already documents re-sign-per-hop; Plan 2 extends only the example block).
+- `culture/agentirc/server_link.py` (886 lines) — the file Plan 2 instruments.
+- `culture/agentirc/client.py:27-60` — `_TRACER_NAME`, `_ATTR_*` constants, `_context_from_traceparent`, `_current_traceparent` — to be hoisted to `culture/telemetry/context.py`.
+- `culture/telemetry/context.py` — `extract_traceparent_from_tags`, `inject_traceparent`, `ExtractResult`, length caps and regex.
+- `tests/conftest.py` — `linked_servers` (yields `(server_a, server_b)` post-handshake), `make_client_a`/`make_client_b` (nicks `alpha-<name>`/`beta-<name>`), `tracing_exporter` (`InMemorySpanExporter` + `SimpleSpanProcessor`). All three compose.
+- `tests/test_federation.py` — pattern reference for two-server tests.
+
+## Approach
+
+### 1. Hoist trace-context helpers to `culture/telemetry/context.py`
+
+`server_link.py` needs `_context_from_traceparent` (build OTEL Context from W3C string) and `_current_traceparent` (W3C string from active span). They live in `client.py:34-60` today. Hoist them — both files end up importing from `culture.telemetry.context`.
+
+- Move `_context_from_traceparent` → `context_from_traceparent` (public; drops underscore).
+- Move `_current_traceparent` → `current_traceparent` (public).
+- Add to `culture/telemetry/__init__.py` `__all__`.
+- Update `client.py` to import from `culture.telemetry`.
+
+### 2. Single choke point for traceparent injection: `ServerLink.send_raw`
+
+Federation has **11 typed `_relay_*` handlers** plus a fallback SEVENT path, all calling `send_raw(line: str)` — a single async method (line 64). Inject at the choke point rather than per call site:
+
+```python
+async def send_raw(self, line: str) -> None:
+    tp = current_traceparent()
+    if tp:
+        line = _prepend_trace_tags(line, tp)
+    try:
+        self.writer.write(f"{line}\r\n".encode("utf-8"))
+        await self.writer.drain()
+    except OSError:
+        pass
+```
+
+`_prepend_trace_tags(line, tp)` is a tiny string helper that handles two cases:
+
+- Line has no `@`-prefix tag block → prepend `@culture.dev/traceparent=<tp> `.
+- Line already has `@`-prefix tag block (rare; today no relay path emits one but be safe) → merge `culture.dev/traceparent=<tp>` into existing block.
+
+Rationale: matches the spec ("re-sign per hop"), gives one place to test, and preserves the property that **PASS/SERVER handshake messages ARE tagged** (the session span is open by then) — additive IRCv3, peer parsers ignore unknown tags.
+
+Tracestate is intentionally not propagated by Plan 2's federation injector (Plan 1's `inject_traceparent` does support it but the relay is span-driven, not message-copy). If observability needs vendor `tracestate` propagation, lift it in a follow-up — current spec only requires `traceparent`.
+
+### 3. Wrap `ServerLink.handle` with `irc.s2s.session` span
+
+Open span before `_send_handshake` so handshake messages carry traceparent. Direction is known at construction (`self.initiator`). Peer name only known after handshake — use `span.set_attribute("s2s.peer", self.peer_name)` from inside `_try_complete_handshake` (line 191) once `peer_name` is set.
+
+```python
+async def handle(self, initial_msg: str | None = None) -> None:
+    tracer = otel_trace.get_tracer(_TRACER_NAME)
+    direction = "outbound" if self.initiator else "inbound"
+    with tracer.start_as_current_span(
+        "irc.s2s.session",
+        attributes={"s2s.direction": direction},
+    ) as span:
+        self._session_span = span  # for late peer attr assignment
+        try:
+            ...existing body...
+        finally:
+            ...existing teardown...
+```
+
+`_try_complete_handshake` adds: `if self._session_span: self._session_span.set_attribute("s2s.peer", self.peer_name)`.
+
+### 4. Wrap `ServerLink._dispatch` for inbound mitigation + per-verb spans
+
+Apply the spec's mitigation rules in one place. Open `irc.s2s.<VERB>` span; if traceparent extracts as `valid`, the span is parented under the remote context; if `malformed`/`too_long`, set attrs but still open as root. Set `culture.trace.origin=remote` and `culture.federation.peer=<peer_name>` always (federation = remote by definition).
+
+```python
+async def _dispatch(self, msg: Message) -> None:
+    verb = msg.command.upper()
+    handler = getattr(self, f"_handle_{msg.command.lower()}", None)
+    tracer = otel_trace.get_tracer(_TRACER_NAME)
+
+    extracted = extract_traceparent_from_tags(msg, peer=self.peer_name)
+    parent_ctx = None
+    if extracted.status == "valid":
+        parent_ctx = context_from_traceparent(extracted.traceparent)
+
+    attrs = {
+        "irc.command": verb,
+        "culture.trace.origin": "remote",
+        "culture.federation.peer": self.peer_name or "",
+    }
+    if extracted.status in ("malformed", "too_long"):
+        attrs["culture.trace.dropped_reason"] = extracted.status
+
+    with tracer.start_as_current_span(
+        f"irc.s2s.{verb}", context=parent_ctx, attributes=attrs
+    ):
+        if handler:
+            await maybe_await(handler(msg))
+```
+
+Note: Plan 1's `_dispatch` in `client.py` uses the same pattern — mirror it. `peer=None` for client, `peer=self.peer_name` for federation.
+
+### 5. Wrap `ServerLink.relay_event` with `irc.s2s.relay` span
+
+The current span context determines what `send_raw` injects, so a fresh `irc.s2s.relay` span here means **child spans on the peer side parent under this relay span, not under the inbound span** — exactly the re-sign-per-hop rule.
+
+```python
+async def relay_event(self, event: Event) -> None:
+    tracer = otel_trace.get_tracer(_TRACER_NAME)
+    event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
+    attrs = {
+        "event.type": event_type_str,
+        "s2s.peer": self.peer_name or "",
+    }
+    with tracer.start_as_current_span("irc.s2s.relay", attributes=attrs):
+        ...existing body...
+```
+
+### 6. Issue #291 fix — `_replay_event` line 821
+
+```python
+event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
+if event_type_str == EventType.MESSAGE.value:
+    ...
+```
+
+### 7. Issue #290 fold-in — `Client.handle` session span + JOIN/PART spans
+
+In `client.py`:
+
+- Wrap `Client.handle` (the connection-loop entry point) with `irc.client.session` span. Attrs: `irc.client.remote_addr` set at entry (peername known); `irc.client.nick` set lazily once `self.nick` is assigned (mirror the `_session_span` field pattern from §3 — set in `_handle_nick` after assignment, line 305).
+- In `_handle_join` (line 350): wrap the body with `irc.join` span, attrs `irc.channel`, `irc.client.nick`. Open span before the `_registered` guard so we still see the rejection if it happens.
+- In `_handle_part` (line 398): wrap with `irc.part` span, same attr shape.
+
+These spans nest naturally under `irc.command.JOIN` / `irc.command.PART` already opened by Plan 1's `_dispatch`. Two-level nesting is intentional: the outer span is verb-level (covers parse-error edge cases via `add_event`), inner span is JOIN/PART semantics with channel attr.
+
+### 8. Documentation
+
+Extend `culture/protocol/extensions/tracing.md` example block with a two-line SEVENT relay illustration showing the trace-id is preserved while parent-id changes per hop. Existing rules already cover the contract.
+
+### 9. Version bump
+
+`/version-bump minor` → `8.2.0` → `8.3.0`. Updates `pyproject.toml`, `culture/__init__.py`, `CHANGELOG.md`. Stage `uv.lock` if it moves.
+
+## Files to modify
+
+- `culture/telemetry/context.py` — add public `context_from_traceparent`, `current_traceparent`.
+- `culture/telemetry/__init__.py` — re-export the new helpers.
+- `culture/agentirc/client.py` — replace local `_context_from_traceparent` / `_current_traceparent` with imports; add `Client.handle` session span + `_handle_join` / `_handle_part` spans (#290).
+- `culture/agentirc/server_link.py` — session span on `handle`, dispatch wrapper, relay span, traceparent injection in `send_raw`, late peer-attr in `_try_complete_handshake`, fix line 821 (#291).
+- `culture/protocol/extensions/tracing.md` — extend example block.
+- `tests/telemetry/test_federation_propagation.py` — **new**, federation propagation tests (see "Tests" below).
+- `tests/telemetry/test_session_span.py` — **new**, `Client.handle` + `_handle_join` / `_handle_part` span coverage for #290.
+- `tests/test_federation.py` (extend) — regression for #291.
+- `pyproject.toml`, `culture/__init__.py`, `CHANGELOG.md` — version bump 8.2.0 → 8.3.0.
+
+## Tests
+
+Use `tracing_exporter` + `linked_servers` together (verified compatible in conftest.py).
+
+**Federation propagation (`test_federation_propagation.py`):**
+
+1. `test_inbound_valid_traceparent_creates_child_span` — peer sends `SMSG` with valid traceparent tag; assert one of the recorded spans on the receiver has matching `trace_id` and an attr `culture.trace.origin=remote` + `culture.federation.peer=<peer>`.
+2. `test_inbound_missing_traceparent_starts_root` — same setup, no tag; receiver span has no remote parent (root) and `culture.trace.origin=remote`.
+3. `test_inbound_malformed_traceparent_dropped` — receiver span attr `culture.trace.dropped_reason=malformed`.
+4. `test_inbound_oversize_tracestate_dropped` — `culture.trace.dropped_reason=too_long`.
+5. `test_relay_reinjects_per_hop` — local PRIVMSG on `alpha`, captured wire bytes on the link to `beta` carry a `culture.dev/traceparent` whose **parent-id differs** from any client-side span's id (it's the relay span's id, not the originating client span's id). `trace_id` matches across.
+6. `test_two_server_propagation_e2e` — `linked_servers` + `tracing_exporter`; client on `alpha` sends PRIVMSG to channel `beta-bob` is in; assert all spans recorded share one `trace_id`, span tree includes both `service.instance.id` resource attrs (`alpha`, `beta`).
+7. `test_session_span_records_peer` — open link, complete handshake, assert one `irc.s2s.session` span has attrs `s2s.peer` + `s2s.direction=inbound|outbound`.
+8. `test_relay_no_active_span_no_inject` — `init_telemetry(enabled=False)`; outbound relay carries no `culture.dev/traceparent` tag.
+
+**#290 spans (`test_session_span.py`):**
+
+9. `test_client_session_span_lifetime` — open client connection, `irc.client.session` span exists, attrs include `irc.client.remote_addr` + (after NICK) `irc.client.nick`.
+10. `test_join_span_emits_with_channel_attr` — JOIN `#general`, an `irc.join` span exists nested under `irc.command.JOIN`, attrs `irc.channel=#general`, `irc.client.nick`.
+11. `test_part_span_emits_with_channel_attr` — same shape for PART.
+
+**#291 regression (extend `test_federation.py`):**
+
+12. `test_replay_unknown_event_type_no_crash` — federated event arrives with a wire `type` not in our `EventType` enum; `_replay_event` does not raise, falls through to generic SEVENT relay rather than the typed fast path. (One assertion: relay completes; second: typed path does not fire.)
+
+## Verification
+
+1. `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — full suite green.
+2. `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/telemetry/` — telemetry suite green.
+3. `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/test_federation.py tests/telemetry/test_federation_propagation.py` — federation + propagation green together (catches `event.type` regression class).
+4. Manual: start two local servers linked, attach weechat to each, send PRIVMSG across; with `telemetry.enabled=true` and a debug-exporter `otelcol-contrib`, confirm one `trace_id` spans both servers' spans.
+5. `Agent(subagent_type="doc-test-alignment", ...)` before first push — flags any new public API surface (`culture.telemetry.context_from_traceparent` / `current_traceparent` are new public API).
+6. `Agent(subagent_type="superpowers:code-reviewer", ...)` on staged diff before first push — `server_link.py` is a transport choke point exactly per CLAUDE.md guidance.
+7. `/sonarclaude` on the branch before declaring PR ready (cognitive-complexity hotspots likely on the new `_dispatch` wrapper).
+
+## Out of scope (future plans)
+
+- `culture.trace.inbound{result, peer}` metric → **Plan 3** (Metrics pillar). Span attrs in §4 already record the same data; the counter is a Plan-3 view over them.
+- Audit JSONL emission of S2S relays → **Plan 4**.
+- Harness-side trace propagation across `IRCTransport` → **Plan 5**.
+- Bot webhook outbound traceparent → **Plan 6** (aiohttp auto-instrument handles it).
+
+## Carry-forward notes (for compaction / future plans)
+
+- `event.type` is `EventType | str` everywhere it crosses the federation boundary (`_parse_event_type` returns either). EVERY new code path that reads `event.type` must use `event.type.value if hasattr(event.type, "value") else str(event.type)`. This caught Plan 1 in pre-push tests and is the root of #291.
+- `tracing_exporter` fixture rebuilds the global TracerProvider per test. Never cache a tracer at module scope — always `otel_trace.get_tracer(_TRACER_NAME)` per call site.
+- `_initialized_for` snapshot in `tracing.py` uses `dataclasses.asdict(tcfg)` on the dataclass to detect mutation. Plan 3 must mirror this if it adds `init_metrics(config)`.
+- Plan-1 lesson: protocol docs go to `culture/protocol/extensions/`, not `protocol/extensions/`. Confirm with `ls culture/protocol/extensions/` before placing.
+- SonarCloud hotspots on `http://localhost:4317` literal in tests are routinely flagged; mark REVIEWED/SAFE via the SonarCloud API after each plan.
+- For client-side tests, `FakeWriter` in `tests/telemetry/_fakes.py` is the convention — server-side tests use real TCP via `linked_servers` (no mocks for the IRCd).

--- a/docs/superpowers/plans/2026-04-25-otel-federation.md
+++ b/docs/superpowers/plans/2026-04-25-otel-federation.md
@@ -163,7 +163,7 @@ Extend `culture/protocol/extensions/tracing.md` example block with a two-line SE
 
 ### 9. Version bump
 
-`/version-bump minor` → `8.2.0` → `8.3.0`. Updates `pyproject.toml`, `culture/__init__.py`, `CHANGELOG.md`. Stage `uv.lock` if it moves.
+`/version-bump minor` → `8.2.0` → `8.3.0`. Updates `pyproject.toml`, `CHANGELOG.md`. Stage `uv.lock` if it moves.
 
 ## Files to modify
 
@@ -175,7 +175,7 @@ Extend `culture/protocol/extensions/tracing.md` example block with a two-line SE
 - `tests/telemetry/test_federation_propagation.py` — **new**, federation propagation tests (see "Tests" below).
 - `tests/telemetry/test_session_span.py` — **new**, `Client.handle` + `_handle_join` / `_handle_part` span coverage for #290.
 - `tests/test_federation.py` (extend) — regression for #291.
-- `pyproject.toml`, `culture/__init__.py`, `CHANGELOG.md` — version bump 8.2.0 → 8.3.0.
+- `pyproject.toml`, `CHANGELOG.md` — version bump 8.2.0 → 8.3.0.
 
 ## Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.2.0"
+version = "8.3.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/telemetry/test_context.py
+++ b/tests/telemetry/test_context.py
@@ -1,4 +1,7 @@
+from opentelemetry import trace as otel_trace
+
 from culture.protocol.message import Message
+from culture.telemetry import context_from_traceparent, current_traceparent
 from culture.telemetry.context import (
     TRACEPARENT_TAG,
     TRACESTATE_TAG,
@@ -103,3 +106,42 @@ def test_wire_roundtrip_through_parse_format():
     assert result.status == "valid"
     assert result.traceparent == VALID_TP
     assert result.tracestate == "vendor=abc"
+
+
+def test_current_traceparent_no_active_span_returns_none(tracing_exporter):
+    # No span started -> returns None even with provider installed.
+    assert current_traceparent() is None
+
+
+def test_current_traceparent_returns_w3c_string_for_active_span(tracing_exporter):
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("smoke"):
+        tp = current_traceparent()
+    assert tp is not None
+    parts = tp.split("-")
+    assert parts[0] == "00"
+    assert len(parts[1]) == 32  # trace-id
+    assert len(parts[2]) == 16  # parent-id
+    assert len(parts[3]) == 2  # flags
+
+
+def test_context_from_traceparent_parents_child_span(tracing_exporter):
+    parent_ctx = context_from_traceparent(VALID_TP)
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("child", context=parent_ctx) as child:
+        child_ctx = child.get_span_context()
+    # Child span shares the trace-id from the synthesized parent.
+    assert format(child_ctx.trace_id, "032x") == "4bf92f3577b34da6a3ce929d0e0e4736"
+    # And is_remote on the parent flowed through (the child is a local span,
+    # so we can't assert is_remote on the child — but matching trace_id is
+    # the load-bearing assertion: the parent context was honored).
+
+
+def test_current_traceparent_roundtrip_through_context_from_traceparent(tracing_exporter):
+    parent_ctx = context_from_traceparent(VALID_TP)
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("child", context=parent_ctx):
+        out = current_traceparent()
+    assert out is not None
+    # Trace-id preserved across the synthesized-parent → child handoff.
+    assert out.split("-")[1] == "4bf92f3577b34da6a3ce929d0e0e4736"

--- a/tests/telemetry/test_federation_propagation.py
+++ b/tests/telemetry/test_federation_propagation.py
@@ -1,0 +1,180 @@
+"""End-to-end trace propagation across two federated servers.
+
+The load-bearing validation of Plan 2: a single trace_id spans every
+hop of a federated message, with each server contributing its own
+spans tied to that trace_id."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+async def _wait_for_span(exporter, name: str, timeout: float = 1.5) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if any(s.name == name for s in exporter.get_finished_spans()):
+            return
+        await asyncio.sleep(0.02)
+
+
+def _spans_with_name(exporter, name):
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+@pytest.mark.asyncio
+async def test_e2e_one_trace_id_across_two_servers(
+    tracing_exporter, linked_servers, make_client_a, make_client_b
+):
+    """Client on alpha sends PRIVMSG to channel beta-bob is in.
+    Confirm alpha-side and beta-side spans share the same trace_id."""
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+
+    # Both join a shared channel.
+    await client_a.send("JOIN #e2e")
+    await client_a.recv_all(timeout=0.5)
+    await client_b.send("JOIN #e2e")
+    await client_b.recv_all(timeout=0.5)
+    # Allow membership to propagate.
+    await asyncio.sleep(0.3)
+
+    tracing_exporter.clear()  # discard JOIN spans, focus on PRIVMSG flow
+
+    await client_a.send("PRIVMSG #e2e :hello-from-alpha")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    # Wait for spans to flush.
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
+
+    spans = tracing_exporter.get_finished_spans()
+    # Bucket by name.
+    by_name: dict[str, list] = {}
+    for s in spans:
+        by_name.setdefault(s.name, []).append(s)
+
+    # We should have at least one of each on the relevant chain:
+    #   alpha side: irc.command.PRIVMSG (from client) + irc.s2s.relay
+    #   beta side:  irc.s2s.SMSG (received) + downstream irc.event.emit
+    assert (
+        "irc.command.PRIVMSG" in by_name
+    ), f"missing alpha-side client dispatch span; got names: {sorted(by_name.keys())}"
+    assert (
+        "irc.s2s.relay" in by_name
+    ), f"missing alpha-side relay span; got names: {sorted(by_name.keys())}"
+    assert (
+        "irc.s2s.SMSG" in by_name
+    ), f"missing beta-side dispatch span; got names: {sorted(by_name.keys())}"
+
+    # All spans on this chain must share one trace_id. Find the originating
+    # client PRIVMSG span; its trace_id is the shared id.
+    privmsg_spans = by_name["irc.command.PRIVMSG"]
+    relay_spans = by_name["irc.s2s.relay"]
+    smsg_spans = by_name["irc.s2s.SMSG"]
+
+    # Filter the relay/SMSG spans to those that share trace_id with at
+    # least one PRIVMSG span (defensive: there could be unrelated spans
+    # in the buffer from a prior background event).
+    privmsg_trace_ids = {s.context.trace_id for s in privmsg_spans}
+
+    matching_relay = [s for s in relay_spans if s.context.trace_id in privmsg_trace_ids]
+    matching_smsg = [s for s in smsg_spans if s.context.trace_id in privmsg_trace_ids]
+
+    assert matching_relay, (
+        f"no irc.s2s.relay span shares trace_id with irc.command.PRIVMSG. "
+        f"PRIVMSG trace_ids: {[format(t, '032x') for t in privmsg_trace_ids]}; "
+        f"relay trace_ids: {[format(s.context.trace_id, '032x') for s in relay_spans]}"
+    )
+    assert matching_smsg, (
+        f"no irc.s2s.SMSG span shares trace_id with irc.command.PRIVMSG. "
+        f"PRIVMSG trace_ids: {[format(t, '032x') for t in privmsg_trace_ids]}; "
+        f"SMSG trace_ids: {[format(s.context.trace_id, '032x') for s in smsg_spans]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_e2e_spans_carry_both_service_instance_ids(
+    tracing_exporter, linked_servers, make_client_a, make_client_b
+):
+    """Resource attributes show spans came from both server instances."""
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_a.send("JOIN #e2e-resource")
+    await client_a.recv_all(timeout=0.5)
+    await client_b.send("JOIN #e2e-resource")
+    await client_b.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+    tracing_exporter.clear()
+
+    await client_a.send("PRIVMSG #e2e-resource :hi")
+    await client_a.recv_all(timeout=0.5)
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
+    await asyncio.sleep(0.2)
+
+    spans = tracing_exporter.get_finished_spans()
+    instance_ids = {
+        s.resource.attributes.get("service.instance.id") for s in spans if s.resource is not None
+    }
+    # Both alpha and beta should appear (or at least one if telemetry isn't
+    # initialized on one side — but it should be initialized on both via
+    # the linked_servers ServerConfig setup).
+    # The tracing_exporter fixture installs ONE global SDK provider, which
+    # both servers share. So all spans get the same resource — verify the
+    # set is not empty rather than expecting both names.
+    # ... Actually, since tracing_exporter installs a SHARED global provider,
+    # both servers' init_telemetry calls are no-ops. Resource attributes
+    # come from the first init or from the global default.
+    # This test mainly proves spans landed in the exporter at all.
+    assert spans, "no spans recorded across the federation hop"
+
+
+@pytest.mark.asyncio
+async def test_relay_no_active_span_no_inject(linked_servers, make_client_a, make_client_b):
+    """When telemetry is disabled (no exporter installed → no recording
+    spans), federation outbound bytes carry no traceparent tag.
+
+    Note: this test deliberately does NOT use the tracing_exporter
+    fixture, so spans are non-recording (current_traceparent returns
+    None) and send_raw injects nothing.
+    """
+    from culture.telemetry.context import TRACEPARENT_TAG
+
+    server_a, server_b = linked_servers
+
+    # Capture wire bytes from alpha to beta.
+    link_to_b = server_a.links["beta"]
+    captured: list[bytes] = []
+    real_write = link_to_b.writer.write
+
+    def recording_write(data):
+        captured.append(data)
+        return real_write(data)
+
+    link_to_b.writer.write = recording_write
+    try:
+        client_a = await make_client_a(nick="alpha-alice", user="alice")
+        client_b = await make_client_b(nick="beta-bob", user="bob")
+        await client_a.send("JOIN #no-trace")
+        await client_a.recv_all(timeout=0.5)
+        await client_b.send("JOIN #no-trace")
+        await client_b.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+
+        await client_a.send("PRIVMSG #no-trace :hi")
+        await client_a.recv_all(timeout=0.5)
+        await asyncio.sleep(0.3)
+    finally:
+        link_to_b.writer.write = real_write
+
+    wire = b"".join(captured).decode("utf-8", errors="replace")
+    assert (
+        TRACEPARENT_TAG not in wire
+    ), f"unexpected traceparent on wire when telemetry disabled: {wire!r}"

--- a/tests/telemetry/test_federation_propagation.py
+++ b/tests/telemetry/test_federation_propagation.py
@@ -29,7 +29,7 @@ async def test_e2e_one_trace_id_across_two_servers(
 ):
     """Client on alpha sends PRIVMSG to channel beta-bob is in.
     Confirm alpha-side and beta-side spans share the same trace_id."""
-    server_a, server_b = linked_servers
+    _, _ = linked_servers
     tracing_exporter.clear()
 
     client_a = await make_client_a(nick="alpha-alice", user="alice")
@@ -98,45 +98,6 @@ async def test_e2e_one_trace_id_across_two_servers(
 
 
 @pytest.mark.asyncio
-async def test_e2e_spans_carry_both_service_instance_ids(
-    tracing_exporter, linked_servers, make_client_a, make_client_b
-):
-    """Resource attributes show spans came from both server instances."""
-    server_a, server_b = linked_servers
-    tracing_exporter.clear()
-
-    client_a = await make_client_a(nick="alpha-alice", user="alice")
-    client_b = await make_client_b(nick="beta-bob", user="bob")
-    await client_a.send("JOIN #e2e-resource")
-    await client_a.recv_all(timeout=0.5)
-    await client_b.send("JOIN #e2e-resource")
-    await client_b.recv_all(timeout=0.5)
-    await asyncio.sleep(0.3)
-    tracing_exporter.clear()
-
-    await client_a.send("PRIVMSG #e2e-resource :hi")
-    await client_a.recv_all(timeout=0.5)
-    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
-    await asyncio.sleep(0.2)
-
-    spans = tracing_exporter.get_finished_spans()
-    instance_ids = {
-        s.resource.attributes.get("service.instance.id") for s in spans if s.resource is not None
-    }
-    # Both alpha and beta should appear (or at least one if telemetry isn't
-    # initialized on one side — but it should be initialized on both via
-    # the linked_servers ServerConfig setup).
-    # The tracing_exporter fixture installs ONE global SDK provider, which
-    # both servers share. So all spans get the same resource — verify the
-    # set is not empty rather than expecting both names.
-    # ... Actually, since tracing_exporter installs a SHARED global provider,
-    # both servers' init_telemetry calls are no-ops. Resource attributes
-    # come from the first init or from the global default.
-    # This test mainly proves spans landed in the exporter at all.
-    assert spans, "no spans recorded across the federation hop"
-
-
-@pytest.mark.asyncio
 async def test_relay_no_active_span_no_inject(linked_servers, make_client_a, make_client_b):
     """When telemetry is disabled (no exporter installed → no recording
     spans), federation outbound bytes carry no traceparent tag.
@@ -147,7 +108,7 @@ async def test_relay_no_active_span_no_inject(linked_servers, make_client_a, mak
     """
     from culture.telemetry.context import TRACEPARENT_TAG
 
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
 
     # Capture wire bytes from alpha to beta.
     link_to_b = server_a.links["beta"]

--- a/tests/telemetry/test_s2s_dispatch_span.py
+++ b/tests/telemetry/test_s2s_dispatch_span.py
@@ -15,9 +15,21 @@ import pytest
 from opentelemetry import trace as otel_trace
 
 from culture.protocol.message import Message
-from culture.telemetry.context import TRACEPARENT_TAG, TRACESTATE_TAG
+from culture.telemetry.context import TRACEPARENT_TAG
 
 VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+async def _wait_for_span(exporter, name: str, timeout: float = 1.0) -> None:
+    """Wait until at least one span with `name` appears in `exporter`,
+    or `timeout` seconds elapse. SimpleSpanProcessor is synchronous, but
+    the federation write travels through an event-loop boundary."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if any(s.name == name for s in exporter.get_finished_spans()):
+            return
+        await asyncio.sleep(0.02)
+    # Fall through; caller's assertion will fail with helpful context.
 
 
 def _spans_with_name(exporter, name):
@@ -40,7 +52,7 @@ async def test_dispatch_valid_traceparent_creates_child(tracing_exporter, linked
     await link_alpha_to_beta.writer.drain()
 
     # Give server_b time to dispatch.
-    await asyncio.sleep(0.2)
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
 
     # Find an s2s.SMSG span on server_b.
     smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
@@ -65,7 +77,7 @@ async def test_dispatch_missing_traceparent_root_span(tracing_exporter, linked_s
     line = ":alpha SMSG #s2s-trace-test alpha-bob :hi"
     link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
     await link_alpha_to_beta.writer.drain()
-    await asyncio.sleep(0.2)
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
 
     smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
     assert smsg_spans
@@ -88,7 +100,7 @@ async def test_dispatch_malformed_traceparent_dropped(tracing_exporter, linked_s
     line = f"@{TRACEPARENT_TAG}=not-a-traceparent " ":alpha SMSG #s2s-trace-test alpha-bob :hi"
     link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
     await link_alpha_to_beta.writer.drain()
-    await asyncio.sleep(0.2)
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
 
     smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
     assert smsg_spans
@@ -110,7 +122,7 @@ async def test_dispatch_oversize_traceparent_dropped(tracing_exporter, linked_se
     line = f"@{TRACEPARENT_TAG}={oversize} " ":alpha SMSG #s2s-trace-test alpha-bob :hi"
     link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
     await link_alpha_to_beta.writer.drain()
-    await asyncio.sleep(0.2)
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
 
     smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
     assert smsg_spans

--- a/tests/telemetry/test_s2s_dispatch_span.py
+++ b/tests/telemetry/test_s2s_dispatch_span.py
@@ -1,0 +1,122 @@
+"""Tests for ServerLink._dispatch span and inbound traceparent mitigation.
+
+Covers the four states defined in culture/protocol/extensions/tracing.md:
+  - valid:     start child span linked to extracted context
+  - missing:   start root span (origin still "remote" — federation always-remote)
+  - malformed: drop tag, root span, dropped_reason="malformed"
+  - too_long:  drop tag, root span, dropped_reason="too_long"
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from opentelemetry import trace as otel_trace
+
+from culture.protocol.message import Message
+from culture.telemetry.context import TRACEPARENT_TAG, TRACESTATE_TAG
+
+VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+def _spans_with_name(exporter, name):
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_valid_traceparent_creates_child(tracing_exporter, linked_servers):
+    """Inbound message with valid traceparent → s2s.<VERB> span is parented
+    under the extracted remote context (shared trace_id)."""
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    # Send a fabricated SMSG line with a valid traceparent tag from alpha→beta.
+    link_alpha_to_beta = server_a.links["beta"]
+    line = f"@{TRACEPARENT_TAG}={VALID_TP} " f":alpha SMSG #s2s-trace-test alpha-bob :hello"
+    # Use the writer directly to inject from alpha's side without going
+    # through send_raw (which would re-sign with alpha's session traceparent).
+    link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
+    await link_alpha_to_beta.writer.drain()
+
+    # Give server_b time to dispatch.
+    await asyncio.sleep(0.2)
+
+    # Find an s2s.SMSG span on server_b.
+    smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
+    assert smsg_spans, "no irc.s2s.SMSG span recorded on receiver"
+    span = smsg_spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("irc.command") == "SMSG"
+    assert attrs.get("culture.trace.origin") == "remote"
+    assert attrs.get("culture.federation.peer") == "alpha"
+    assert "culture.trace.dropped_reason" not in attrs
+    # Child span shares trace-id from VALID_TP.
+    assert format(span.context.trace_id, "032x") == "4bf92f3577b34da6a3ce929d0e0e4736"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_missing_traceparent_root_span(tracing_exporter, linked_servers):
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    link_alpha_to_beta = server_a.links["beta"]
+    # Plain SMSG, no traceparent tag.
+    line = ":alpha SMSG #s2s-trace-test alpha-bob :hi"
+    link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
+    await link_alpha_to_beta.writer.drain()
+    await asyncio.sleep(0.2)
+
+    smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
+    assert smsg_spans
+    span = smsg_spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("culture.trace.origin") == "remote"
+    assert attrs.get("culture.federation.peer") == "alpha"
+    # No dropped_reason — tag was simply absent.
+    assert "culture.trace.dropped_reason" not in attrs
+    # Not parented to a remote trace (no traceparent on the wire).
+    assert span.parent is None or not span.parent.is_remote
+
+
+@pytest.mark.asyncio
+async def test_dispatch_malformed_traceparent_dropped(tracing_exporter, linked_servers):
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    link_alpha_to_beta = server_a.links["beta"]
+    line = f"@{TRACEPARENT_TAG}=not-a-traceparent " ":alpha SMSG #s2s-trace-test alpha-bob :hi"
+    link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
+    await link_alpha_to_beta.writer.drain()
+    await asyncio.sleep(0.2)
+
+    smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
+    assert smsg_spans
+    span = smsg_spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("culture.trace.dropped_reason") == "malformed"
+    assert attrs.get("culture.federation.peer") == "alpha"
+    # Tag was dropped — span is not parented to a remote trace.
+    assert span.parent is None or not span.parent.is_remote
+
+
+@pytest.mark.asyncio
+async def test_dispatch_oversize_traceparent_dropped(tracing_exporter, linked_servers):
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    link_alpha_to_beta = server_a.links["beta"]
+    oversize = VALID_TP + "extrachars"
+    line = f"@{TRACEPARENT_TAG}={oversize} " ":alpha SMSG #s2s-trace-test alpha-bob :hi"
+    link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
+    await link_alpha_to_beta.writer.drain()
+    await asyncio.sleep(0.2)
+
+    smsg_spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
+    assert smsg_spans
+    span = smsg_spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("culture.trace.dropped_reason") == "too_long"
+    assert attrs.get("culture.federation.peer") == "alpha"
+    # Tag was dropped — span is not parented to a remote trace.
+    assert span.parent is None or not span.parent.is_remote

--- a/tests/telemetry/test_s2s_dispatch_span.py
+++ b/tests/telemetry/test_s2s_dispatch_span.py
@@ -40,12 +40,12 @@ def _spans_with_name(exporter, name):
 async def test_dispatch_valid_traceparent_creates_child(tracing_exporter, linked_servers):
     """Inbound message with valid traceparent → s2s.<VERB> span is parented
     under the extracted remote context (shared trace_id)."""
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     tracing_exporter.clear()
 
     # Send a fabricated SMSG line with a valid traceparent tag from alpha→beta.
     link_alpha_to_beta = server_a.links["beta"]
-    line = f"@{TRACEPARENT_TAG}={VALID_TP} " f":alpha SMSG #s2s-trace-test alpha-bob :hello"
+    line = f"@{TRACEPARENT_TAG}={VALID_TP} :alpha SMSG #s2s-trace-test alpha-bob :hello"
     # Use the writer directly to inject from alpha's side without going
     # through send_raw (which would re-sign with alpha's session traceparent).
     link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
@@ -69,7 +69,7 @@ async def test_dispatch_valid_traceparent_creates_child(tracing_exporter, linked
 
 @pytest.mark.asyncio
 async def test_dispatch_missing_traceparent_root_span(tracing_exporter, linked_servers):
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     tracing_exporter.clear()
 
     link_alpha_to_beta = server_a.links["beta"]
@@ -93,11 +93,11 @@ async def test_dispatch_missing_traceparent_root_span(tracing_exporter, linked_s
 
 @pytest.mark.asyncio
 async def test_dispatch_malformed_traceparent_dropped(tracing_exporter, linked_servers):
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     tracing_exporter.clear()
 
     link_alpha_to_beta = server_a.links["beta"]
-    line = f"@{TRACEPARENT_TAG}=not-a-traceparent " ":alpha SMSG #s2s-trace-test alpha-bob :hi"
+    line = f"@{TRACEPARENT_TAG}=not-a-traceparent :alpha SMSG #s2s-trace-test alpha-bob :hi"
     link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
     await link_alpha_to_beta.writer.drain()
     await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
@@ -114,12 +114,12 @@ async def test_dispatch_malformed_traceparent_dropped(tracing_exporter, linked_s
 
 @pytest.mark.asyncio
 async def test_dispatch_oversize_traceparent_dropped(tracing_exporter, linked_servers):
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     tracing_exporter.clear()
 
     link_alpha_to_beta = server_a.links["beta"]
     oversize = VALID_TP + "extrachars"
-    line = f"@{TRACEPARENT_TAG}={oversize} " ":alpha SMSG #s2s-trace-test alpha-bob :hi"
+    line = f"@{TRACEPARENT_TAG}={oversize} :alpha SMSG #s2s-trace-test alpha-bob :hi"
     link_alpha_to_beta.writer.write((line + "\r\n").encode("utf-8"))
     await link_alpha_to_beta.writer.drain()
     await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
@@ -132,3 +132,25 @@ async def test_dispatch_oversize_traceparent_dropped(tracing_exporter, linked_se
     assert attrs.get("culture.federation.peer") == "alpha"
     # Tag was dropped — span is not parented to a remote trace.
     assert span.parent is None or not span.parent.is_remote
+
+
+@pytest.mark.asyncio
+async def test_s2s_dispatch_span_is_root_when_no_traceparent(tracing_exporter, linked_servers):
+    """Plan 2 spec: missing traceparent → root span on inbound S2S, even
+    though irc.s2s.session is active."""
+    server_a, _ = linked_servers
+    tracing_exporter.clear()
+
+    link_alpha_to_beta = server_a.links["beta"]
+    # Plain SMSG, no traceparent tag.
+    link_alpha_to_beta.writer.write(b":alpha SMSG #root-test alpha-bob :no-tp\r\n")
+    await link_alpha_to_beta.writer.drain()
+    await _wait_for_span(tracing_exporter, "irc.s2s.SMSG")
+
+    spans = _spans_with_name(tracing_exporter, "irc.s2s.SMSG")
+    assert spans
+    span = spans[-1]
+    assert span.parent is None, (
+        f"irc.s2s.SMSG should be root when no traceparent, "
+        f"got parent {span.parent} (likely inherited irc.s2s.session)"
+    )

--- a/tests/telemetry/test_s2s_relay_span.py
+++ b/tests/telemetry/test_s2s_relay_span.py
@@ -1,0 +1,114 @@
+"""Tests for the irc.s2s.relay span on ServerLink.relay_event.
+
+Verifies the per-hop re-sign rule from culture/protocol/extensions/tracing.md:
+the wire-injected traceparent's parent-id matches the relay span's id (NOT
+the inbound trace's parent-id), even when an inbound trace context is active.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from opentelemetry import trace as otel_trace
+
+from culture.agentirc.skill import Event, EventType
+from culture.telemetry.context import TRACEPARENT_TAG
+
+
+async def _wait_for_span(exporter, name: str, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if any(s.name == name for s in exporter.get_finished_spans()):
+            return
+        await asyncio.sleep(0.02)
+
+
+def _spans_with_name(exporter, name):
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+@pytest.mark.asyncio
+async def test_relay_span_recorded_with_event_type_and_peer(tracing_exporter, linked_servers):
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    # Trigger a relay by calling relay_event directly (skip _dispatch path).
+    link_to_b = server_a.links["beta"]
+    event = Event(
+        type=EventType.MESSAGE,
+        channel=None,
+        nick="alpha-bob",
+        data={"target": "alpha-charlie", "text": "hi"},
+    )
+    await link_to_b.relay_event(event)
+
+    await _wait_for_span(tracing_exporter, "irc.s2s.relay")
+    spans = _spans_with_name(tracing_exporter, "irc.s2s.relay")
+    assert spans, "no irc.s2s.relay span recorded"
+    span = spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("event.type") == "message"
+    assert attrs.get("s2s.peer") == "beta"
+
+
+@pytest.mark.asyncio
+async def test_relay_resigns_per_hop(tracing_exporter, linked_servers):
+    """Outbound traceparent on relayed wire bytes points to the relay span,
+    NOT to whatever inbound trace was active. This is the per-hop re-sign rule.
+    """
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    # Record raw bytes server_b sees on the link from alpha. We swap the
+    # writer's `write` method on the alpha->beta link with a recording one,
+    # then call relay_event from inside an outer span. The outer span
+    # simulates an "inbound" trace context that should NOT leak into the wire.
+    link_to_b = server_a.links["beta"]
+    captured: list[bytes] = []
+    real_write = link_to_b.writer.write
+
+    def recording_write(data):
+        captured.append(data)
+        return real_write(data)
+
+    link_to_b.writer.write = recording_write
+
+    tracer = otel_trace.get_tracer("test")
+    outer_span_id_hex = None
+    try:
+        with tracer.start_as_current_span("simulated_inbound") as outer:
+            outer_span_id_hex = format(outer.get_span_context().span_id, "016x")
+            event = Event(
+                type=EventType.MESSAGE,
+                channel=None,
+                nick="alpha-bob",
+                data={"target": "alpha-charlie", "text": "ping"},
+            )
+            await link_to_b.relay_event(event)
+    finally:
+        link_to_b.writer.write = real_write
+
+    # Find the wire bytes that carry the SMSG line.
+    relayed = [b.decode("utf-8", errors="replace") for b in captured]
+    smsg_lines = [
+        line
+        for line in "".join(relayed).split("\r\n")
+        if " SMSG " in line and TRACEPARENT_TAG in line
+    ]
+    assert smsg_lines, f"expected an SMSG line carrying traceparent, got: {relayed!r}"
+    line = smsg_lines[0]
+    # Extract the traceparent value from the @-tag block.
+    tag_block = line.split(" ", 1)[0][1:]
+    tags = dict(t.split("=", 1) for t in tag_block.split(";") if "=" in t)
+    tp_value = tags[TRACEPARENT_TAG]
+    # W3C: 00-<trace-id>-<parent-id>-<flags>
+    parts = tp_value.split("-")
+    assert len(parts) == 4, f"malformed traceparent: {tp_value!r}"
+    parent_id_hex = parts[2]
+    # The wire parent-id MUST NOT equal the outer span's id — that would mean
+    # we copied the inbound traceparent verbatim instead of re-signing.
+    assert parent_id_hex != outer_span_id_hex, (
+        f"wire parent-id {parent_id_hex!r} matches outer span "
+        f"{outer_span_id_hex!r} — re-sign rule violated"
+    )

--- a/tests/telemetry/test_s2s_relay_span.py
+++ b/tests/telemetry/test_s2s_relay_span.py
@@ -100,7 +100,7 @@ async def test_relay_resigns_per_hop(tracing_exporter, linked_servers):
     line = smsg_lines[0]
     # Extract the traceparent value from the @-tag block.
     tag_block = line.split(" ", 1)[0][1:]
-    tags = {k: v for k, v in (t.split("=", 1) for t in tag_block.split(";") if "=" in t)}
+    tags = dict(t.split("=", 1) for t in tag_block.split(";") if "=" in t)
     tp_value = tags[TRACEPARENT_TAG]
     # W3C: 00-<trace-id>-<parent-id>-<flags>
     parts = tp_value.split("-")

--- a/tests/telemetry/test_s2s_relay_span.py
+++ b/tests/telemetry/test_s2s_relay_span.py
@@ -30,7 +30,7 @@ def _spans_with_name(exporter, name):
 
 @pytest.mark.asyncio
 async def test_relay_span_recorded_with_event_type_and_peer(tracing_exporter, linked_servers):
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     tracing_exporter.clear()
 
     # Trigger a relay by calling relay_event directly (skip _dispatch path).
@@ -57,7 +57,7 @@ async def test_relay_resigns_per_hop(tracing_exporter, linked_servers):
     """Outbound traceparent on relayed wire bytes points to the relay span,
     NOT to whatever inbound trace was active. This is the per-hop re-sign rule.
     """
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     tracing_exporter.clear()
 
     # Record raw bytes server_b sees on the link from alpha. We swap the
@@ -100,7 +100,7 @@ async def test_relay_resigns_per_hop(tracing_exporter, linked_servers):
     line = smsg_lines[0]
     # Extract the traceparent value from the @-tag block.
     tag_block = line.split(" ", 1)[0][1:]
-    tags = dict(t.split("=", 1) for t in tag_block.split(";") if "=" in t)
+    tags = {k: v for k, v in (t.split("=", 1) for t in tag_block.split(";") if "=" in t)}
     tp_value = tags[TRACEPARENT_TAG]
     # W3C: 00-<trace-id>-<parent-id>-<flags>
     parts = tp_value.split("-")

--- a/tests/telemetry/test_s2s_session_span.py
+++ b/tests/telemetry/test_s2s_session_span.py
@@ -12,66 +12,53 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_session_span_recorded_with_direction_and_peer(
-    tracing_exporter,  # Activate SDK exporter FIRST...
-    linked_servers,  # ...then link, so handshake spans use the exporter.
+async def test_session_span_records_direction_and_peer_for_both_sides(
+    tracing_exporter,
+    linked_servers,
 ):
+    """Both ends of a federation link record an irc.s2s.session span with
+    the right s2s.direction and s2s.peer attributes after teardown."""
     server_a, server_b = linked_servers
+    tracing_exporter.clear()  # discard handshake spans recorded by the fixture
 
-    # The linked_servers fixture completes the handshake before yielding.
-    # Inspect the active session spans directly via the _session_span field.
+    # Tear down the link from server_a's side; both sides' session spans end.
     link_to_b = server_a.links.get("beta")
-    if link_to_b is None:
-        pytest.skip("linked_servers fixture did not produce expected link alpha->beta")
-
-    span = link_to_b._session_span
-    assert span is not None
-    attrs = dict(span.attributes or {})
-    assert attrs.get("s2s.direction") == "outbound"
-    assert attrs.get("s2s.peer") == "beta"
-
-    link_from_a = server_b.links.get("alpha")
-    if link_from_a is None:
-        pytest.skip("linked_servers fixture did not produce expected link beta->alpha")
-
-    span = link_from_a._session_span
-    assert span is not None
-    attrs = dict(span.attributes or {})
-    assert attrs.get("s2s.direction") == "inbound"
-    assert attrs.get("s2s.peer") == "alpha"
-
-
-@pytest.mark.asyncio
-async def test_session_span_finishes_on_link_teardown(
-    tracing_exporter,  # Activate SDK exporter FIRST...
-    linked_servers,  # ...then link, so handshake spans use the exporter.
-):
-    server_a, server_b = linked_servers
-    tracing_exporter.clear()
-
-    link_to_b = server_a.links.get("beta")
-    if link_to_b is None:
-        pytest.skip("linked_servers fixture did not produce expected link")
-
+    assert link_to_b is not None, "linked_servers fixture failed to establish A->B link"
     link_to_b.writer.close()
     try:
         await link_to_b.writer.wait_closed()
     except ConnectionError:
         pass
     for _ in range(50):
-        if "beta" not in server_a.links:
+        if "beta" not in server_a.links and "alpha" not in server_b.links:
             break
         await asyncio.sleep(0.05)
-    # Allow teardown spans to flush.
+    # Allow span flush.
     await asyncio.sleep(0.1)
 
     spans = tracing_exporter.get_finished_spans()
     session_spans = [s for s in spans if s.name == "irc.s2s.session"]
-    # At least one session span should now be finished (the one we tore down).
-    assert len(session_spans) >= 1
-    finished = session_spans[-1]
-    finished_attrs = dict(finished.attributes or {})
-    assert finished_attrs.get("s2s.direction") in {"inbound", "outbound"}
-    # peer attr may or may not be on the torn-down side depending on which
-    # side closed first; both sides eventually close. The assertion is
-    # weaker for that reason.
+    assert len(session_spans) >= 2, (
+        f"expected at least 2 session spans (one per side), got "
+        f"{len(session_spans)}: {[s.name for s in spans]}"
+    )
+
+    # Bucket by direction; expect one inbound and one outbound.
+    by_direction: dict[str, list] = {"inbound": [], "outbound": []}
+    for span in session_spans:
+        attrs = dict(span.attributes or {})
+        direction = attrs.get("s2s.direction")
+        if direction in by_direction:
+            by_direction[direction].append(attrs)
+
+    assert by_direction["outbound"], "no outbound session span recorded"
+    assert by_direction["inbound"], "no inbound session span recorded"
+
+    # The outbound side (server_a -> beta) carries s2s.peer = "beta".
+    outbound_peers = {a.get("s2s.peer") for a in by_direction["outbound"]}
+    assert (
+        "beta" in outbound_peers
+    ), f"expected s2s.peer=beta on outbound side, got {outbound_peers}"
+    # The inbound side (server_b accepted from alpha) carries s2s.peer = "alpha".
+    inbound_peers = {a.get("s2s.peer") for a in by_direction["inbound"]}
+    assert "alpha" in inbound_peers, f"expected s2s.peer=alpha on inbound side, got {inbound_peers}"

--- a/tests/telemetry/test_s2s_session_span.py
+++ b/tests/telemetry/test_s2s_session_span.py
@@ -1,0 +1,77 @@
+"""Tests for the irc.s2s.session span on ServerLink.handle.
+
+Covers direction attribute (set at span start) and peer attribute (set lazily
+in _try_complete_handshake once peer_name is known).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_session_span_recorded_with_direction_and_peer(
+    tracing_exporter,  # Activate SDK exporter FIRST...
+    linked_servers,  # ...then link, so handshake spans use the exporter.
+):
+    server_a, server_b = linked_servers
+
+    # The linked_servers fixture completes the handshake before yielding.
+    # Inspect the active session spans directly via the _session_span field.
+    link_to_b = server_a.links.get("beta")
+    if link_to_b is None:
+        pytest.skip("linked_servers fixture did not produce expected link alpha->beta")
+
+    span = link_to_b._session_span
+    assert span is not None
+    attrs = dict(span.attributes or {})
+    assert attrs.get("s2s.direction") == "outbound"
+    assert attrs.get("s2s.peer") == "beta"
+
+    link_from_a = server_b.links.get("alpha")
+    if link_from_a is None:
+        pytest.skip("linked_servers fixture did not produce expected link beta->alpha")
+
+    span = link_from_a._session_span
+    assert span is not None
+    attrs = dict(span.attributes or {})
+    assert attrs.get("s2s.direction") == "inbound"
+    assert attrs.get("s2s.peer") == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_session_span_finishes_on_link_teardown(
+    tracing_exporter,  # Activate SDK exporter FIRST...
+    linked_servers,  # ...then link, so handshake spans use the exporter.
+):
+    server_a, server_b = linked_servers
+    tracing_exporter.clear()
+
+    link_to_b = server_a.links.get("beta")
+    if link_to_b is None:
+        pytest.skip("linked_servers fixture did not produce expected link")
+
+    link_to_b.writer.close()
+    try:
+        await link_to_b.writer.wait_closed()
+    except ConnectionError:
+        pass
+    for _ in range(50):
+        if "beta" not in server_a.links:
+            break
+        await asyncio.sleep(0.05)
+    # Allow teardown spans to flush.
+    await asyncio.sleep(0.1)
+
+    spans = tracing_exporter.get_finished_spans()
+    session_spans = [s for s in spans if s.name == "irc.s2s.session"]
+    # At least one session span should now be finished (the one we tore down).
+    assert len(session_spans) >= 1
+    finished = session_spans[-1]
+    finished_attrs = dict(finished.attributes or {})
+    assert finished_attrs.get("s2s.direction") in {"inbound", "outbound"}
+    # peer attr may or may not be on the torn-down side depending on which
+    # side closed first; both sides eventually close. The assertion is
+    # weaker for that reason.

--- a/tests/telemetry/test_server_link_inject.py
+++ b/tests/telemetry/test_server_link_inject.py
@@ -1,0 +1,103 @@
+"""Wire-level injection tests for ServerLink.send_raw — the single choke point
+that re-signs every outbound federation line with the current span's W3C
+traceparent (per `culture/protocol/extensions/tracing.md`)."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace as otel_trace
+
+from culture.agentirc.server_link import _prepend_trace_tags
+from culture.telemetry.context import TRACEPARENT_TAG
+
+VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+# --- _prepend_trace_tags helper unit tests --------------------------------
+
+
+def test_prepend_to_untagged_line():
+    line = ":alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert out == f"@{TRACEPARENT_TAG}={VALID_TP} {line}"
+
+
+def test_prepend_merges_into_existing_tag_block():
+    line = "@vendor=foo :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert out == f"@vendor=foo;{TRACEPARENT_TAG}={VALID_TP} :alpha SMSG #room alpha-bob :hi"
+
+
+def test_prepend_replaces_existing_traceparent_in_tag_block():
+    stale = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00"
+    line = f"@{TRACEPARENT_TAG}={stale};vendor=x :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
+    assert stale not in out
+    assert "vendor=x" in out
+
+
+def test_prepend_empty_line_no_op():
+    assert _prepend_trace_tags("", VALID_TP) == ""
+
+
+# --- ServerLink.send_raw injection (uses ServerLink with a fake writer) ----
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.buf: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.buf.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def get_extra_info(self, *_a, **_kw):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_send_raw_injects_traceparent_when_span_active(tracing_exporter):
+    from culture.agentirc.server_link import ServerLink
+
+    writer = _FakeWriter()
+    link = ServerLink(reader=None, writer=writer, server=None, password=None)
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("smoke"):
+        await link.send_raw(":alpha SMSG #room alpha-bob :hi")
+
+    assert len(writer.buf) == 1
+    line = writer.buf[0].decode("utf-8").rstrip("\r\n")
+    assert line.startswith("@")
+    assert TRACEPARENT_TAG + "=" in line
+    assert ":alpha SMSG #room alpha-bob :hi" in line
+
+
+@pytest.mark.asyncio
+async def test_send_raw_no_injection_when_no_span(tracing_exporter):
+    from culture.agentirc.server_link import ServerLink
+
+    writer = _FakeWriter()
+    link = ServerLink(reader=None, writer=writer, server=None, password=None)
+    # No span started.
+    await link.send_raw(":alpha SMSG #room alpha-bob :hi")
+    line = writer.buf[0].decode("utf-8").rstrip("\r\n")
+    assert TRACEPARENT_TAG not in line
+
+
+@pytest.mark.asyncio
+async def test_send_raw_traceparent_matches_active_span(tracing_exporter):
+    from culture.agentirc.server_link import ServerLink
+    from culture.telemetry import current_traceparent
+
+    writer = _FakeWriter()
+    link = ServerLink(reader=None, writer=writer, server=None, password=None)
+    tracer = otel_trace.get_tracer("test")
+    with tracer.start_as_current_span("smoke"):
+        expected_tp = current_traceparent()
+        await link.send_raw(":alpha SMSG #room alpha-bob :hi")
+
+    line = writer.buf[0].decode("utf-8").rstrip("\r\n")
+    assert f"{TRACEPARENT_TAG}={expected_tp}" in line

--- a/tests/telemetry/test_server_link_inject.py
+++ b/tests/telemetry/test_server_link_inject.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import pytest
 from opentelemetry import trace as otel_trace
 
-from culture.agentirc.server_link import _prepend_trace_tags
+from culture.agentirc.server_link import ServerLink, _prepend_trace_tags
+from culture.telemetry import current_traceparent
 from culture.telemetry.context import TRACEPARENT_TAG
 
 VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
@@ -32,13 +33,38 @@ def test_prepend_replaces_existing_traceparent_in_tag_block():
     stale = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-00"
     line = f"@{TRACEPARENT_TAG}={stale};vendor=x :alpha SMSG #room alpha-bob :hi"
     out = _prepend_trace_tags(line, VALID_TP)
-    assert TRACEPARENT_TAG + "=" + VALID_TP in out
-    assert stale not in out
-    assert "vendor=x" in out
+    expected = f"@{TRACEPARENT_TAG}={VALID_TP};vendor=x :alpha SMSG #room alpha-bob :hi"
+    assert out == expected
 
 
 def test_prepend_empty_line_no_op():
     assert _prepend_trace_tags("", VALID_TP) == ""
+
+
+def test_prepend_into_tag_only_line_with_no_space():
+    # Edge case: line is entirely a tag block with no body. Defensive only —
+    # never happens on the wire, but the helper must not raise.
+    line = "@vendor=foo"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
+    assert "vendor=foo" in out
+
+
+def test_prepend_preserves_tag_value_with_equals_signs():
+    # Tag values can legally contain '=' inside the value portion.
+    line = "@vendor=k=v :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert "vendor=k=v" in out
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
+
+
+def test_prepend_into_empty_tag_block_no_leading_semicolon():
+    # @<empty> rest — must not produce '@;TP=...' (leading empty tag).
+    line = "@ :alpha SMSG #room alpha-bob :hi"
+    out = _prepend_trace_tags(line, VALID_TP)
+    assert ";;" not in out
+    assert not out.startswith("@;")
+    assert TRACEPARENT_TAG + "=" + VALID_TP in out
 
 
 # --- ServerLink.send_raw injection (uses ServerLink with a fake writer) ----
@@ -54,14 +80,9 @@ class _FakeWriter:
     async def drain(self) -> None:
         pass
 
-    def get_extra_info(self, *_a, **_kw):
-        return None
-
 
 @pytest.mark.asyncio
 async def test_send_raw_injects_traceparent_when_span_active(tracing_exporter):
-    from culture.agentirc.server_link import ServerLink
-
     writer = _FakeWriter()
     link = ServerLink(reader=None, writer=writer, server=None, password=None)
     tracer = otel_trace.get_tracer("test")
@@ -70,15 +91,18 @@ async def test_send_raw_injects_traceparent_when_span_active(tracing_exporter):
 
     assert len(writer.buf) == 1
     line = writer.buf[0].decode("utf-8").rstrip("\r\n")
-    assert line.startswith("@")
-    assert TRACEPARENT_TAG + "=" in line
-    assert ":alpha SMSG #room alpha-bob :hi" in line
+    prefix, sep, body = line.partition(" ")
+    assert sep == " "
+    assert prefix.startswith("@")
+    tags = dict(t.split("=", 1) for t in prefix[1:].split(";") if "=" in t)
+    assert TRACEPARENT_TAG in tags
+    # Tag value must be 55-char W3C format
+    assert len(tags[TRACEPARENT_TAG]) == 55
+    assert body == ":alpha SMSG #room alpha-bob :hi"
 
 
 @pytest.mark.asyncio
 async def test_send_raw_no_injection_when_no_span(tracing_exporter):
-    from culture.agentirc.server_link import ServerLink
-
     writer = _FakeWriter()
     link = ServerLink(reader=None, writer=writer, server=None, password=None)
     # No span started.
@@ -89,9 +113,6 @@ async def test_send_raw_no_injection_when_no_span(tracing_exporter):
 
 @pytest.mark.asyncio
 async def test_send_raw_traceparent_matches_active_span(tracing_exporter):
-    from culture.agentirc.server_link import ServerLink
-    from culture.telemetry import current_traceparent
-
     writer = _FakeWriter()
     link = ServerLink(reader=None, writer=writer, server=None, password=None)
     tracer = otel_trace.get_tracer("test")

--- a/tests/telemetry/test_server_link_inject.py
+++ b/tests/telemetry/test_server_link_inject.py
@@ -78,7 +78,7 @@ class _FakeWriter:
         self.buf.append(data)
 
     async def drain(self) -> None:
-        pass
+        """No-op: tests don't exercise asyncio writer back-pressure."""
 
 
 @pytest.mark.asyncio

--- a/tests/telemetry/test_session_span.py
+++ b/tests/telemetry/test_session_span.py
@@ -23,25 +23,14 @@ def _spans_with_name(exporter, name):
 async def test_client_session_span_records_remote_addr_and_nick(
     tracing_exporter, server, make_client
 ):
-    """irc.client.session span carries remote_addr and (after NICK) nick."""
+    """irc.client.session span records remote_addr and (after NICK) nick."""
     tracing_exporter.clear()
 
     client = await make_client(nick="testserv-alice", user="alice")
-    # Connection is open. Inspect the live span via the Client object on
-    # the server side (client is IRCTestClient — look up via server.clients).
-    assert "testserv-alice" in server.clients, "server did not register nick"
-    server_side_clients = server.clients
-    server_client = server_side_clients["testserv-alice"]
-    span = server_client._session_span
-    assert span is not None
-    attrs = dict(span.attributes or {})
-    assert attrs.get("irc.client.nick") == "testserv-alice"
-    remote_addr = attrs.get("irc.client.remote_addr", "")
-    assert ":" in remote_addr  # "ip:port" shape
+    assert "testserv-alice" in server.clients
 
-    # Now close — span should finish and land in exporter.
+    # Close — session span finishes and lands in exporter.
     await client.close()
-    # Allow teardown.
     for _ in range(50):
         if "testserv-alice" not in server.clients:
             break

--- a/tests/telemetry/test_session_span.py
+++ b/tests/telemetry/test_session_span.py
@@ -1,0 +1,90 @@
+"""Tests for #290: Client.handle session span + irc.join/irc.part spans."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+async def _wait_for_span(exporter, name: str, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if any(s.name == name for s in exporter.get_finished_spans()):
+            return
+        await asyncio.sleep(0.02)
+
+
+def _spans_with_name(exporter, name):
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+@pytest.mark.asyncio
+async def test_client_session_span_records_remote_addr_and_nick(
+    tracing_exporter, server, make_client
+):
+    """irc.client.session span carries remote_addr and (after NICK) nick."""
+    tracing_exporter.clear()
+
+    client = await make_client(nick="testserv-alice", user="alice")
+    # Connection is open. Inspect the live span via the Client object on
+    # the server side (client is IRCTestClient — look up via server.clients).
+    assert "testserv-alice" in server.clients, "server did not register nick"
+    server_side_clients = server.clients
+    server_client = server_side_clients["testserv-alice"]
+    span = server_client._session_span
+    assert span is not None
+    attrs = dict(span.attributes or {})
+    assert attrs.get("irc.client.nick") == "testserv-alice"
+    remote_addr = attrs.get("irc.client.remote_addr", "")
+    assert ":" in remote_addr  # "ip:port" shape
+
+    # Now close — span should finish and land in exporter.
+    await client.close()
+    # Allow teardown.
+    for _ in range(50):
+        if "testserv-alice" not in server.clients:
+            break
+        await asyncio.sleep(0.05)
+    await asyncio.sleep(0.1)
+
+    finished = _spans_with_name(tracing_exporter, "irc.client.session")
+    assert finished, "no finished irc.client.session span recorded"
+    last = finished[-1]
+    last_attrs = dict(last.attributes or {})
+    assert last_attrs.get("irc.client.nick") == "testserv-alice"
+    assert ":" in last_attrs.get("irc.client.remote_addr", "")
+
+
+@pytest.mark.asyncio
+async def test_join_span_records_channel_and_nick(tracing_exporter, server, make_client):
+    tracing_exporter.clear()
+    client = await make_client(nick="testserv-bob", user="bob")
+    await client.send("JOIN #join-test")
+    await client.recv_all(timeout=0.5)
+    await _wait_for_span(tracing_exporter, "irc.join")
+
+    spans = _spans_with_name(tracing_exporter, "irc.join")
+    assert spans, "no irc.join span recorded"
+    span = spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("irc.channel") == "#join-test"
+    assert attrs.get("irc.client.nick") == "testserv-bob"
+
+
+@pytest.mark.asyncio
+async def test_part_span_records_channel_and_nick(tracing_exporter, server, make_client):
+    tracing_exporter.clear()
+    client = await make_client(nick="testserv-carol", user="carol")
+    await client.send("JOIN #part-test")
+    await client.recv_all(timeout=0.5)
+    await client.send("PART #part-test :bye")
+    await client.recv_all(timeout=0.5)
+    await _wait_for_span(tracing_exporter, "irc.part")
+
+    spans = _spans_with_name(tracing_exporter, "irc.part")
+    assert spans, "no irc.part span recorded"
+    span = spans[-1]
+    attrs = dict(span.attributes or {})
+    assert attrs.get("irc.channel") == "#part-test"
+    assert attrs.get("irc.client.nick") == "testserv-carol"

--- a/tests/telemetry/test_session_span.py
+++ b/tests/telemetry/test_session_span.py
@@ -77,3 +77,29 @@ async def test_part_span_records_channel_and_nick(tracing_exporter, server, make
     attrs = dict(span.attributes or {})
     assert attrs.get("irc.channel") == "#part-test"
     assert attrs.get("irc.client.nick") == "testserv-carol"
+
+
+@pytest.mark.asyncio
+async def test_command_span_is_root_when_no_traceparent(tracing_exporter, server, make_client):
+    """Plan 2 spec: missing traceparent → root span. Must NOT inherit
+    irc.client.session as parent."""
+    tracing_exporter.clear()
+    client = await make_client(nick="testserv-root", user="root")
+    await client.send("PING token")
+    await client.recv_all(timeout=0.5)
+
+    # Wait for the PING command span.
+    for _ in range(50):
+        spans = [s for s in tracing_exporter.get_finished_spans() if s.name == "irc.command.PING"]
+        if spans:
+            break
+        await asyncio.sleep(0.02)
+
+    spans = [s for s in tracing_exporter.get_finished_spans() if s.name == "irc.command.PING"]
+    assert spans, "no irc.command.PING span recorded"
+    span = spans[-1]
+    # Span must be root (no parent) — must NOT be parented to irc.client.session.
+    assert span.parent is None, (
+        f"irc.command.PING should be root when no traceparent, "
+        f"got parent {span.parent} (likely inherited the session span)"
+    )

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -8,6 +8,7 @@ import pytest_asyncio  # noqa: F401
 
 from culture.agentirc.config import LinkConfig, ServerConfig
 from culture.agentirc.ircd import IRCd
+from culture.agentirc.skill import Event
 from tests.conftest import TEST_LINK_PASSWORD, IRCTestClient
 
 # =============================================================================
@@ -1202,3 +1203,49 @@ async def test_new_channel_on_restricted_link_not_relayed():
             pass
         await server_a.stop()
         await server_b.stop()
+
+
+# =============================================================================
+# Phase 8: Replay regression — issue #291
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_replay_event_handles_string_typed_message_event(linked_servers):
+    """Regression for #291: _replay_event must accept event.type as a plain
+    string (the shape produced by _parse_event_type for non-enum wire types).
+
+    Before the fix, ``event.type == EventType.MESSAGE`` returned False when
+    ``event.type`` was the string ``"message"``, so the typed fast path
+    silently skipped — a federated MESSAGE event reaching backfill replay
+    would not produce the SMSG/SNOTICE wire output.
+    """
+    server_a, server_b = linked_servers
+    link_to_b = server_a.links["beta"]
+
+    captured: list[bytes] = []
+    real_write = link_to_b.writer.write
+
+    def recording_write(data):
+        captured.append(data)
+        return real_write(data)
+
+    link_to_b.writer.write = recording_write
+    try:
+        # Construct a string-typed MESSAGE event — the exact shape
+        # _parse_event_type emits.
+        event = Event(
+            type="message",  # type: ignore[arg-type] -- intentional string
+            channel=None,
+            nick="alpha-bob",
+            data={"target": "beta-charlie", "text": "ping-291"},
+        )
+        await link_to_b._replay_event(seq=42, event=event)
+    finally:
+        link_to_b.writer.write = real_write
+
+    wire = b"".join(captured).decode("utf-8", errors="replace")
+    assert (
+        " SMSG " in wire
+    ), f"expected SMSG in wire output for string-typed MESSAGE event, got: {wire!r}"
+    assert "ping-291" in wire

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1220,7 +1220,7 @@ async def test_replay_event_handles_string_typed_message_event(linked_servers):
     silently skipped — a federated MESSAGE event reaching backfill replay
     would not produce the SMSG/SNOTICE wire output.
     """
-    server_a, server_b = linked_servers
+    server_a, _ = linked_servers
     link_to_b = server_a.links["beta"]
 
     captured: list[bytes] = []

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.2.0"
+version = "8.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Trace context now spans federation: a single `trace_id` covers every hop of a federated message (client → originating server → S2S relay → receiving server → bot/skill), producing a parent-per-hop span tree per `culture/protocol/extensions/tracing.md`.
- Six new spans on the IRC server: `irc.client.session`, `irc.join`, `irc.part`, `irc.s2s.session`, `irc.s2s.<VERB>`, `irc.s2s.relay`.
- Single traceparent injection choke point at `ServerLink.send_raw` enforces the re-sign-per-hop rule for every outbound federation line.
- Folds in #290 (deferred Plan-1 client session + JOIN/PART spans) and #291 (`event.type` enum-vs-string fast-path bug in `_replay_event`).

This is **Plan 2 of 6** of the OTEL observability initiative ([design spec](https://github.com/agentculture/culture/blob/main/docs/superpowers/specs/2026-04-24-otel-observability-design.md), [plan](https://github.com/agentculture/culture/blob/main/docs/superpowers/plans/2026-04-25-otel-federation.md)). Plan 1 shipped in #292 as 8.2.0.

## What changed

- **Hoisted** `context_from_traceparent` and `current_traceparent` to public API at `culture.telemetry.context`.
- **Added** `irc.s2s.session` span over `ServerLink.handle()` lifetime; `s2s.direction` set at start, `s2s.peer` set lazily after handshake.
- **Added** `irc.s2s.<VERB>` per-verb spans on `ServerLink._dispatch` with inbound traceparent extraction + four-state mitigation (valid / missing / malformed / too_long). Federation is always-remote, so `culture.trace.origin="remote"` is unconditional.
- **Added** `irc.s2s.relay` span on `ServerLink.relay_event` — the per-hop re-sign anchor.
- **Added** traceparent injection at `ServerLink.send_raw`: every outbound federation line carries the current span's W3C traceparent. Best-effort try/except so a telemetry bug can't break a link.
- **Added** `irc.client.session`, `irc.join`, `irc.part` spans (#290).
- **Fixed** #291: `_replay_event` uses the hasattr-guarded comparison so string-typed federated `event.type` no longer skips the typed fast path.
- **Normalized** `Client._dispatch` span name + `irc.command` attr to uppercase, matching `ServerLink._dispatch` convention.
- **Documented** wire-level re-sign-per-hop example in `culture/protocol/extensions/tracing.md`.
- **Updated** `docs/agentirc/telemetry.md` with the 8.3.0 span inventory and new public helpers.

## Test plan

- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — 991 passed.
- [x] `tests/telemetry/test_federation_propagation.py` — end-to-end one-trace-id-spans-two-servers test passes; off-switch test confirms no traceparent on wire when telemetry disabled.
- [x] `tests/test_federation.py` — full federation suite (34 tests) green; #291 regression covered.
- [ ] Manual end-to-end: link two local IRCds with `telemetry.enabled: true`, attach weechat to each, send PRIVMSG across; verify single `trace_id` across both servers' spans in collector debug output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)