### PR TITLE
feat(telemetry): OTEL metrics pillar (server-side, 8.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.4.0] - 2026-04-25
+
+### Added
+
+- `culture/telemetry/metrics.py`: `init_metrics(config)` + `MetricsRegistry` dataclass for all 15 server-side instruments — mirrors `tracing.py`'s idempotency + no-op pattern.
+- Public `culture.telemetry.MetricsRegistry` and `culture.telemetry.init_metrics`.
+- `TelemetryConfig.metrics_enabled` (default `True`) and `metrics_export_interval_ms` (default 10000).
+- Message-flow metrics: `culture.irc.bytes_sent`, `culture.irc.bytes_received`, `culture.irc.message.size`, `culture.privmsg.delivered`.
+- Events metrics: `culture.events.emitted`, `culture.events.render.duration`.
+- Federation metrics: `culture.s2s.messages` (inbound), `culture.s2s.relay_latency`, `culture.s2s.links_active`, `culture.s2s.link_events`.
+- Client metrics: `culture.clients.connected`, `culture.client.session.duration`, `culture.client.command.duration`.
+- `culture.trace.inbound` counter — closes Plan 2's deferral.
+- `tests/conftest.py` `metrics_reader` fixture parallel to `tracing_exporter`.
+- `tests/telemetry/_metrics_helpers.py` — `get_counter_value`, `get_histogram_count`, `get_up_down_value`.
+
 ## [8.3.0] - 2026-04-25
 
 ### Added

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as _otel_trace
@@ -162,6 +163,9 @@ class Client:
     async def handle(self, initial_msg: str | None = None) -> None:
         peer_info = self.writer.get_extra_info("peername")
         remote_addr = f"{peer_info[0]}:{peer_info[1]}" if peer_info else ""
+        kind = "human"  # Plan 5/6 will refine to bot/harness
+        self.server.metrics.clients_connected.add(1, {"kind": kind})
+        session_started = time.perf_counter()
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             "irc.client.session",
             attributes={"irc.client.remote_addr": remote_addr},
@@ -185,6 +189,11 @@ class Client:
                     buffer = await self._process_buffer(buffer)
             except (ConnectionError, asyncio.IncompleteReadError):
                 pass
+            finally:
+                self.server.metrics.clients_connected.add(-1, {"kind": kind})
+                self.server.metrics.client_session_duration.record(
+                    time.perf_counter() - session_started, {"kind": kind}
+                )
 
     async def _dispatch(self, msg: Message) -> None:
         extract = extract_traceparent_from_tags(msg, peer=None)
@@ -204,6 +213,7 @@ class Client:
             attrs["culture.trace.dropped_reason"] = extract.status
 
         # Per-call get_tracer: test fixture swaps provider between tests.
+        cmd_started = time.perf_counter()
         with _otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
             f"irc.command.{verb}",
             context=parent_ctx,
@@ -225,6 +235,9 @@ class Client:
                     await self.send_numeric(
                         replies.ERR_UNKNOWNCOMMAND, msg.command, "Unknown command"
                     )
+        self.server.metrics.client_command_duration.record(
+            (time.perf_counter() - cmd_started) * 1000.0, {"verb": verb}
+        )
 
     async def _handle_ping(self, msg: Message) -> None:
         token = msg.params[0] if msg.params else ""

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -175,6 +175,7 @@ class Client:
 
     async def _dispatch(self, msg: Message) -> None:
         extract = extract_traceparent_from_tags(msg, peer=None)
+        self.server.metrics.trace_inbound.add(1, {"result": extract.status, "peer": ""})
         if extract.status == "valid":
             parent_ctx: _OtelContext | None = context_from_traceparent(extract.traceparent)
         else:

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -77,8 +77,12 @@ class Client:
             if tp is not None:
                 _inject_traceparent(message, traceparent=tp, tracestate=None)
         try:
-            self.writer.write(message.format().encode("utf-8"))
+            wire = message.format().encode("utf-8")
+            self.writer.write(wire)
             await self.writer.drain()
+            # Record bytes after a successful drain so we don't count
+            # writes that immediately faulted.
+            self.server.metrics.irc_bytes_sent.add(len(wire), {"direction": "s2c"})
         except OSError:
             pass  # Client disconnected; cleanup happens in ircd._handle_connection
 
@@ -96,8 +100,10 @@ class Client:
                 # block; prefix a fresh @tag.
                 line = f"@{_TP_TAG_NAME}={tp} {line}"
         try:
-            self.writer.write(f"{line}\r\n".encode("utf-8"))
+            wire = f"{line}\r\n".encode("utf-8")
+            self.writer.write(wire)
             await self.writer.drain()
+            self.server.metrics.irc_bytes_sent.add(len(wire), {"direction": "s2c"})
         except OSError:
             pass  # Client disconnected; cleanup happens in ircd._handle_connection
 
@@ -142,6 +148,13 @@ class Client:
                         },
                     )
                     continue
+                # Record received bytes + message size for every successfully-parsed
+                # line.  +2 accounts for the \r\n that was stripped during line-split.
+                line_bytes = len(line.encode("utf-8")) + 2
+                self.server.metrics.irc_bytes_received.add(line_bytes, {"direction": "c2s"})
+                self.server.metrics.irc_message_size.record(
+                    line_bytes, {"verb": msg.command, "direction": "c2s"}
+                )
                 if msg.command:
                     await self._dispatch(msg)
             return buffer
@@ -725,6 +738,7 @@ class Client:
             for member in list(channel.members):
                 if member is not self:
                     await member.send(relay)
+            self.server.metrics.privmsg_delivered.add(1, {"kind": "channel", "channel": target})
             event_data = {"text": text}
             if is_notice:
                 event_data["notice"] = True
@@ -759,6 +773,7 @@ class Client:
                 )
             else:
                 await recipient.send(relay)
+            self.server.metrics.privmsg_delivered.add(1, {"kind": "dm"})
             event_data = {"text": text, "target": target}
             if is_notice:
                 event_data["notice"] = True

--- a/culture/agentirc/config.py
+++ b/culture/agentirc/config.py
@@ -24,6 +24,8 @@ class TelemetryConfig:
     otlp_compression: str = "gzip"  # gzip | none
     traces_enabled: bool = True
     traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
 
 
 @dataclass

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -35,10 +35,11 @@ class IRCd:
     """The culture IRC server."""
 
     def __init__(self, config: ServerConfig):
-        from culture.telemetry import init_telemetry
+        from culture.telemetry import init_metrics, init_telemetry
 
         self.config = config
         self.tracer = init_telemetry(config)
+        self.metrics = init_metrics(config)
         self.clients: dict[str, Client | VirtualClient] = {}  # nick -> Client
         self.channels: dict[str, Channel] = {}  # name -> Channel
         self.skills: list[Skill] = []

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -26,6 +26,9 @@ from culture.protocol.message import Message
 
 logger = logging.getLogger(__name__)
 
+# Span/metric attribute keys defined once so a future rename has one edit point.
+_ATTR_EVENT_TYPE = "event.type"
+
 if TYPE_CHECKING:
     from culture.agentirc.client import Client
     from culture.agentirc.remote_client import RemoteClient
@@ -180,7 +183,7 @@ class IRCd:
         # server_link.py).
         event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
         attrs: dict[str, str] = {
-            "event.type": event_type_str,
+            _ATTR_EVENT_TYPE: event_type_str,
             "event.origin": "federated" if origin_tag else "local",
         }
         if event.channel:
@@ -214,10 +217,10 @@ class IRCd:
     async def emit_event(self, event: Event) -> None:
         origin_tag = event.data.get("_origin")
         attrs = self._build_event_span_attrs(event, origin_tag)
-        event_type_str = attrs["event.type"]
+        event_type_str = attrs[_ATTR_EVENT_TYPE]
         origin_str = "federated" if origin_tag else "local"
 
-        self.metrics.events_emitted.add(1, {"event.type": event_type_str, "origin": origin_str})
+        self.metrics.events_emitted.add(1, {_ATTR_EVENT_TYPE: event_type_str, "origin": origin_str})
         render_started = time.perf_counter()
 
         # Per-call get_tracer: the `tracing_exporter` test fixture swaps the
@@ -235,7 +238,7 @@ class IRCd:
             await self._surface_event_privmsg(event)
 
         render_ms = (time.perf_counter() - render_started) * 1000.0
-        self.metrics.events_render_duration.record(render_ms, {"event.type": event_type_str})
+        self.metrics.events_render_duration.record(render_ms, {_ATTR_EVENT_TYPE: event_type_str})
 
     _NO_SURFACE_TYPES = NO_SURFACE_EVENT_TYPES
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import json
 import logging
+import time
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -213,6 +214,12 @@ class IRCd:
     async def emit_event(self, event: Event) -> None:
         origin_tag = event.data.get("_origin")
         attrs = self._build_event_span_attrs(event, origin_tag)
+        event_type_str = attrs["event.type"]
+        origin_str = "federated" if origin_tag else "local"
+
+        self.metrics.events_emitted.add(1, {"event.type": event_type_str, "origin": origin_str})
+        render_started = time.perf_counter()
+
         # Per-call get_tracer: the `tracing_exporter` test fixture swaps the
         # global provider between tests; a cached Tracer would bind to the
         # first test's provider and stop delivering to later ones.
@@ -226,6 +233,9 @@ class IRCd:
                 await self._relay_to_peers(event)
             await self._dispatch_to_bots(event)
             await self._surface_event_privmsg(event)
+
+        render_ms = (time.perf_counter() - render_started) * 1000.0
+        self.metrics.events_render_duration.record(render_ms, {"event.type": event_type_str})
 
     _NO_SURFACE_TYPES = NO_SURFACE_EVENT_TYPES
 

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -1012,9 +1012,7 @@ class ServerLink:
                 encoded = self.server._encode_event_data(payload, event_type_str)
                 target = event.channel or "*"
                 # Egress trust check: channel-scoped events respect should_relay; global events always relay
-                if event.channel is not None and not self.should_relay(event.channel):
-                    pass
-                else:
+                if event.channel is None or self.should_relay(event.channel):
                     seq = self.server._seq  # current local seq; peer stores but doesn't re-sequence
                     await self.send_raw(
                         f":{origin} SEVENT {origin} {seq} {event_type_str} {target} :{encoded}"

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -158,12 +158,13 @@ class ServerLink:
             line, buffer = buffer.split("\n", 1)
             if line.strip():
                 msg = Message.parse(line)
-                # +2 accounts for the \r\n that was stripped during line-split.
-                line_bytes = len(line.encode("utf-8")) + 2
-                self.server.metrics.irc_bytes_received.add(line_bytes, {"direction": "s2s"})
-                self.server.metrics.irc_message_size.record(
-                    line_bytes, {"verb": msg.command, "direction": "s2s"}
-                )
+                if self.server is not None:
+                    # +2 accounts for the \r\n that was stripped during line-split.
+                    line_bytes = len(line.encode("utf-8")) + 2
+                    self.server.metrics.irc_bytes_received.add(line_bytes, {"direction": "s2s"})
+                    self.server.metrics.irc_message_size.record(
+                        line_bytes, {"verb": msg.command, "direction": "s2s"}
+                    )
                 if msg.command:
                     await self._dispatch(msg)
         return buffer

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -203,6 +203,9 @@ class ServerLink:
         handler = getattr(self, f"_handle_{msg.command.lower()}", None)
 
         extracted = extract_traceparent_from_tags(msg, peer=self.peer_name)
+        self.server.metrics.trace_inbound.add(
+            1, {"result": extracted.status, "peer": self.peer_name or ""}
+        )
         if extracted.status == "valid":
             parent_ctx: _OtelContext | None = context_from_traceparent(extracted.traceparent)
         else:

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -996,6 +996,7 @@ class ServerLink:
             "s2s.peer": self.peer_name or "",
         }
         relay_started = time.perf_counter()
+        relayed = False
         # Single span name (no verb suffix): the wire verb is decided downstream
         # by _RELAY_DISPATCH or the SEVENT fallback, after this span opens.
         with otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
@@ -1005,6 +1006,11 @@ class ServerLink:
             handler = self._RELAY_DISPATCH.get(event.type)
             if handler:
                 await maybe_await(handler(self, event, origin))
+                # v1: typed _relay_* handlers may early-return on internal trust checks
+                # without signaling. We optimistically count typed dispatch as relayed.
+                # Future: refactor _relay_* to return bool so latency only fires on
+                # genuine sends.
+                relayed = True
             else:
                 # If no typed relay exists, fall back to generic SEVENT.
                 # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
@@ -1017,11 +1023,13 @@ class ServerLink:
                     await self.send_raw(
                         f":{origin} SEVENT {origin} {seq} {event_type_str} {target} :{encoded}"
                     )
+                    relayed = True
 
-        self.server.metrics.s2s_relay_latency.record(
-            (time.perf_counter() - relay_started) * 1000.0,
-            {"event.type": event_type_str, "peer": self.peer_name or ""},
-        )
+        if relayed:
+            self.server.metrics.s2s_relay_latency.record(
+                (time.perf_counter() - relay_started) * 1000.0,
+                {"event.type": event_type_str, "peer": self.peer_name or ""},
+            )
 
     async def _relay_message(self, event: Event, origin: str) -> None:
         target = event.channel or event.data.get("target", "")

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import json
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as otel_trace
@@ -197,6 +198,14 @@ class ServerLink:
             except (ConnectionError, asyncio.IncompleteReadError):
                 pass
             finally:
+                if self._authenticated:
+                    direction = "outbound" if self.initiator else "inbound"
+                    self.server.metrics.s2s_links_active.add(
+                        -1, {"peer": self.peer_name or "", "direction": direction}
+                    )
+                    self.server.metrics.s2s_link_events.add(
+                        1, {"peer": self.peer_name or "", "event": "disconnect"}
+                    )
                 await self.server._remove_link(self, squit=self._squit_received)
                 self.writer.close()
                 try:
@@ -220,6 +229,12 @@ class ServerLink:
             parent_ctx: _OtelContext | None = context_from_traceparent(extracted.traceparent)
         else:
             parent_ctx = _OtelContext()  # force root: detach from session span
+
+        if self.server is not None:
+            self.server.metrics.s2s_messages.add(
+                1,
+                {"verb": verb, "direction": "inbound", "peer": self.peer_name or ""},
+            )
 
         attrs = {
             "irc.command": verb,
@@ -279,17 +294,26 @@ class ServerLink:
         """
         if self._peer_pass != self.password:
             logger.warning("Bad password from peer %s", self.peer_name)
+            self.server.metrics.s2s_link_events.add(
+                1, {"peer": self.peer_name or "", "event": "auth_fail"}
+            )
             await self.send_raw("ERROR :Bad password")
             raise ConnectionError("Bad S2S password")
 
         # Check for duplicate server name
         if self.peer_name in self.server.links:
             logger.warning("Duplicate server name %s", self.peer_name)
+            self.server.metrics.s2s_link_events.add(
+                1, {"peer": self.peer_name or "", "event": "auth_fail"}
+            )
             await self.send_raw(f"ERROR :Server name {self.peer_name} already linked")
             raise ConnectionError("Duplicate server name")
 
         if self.peer_name == self.server.config.name:
             logger.warning("Peer has same name as us: %s", self.peer_name)
+            self.server.metrics.s2s_link_events.add(
+                1, {"peer": self.peer_name or "", "event": "auth_fail"}
+            )
             await self.send_raw("ERROR :Cannot link to self")
             raise ConnectionError("Cannot link to self")
 
@@ -304,6 +328,11 @@ class ServerLink:
         await self._validate_peer_credentials()
 
         self._authenticated = True
+        direction = "outbound" if self.initiator else "inbound"
+        self.server.metrics.s2s_links_active.add(
+            1, {"peer": self.peer_name, "direction": direction}
+        )
+        self.server.metrics.s2s_link_events.add(1, {"peer": self.peer_name, "event": "connect"})
         if self._session_span is not None:
             self._session_span.set_attribute("s2s.peer", self.peer_name)
         self.server.links[self.peer_name] = self
@@ -913,6 +942,10 @@ class ServerLink:
         except ValueError:
             return
 
+        self.server.metrics.s2s_link_events.add(
+            1, {"peer": self.peer_name or "", "event": "backfill_start"}
+        )
+
         # Use the higher of: what peer claims, or what we know they acked
         # (during real-time relay, peer saw everything up to our _seq at link drop)
         acked = self.server._peer_acked_seq.get(self.peer_name, 0)
@@ -923,6 +956,9 @@ class ServerLink:
                 await self._replay_event(seq, event)
 
         await self.send_raw(f":{self.server.config.name} BACKFILLEND {self.server._seq}")
+        self.server.metrics.s2s_link_events.add(
+            1, {"peer": self.peer_name or "", "event": "backfill_complete"}
+        )
 
     def _handle_backfillend(self, msg: Message) -> None:
         """Peer finished backfilling."""
@@ -959,6 +995,7 @@ class ServerLink:
             "event.type": event_type_str,
             "s2s.peer": self.peer_name or "",
         }
+        relay_started = time.perf_counter()
         # Single span name (no verb suffix): the wire verb is decided downstream
         # by _RELAY_DISPATCH or the SEVENT fallback, after this span opens.
         with otel_trace.get_tracer(_TRACER_NAME).start_as_current_span(
@@ -968,20 +1005,25 @@ class ServerLink:
             handler = self._RELAY_DISPATCH.get(event.type)
             if handler:
                 await maybe_await(handler(self, event, origin))
-                return
+            else:
+                # If no typed relay exists, fall back to generic SEVENT.
+                # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
+                payload = self.server._build_event_payload(event)
+                encoded = self.server._encode_event_data(payload, event_type_str)
+                target = event.channel or "*"
+                # Egress trust check: channel-scoped events respect should_relay; global events always relay
+                if event.channel is not None and not self.should_relay(event.channel):
+                    pass
+                else:
+                    seq = self.server._seq  # current local seq; peer stores but doesn't re-sequence
+                    await self.send_raw(
+                        f":{origin} SEVENT {origin} {seq} {event_type_str} {target} :{encoded}"
+                    )
 
-            # If no typed relay exists, fall back to generic SEVENT.
-            # v1 assumes all peers support SEVENT; cap negotiation is deferred — see plan task 12.
-            payload = self.server._build_event_payload(event)
-            encoded = self.server._encode_event_data(payload, event_type_str)
-            target = event.channel or "*"
-            # Egress trust check: channel-scoped events respect should_relay; global events always relay
-            if event.channel is not None and not self.should_relay(event.channel):
-                return
-            seq = self.server._seq  # current local seq; peer stores but doesn't re-sequence
-            await self.send_raw(
-                f":{origin} SEVENT {origin} {seq} {event_type_str} {target} :{encoded}"
-            )
+        self.server.metrics.s2s_relay_latency.record(
+            (time.perf_counter() - relay_started) * 1000.0,
+            {"event.type": event_type_str, "peer": self.peer_name or ""},
+        )
 
     async def _relay_message(self, event: Event, origin: str) -> None:
         target = event.channel or event.data.get("target", "")

--- a/culture/agentirc/server_link.py
+++ b/culture/agentirc/server_link.py
@@ -137,8 +137,11 @@ class ServerLink:
             except Exception:  # noqa: BLE001 - telemetry must never break the link
                 logger.debug("traceparent injection failed; sending untagged", exc_info=True)
         try:
-            self.writer.write(f"{line}\r\n".encode("utf-8"))
+            wire = f"{line}\r\n".encode("utf-8")
+            self.writer.write(wire)
             await self.writer.drain()
+            if self.server is not None:
+                self.server.metrics.irc_bytes_sent.add(len(wire), {"direction": "s2s"})
         except OSError:
             pass
 
@@ -155,6 +158,12 @@ class ServerLink:
             line, buffer = buffer.split("\n", 1)
             if line.strip():
                 msg = Message.parse(line)
+                # +2 accounts for the \r\n that was stripped during line-split.
+                line_bytes = len(line.encode("utf-8")) + 2
+                self.server.metrics.irc_bytes_received.add(line_bytes, {"direction": "s2s"})
+                self.server.metrics.irc_message_size.record(
+                    line_bytes, {"verb": msg.command, "direction": "s2s"}
+                )
                 if msg.command:
                     await self._dispatch(msg)
         return buffer

--- a/culture/protocol/extensions/tracing.md
+++ b/culture/protocol/extensions/tracing.md
@@ -11,7 +11,7 @@
 
 1. Tag absent → start a new root span. Attribute: `culture.trace.origin=local`.
 2. Tag present and valid → start a child span linked to the extracted context. Attributes: `culture.trace.origin=remote`, `culture.federation.peer=<peer>`.
-3. Tag present but malformed or over the length cap → drop the tag, start a new root span. Attributes: `culture.trace.origin=remote`, `culture.trace.dropped_reason=malformed|too_long`, `culture.federation.peer=<peer>`. Log a rate-limited warning. Increment `culture.trace.inbound{result=malformed|too_long, peer=<peer>}`.
+3. Tag present but malformed or over the length cap → drop the tag, start a new root span. Attributes: `culture.trace.origin=remote`, `culture.trace.dropped_reason=malformed|too_long`, `culture.federation.peer=<peer>`. Log a rate-limited warning. Increment `culture.trace.inbound{result=malformed|too_long, peer=<peer>}` (shipped in culture 8.4.0; on every inbound regardless of result, so `result=valid` and `result=missing` are also recorded).
 
 **Length caps** (hard-coded, not configurable):
 

--- a/culture/telemetry/__init__.py
+++ b/culture/telemetry/__init__.py
@@ -12,15 +12,18 @@ from culture.telemetry.context import (
     extract_traceparent_from_tags,
     inject_traceparent,
 )
+from culture.telemetry.metrics import MetricsRegistry, init_metrics
 from culture.telemetry.tracing import init_telemetry
 
 __all__ = [
     "ExtractResult",
+    "MetricsRegistry",
     "TRACEPARENT_TAG",
     "TRACESTATE_TAG",
     "context_from_traceparent",
     "current_traceparent",
     "extract_traceparent_from_tags",
+    "init_metrics",
     "init_telemetry",
     "inject_traceparent",
 ]

--- a/culture/telemetry/metrics.py
+++ b/culture/telemetry/metrics.py
@@ -1,0 +1,203 @@
+"""OpenTelemetry MeterProvider bootstrap for Culture.
+
+`init_metrics(config)` is idempotent — safe to call from multiple places.
+When `config.telemetry.enabled` or `metrics_enabled` is False, returns a
+no-op MetricsRegistry whose instruments are bound to the no-op meter
+(call sites can `instrument.add(...)` unconditionally without guards).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+
+from culture.agentirc.config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+_CULTURE_METER_NAME = "culture.agentirc"
+_initialized_for: dict | None = None
+_meter_provider: MeterProvider | None = None
+_registry: "MetricsRegistry | None" = None
+
+
+@dataclass
+class MetricsRegistry:
+    """All Plan-3 server-side instruments, registered once during init_metrics.
+
+    Plan 4/5/6 will extend by adding fields for audit / harness / bots.
+    Keep this a single dataclass and grow it — don't spawn parallel
+    registries per category.
+    """
+
+    # Message flow
+    irc_bytes_sent: Counter
+    irc_bytes_received: Counter
+    irc_message_size: Histogram
+    privmsg_delivered: Counter
+    # Events
+    events_emitted: Counter
+    events_render_duration: Histogram
+    # Federation
+    s2s_messages: Counter
+    s2s_relay_latency: Histogram
+    s2s_links_active: UpDownCounter
+    s2s_link_events: Counter
+    # Clients & sessions
+    clients_connected: UpDownCounter
+    client_session_duration: Histogram
+    client_command_duration: Histogram
+    # Trace-context hygiene
+    trace_inbound: Counter
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only."""
+    global _initialized_for, _meter_provider, _registry
+    _initialized_for = None
+    _meter_provider = None
+    _registry = None
+    # _METER_PROVIDER and Once live on the _internal sub-package, not the
+    # top-level metrics module (unlike the trace API which exposes them directly).
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    _mi._METER_PROVIDER = None
+    _mi._METER_PROVIDER_SET_ONCE = _mi.Once()
+
+
+def _build_registry(meter: Meter) -> MetricsRegistry:
+    """Single source of truth for instrument names / units / descriptions.
+
+    Names and units must match docs/superpowers/specs/2026-04-24-otel-observability-design.md
+    Metrics catalog section.
+    """
+    return MetricsRegistry(
+        # Message flow
+        irc_bytes_sent=meter.create_counter(
+            "culture.irc.bytes_sent",
+            unit="By",
+            description="Bytes written to client/peer sockets",
+        ),
+        irc_bytes_received=meter.create_counter(
+            "culture.irc.bytes_received",
+            unit="By",
+            description="Bytes read from client/peer sockets",
+        ),
+        irc_message_size=meter.create_histogram(
+            "culture.irc.message.size",
+            unit="By",
+            description="Per-message byte size at parse time",
+        ),
+        privmsg_delivered=meter.create_counter(
+            "culture.privmsg.delivered",
+            description="Per-PRIVMSG delivery count, labeled by kind=dm|channel",
+        ),
+        # Events
+        events_emitted=meter.create_counter(
+            "culture.events.emitted",
+            description="Events through IRCd.emit_event, labeled by type and origin",
+        ),
+        events_render_duration=meter.create_histogram(
+            "culture.events.render.duration",
+            unit="ms",
+            description="Time spent in skill hooks + bot dispatch + surfacing",
+        ),
+        # Federation
+        s2s_messages=meter.create_counter(
+            "culture.s2s.messages",
+            description="Inbound/outbound S2S messages by verb and peer",
+        ),
+        s2s_relay_latency=meter.create_histogram(
+            "culture.s2s.relay_latency",
+            unit="ms",
+            description="Per-event relay duration in ServerLink.relay_event",
+        ),
+        s2s_links_active=meter.create_up_down_counter(
+            "culture.s2s.links_active",
+            description="Currently active federation links",
+        ),
+        s2s_link_events=meter.create_counter(
+            "culture.s2s.link_events",
+            description="Federation lifecycle events: connect/disconnect/auth_fail/backfill_*",
+        ),
+        # Clients & sessions
+        clients_connected=meter.create_up_down_counter(
+            "culture.clients.connected",
+            description="Currently connected clients by kind=human|bot|harness",
+        ),
+        client_session_duration=meter.create_histogram(
+            "culture.client.session.duration",
+            unit="s",
+            description="Per-client connection lifetime",
+        ),
+        client_command_duration=meter.create_histogram(
+            "culture.client.command.duration",
+            unit="ms",
+            description="Per-command dispatch duration by verb",
+        ),
+        # Trace-context hygiene
+        trace_inbound=meter.create_counter(
+            "culture.trace.inbound",
+            description="Inbound traceparent extraction outcome by result and peer",
+        ),
+    )
+
+
+def init_metrics(config: ServerConfig) -> MetricsRegistry:
+    """Initialize MeterProvider + register instruments. Idempotent.
+
+    Returns a MetricsRegistry. When telemetry is disabled or
+    metrics_enabled is False, returns a no-op registry whose instruments
+    are bound to the global no-op meter — call sites can record()
+    unconditionally without guards.
+    """
+    global _initialized_for, _meter_provider, _registry
+
+    tcfg = config.telemetry
+    snapshot = asdict(tcfg)
+    if _initialized_for == snapshot and _registry is not None:
+        return _registry
+
+    if not tcfg.enabled or not tcfg.metrics_enabled:
+        meter = metrics.get_meter(_CULTURE_METER_NAME)
+        _registry = _build_registry(meter)
+        _initialized_for = snapshot
+        return _registry
+
+    resource = Resource.create(
+        {
+            "service.name": tcfg.service_name,
+            "service.instance.id": config.name,
+        }
+    )
+    exporter = OTLPMetricExporter(
+        endpoint=tcfg.otlp_endpoint,
+        timeout=tcfg.otlp_timeout_ms / 1000.0,
+        compression=(None if tcfg.otlp_compression == "none" else tcfg.otlp_compression),
+    )
+    reader = PeriodicExportingMetricReader(
+        exporter=exporter,
+        export_interval_millis=tcfg.metrics_export_interval_ms,
+    )
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+
+    meter = metrics.get_meter(_CULTURE_METER_NAME)
+    _registry = _build_registry(meter)
+    _initialized_for = snapshot
+    _meter_provider = provider
+    logger.info(
+        "OTEL metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
+        tcfg.service_name,
+        config.name,
+        tcfg.otlp_endpoint,
+        tcfg.metrics_export_interval_ms,
+    )
+    return _registry

--- a/culture/telemetry/metrics.py
+++ b/culture/telemetry/metrics.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 _CULTURE_METER_NAME = "culture.agentirc"
 _initialized_for: dict | None = None
+_meter_provider: "MeterProvider | None" = None
 _registry: "MetricsRegistry | None" = None
 
 
@@ -63,7 +64,13 @@ class MetricsRegistry:
 
 def reset_for_tests() -> None:
     """Reset module state so each test gets a fresh provider. Test-only."""
-    global _initialized_for, _registry
+    global _initialized_for, _meter_provider, _registry
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        _meter_provider = None
     _initialized_for = None
     _registry = None
     # _METER_PROVIDER and Once live on the _internal sub-package, not the
@@ -114,7 +121,7 @@ def _build_registry(meter: Meter) -> MetricsRegistry:
         # Federation
         s2s_messages=meter.create_counter(
             "culture.s2s.messages",
-            description="Inbound/outbound S2S messages by verb and peer",
+            description="Inbound S2S messages by verb and peer (outbound deferred)",
         ),
         s2s_relay_latency=meter.create_histogram(
             "culture.s2s.relay_latency",
@@ -160,12 +167,25 @@ def init_metrics(config: ServerConfig) -> MetricsRegistry:
     — call sites can `instrument.add(...)` / `.record(...)` unconditionally
     without guards. Production never installs a provider in this case.
     """
-    global _initialized_for, _registry
+    global _initialized_for, _meter_provider, _registry
 
     tcfg = config.telemetry
-    snapshot = asdict(tcfg)
+    # Include config.name so two IRCd instances with identical TelemetryConfig
+    # but different names each get their own registry and correct
+    # service.instance.id resource attribute.
+    snapshot = {"telemetry": asdict(tcfg), "instance": config.name}
     if _initialized_for == snapshot and _registry is not None:
         return _registry
+
+    # Tear down the previous SDK provider before installing a new one.
+    # PeriodicExportingMetricReader spawns a background thread that needs an
+    # explicit shutdown call; otherwise tests leak workers and may double-export.
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown errors must not crash init
+            logger.debug("MeterProvider shutdown failed", exc_info=True)
+        _meter_provider = None
 
     if not tcfg.enabled or not tcfg.metrics_enabled:
         meter = metrics.get_meter(_CULTURE_METER_NAME)
@@ -190,6 +210,7 @@ def init_metrics(config: ServerConfig) -> MetricsRegistry:
     )
     provider = MeterProvider(resource=resource, metric_readers=[reader])
     metrics.set_meter_provider(provider)
+    _meter_provider = provider
 
     meter = metrics.get_meter(_CULTURE_METER_NAME)
     _registry = _build_registry(meter)

--- a/culture/telemetry/metrics.py
+++ b/culture/telemetry/metrics.py
@@ -2,8 +2,12 @@
 
 `init_metrics(config)` is idempotent — safe to call from multiple places.
 When `config.telemetry.enabled` or `metrics_enabled` is False, returns a
-no-op MetricsRegistry whose instruments are bound to the no-op meter
-(call sites can `instrument.add(...)` unconditionally without guards).
+MetricsRegistry whose instruments are bound to OTEL's proxy meter that
+becomes a real meter only if a provider is later installed. In production
+this is effectively no-op (no provider is installed). In tests, callers
+MUST `reset_for_tests()` between disabled-init and the `metrics_reader`
+fixture, otherwise the cached proxy instruments would forward to the
+freshly-installed test provider.
 """
 
 from __future__ import annotations
@@ -24,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 _CULTURE_METER_NAME = "culture.agentirc"
 _initialized_for: dict | None = None
-_meter_provider: MeterProvider | None = None
 _registry: "MetricsRegistry | None" = None
 
 
@@ -60,9 +63,8 @@ class MetricsRegistry:
 
 def reset_for_tests() -> None:
     """Reset module state so each test gets a fresh provider. Test-only."""
-    global _initialized_for, _meter_provider, _registry
+    global _initialized_for, _registry
     _initialized_for = None
-    _meter_provider = None
     _registry = None
     # _METER_PROVIDER and Once live on the _internal sub-package, not the
     # top-level metrics module (unlike the trace API which exposes them directly).
@@ -154,11 +156,11 @@ def init_metrics(config: ServerConfig) -> MetricsRegistry:
     """Initialize MeterProvider + register instruments. Idempotent.
 
     Returns a MetricsRegistry. When telemetry is disabled or
-    metrics_enabled is False, returns a no-op registry whose instruments
-    are bound to the global no-op meter — call sites can record()
-    unconditionally without guards.
+    metrics_enabled is False, instruments are bound to OTEL's proxy meter
+    — call sites can `instrument.add(...)` / `.record(...)` unconditionally
+    without guards. Production never installs a provider in this case.
     """
-    global _initialized_for, _meter_provider, _registry
+    global _initialized_for, _registry
 
     tcfg = config.telemetry
     snapshot = asdict(tcfg)
@@ -192,7 +194,6 @@ def init_metrics(config: ServerConfig) -> MetricsRegistry:
     meter = metrics.get_meter(_CULTURE_METER_NAME)
     _registry = _build_registry(meter)
     _initialized_for = snapshot
-    _meter_provider = provider
     logger.info(
         "OTEL metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
         tcfg.service_name,

--- a/culture/telemetry/tracing.py
+++ b/culture/telemetry/tracing.py
@@ -78,7 +78,10 @@ def init_telemetry(config: ServerConfig) -> Tracer:
     tcfg = config.telemetry
     # Compare against an immutable snapshot so in-place mutation of the
     # caller's TelemetryConfig is detected (the dataclass is not frozen).
-    snapshot = asdict(tcfg)
+    # Include config.name so two IRCd instances with identical TelemetryConfig
+    # but different names each get their own tracer and correct
+    # service.instance.id resource attribute. Mirrors metrics.py for parity.
+    snapshot = {"telemetry": asdict(tcfg), "instance": config.name}
     if _initialized_for == snapshot and _tracer is not None:
         return _tracer
 

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -84,6 +84,8 @@ The metrics pillar lands: 15 server-side instruments registered once via `init_m
 
 When telemetry or metrics are disabled, the SDK is not installed and instruments are bound to OTEL's proxy meter — call sites can `instrument.add(...)` / `.record(...)` unconditionally without guards.
 
+`init_metrics(config)` returns a `MetricsRegistry` dataclass — every instrument above is a typed attribute on it (e.g. `registry.irc_bytes_sent`, `registry.events_emitted`, `registry.s2s_links_active`). The `IRCd` instance carries `self.metrics: MetricsRegistry`, so call sites use `self.server.metrics.<instrument>`. Future plans (audit / harness / bots) extend the same registry rather than spawning parallel ones.
+
 ## Configuration
 
 Telemetry is **off by default**. Enable it in `~/.culture/server.yaml`:

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -9,7 +9,7 @@ nav_order: 90
 
 Culture ships with first-class OpenTelemetry support: traces for every IRC command and event, W3C trace context carried across federation via a new IRCv3 tag, and a local collector pattern that keeps Culture's surface small.
 
-This page covers the **Foundation + Server Tracing** release (culture 8.2.0) plus **Federation Trace-Context Relay** (culture 8.3.0). Metrics, audit, harness instrumentation, and bot instrumentation ship in subsequent releases.
+This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), and the **Metrics Pillar** (culture 8.4.0). Audit, harness instrumentation, and bot instrumentation ship in subsequent releases.
 
 ## What you get in 8.2.0
 
@@ -49,6 +49,41 @@ New public helpers in `culture.telemetry`:
 
 These power the federation re-sign loop and are also useful for embedding Culture's tracer into other Python code that needs to bridge IRC trace context to non-IRC transports.
 
+## What you get in 8.4.0
+
+The metrics pillar lands: 15 server-side instruments registered once via `init_metrics(config)` (called from `IRCd.__init__` next to `init_telemetry`). When `telemetry.enabled: true` and `metrics_enabled: true`, the SDK exports every `metrics_export_interval_ms` (default 10s) to your collector via OTLP/gRPC. Five categories:
+
+**Message flow:**
+
+- `culture.irc.bytes_sent` — Counter, `By`. Labels: `direction=c2s|s2c|s2s`.
+- `culture.irc.bytes_received` — Counter, `By`. Labels: `direction`.
+- `culture.irc.message.size` — Histogram, `By`. Labels: `verb`, `direction`.
+- `culture.privmsg.delivered` — Counter. Labels: `kind=channel|dm` (channel-only carries `channel=<name>`).
+
+**Events:**
+
+- `culture.events.emitted` — Counter. Labels: `event.type`, `origin=local|federated`.
+- `culture.events.render.duration` — Histogram, `ms`. Labels: `event.type`. Measures total time inside `IRCd.emit_event` (skill hooks + bot dispatch + surfacing).
+
+**Federation:**
+
+- `culture.s2s.messages` — Counter (inbound only in 8.4.0). Labels: `verb`, `direction=inbound`, `peer`.
+- `culture.s2s.relay_latency` — Histogram, `ms`. Labels: `event.type`, `peer`.
+- `culture.s2s.links_active` — UpDownCounter. Labels: `peer`, `direction=inbound|outbound`.
+- `culture.s2s.link_events` — Counter. Labels: `peer`, `event=connect|disconnect|auth_fail|backfill_start|backfill_complete`.
+
+**Clients & sessions:**
+
+- `culture.clients.connected` — UpDownCounter. Labels: `kind=human` (Plan 5/6 will refine to `bot`/`harness`).
+- `culture.client.session.duration` — Histogram, `s`. Labels: `kind`.
+- `culture.client.command.duration` — Histogram, `ms`. Labels: `verb` (uppercase).
+
+**Trace-context hygiene:**
+
+- `culture.trace.inbound` — Counter. Labels: `result=valid|missing|malformed|too_long`, `peer` (empty for client-side dispatch). Closes Plan 2's deferred metric.
+
+When telemetry or metrics are disabled, the SDK is not installed and instruments are bound to OTEL's proxy meter — call sites can `instrument.add(...)` / `.record(...)` unconditionally without guards.
+
 ## Configuration
 
 Telemetry is **off by default**. Enable it in `~/.culture/server.yaml`:
@@ -63,6 +98,8 @@ telemetry:
   otlp_compression: gzip
   traces_enabled: true
   traces_sampler: parentbased_always_on
+  metrics_enabled: true
+  metrics_export_interval_ms: 10000
 ```
 
 - `enabled: false` (default) → no SDK init, no export, no overhead. Traceparent tags on inbound messages are still parsed and validated (for the future mitigation metric), but no spans are created.
@@ -89,13 +126,13 @@ When telemetry is enabled and a span is active, outbound client messages carry t
 
 Protocol details, length caps, and inbound mitigation rules: see [`tracing.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/tracing.md) (lives under `culture/` in the repo; Jekyll excludes that path from the published site).
 
-## What's not in 8.3.0
+## What's not in 8.4.0
 
 The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces ship in later releases:
 
-- Metrics pillar (message counters, histograms, federation health, including `culture.trace.inbound{result, peer}` for the inbound mitigation states already attribute-tagged on `irc.s2s.<VERB>` spans).
-- Audit JSONL sink.
-- Harness-side tracing for `claude`/`codex`/`copilot`/`acp`.
-- Bot webhook HTTP instrumentation.
+- Audit JSONL sink + audit metrics (`culture.audit.writes`, `culture.audit.queue_depth`).
+- Harness-side tracing for `claude`/`codex`/`copilot`/`acp` + harness LLM metrics (`culture.harness.llm.*`).
+- Bot webhook HTTP instrumentation + bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`).
+- Outbound `culture.s2s.messages` (8.4.0 records inbound only — outbound needs a clean verb-extraction site without parsing every `send_raw` line).
 
 Each will get an entry under "What you get in \<version\>" as it lands.

--- a/docs/superpowers/plans/2026-04-26-otel-metrics.md
+++ b/docs/superpowers/plans/2026-04-26-otel-metrics.md
@@ -1,0 +1,303 @@
+# OTEL Metrics Pillar (Server-Side) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the metrics pillar of OTEL — 15 server-side instruments across 5 categories — so an operator can answer SLO questions about message throughput, federation health, client lifecycle, and trace-context hygiene from a Prometheus / Grafana Cloud / Tempo backend.
+
+**Architecture:** New `culture/telemetry/metrics.py` mirrors `tracing.py`'s idempotency + no-op pattern. Public `MetricsRegistry` dataclass holds every instrument; `init_metrics(config)` returns one instance and is called next to `init_telemetry(config)` from `IRCd.__init__`. Per-category wiring touches the same span sites Plans 1+2 already established. Closes Plan 2's deferred `culture.trace.inbound` counter.
+
+**Tech Stack:** OpenTelemetry SDK metrics (`opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc` — already a dependency for traces, includes `OTLPMetricExporter`).
+
+---
+
+## Context
+
+Plans 1 and 2 shipped the **traces** pillar of OTEL: server-side spans (Plan 1, PR #292, 8.2.0) and federation trace-context relay (Plan 2, PR #293, 8.3.0). Plan 3 adds the second pillar — **metrics** — for everything the server can measure: message flow, event throughput, federation health, client/session lifecycle, and trace-context hygiene.
+
+After this plan ships, an operator with `otelcol-contrib` pointed at Prometheus / Grafana Cloud / etc. can answer: how many messages per second is the mesh moving, what's the federation relay latency, how many active links / clients / channels, what fraction of inbound peer traceparents were malformed, and how do command-duration histograms look per verb. This is the foundation for SLO dashboards on the mesh.
+
+**Out of scope** (deferred to later plans, but already designed in the spec):
+
+- Bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`) → **Plan 6** (bot instrumentation).
+- Audit sink metrics (`culture.audit.writes`, `culture.audit.queue_depth`) → **Plan 4** (audit JSONL sink).
+- Harness LLM metrics (`culture.harness.llm.*`) → **Plan 5** (harness tracing).
+
+Plan 3 instruments **15 server-side metrics across 5 categories**. The full catalog is in `docs/superpowers/specs/2026-04-24-otel-observability-design.md:109-150`; this plan implements the server-side subset. Plan 4/5/6 will each add their own metric registrations alongside the registry Plan 3 creates.
+
+## Critical files to read before implementing
+
+- `docs/superpowers/specs/2026-04-24-otel-observability-design.md:109-150` — the full metrics catalog with exact name/type/unit/labels.
+- `docs/superpowers/plans/2026-04-25-otel-federation.md` — Plan 2 reference for tone, TDD discipline, two-stage review pattern, version-bump shape.
+- `culture/telemetry/tracing.py` — pattern to mirror (idempotency snapshot, `enabled=False` no-op short-circuit, per-call tracer access). New `metrics.py` will use the same shape.
+- `culture/telemetry/__init__.py` — re-exports for the public surface.
+- `culture/agentirc/config.py:16-27` — `TelemetryConfig` dataclass; needs two new fields.
+- `tests/conftest.py:328-344` — `tracing_exporter` fixture; pattern for the new `metrics_reader` fixture.
+- `culture/agentirc/ircd.py:212-227` — `emit_event` (event metric site).
+- `culture/agentirc/client.py:80-97, 124-147, 149-197, 714-760` — send/send_raw, _process_buffer, handle, dispatch, PRIVMSG delivery (most client-side metric sites).
+- `culture/agentirc/server_link.py:132-225, 942-963` — send_raw, handle, _dispatch, relay_event (federation metric sites).
+- `pyproject.toml:25-28` — current OTEL deps; `opentelemetry-exporter-otlp-proto-grpc` already includes `OTLPMetricExporter`, no new deps needed.
+
+## Approach
+
+### 1. `TelemetryConfig` — two new fields
+
+In `culture/agentirc/config.py::TelemetryConfig`, add:
+
+```python
+metrics_enabled: bool = True
+metrics_export_interval_ms: int = 10000
+```
+
+`metrics_enabled` is gated by the existing `enabled` (parent gate). Both must be true for the SDK to install. Default `True` matches `traces_enabled` symmetry — when telemetry is `enabled`, both pillars come up by default.
+
+### 2. New module `culture/telemetry/metrics.py`
+
+Mirror `tracing.py`'s shape:
+
+```python
+_CULTURE_METER_NAME = "culture.agentirc"
+_initialized_for: dict | None = None
+_meter_provider: MeterProvider | None = None
+_registry: MetricsRegistry | None = None
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only."""
+    global _initialized_for, _meter_provider, _registry
+    ...
+    metrics._METER_PROVIDER = None  # type: ignore[attr-defined]
+
+
+@dataclass
+class MetricsRegistry:
+    """All Plan-3 instruments, registered once during init_metrics(config).
+
+    Plan 4/5/6 will extend by registering their own instruments alongside —
+    Plan 3 owns server-side; later plans own audit / harness / bots.
+    """
+    # Message flow
+    irc_bytes_sent: Counter
+    irc_bytes_received: Counter
+    irc_message_size: Histogram
+    privmsg_delivered: Counter
+    # Events
+    events_emitted: Counter
+    events_render_duration: Histogram
+    # Federation
+    s2s_messages: Counter
+    s2s_relay_latency: Histogram
+    s2s_links_active: UpDownCounter
+    s2s_link_events: Counter
+    # Clients & sessions
+    clients_connected: UpDownCounter
+    client_session_duration: Histogram
+    client_command_duration: Histogram
+    # Trace-context hygiene
+    trace_inbound: Counter
+
+
+def init_metrics(config: ServerConfig) -> MetricsRegistry:
+    """Initialize MeterProvider + register instruments. Idempotent.
+
+    Returns a MetricsRegistry. When telemetry is disabled or
+    metrics_enabled is False, returns a no-op registry whose instruments
+    are all silently bound to the no-op meter — call sites can record()
+    unconditionally.
+    """
+    global _initialized_for, _meter_provider, _registry
+
+    tcfg = config.telemetry
+    snapshot = asdict(tcfg)
+    if _initialized_for == snapshot and _registry is not None:
+        return _registry
+
+    if not tcfg.enabled or not tcfg.metrics_enabled:
+        # No-op meter — instruments still satisfy the type, record() is a no-op.
+        meter = metrics.get_meter(_CULTURE_METER_NAME)
+        _registry = _build_registry(meter)
+        _initialized_for = snapshot
+        return _registry
+
+    resource = Resource.create({...})  # service.name + service.instance.id
+    exporter = OTLPMetricExporter(
+        endpoint=tcfg.otlp_endpoint,
+        timeout=tcfg.otlp_timeout_ms / 1000.0,
+        compression=(None if tcfg.otlp_compression == "none" else tcfg.otlp_compression),
+    )
+    reader = PeriodicExportingMetricReader(
+        exporter=exporter,
+        export_interval_millis=tcfg.metrics_export_interval_ms,
+    )
+    provider = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(provider)
+    meter = metrics.get_meter(_CULTURE_METER_NAME)
+    _registry = _build_registry(meter)
+    _initialized_for = snapshot
+    _meter_provider = provider
+    return _registry
+```
+
+`_build_registry(meter)` is a private function that calls `meter.create_counter(...)`, `meter.create_histogram(...)`, `meter.create_up_down_counter(...)` for each metric in the spec, with the names/units from the catalog. Single source of truth so name/unit drift is impossible.
+
+Add to `culture/telemetry/__init__.py` `__all__`:
+
+```python
+"MetricsRegistry",
+"init_metrics",
+```
+
+### 3. Test fixture `metrics_reader` in `tests/conftest.py`
+
+Mirror `tracing_exporter`:
+
+```python
+@pytest_asyncio.fixture
+async def metrics_reader():
+    """In-memory metric reader for telemetry integration tests."""
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+    _reset_metrics()  # parallel to _reset_telemetry()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+    )
+    metrics.set_meter_provider(provider)
+    try:
+        yield reader
+    finally:
+        _reset_metrics()
+```
+
+Tests assert via `reader.get_metrics_data()` → walk resource_metrics → scope_metrics → metrics → data points. Helpers `get_counter_value(reader, name, **attrs)`, `get_histogram_count(reader, name, **attrs)`, `get_up_down_value(reader, name, **attrs)` live in `tests/telemetry/_metrics_helpers.py` (parallel to `tests/telemetry/_fakes.py`).
+
+### 4. Instrument wiring (per-category tasks)
+
+Each task = wire one category + write its tests + commit. Categories are mostly independent (different files / different choke points), so they can land in any order; for code-review legibility we'll order them by impact.
+
+**Order:**
+
+1. Trace-context hygiene (`culture.trace.inbound`) — closes Plan 2's explicit deferral.
+2. Events (`culture.events.emitted`, `culture.events.render.duration`) — single choke point in `IRCd.emit_event`.
+3. Message flow (`culture.irc.bytes_*`, `culture.irc.message.size`, `culture.privmsg.delivered`) — touches `Client.send_raw`, `ServerLink.send_raw`, `_process_buffer` (both), and PRIVMSG delivery.
+4. Clients & sessions (`culture.clients.connected`, `culture.client.session.duration`, `culture.client.command.duration`) — `Client.handle` entry/exit + command-span duration via OTEL's existing span timing.
+5. Federation (`culture.s2s.messages`, `culture.s2s.relay_latency`, `culture.s2s.links_active`, `culture.s2s.link_events`) — `ServerLink._dispatch`, `relay_event`, `handle`, `_try_complete_handshake`, `_remove_link`.
+
+### 4a. Trace-context hygiene metric — `culture.trace.inbound`
+
+Increment after every `extract_traceparent_from_tags` call, with `result=<extract.status>` and `peer=<peer or "">` labels:
+
+- `culture/agentirc/client.py::_dispatch` — peer is `""` (client-side; spec reserves the peer label for federation).
+- `culture/agentirc/server_link.py::_dispatch` — peer is `self.peer_name or ""`.
+
+Tests cover all four `result` values for both code paths (8 total, but consolidate to ~4 representative cases — the four states are already exhaustively tested for span attrs in Plan 2; metrics tests just verify the counter increments).
+
+### 4b. Events metrics
+
+In `IRCd.emit_event`:
+
+- `events_emitted.add(1, {"event.type": event_type_str, "origin": "federated" if event.data.get("_origin") else "local"})` at span open.
+- `events_render_duration.record(elapsed_ms, {"event.type": event_type_str})` after `_run_skill_hooks` + `_dispatch_to_bots` + `_surface_event_privmsg` (the actual rendering work — wrap with a `time.perf_counter()` stopwatch).
+
+Test: emit N events, assert `events_emitted` counter == N with right labels and `events_render_duration` has N data points.
+
+### 4c. Message-flow metrics
+
+Sites:
+
+- **`Client.send_raw`** (line 80–97): `irc_bytes_sent.add(len(line.encode("utf-8")) + 2, {"direction": "s2c"})` (the `+2` is `\r\n`).
+- **`ServerLink.send_raw`** (line 132–143): `irc_bytes_sent.add(len(line) + 2, {"direction": "s2s"})`.
+- **`Client._process_buffer`** (line 124–147): `irc_bytes_received.add(len(line.encode("utf-8")) + 2, {"direction": "c2s"})` per parsed line; `irc_message_size.record(len(...), {"verb": msg.command, "direction": "c2s"})`.
+- **`ServerLink._process_buffer`** (line 152–160): same shape with `direction="s2s"`.
+- **`_send_to_channel`** / **`_send_to_client`** (lines 714–760): `privmsg_delivered.add(1, {"kind": "channel", "channel": channel.name})` / `("kind": "dm")`.
+
+Tests use the `metrics_reader` fixture and a single client + a single PRIVMSG, asserting expected counter increments.
+
+### 4d. Clients & sessions
+
+- **`Client.handle`** entry: `clients_connected.add(1, {"kind": kind})` where `kind` is heuristic; for v1 default `"human"` everywhere — Plan 5 (harness) and Plan 6 (bots) will refine the label.
+- **`Client.handle`** exit (in `finally` of the existing session-span block): `clients_connected.add(-1, {"kind": kind})` and `client_session_duration.record(session_duration_s, {"kind": kind})`.
+- **`Client._dispatch`**: wrap with `time.perf_counter()` to measure dispatch duration; `client_command_duration.record(elapsed_ms, {"verb": verb})` after the handler runs.
+
+### 4e. Federation metrics
+
+- **`ServerLink._dispatch`**: `s2s_messages.add(1, {"verb": verb, "direction": "inbound", "peer": self.peer_name or ""})`.
+- **`ServerLink.relay_event`**: stopwatch around the dispatch+handler block; `s2s_relay_latency.record(elapsed_ms, {"event.type": event_type_str, "peer": self.peer_name or ""})`.
+- **`ServerLink._try_complete_handshake`** (after `self._authenticated = True`): `s2s_links_active.add(1, {"peer": self.peer_name, "direction": "outbound" if self.initiator else "inbound"})` AND `s2s_link_events.add(1, {"peer": self.peer_name, "event": "connect"})`.
+- **`ServerLink.handle`** finally: `s2s_links_active.add(-1, {"peer": self.peer_name or "", "direction": ...})` AND `s2s_link_events.add(1, {"peer": ..., "event": "disconnect"})` (only if `self._authenticated` was true — never-authenticated drops shouldn't decrement).
+- **Auth-failure paths** in `_validate_peer_credentials` / `_handle_pass`: `s2s_link_events.add(1, {"peer": ..., "event": "auth_fail"})`.
+- **Backfill choke points** in `_handle_backfill` start / `_handle_backfillend`: `s2s_link_events.add(1, {"peer": ..., "event": "backfill_start"|"backfill_complete"})`.
+
+### 5. Documentation
+
+Update `docs/agentirc/telemetry.md`:
+
+- Add "What you get in 8.4.0" section listing the 15 new metrics with units and labels (the spec catalog can be referenced rather than duplicated; one-line bullet per metric is enough).
+- Update "What's not in" to remove "Metrics pillar" and add a note that bot/audit/harness metrics are still upcoming.
+
+Update `culture/protocol/extensions/tracing.md` "Inbound handling" section: cross-reference the new `culture.trace.inbound{result, peer}` metric (the protocol doc already mentions it as a future hook — Plan 2 left this dangling).
+
+### 6. Version bump
+
+`/version-bump minor` → `8.3.0` → `8.4.0`. Updates `pyproject.toml` and `CHANGELOG.md`.
+
+## Files to modify / create
+
+**New:**
+
+- `culture/telemetry/metrics.py` — `init_metrics`, `MetricsRegistry`, `_build_registry`, `reset_for_tests`.
+- `tests/telemetry/_metrics_helpers.py` — `get_counter_value(reader, name, **attrs)`, `get_histogram_count(reader, name, **attrs)`, `get_up_down_value(reader, name, **attrs)`.
+- `tests/telemetry/test_metrics_init.py` — `init_metrics` idempotency, no-op when disabled, reset behavior.
+- `tests/telemetry/test_metrics_trace_inbound.py` — `culture.trace.inbound` for both client and server_link dispatch, all four result values.
+- `tests/telemetry/test_metrics_events.py` — `culture.events.*`.
+- `tests/telemetry/test_metrics_irc.py` — bytes, message size, privmsg.delivered.
+- `tests/telemetry/test_metrics_clients.py` — `clients_connected`, `client_session_duration`, `client_command_duration`.
+- `tests/telemetry/test_metrics_s2s.py` — federation metrics.
+
+**Modified:**
+
+- `culture/agentirc/config.py` — add `metrics_enabled` + `metrics_export_interval_ms` to `TelemetryConfig`.
+- `culture/telemetry/__init__.py` — re-export `MetricsRegistry`, `init_metrics`.
+- `culture/agentirc/ircd.py` — call `init_metrics` next to existing `init_telemetry`; instrument `emit_event`.
+- `culture/agentirc/client.py` — instrument `send_raw`, `_process_buffer`, `_dispatch`, `handle`, `_send_to_channel`, `_send_to_client`.
+- `culture/agentirc/server_link.py` — instrument `send_raw`, `_process_buffer`, `_dispatch`, `relay_event`, `handle`, `_try_complete_handshake`, `_remove_link`-callsite, `_handle_backfill`, `_handle_backfillend`.
+- `tests/conftest.py` — add `metrics_reader` fixture parallel to `tracing_exporter`.
+- `culture/protocol/extensions/tracing.md` — cross-reference `culture.trace.inbound` metric.
+- `docs/agentirc/telemetry.md` — "What you get in 8.4.0" section.
+- `pyproject.toml`, `CHANGELOG.md` — version bump.
+
+## Tests
+
+Per-category tests live in `tests/telemetry/test_metrics_*.py`. Each test:
+
+1. Uses `metrics_reader` fixture (and `linked_servers` for federation tests).
+2. Triggers the instrumented behavior.
+3. Asserts on `reader.get_metrics_data()` via the helpers.
+
+Cross-category invariant: full suite runs in <60s. Metrics tests should be fast — no real OTLP export, just in-memory reader. New tests target ~25-30 cases.
+
+## Verification
+
+1. `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — full suite green (current baseline: 992 + Plan 3 additions).
+2. `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/telemetry/` — telemetry suite green.
+3. Manual: start `otelcol-contrib` with the project's debug-exporter template; start a server with `telemetry.enabled: true` and `metrics_enabled: true`; connect weechat; send PRIVMSG; verify counters/histograms appear in collector debug output every `metrics_export_interval_ms`.
+4. `Agent(subagent_type="doc-test-alignment", ...)` — flag any new public API (`MetricsRegistry`, `init_metrics`) not mentioned in `docs/`.
+5. `Agent(subagent_type="superpowers:code-reviewer", ...)` on staged diff — `metrics.py` is a new public module + multiple shared choke-point edits, exactly the CLAUDE.md case for pre-push review.
+6. `bash ~/.claude/skills/pr-review/scripts/pr-status.sh <PR>` after push — clean CI + SonarCloud quality gate.
+
+## Out of scope (future plans)
+
+- Bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`) → Plan 6.
+- Audit metrics (`culture.audit.writes`, `culture.audit.queue_depth`) → Plan 4.
+- Harness LLM metrics (`culture.harness.llm.*`) → Plan 5.
+- `culture.events.render.duration` per-skill breakdown — current scope only measures total render time per event; per-skill would need per-skill spans/metrics, deferred.
+- Process / GC / memory metrics — collector-side `hostmetrics` receiver or `opentelemetry-instrumentation-system-metrics`; out-of-band of Culture proper.
+
+## Carry-forward notes (for compaction / future plans)
+
+- **MetricsRegistry pattern is extensible.** Plans 4/5/6 will register their own instruments alongside Plan 3's by extending `MetricsRegistry` (audit fields, harness fields, bot fields). Keep the registry a single dataclass and grow it — DON'T spawn parallel registries per category.
+- **Config field naming.** `metrics_enabled` mirrors `traces_enabled` — Plan 4 should use `audit_enabled` (already in spec), Plan 5 `harness_metrics_enabled` (or similar — TBD when Plan 5 lands). Avoid abbreviations; keep parallelism with existing `*_enabled` fields.
+- **No-op meter behavior.** When telemetry is disabled, `metrics.get_meter()` returns a no-op meter whose `create_counter` etc. return no-op instruments — `instrument.add(...)` becomes a free statement. This means call sites NEVER need `if registry is not None` guards; just call `registry.foo.add(...)` unconditionally. Same model as the no-op tracer pattern.
+- **Idempotency snapshot.** Same `dataclasses.asdict(tcfg)` snapshot pattern as Plan 1 — needed because `TelemetryConfig` is mutable. Carry forward to Plan 4's `init_audit(config)` if it follows the same shape.
+- **Plan 2's deferred `culture.trace.inbound` metric** finally lands here; the spec attribute (`culture.trace.dropped_reason`) on `_dispatch` spans already records the same data, but the counter is what dashboards typically scrape.
+- **Test-suite runtime budget.** Adding 25-30 metrics tests must keep the suite under 60s. Use `linked_servers` only when federation metrics need it; for client/event tests use the lighter `server` fixture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.3.0"
+version = "8.4.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,10 @@ import asyncio
 from unittest.mock import patch
 
 import pytest_asyncio
+from opentelemetry import metrics as otel_metrics
 from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -11,6 +14,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from culture.agentirc.config import LinkConfig, ServerConfig
 from culture.agentirc.ircd import IRCd
+from culture.telemetry.metrics import reset_for_tests as _reset_metrics
 from culture.telemetry.tracing import reset_for_tests as _reset_telemetry
 
 # Test-only link password — not a real credential (S2068)
@@ -342,3 +346,24 @@ async def tracing_exporter():
     finally:
         exporter.clear()
         _reset_telemetry()
+
+
+@pytest_asyncio.fixture
+async def metrics_reader():
+    """In-memory metric reader for telemetry integration tests.
+
+    Installs a dedicated SDK MeterProvider with an InMemoryMetricReader so
+    tests can `reader.get_metrics_data()` to walk recorded data points.
+    Cleans up after the test so it doesn't leak into parallel workers.
+    """
+    _reset_metrics()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    try:
+        yield reader
+    finally:
+        _reset_metrics()

--- a/tests/telemetry/_metrics_helpers.py
+++ b/tests/telemetry/_metrics_helpers.py
@@ -1,0 +1,51 @@
+"""Helpers for asserting on InMemoryMetricReader output in metrics tests.
+
+reader.get_metrics_data() returns a MetricsData object whose nested
+structure is resource_metrics → scope_metrics → metrics → data points.
+These helpers walk it for the common assertions we need."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _walk_data_points(reader, name: str):
+    """Yield every data point across all resources/scopes for a metric `name`."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name == name:
+                    yield from metric.data.data_points
+
+
+def _attrs_match(point_attrs: dict, expected: dict) -> bool:
+    return all(point_attrs.get(k) == v for k, v in expected.items())
+
+
+def get_counter_value(reader, name: str, **attrs: Any) -> float:
+    """Sum of counter values for points matching `attrs`. 0.0 if absent."""
+    total = 0.0
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            total += point.value
+    return total
+
+
+def get_up_down_value(reader, name: str, **attrs: Any) -> float:
+    """Latest UpDownCounter value for points matching `attrs`. 0.0 if absent."""
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            return point.value
+    return 0.0
+
+
+def get_histogram_count(reader, name: str, **attrs: Any) -> int:
+    """Count of recorded values for histogram points matching `attrs`."""
+    total = 0
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            total += point.count
+    return total

--- a/tests/telemetry/_metrics_helpers.py
+++ b/tests/telemetry/_metrics_helpers.py
@@ -6,8 +6,6 @@ These helpers walk it for the common assertions we need."""
 
 from __future__ import annotations
 
-from typing import Any
-
 
 def _walk_data_points(reader, name: str):
     """Yield every data point across all resources/scopes for a metric `name`."""
@@ -21,12 +19,19 @@ def _walk_data_points(reader, name: str):
                     yield from metric.data.data_points
 
 
-def _attrs_match(point_attrs: dict, expected: dict) -> bool:
+def _attrs_match(point_attrs: dict, expected: dict | None) -> bool:
+    if not expected:
+        return True
     return all(point_attrs.get(k) == v for k, v in expected.items())
 
 
-def get_counter_value(reader, name: str, **attrs: Any) -> float:
-    """Sum of counter values for points matching `attrs`. 0.0 if absent."""
+def get_counter_value(reader, name: str, attrs: dict | None = None) -> float:
+    """Sum of counter values for points matching `attrs`. 0.0 if absent.
+
+    attrs=None or attrs={} matches all points (sums across all label combinations).
+    attrs={"k": "v"} filters to points where attributes contain those k→v pairs.
+    Supports label keys with dots (e.g. ``event.type``).
+    """
     total = 0.0
     for point in _walk_data_points(reader, name):
         if _attrs_match(dict(point.attributes), attrs):
@@ -34,16 +39,26 @@ def get_counter_value(reader, name: str, **attrs: Any) -> float:
     return total
 
 
-def get_up_down_value(reader, name: str, **attrs: Any) -> float:
-    """Latest UpDownCounter value for points matching `attrs`. 0.0 if absent."""
+def get_up_down_value(reader, name: str, attrs: dict | None = None) -> float:
+    """Latest UpDownCounter value for points matching `attrs`. 0.0 if absent.
+
+    attrs=None or attrs={} matches all points.
+    attrs={"k": "v"} filters to points where attributes contain those k→v pairs.
+    Supports label keys with dots (e.g. ``event.type``).
+    """
     for point in _walk_data_points(reader, name):
         if _attrs_match(dict(point.attributes), attrs):
             return point.value
     return 0.0
 
 
-def get_histogram_count(reader, name: str, **attrs: Any) -> int:
-    """Count of recorded values for histogram points matching `attrs`."""
+def get_histogram_count(reader, name: str, attrs: dict | None = None) -> int:
+    """Count of recorded values for histogram points matching `attrs`.
+
+    attrs=None or attrs={} matches all points (sums counts across all label combinations).
+    attrs={"k": "v"} filters to points where attributes contain those k→v pairs.
+    Supports label keys with dots (e.g. ``event.type``).
+    """
     total = 0
     for point in _walk_data_points(reader, name):
         if _attrs_match(dict(point.attributes), attrs):

--- a/tests/telemetry/test_metrics_clients.py
+++ b/tests/telemetry/test_metrics_clients.py
@@ -1,0 +1,80 @@
+"""Tests for client/session metrics: clients.connected, session.duration, command.duration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests.telemetry._metrics_helpers import (
+    get_counter_value,
+    get_histogram_count,
+    get_up_down_value,
+)
+
+
+@pytest.mark.asyncio
+async def test_clients_connected_increments_on_connect_and_decrements_on_disconnect(
+    metrics_reader, server, make_client
+):
+    """clients_connected goes up on connect, returns to baseline on disconnect."""
+    baseline = get_up_down_value(
+        metrics_reader, "culture.clients.connected", attrs={"kind": "human"}
+    )
+    client = await make_client(nick="testserv-alice", user="alice")
+    # During session, gauge is +1 from baseline.
+    # InMemoryMetricReader collects the latest value at read time, so
+    # we can check the live value.
+    during = get_up_down_value(metrics_reader, "culture.clients.connected", attrs={"kind": "human"})
+    assert during == baseline + 1, (
+        f"expected baseline+1 connected during session, got " f"baseline={baseline} during={during}"
+    )
+
+    await client.close()
+    # Allow handle()'s finally to run.
+    for _ in range(50):
+        post = get_up_down_value(
+            metrics_reader, "culture.clients.connected", attrs={"kind": "human"}
+        )
+        if post == baseline:
+            break
+        await asyncio.sleep(0.02)
+    post = get_up_down_value(metrics_reader, "culture.clients.connected", attrs={"kind": "human"})
+    assert post == baseline, f"expected baseline after disconnect, got {post}"
+
+
+@pytest.mark.asyncio
+async def test_client_session_duration_recorded_on_disconnect(metrics_reader, server, make_client):
+    """session_duration histogram gets a data point when the connection closes."""
+    client = await make_client(nick="testserv-bob", user="bob")
+    await client.close()
+    # Allow handle()'s finally to run.
+    for _ in range(50):
+        n = get_histogram_count(
+            metrics_reader,
+            "culture.client.session.duration",
+            attrs={"kind": "human"},
+        )
+        if n >= 1:
+            break
+        await asyncio.sleep(0.02)
+    count = get_histogram_count(
+        metrics_reader,
+        "culture.client.session.duration",
+        attrs={"kind": "human"},
+    )
+    assert count >= 1, f"expected ≥1 session duration sample, got {count}"
+
+
+@pytest.mark.asyncio
+async def test_client_command_duration_recorded_per_verb(metrics_reader, server, make_client):
+    """command_duration histogram records per dispatched verb (uppercase)."""
+    client = await make_client(nick="testserv-carol", user="carol")
+    await client.send("PING token")
+    await client.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    n = get_histogram_count(
+        metrics_reader, "culture.client.command.duration", attrs={"verb": "PING"}
+    )
+    assert n >= 1, f"expected ≥1 PING command duration, got {n}"

--- a/tests/telemetry/test_metrics_clients.py
+++ b/tests/telemetry/test_metrics_clients.py
@@ -7,7 +7,6 @@ import asyncio
 import pytest
 
 from tests.telemetry._metrics_helpers import (
-    get_counter_value,
     get_histogram_count,
     get_up_down_value,
 )

--- a/tests/telemetry/test_metrics_clients.py
+++ b/tests/telemetry/test_metrics_clients.py
@@ -25,9 +25,9 @@ async def test_clients_connected_increments_on_connect_and_decrements_on_disconn
     # InMemoryMetricReader collects the latest value at read time, so
     # we can check the live value.
     during = get_up_down_value(metrics_reader, "culture.clients.connected", attrs={"kind": "human"})
-    assert during == baseline + 1, (
-        f"expected baseline+1 connected during session, got " f"baseline={baseline} during={during}"
-    )
+    assert (
+        during == baseline + 1
+    ), f"expected baseline+1 connected during session, got baseline={baseline} during={during}"
 
     await client.close()
     # Allow handle()'s finally to run.

--- a/tests/telemetry/test_metrics_events.py
+++ b/tests/telemetry/test_metrics_events.py
@@ -1,0 +1,81 @@
+"""Tests for culture.events.emitted + culture.events.render.duration."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests.telemetry._metrics_helpers import get_counter_value, get_histogram_count
+
+
+@pytest.mark.asyncio
+async def test_events_emitted_counter_increments_per_event(metrics_reader, server, make_client):
+    """Each event through emit_event increments events_emitted with correct labels."""
+    client = await make_client(nick="testserv-eve", user="eve")
+    # JOIN emits EventType.JOIN; PART emits EventType.PART.
+    await client.send("JOIN #events-test")
+    await client.recv_all(timeout=0.5)
+    await client.send("PART #events-test")
+    await client.recv_all(timeout=0.5)
+    # Allow event-loop drain.
+    await asyncio.sleep(0.1)
+
+    join_count = get_counter_value(
+        metrics_reader,
+        "culture.events.emitted",
+        attrs={"event.type": "user.join", "origin": "local"},
+    )
+    part_count = get_counter_value(
+        metrics_reader,
+        "culture.events.emitted",
+        attrs={"event.type": "user.part", "origin": "local"},
+    )
+    assert join_count >= 1, f"expected ≥1 join event, got {join_count}"
+    assert part_count >= 1, f"expected ≥1 part event, got {part_count}"
+
+
+@pytest.mark.asyncio
+async def test_events_render_duration_histogram_records_per_event(
+    metrics_reader, server, make_client
+):
+    """Each event records into events_render_duration with the right type label."""
+    client = await make_client(nick="testserv-frank", user="frank")
+    await client.send("JOIN #render-test")
+    await client.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.events.render.duration",
+        attrs={"event.type": "user.join"},
+    )
+    assert n >= 1, f"expected ≥1 join render datapoint, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_events_emitted_origin_federated_for_inbound_sevent(metrics_reader, linked_servers):
+    """A federated event arriving via SEVENT increments events_emitted with origin=federated on the receiver."""
+    server_a, _ = linked_servers
+    link_alpha_to_beta = server_a.links["beta"]
+    # Compose a minimal SEVENT line for a 'message' event.
+    line = b":alpha SEVENT alpha 1 message * :eyJ0ZXh0IjoiaGkifQ==\r\n"
+    link_alpha_to_beta.writer.write(line)
+    await link_alpha_to_beta.writer.drain()
+
+    # Poll for the federated message event on beta.
+    for _ in range(50):
+        n = get_counter_value(
+            metrics_reader,
+            "culture.events.emitted",
+            attrs={"event.type": "message", "origin": "federated"},
+        )
+        if n >= 1:
+            break
+        await asyncio.sleep(0.02)
+    count = get_counter_value(
+        metrics_reader,
+        "culture.events.emitted",
+        attrs={"event.type": "message", "origin": "federated"},
+    )
+    assert count >= 1, f"expected ≥1 federated message event, got {count}"

--- a/tests/telemetry/test_metrics_init.py
+++ b/tests/telemetry/test_metrics_init.py
@@ -1,0 +1,58 @@
+"""Tests for init_metrics + reset_for_tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.agentirc.config import ServerConfig, TelemetryConfig
+from culture.telemetry import MetricsRegistry, init_metrics
+from culture.telemetry.metrics import reset_for_tests as _reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_metrics()
+    yield
+    _reset_metrics()
+
+
+def test_init_metrics_returns_registry_when_disabled():
+    cfg = ServerConfig(name="testserv", telemetry=TelemetryConfig(enabled=False))
+    reg = init_metrics(cfg)
+    assert isinstance(reg, MetricsRegistry)
+    # No-op meter still satisfies the interface — call sites can record unconditionally.
+    reg.events_emitted.add(1, {"event.type": "MESSAGE", "origin": "local"})
+
+
+def test_init_metrics_returns_registry_when_metrics_disabled_only():
+    cfg = ServerConfig(
+        name="testserv",
+        telemetry=TelemetryConfig(enabled=True, metrics_enabled=False),
+    )
+    reg = init_metrics(cfg)
+    assert isinstance(reg, MetricsRegistry)
+
+
+def test_init_metrics_idempotent_same_config():
+    cfg = ServerConfig(name="testserv", telemetry=TelemetryConfig(enabled=False))
+    reg1 = init_metrics(cfg)
+    reg2 = init_metrics(cfg)
+    assert reg1 is reg2
+
+
+def test_init_metrics_reinit_on_config_mutation():
+    tcfg = TelemetryConfig(enabled=False)
+    cfg = ServerConfig(name="testserv", telemetry=tcfg)
+    reg1 = init_metrics(cfg)
+    # Mutate the config in place — snapshot diff should trigger reinit.
+    tcfg.metrics_export_interval_ms = 5000
+    reg2 = init_metrics(cfg)
+    assert reg1 is not reg2
+
+
+def test_reset_for_tests_clears_state():
+    cfg = ServerConfig(name="testserv", telemetry=TelemetryConfig(enabled=False))
+    reg1 = init_metrics(cfg)
+    _reset_metrics()
+    reg2 = init_metrics(cfg)
+    assert reg1 is not reg2

--- a/tests/telemetry/test_metrics_irc.py
+++ b/tests/telemetry/test_metrics_irc.py
@@ -74,7 +74,8 @@ async def test_privmsg_delivered_channel(metrics_reader, server, make_client):
 async def test_privmsg_delivered_dm(metrics_reader, server, make_client):
     """PRIVMSG to a nick increments delivered with kind=dm."""
     sender = await make_client(nick="testserv-frank", user="frank")
-    receiver = await make_client(nick="testserv-grace", user="grace")
+    # Receiver must exist so the dm path increments delivered; we don't read it.
+    await make_client(nick="testserv-grace", user="grace")
     await sender.send("PRIVMSG testserv-grace :hello")
     await sender.recv_all(timeout=0.5)
     await asyncio.sleep(0.1)

--- a/tests/telemetry/test_metrics_irc.py
+++ b/tests/telemetry/test_metrics_irc.py
@@ -1,0 +1,98 @@
+"""Tests for message-flow metrics: bytes_sent, bytes_received, message.size, privmsg.delivered."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests.telemetry._metrics_helpers import (
+    get_counter_value,
+    get_histogram_count,
+)
+
+
+@pytest.mark.asyncio
+async def test_bytes_sent_counter_records_outgoing_to_client(metrics_reader, server, make_client):
+    """Server-to-client write increments bytes_sent with direction=s2c."""
+    client = await make_client(nick="testserv-alice", user="alice")
+    await client.send("PING token")
+    await client.recv_all(timeout=0.5)
+    n = get_counter_value(metrics_reader, "culture.irc.bytes_sent", attrs={"direction": "s2c"})
+    # NICK/USER welcome numerics + PONG response — guaranteed > 0.
+    assert n > 0, f"expected s2c bytes_sent > 0, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_bytes_received_counter_records_incoming_from_client(
+    metrics_reader, server, make_client
+):
+    """Client-to-server read increments bytes_received with direction=c2s."""
+    client = await make_client(nick="testserv-bob", user="bob")
+    await client.send("PING token")
+    await client.recv_all(timeout=0.5)
+    n = get_counter_value(metrics_reader, "culture.irc.bytes_received", attrs={"direction": "c2s"})
+    assert n > 0, f"expected c2s bytes_received > 0, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_message_size_histogram_records_per_verb_per_direction(
+    metrics_reader, server, make_client
+):
+    client = await make_client(nick="testserv-carol", user="carol")
+    await client.send("PING ping1")
+    await client.recv_all(timeout=0.5)
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.irc.message.size",
+        attrs={"verb": "PING", "direction": "c2s"},
+    )
+    assert n >= 1, f"expected ≥1 PING c2s sample, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_privmsg_delivered_channel(metrics_reader, server, make_client):
+    """PRIVMSG to a channel increments delivered with kind=channel + channel label."""
+    sender = await make_client(nick="testserv-dan", user="dan")
+    listener = await make_client(nick="testserv-eve", user="eve")
+    await sender.send("JOIN #pm-test")
+    await sender.recv_all(timeout=0.5)
+    await listener.send("JOIN #pm-test")
+    await listener.recv_all(timeout=0.5)
+    await sender.send("PRIVMSG #pm-test :hello")
+    await sender.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+    n = get_counter_value(
+        metrics_reader,
+        "culture.privmsg.delivered",
+        attrs={"kind": "channel", "channel": "#pm-test"},
+    )
+    assert n >= 1, f"expected ≥1 channel delivery, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_privmsg_delivered_dm(metrics_reader, server, make_client):
+    """PRIVMSG to a nick increments delivered with kind=dm."""
+    sender = await make_client(nick="testserv-frank", user="frank")
+    receiver = await make_client(nick="testserv-grace", user="grace")
+    await sender.send("PRIVMSG testserv-grace :hello")
+    await sender.recv_all(timeout=0.5)
+    await asyncio.sleep(0.1)
+    n = get_counter_value(metrics_reader, "culture.privmsg.delivered", attrs={"kind": "dm"})
+    assert n >= 1, f"expected ≥1 dm delivery, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_bytes_sent_recorded(metrics_reader, linked_servers):
+    """S2S writes record bytes_sent with direction=s2s."""
+    # The handshake itself (PASS + SERVER + bursts) generates s2s traffic.
+    # By the time the linked_servers fixture yields, bytes_sent has fired.
+    n = get_counter_value(metrics_reader, "culture.irc.bytes_sent", attrs={"direction": "s2s"})
+    assert n > 0, f"expected s2s bytes_sent > 0 after handshake, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_bytes_received_recorded(metrics_reader, linked_servers):
+    """S2S reads record bytes_received with direction=s2s."""
+    n = get_counter_value(metrics_reader, "culture.irc.bytes_received", attrs={"direction": "s2s"})
+    assert n > 0, f"expected s2s bytes_received > 0 after handshake, got {n}"

--- a/tests/telemetry/test_metrics_s2s.py
+++ b/tests/telemetry/test_metrics_s2s.py
@@ -72,7 +72,7 @@ async def test_s2s_link_events_connect(metrics_reader, linked_servers):
 @pytest.mark.asyncio
 async def test_s2s_relay_latency_histogram(metrics_reader, linked_servers, make_client_a):
     """relay_event records to s2s_relay_latency when an event relays."""
-    server_a, _ = linked_servers
+    _ = linked_servers  # required for fixture setup
     client_a = await make_client_a(nick="alpha-alice", user="alice")
     await client_a.send("JOIN #relay-test")
     await client_a.recv_all(timeout=0.5)
@@ -127,7 +127,14 @@ async def test_s2s_link_events_auth_fail():
             name="beta",
             host="127.0.0.1",
             port=0,
-            links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password="correct")],
+            links=[
+                LinkConfig(
+                    name="alpha",
+                    host="127.0.0.1",
+                    port=0,
+                    password="correct",  # nosec B106 - test fixture, intentional bad-password assertion
+                )
+            ],
         )
 
         server_a = IRCd(config_a)

--- a/tests/telemetry/test_metrics_s2s.py
+++ b/tests/telemetry/test_metrics_s2s.py
@@ -8,7 +8,6 @@ import pytest
 
 from culture.agentirc.config import LinkConfig, ServerConfig
 from culture.agentirc.ircd import IRCd
-from tests.conftest import TEST_LINK_PASSWORD
 from tests.telemetry._metrics_helpers import (
     get_counter_value,
     get_histogram_count,

--- a/tests/telemetry/test_metrics_s2s.py
+++ b/tests/telemetry/test_metrics_s2s.py
@@ -1,0 +1,154 @@
+"""Tests for federation metrics: s2s.messages, relay_latency, links_active, link_events."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from culture.agentirc.config import LinkConfig, ServerConfig
+from culture.agentirc.ircd import IRCd
+from tests.conftest import TEST_LINK_PASSWORD
+from tests.telemetry._metrics_helpers import (
+    get_counter_value,
+    get_histogram_count,
+    get_up_down_value,
+)
+
+
+@pytest.mark.asyncio
+async def test_s2s_messages_counter_inbound(metrics_reader, linked_servers):
+    """Inbound S2S verbs (handshake + burst) increment s2s_messages."""
+    # By the time linked_servers yields, PASS, SERVER, and burst messages
+    # have all flowed inbound on each side.
+    n_pass = get_counter_value(
+        metrics_reader,
+        "culture.s2s.messages",
+        attrs={"verb": "PASS", "direction": "inbound"},
+    )
+    n_server = get_counter_value(
+        metrics_reader,
+        "culture.s2s.messages",
+        attrs={"verb": "SERVER", "direction": "inbound"},
+    )
+    assert n_pass >= 1, f"expected ≥1 PASS, got {n_pass}"
+    assert n_server >= 1, f"expected ≥1 SERVER, got {n_server}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_links_active_increments_after_handshake(metrics_reader, linked_servers):
+    """links_active = +1 on each side once handshake completes."""
+    n_outbound = get_up_down_value(
+        metrics_reader,
+        "culture.s2s.links_active",
+        attrs={"peer": "beta", "direction": "outbound"},
+    )
+    n_inbound = get_up_down_value(
+        metrics_reader,
+        "culture.s2s.links_active",
+        attrs={"peer": "alpha", "direction": "inbound"},
+    )
+    assert n_outbound == 1, f"expected 1 outbound link, got {n_outbound}"
+    assert n_inbound == 1, f"expected 1 inbound link, got {n_inbound}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_link_events_connect(metrics_reader, linked_servers):
+    """connect event fires once per side on handshake completion."""
+    n_outbound = get_counter_value(
+        metrics_reader,
+        "culture.s2s.link_events",
+        attrs={"peer": "beta", "event": "connect"},
+    )
+    n_inbound = get_counter_value(
+        metrics_reader,
+        "culture.s2s.link_events",
+        attrs={"peer": "alpha", "event": "connect"},
+    )
+    assert n_outbound >= 1, f"expected ≥1 outbound connect, got {n_outbound}"
+    assert n_inbound >= 1, f"expected ≥1 inbound connect, got {n_inbound}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_relay_latency_histogram(metrics_reader, linked_servers, make_client_a):
+    """relay_event records to s2s_relay_latency when an event relays."""
+    server_a, _ = linked_servers
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #relay-test")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+    # JOIN events relay to peer; relay_event fires.
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.s2s.relay_latency",
+        attrs={"peer": "beta"},
+    )
+    assert n >= 1, f"expected ≥1 relay latency sample, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_link_events_disconnect(metrics_reader, linked_servers):
+    """disconnect event fires when the link tears down."""
+    server_a, _ = linked_servers
+    link = server_a.links["beta"]
+    await link.send_raw("SQUIT alpha :test shutdown")
+    await asyncio.sleep(0.5)
+    # Allow finally block to run on both sides.
+    n = get_counter_value(
+        metrics_reader,
+        "culture.s2s.link_events",
+        attrs={"peer": "beta", "event": "disconnect"},
+    )
+    assert n >= 1, f"expected ≥1 disconnect, got {n}"
+
+
+@pytest.mark.asyncio
+async def test_s2s_link_events_auth_fail():
+    """Bad password fires auth_fail."""
+    # We need a manually-built tracing setup since this test doesn't use
+    # linked_servers. Use a fresh metrics_reader fixture pattern inline.
+    from opentelemetry import metrics as otel_metrics
+    from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.sdk.resources import Resource
+
+    from culture.telemetry.metrics import reset_for_tests as _reset_metrics
+
+    _reset_metrics()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    try:
+        config_a = ServerConfig(name="alpha", host="127.0.0.1", port=0)
+        config_b = ServerConfig(
+            name="beta",
+            host="127.0.0.1",
+            port=0,
+            links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password="correct")],
+        )
+
+        server_a = IRCd(config_a)
+        server_b = IRCd(config_b)
+        await server_a.start()
+        await server_b.start()
+
+        server_a.config.port = server_a._server.sockets[0].getsockname()[1]
+        server_b.config.port = server_b._server.sockets[0].getsockname()[1]
+
+        try:
+            await server_a.connect_to_peer("127.0.0.1", server_b.config.port, "wrong")
+            await asyncio.sleep(0.5)
+            n = get_counter_value(
+                reader,
+                "culture.s2s.link_events",
+                attrs={"peer": "alpha", "event": "auth_fail"},
+            )
+            assert n >= 1, f"expected ≥1 auth_fail on bad password, got {n}"
+        finally:
+            await server_a.stop()
+            await server_b.stop()
+    finally:
+        _reset_metrics()

--- a/tests/telemetry/test_metrics_trace_inbound.py
+++ b/tests/telemetry/test_metrics_trace_inbound.py
@@ -7,6 +7,8 @@ all four extract.status values: missing, valid, malformed, too_long.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from culture.telemetry.context import TRACEPARENT_TAG
@@ -82,7 +84,6 @@ async def test_trace_inbound_missing_on_s2s_dispatch(metrics_reader, linked_serv
     link_alpha_to_beta.writer.write(b":alpha SMSG #trace-test alpha-bob :hello\r\n")
     await link_alpha_to_beta.writer.drain()
     # Wait briefly for dispatch.
-    import asyncio as _asyncio
 
     for _ in range(50):
         n = get_counter_value(
@@ -92,7 +93,7 @@ async def test_trace_inbound_missing_on_s2s_dispatch(metrics_reader, linked_serv
         )
         if n >= 1:
             break
-        await _asyncio.sleep(0.02)
+        await asyncio.sleep(0.02)
     count = get_counter_value(
         metrics_reader,
         "culture.trace.inbound",
@@ -108,7 +109,6 @@ async def test_trace_inbound_valid_on_s2s_dispatch(metrics_reader, linked_server
     line = f"@{TRACEPARENT_TAG}={VALID_TP} :alpha SMSG #trace-test alpha-bob :ping\r\n"
     link_alpha_to_beta.writer.write(line.encode("utf-8"))
     await link_alpha_to_beta.writer.drain()
-    import asyncio as _asyncio
 
     for _ in range(50):
         n = get_counter_value(
@@ -118,7 +118,7 @@ async def test_trace_inbound_valid_on_s2s_dispatch(metrics_reader, linked_server
         )
         if n >= 1:
             break
-        await _asyncio.sleep(0.02)
+        await asyncio.sleep(0.02)
     count = get_counter_value(
         metrics_reader,
         "culture.trace.inbound",

--- a/tests/telemetry/test_metrics_trace_inbound.py
+++ b/tests/telemetry/test_metrics_trace_inbound.py
@@ -1,0 +1,127 @@
+"""Tests for culture.trace.inbound counter — closes Plan 2's deferral.
+
+Verifies the counter increments with the right result + peer labels for both
+Client._dispatch (peer="") and ServerLink._dispatch (peer=<peer_name>) across
+all four extract.status values: missing, valid, malformed, too_long.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.telemetry.context import TRACEPARENT_TAG
+from tests.telemetry._metrics_helpers import get_counter_value
+
+VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+# --- Client-side dispatch (peer="") ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trace_inbound_missing_on_client_dispatch(metrics_reader, server, make_client):
+    """Plain message with no traceparent tag → result=missing."""
+    client = await make_client(nick="testserv-alice", user="alice")
+    await client.send("PING token1")
+    await client.recv_all(timeout=0.5)
+    # PING and prior NICK/USER all produce 'missing' inbound.
+    count = get_counter_value(
+        metrics_reader, "culture.trace.inbound", attrs={"result": "missing", "peer": ""}
+    )
+    assert count >= 1, f"expected ≥1 missing, got {count}"
+
+
+@pytest.mark.asyncio
+async def test_trace_inbound_valid_on_client_dispatch(metrics_reader, server, make_client):
+    """Message carrying a valid traceparent tag → result=valid."""
+    client = await make_client(nick="testserv-bob", user="bob")
+    # Send a tagged PING via raw write so we control the wire bytes.
+    await client.send(f"@{TRACEPARENT_TAG}={VALID_TP} PING token2")
+    await client.recv_all(timeout=0.5)
+    count = get_counter_value(
+        metrics_reader, "culture.trace.inbound", attrs={"result": "valid", "peer": ""}
+    )
+    assert count >= 1, f"expected ≥1 valid, got {count}"
+
+
+@pytest.mark.asyncio
+async def test_trace_inbound_malformed_on_client_dispatch(metrics_reader, server, make_client):
+    client = await make_client(nick="testserv-carol", user="carol")
+    await client.send(f"@{TRACEPARENT_TAG}=not-a-traceparent PING token3")
+    await client.recv_all(timeout=0.5)
+    count = get_counter_value(
+        metrics_reader,
+        "culture.trace.inbound",
+        attrs={"result": "malformed", "peer": ""},
+    )
+    assert count >= 1, f"expected ≥1 malformed, got {count}"
+
+
+@pytest.mark.asyncio
+async def test_trace_inbound_too_long_on_client_dispatch(metrics_reader, server, make_client):
+    oversize = VALID_TP + "extrachars"
+    client = await make_client(nick="testserv-dan", user="dan")
+    await client.send(f"@{TRACEPARENT_TAG}={oversize} PING token4")
+    await client.recv_all(timeout=0.5)
+    count = get_counter_value(
+        metrics_reader,
+        "culture.trace.inbound",
+        attrs={"result": "too_long", "peer": ""},
+    )
+    assert count >= 1, f"expected ≥1 too_long, got {count}"
+
+
+# --- Server-side dispatch (peer=<peer_name>) -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trace_inbound_missing_on_s2s_dispatch(metrics_reader, linked_servers):
+    """Plain S2S SMSG with no traceparent → result=missing, peer=alpha (on beta)."""
+    server_a, _ = linked_servers
+    link_alpha_to_beta = server_a.links["beta"]
+    link_alpha_to_beta.writer.write(b":alpha SMSG #trace-test alpha-bob :hello\r\n")
+    await link_alpha_to_beta.writer.drain()
+    # Wait briefly for dispatch.
+    import asyncio as _asyncio
+
+    for _ in range(50):
+        n = get_counter_value(
+            metrics_reader,
+            "culture.trace.inbound",
+            attrs={"result": "missing", "peer": "alpha"},
+        )
+        if n >= 1:
+            break
+        await _asyncio.sleep(0.02)
+    count = get_counter_value(
+        metrics_reader,
+        "culture.trace.inbound",
+        attrs={"result": "missing", "peer": "alpha"},
+    )
+    assert count >= 1, f"expected ≥1 missing on s2s, got {count}"
+
+
+@pytest.mark.asyncio
+async def test_trace_inbound_valid_on_s2s_dispatch(metrics_reader, linked_servers):
+    server_a, _ = linked_servers
+    link_alpha_to_beta = server_a.links["beta"]
+    line = f"@{TRACEPARENT_TAG}={VALID_TP} :alpha SMSG #trace-test alpha-bob :ping\r\n"
+    link_alpha_to_beta.writer.write(line.encode("utf-8"))
+    await link_alpha_to_beta.writer.drain()
+    import asyncio as _asyncio
+
+    for _ in range(50):
+        n = get_counter_value(
+            metrics_reader,
+            "culture.trace.inbound",
+            attrs={"result": "valid", "peer": "alpha"},
+        )
+        if n >= 1:
+            break
+        await _asyncio.sleep(0.02)
+    count = get_counter_value(
+        metrics_reader,
+        "culture.trace.inbound",
+        attrs={"result": "valid", "peer": "alpha"},
+    )
+    assert count >= 1, f"expected ≥1 valid on s2s, got {count}"

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.3.0"
+version = "8.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- 15 server-side OTEL metrics across 5 categories: message flow, events, federation, clients/sessions, trace-context hygiene.
- New `culture/telemetry/metrics.py` mirrors `tracing.py`'s idempotency + no-op pattern; new public `MetricsRegistry` dataclass holds every instrument; `init_metrics(config)` is called from `IRCd.__init__` next to `init_telemetry`.
- Closes Plan 2's deferred `culture.trace.inbound{result, peer}` counter.

This is **Plan 3 of 6** of the OTEL observability initiative ([design spec](https://github.com/agentculture/culture/blob/main/docs/superpowers/specs/2026-04-24-otel-observability-design.md), [plan](https://github.com/agentculture/culture/blob/main/docs/superpowers/plans/2026-04-26-otel-metrics.md)). Plans 1+2 shipped the traces pillar in #292 + #293.

## Metrics shipped

**Message flow:** `culture.irc.bytes_sent`, `bytes_received`, `message.size`, `culture.privmsg.delivered`.

**Events:** `culture.events.emitted`, `culture.events.render.duration`.

**Federation:** `culture.s2s.messages` (inbound), `s2s.relay_latency`, `s2s.links_active`, `s2s.link_events`.

**Clients/sessions:** `culture.clients.connected`, `client.session.duration`, `client.command.duration`.

**Trace hygiene:** `culture.trace.inbound`.

Outbound `culture.s2s.messages` is intentionally deferred — `send_raw` doesn't have a clean verb-extraction site without parsing every line. Plan 3 ships inbound only.

## Configuration

```yaml
telemetry:
  enabled: true
  metrics_enabled: true            # NEW (default true)
  metrics_export_interval_ms: 10000  # NEW (default 10s)
  ...existing fields unchanged...
```

When telemetry or metrics are disabled, instruments are bound to OTEL's proxy meter and `instrument.add(...)` is a free statement — no guards needed at call sites.

## What changed

- **New module:** `culture/telemetry/metrics.py` (`MetricsRegistry`, `init_metrics`, `_build_registry`, `reset_for_tests`).
- **New test fixture:** `tests/conftest.py::metrics_reader` (parallel to `tracing_exporter`, uses `InMemoryMetricReader`).
- **New test helper:** `tests/telemetry/_metrics_helpers.py` (`get_counter_value`, `get_histogram_count`, `get_up_down_value`).
- **TelemetryConfig:** two new fields.
- **`IRCd.__init__`:** `self.metrics = init_metrics(config)`.
- **Instrumented:** `IRCd.emit_event`, `Client.send`/`send_raw`/`_process_buffer`/`_dispatch`/`handle`/`_send_to_channel`/`_send_to_client`, `ServerLink.send_raw`/`_process_buffer`/`_dispatch`/`relay_event`/`handle`/`_try_complete_handshake`/`_validate_peer_credentials`/`_handle_backfill`.
- **Documentation:** `docs/agentirc/telemetry.md` "What you get in 8.4.0" section; `culture/protocol/extensions/tracing.md` cross-link.
- **Tests:** 30 new tests across 6 files (1022 total, was 992 baseline).
- **No new dependencies:** `opentelemetry-exporter-otlp-proto-grpc` already includes `OTLPMetricExporter`.

## Test plan

- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — 1022 passed.
- [x] `tests/telemetry/test_metrics_*.py` — 30 new tests cover every instrument across local + federated paths.
- [x] No regression in `tests/test_federation.py` — federation suite stays green.
- [ ] Manual: `otelcol-contrib` debug-exporter; weechat → PRIVMSG → confirm counters/histograms appear every 10s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)