### PR TITLE
feat(telemetry): OTEL audit JSONL sink (8.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.5.0] - 2026-04-25
+
+### Added
+
+- `culture/telemetry/audit.py` — `AuditSink` with bounded `asyncio.Queue` + dedicated writer task + daily/size rotation + `0600`/`0700` perms.
+- Public `culture.telemetry.AuditSink`, `init_audit`, `build_audit_record`, `utc_iso_timestamp`.
+- `TelemetryConfig.audit_enabled` (default `True`), `audit_dir`, `audit_max_file_bytes`, `audit_rotate_utc_midnight`, `audit_queue_depth` — independent of `telemetry.enabled` (audit fires even with OTEL off).
+- `culture/protocol/extensions/audit.md` — JSONL record schema as a stable contract.
+- `docs/agentirc/audit.md` — operator guide.
+- Audit metrics extend the Plan-3 `MetricsRegistry`: `culture.audit.writes` (Counter, labels `outcome=ok|error`) and `culture.audit.queue_depth` (UpDownCounter).
+- `IRCd.__init__` creates the sink; `IRCd.start()` awaits `sink.start()`; `IRCd.stop()` awaits `sink.shutdown()` so SERVER_WAKE / SERVER_SLEEP both land in the JSONL.
+- `IRCd.emit_event` submits one record per event after the `irc.event.emit` span; `trace_id` / `span_id` captured inside the span for cross-pillar joins.
+- `Client._process_buffer` submits `PARSE_ERROR` records for malformed inbound lines.
+- Federation audit: federated `message` events arrive on the receiver with `origin=federated`, `peer=<peer_name>`. Federated lifecycle events (JOIN/PART/QUIT) are deferred — see #296.
+
 ## [8.4.0] - 2026-04-25
 
 ### Added

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -17,6 +17,7 @@ from culture.aio import maybe_await
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol import replies
 from culture.protocol.message import Message
+from culture.telemetry.audit import utc_iso_timestamp as _utc_iso_timestamp
 from culture.telemetry.context import TRACEPARENT_TAG as _TP_TAG_NAME
 from culture.telemetry.context import (
     context_from_traceparent,
@@ -148,6 +149,7 @@ class Client:
                             "error": type(exc).__name__,
                         },
                     )
+                    self._submit_parse_error_audit(line, exc)
                     continue
                 # Record received bytes + message size for every successfully-parsed
                 # line.  +2 accounts for the \r\n that was stripped during line-split.
@@ -159,6 +161,48 @@ class Client:
                 if msg.command:
                     await self._dispatch(msg)
             return buffer
+
+    def _submit_parse_error_audit(self, line: str, exc: BaseException) -> None:
+        """Build and submit a PARSE_ERROR audit record for a malformed inbound line.
+
+        The record cannot go through build_audit_record (which expects an Event);
+        PARSE_ERROR is a synthetic event_type with no Event object behind it.
+        """
+        # Capture trace/span ids from the active span (the
+        # `irc.client.process_buffer` we're inside of).
+        span = _otel_trace.get_current_span()
+        ctx = span.get_span_context()
+        trace_id_hex = format(ctx.trace_id, "032x") if ctx.is_valid else ""
+        span_id_hex = format(ctx.span_id, "016x") if ctx.is_valid else ""
+
+        peer_info = self.writer.get_extra_info("peername")
+        remote_addr = f"{peer_info[0]}:{peer_info[1]}" if peer_info else ""
+
+        tags: dict[str, str] = {}
+        if trace_id_hex and span_id_hex:
+            tags["culture.dev/traceparent"] = f"00-{trace_id_hex}-{span_id_hex}-01"
+
+        record = {
+            "ts": _utc_iso_timestamp(time.time()),
+            "server": self.server.config.name,
+            "event_type": "PARSE_ERROR",
+            "origin": "local",
+            "peer": "",
+            "trace_id": trace_id_hex,
+            "span_id": span_id_hex,
+            "actor": {
+                "nick": self.nick or "",
+                "kind": "human",
+                "remote_addr": remote_addr,
+            },
+            "target": {"kind": "", "name": ""},
+            "payload": {
+                "line_preview": line[:64],
+                "error": type(exc).__name__,
+            },
+            "tags": tags,
+        }
+        self.server.audit.submit(record)
 
     async def handle(self, initial_msg: str | None = None) -> None:
         peer_info = self.writer.get_extra_info("peername")

--- a/culture/agentirc/client.py
+++ b/culture/agentirc/client.py
@@ -179,8 +179,9 @@ class Client:
         remote_addr = f"{peer_info[0]}:{peer_info[1]}" if peer_info else ""
 
         tags: dict[str, str] = {}
-        if trace_id_hex and span_id_hex:
-            tags["culture.dev/traceparent"] = f"00-{trace_id_hex}-{span_id_hex}-01"
+        tp = current_traceparent()
+        if tp:
+            tags["culture.dev/traceparent"] = tp
 
         record = {
             "ts": _utc_iso_timestamp(time.time()),

--- a/culture/agentirc/config.py
+++ b/culture/agentirc/config.py
@@ -26,6 +26,13 @@ class TelemetryConfig:
     traces_sampler: str = "parentbased_always_on"
     metrics_enabled: bool = True
     metrics_export_interval_ms: int = 10000
+    # Audit JSONL sink (Plan 4). Independent of `enabled` — audit fires
+    # even when telemetry is off so admins always have the trail.
+    audit_enabled: bool = True
+    audit_dir: str = "~/.culture/audit"
+    audit_max_file_bytes: int = 256 * 1024 * 1024  # 256 MiB
+    audit_rotate_utc_midnight: bool = True
+    audit_queue_depth: int = 10000
 
 
 @dataclass

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -23,11 +23,22 @@ from culture.constants import (
     SYSTEM_USER_PREFIX,
 )
 from culture.protocol.message import Message
+from culture.telemetry.audit import build_audit_record
 
 logger = logging.getLogger(__name__)
 
 # Span/metric attribute keys defined once so a future rename has one edit point.
 _ATTR_EVENT_TYPE = "event.type"
+
+
+def _traceparent_tag_dict(trace_id_hex: str, span_id_hex: str) -> dict[str, str]:
+    """Build a {culture.dev/traceparent: <w3c-string>} dict for audit tags.
+
+    Returns {} when either id is empty (no active span context)."""
+    if not trace_id_hex or not span_id_hex:
+        return {}
+    return {"culture.dev/traceparent": f"00-{trace_id_hex}-{span_id_hex}-01"}
+
 
 if TYPE_CHECKING:
     from culture.agentirc.client import Client
@@ -226,14 +237,21 @@ class IRCd:
         self.metrics.events_emitted.add(1, {_ATTR_EVENT_TYPE: event_type_str, "origin": origin_str})
         render_started = time.perf_counter()
 
+        trace_id_hex = ""
+        span_id_hex = ""
+
         # Per-call get_tracer: the `tracing_exporter` test fixture swaps the
         # global provider between tests; a cached Tracer would bind to the
         # first test's provider and stop delivering to later ones.
         with _otel_trace.get_tracer("culture.agentirc").start_as_current_span(
             "irc.event.emit", attributes=attrs
-        ):
+        ) as span:
             seq = self.next_seq()
             self._event_log.append((seq, event))
+            ctx = span.get_span_context()
+            if ctx.is_valid:
+                trace_id_hex = format(ctx.trace_id, "032x")
+                span_id_hex = format(ctx.span_id, "016x")
             await self._run_skill_hooks(event)
             if not origin_tag:
                 await self._relay_to_peers(event)
@@ -242,6 +260,21 @@ class IRCd:
 
         render_ms = (time.perf_counter() - render_started) * 1000.0
         self.metrics.events_render_duration.record(render_ms, {_ATTR_EVENT_TYPE: event_type_str})
+
+        # Audit submit happens after the span exits so it doesn't sit inside
+        # the irc.event.emit span (would skew render duration). The trace_id/
+        # span_id captured inside the span point back at it for cross-pillar
+        # joins.
+        self.audit.submit(
+            build_audit_record(
+                server_name=self.config.name,
+                event=event,
+                origin_tag=origin_tag,
+                trace_id=trace_id_hex,
+                span_id=span_id_hex,
+                extra_tags=_traceparent_tag_dict(trace_id_hex, span_id_hex),
+            )
+        )
 
     _NO_SURFACE_TYPES = NO_SURFACE_EVENT_TYPES
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -39,11 +39,12 @@ class IRCd:
     """The culture IRC server."""
 
     def __init__(self, config: ServerConfig):
-        from culture.telemetry import init_metrics, init_telemetry
+        from culture.telemetry import init_audit, init_metrics, init_telemetry
 
         self.config = config
         self.tracer = init_telemetry(config)
         self.metrics = init_metrics(config)
+        self.audit = init_audit(config, self.metrics)
         self.clients: dict[str, Client | VirtualClient] = {}  # nick -> Client
         self.channels: dict[str, Channel] = {}  # name -> Channel
         self.skills: list[Skill] = []
@@ -73,6 +74,8 @@ class IRCd:
 
         logger.info("Bootstrapping system identity...")
         self._bootstrap_system_identity()
+
+        await self.audit.start()
 
         await self.emit_event(
             Event(
@@ -395,6 +398,7 @@ class IRCd:
             if self._server:
                 self._server.close()
                 await self._server.wait_closed()
+            await self.audit.shutdown()
         finally:
             self._stopped.set()
 

--- a/culture/agentirc/ircd.py
+++ b/culture/agentirc/ircd.py
@@ -23,21 +23,12 @@ from culture.constants import (
     SYSTEM_USER_PREFIX,
 )
 from culture.protocol.message import Message
-from culture.telemetry.audit import build_audit_record
+from culture.telemetry import build_audit_record, current_traceparent
 
 logger = logging.getLogger(__name__)
 
 # Span/metric attribute keys defined once so a future rename has one edit point.
 _ATTR_EVENT_TYPE = "event.type"
-
-
-def _traceparent_tag_dict(trace_id_hex: str, span_id_hex: str) -> dict[str, str]:
-    """Build a {culture.dev/traceparent: <w3c-string>} dict for audit tags.
-
-    Returns {} when either id is empty (no active span context)."""
-    if not trace_id_hex or not span_id_hex:
-        return {}
-    return {"culture.dev/traceparent": f"00-{trace_id_hex}-{span_id_hex}-01"}
 
 
 if TYPE_CHECKING:
@@ -239,6 +230,7 @@ class IRCd:
 
         trace_id_hex = ""
         span_id_hex = ""
+        tp: str | None = None
 
         # Per-call get_tracer: the `tracing_exporter` test fixture swaps the
         # global provider between tests; a cached Tracer would bind to the
@@ -252,6 +244,9 @@ class IRCd:
             if ctx.is_valid:
                 trace_id_hex = format(ctx.trace_id, "032x")
                 span_id_hex = format(ctx.span_id, "016x")
+            # Capture traceparent inside the span so trace_flags reflect
+            # the actual sampling decision for this span, not a hardcoded -01.
+            tp = current_traceparent()
             await self._run_skill_hooks(event)
             if not origin_tag:
                 await self._relay_to_peers(event)
@@ -265,6 +260,7 @@ class IRCd:
         # the irc.event.emit span (would skew render duration). The trace_id/
         # span_id captured inside the span point back at it for cross-pillar
         # joins.
+        tags: dict[str, str] = {"culture.dev/traceparent": tp} if tp else {}
         self.audit.submit(
             build_audit_record(
                 server_name=self.config.name,
@@ -272,7 +268,7 @@ class IRCd:
                 origin_tag=origin_tag,
                 trace_id=trace_id_hex,
                 span_id=span_id_hex,
-                extra_tags=_traceparent_tag_dict(trace_id_hex, span_id_hex),
+                extra_tags=tags,
             )
         )
 

--- a/culture/protocol/extensions/audit.md
+++ b/culture/protocol/extensions/audit.md
@@ -1,0 +1,101 @@
+# Extension: Audit JSONL Sink
+
+The audit log is a durable, file-based JSON-Lines (`.jsonl`) trail of every event the server
+emits. It is **separate from OTEL traces / metrics / logs** — audit lands directly on local disk
+and never depends on a running collector. Admin-only "who said what to whom, when, via what path."
+
+## File Layout
+
+- **Path:** `<audit_dir>/<server_name>-<YYYY-MM-DD>.jsonl` where `<audit_dir>` defaults to
+  `~/.culture/audit/` (configurable via `telemetry.audit_dir`). The date is **UTC**.
+- **File mode:** `0600` (owner read/write only).
+- **Directory mode:** `0700` (owner only). Created on demand if missing; existing dir mode is
+  left as-is.
+- **Rotation suffix:** when the daily file hits the size cap, the next file gets `.1`, then
+  `.2`, … same date. New day starts a fresh file with no suffix.
+
+Example for server `spark` on 2026-04-27 with two size-cap rotations:
+
+```text
+~/.culture/audit/spark-2026-04-27.jsonl     # first 256 MiB
+~/.culture/audit/spark-2026-04-27.1.jsonl   # next 256 MiB
+~/.culture/audit/spark-2026-04-27.2.jsonl   # current
+```
+
+## Record Schema
+
+Each line in the file is a single JSON object. Lines never wrap. Keys are lowercase with `_`
+separators. Order is canonicalized at write time (stable across writes). Future schema additions
+are additive only — consumers must tolerate unknown keys.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ts` | string | yes | ISO 8601 UTC timestamp with microsecond precision and trailing `Z` (e.g. `2026-04-27T14:32:05.123456Z`). |
+| `server` | string | yes | Server name from `ServerConfig.name`. |
+| `event_type` | string | yes | `EventType.value` (e.g. `message`, `user.join`, `room.create`) or the special string `PARSE_ERROR` for malformed inbound lines. |
+| `origin` | string | yes | `local` if the event originated on this server; `federated` if it arrived via a peer link. |
+| `peer` | string | yes | Peer server name when `origin=federated`; empty string `""` otherwise. |
+| `trace_id` | string | yes | OTEL trace-id (32 hex chars) of the active span at submit time, or `""` if no span. |
+| `span_id` | string | yes | OTEL span-id (16 hex chars) of the active span, or `""`. |
+| `actor` | object | yes | `{nick, kind, remote_addr}` describing who/what produced the event. |
+| `actor.nick` | string | yes | The nick from the event (`event.nick`), or `""`. |
+| `actor.kind` | string | yes | One of `human`, `bot`, `harness`. v1 always emits `human` — Plans 5/6 refine. |
+| `actor.remote_addr` | string | yes | `"<ip>:<port>"` if known (PARSE_ERROR via Client; empty for server-internal sites). |
+| `target` | object | yes | `{kind, name}` describing what the event affected. |
+| `target.kind` | string | yes | `channel` (event.channel set), `nick` (DM target), or `""` for global events. |
+| `target.name` | string | yes | The channel or nick; `""` for global. |
+| `payload` | object | yes | `event.data` with all underscore-prefix keys (`_origin`, etc.) stripped. May include `nick` / `channel` defaulted from `event.nick`/`event.channel`. |
+| `tags` | object | yes | IRCv3-style tag bag. v1 emits at most `culture.dev/traceparent` derived from the active span; empty `{}` if no span. |
+
+## Rotation
+
+Rotation fires when **either** condition is met, checked at the top of every record write:
+
+1. The current UTC date differs from `current_date` (daily roll, controlled by
+   `telemetry.audit_rotate_utc_midnight`).
+2. The current file size + the about-to-be-written record size exceeds
+   `telemetry.audit_max_file_bytes` (default 256 MiB).
+
+The new file is opened with `O_WRONLY | O_APPEND | O_CREAT` mode `0600`. Writes use a single
+`os.write` per record so partial-line interleaving is impossible.
+
+## Durability
+
+Records flow through a bounded `asyncio.Queue` (depth `telemetry.audit_queue_depth`, default
+10000). A dedicated writer task drains the queue and writes each record. On queue overflow, the
+record is **dropped** and `culture.audit.writes{outcome=error}` increments. A stderr warning is
+logged.
+
+This is a deliberate trade-off: dropping records is preferable to blocking `IRCd.emit_event`. A
+real-world audit gap is rare and recoverable; a blocked event loop is catastrophic.
+
+No `fsync` per record — writes hit the page cache and rely on the OS to flush. A hard crash can
+lose the in-flight record.
+
+## Retention
+
+Files are not auto-pruned in v1. Operators prune manually:
+
+```bash
+find ~/.culture/audit -name 'spark-*.jsonl*' -mtime +30 -delete
+```
+
+A future `audit-prune` CLI is TODO.
+
+## Compat
+
+The schema is a stable contract:
+
+- New fields can be added in future versions; old consumers must tolerate unknown keys.
+- Existing keys keep their type and semantics across versions.
+- If a future version needs a breaking change, a top-level `schema_version` integer will be
+  added and bumped — until that exists, treat the schema as version 1.
+
+## Example
+
+PRIVMSG from `alpha-alice` (a federated client on the `alpha` peer) to channel `#general` on
+the local server `spark`:
+
+```json
+{"ts":"2026-04-27T14:32:05.123456Z","server":"spark","event_type":"message","origin":"federated","peer":"alpha","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","actor":{"nick":"alpha-alice","kind":"human","remote_addr":""},"target":{"kind":"channel","name":"#general"},"payload":{"text":"hi","nick":"alpha-alice","channel":"#general"},"tags":{"culture.dev/traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}}
+```

--- a/culture/protocol/extensions/audit.md
+++ b/culture/protocol/extensions/audit.md
@@ -59,6 +59,10 @@ Rotation fires when **either** condition is met, checked at the top of every rec
 The new file is opened with `O_WRONLY | O_APPEND | O_CREAT` mode `0600`. Writes use a single
 `os.write` per record so partial-line interleaving is impossible.
 
+A record larger than `audit_max_file_bytes` is still written — the cap is a soft
+ceiling for accumulated bytes, not a hard reject. The oversized record lands in
+its own freshly-rotated file, and the next record triggers another rotation.
+
 ## Durability
 
 Records flow through a bounded `asyncio.Queue` (depth `telemetry.audit_queue_depth`, default

--- a/culture/protocol/extensions/audit.md
+++ b/culture/protocol/extensions/audit.md
@@ -28,6 +28,10 @@ Each line in the file is a single JSON object. Lines never wrap. Keys are lowerc
 separators. Order is canonicalized at write time (stable across writes). Future schema additions
 are additive only — consumers must tolerate unknown keys.
 
+Keys within each record are alphabetically sorted (the writer uses
+`json.dumps(..., sort_keys=True)`). Consumers SHOULD NOT rely on
+insertion order; future producers may emit keys in any order.
+
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `ts` | string | yes | ISO 8601 UTC timestamp with microsecond precision and trailing `Z` (e.g. `2026-04-27T14:32:05.123456Z`). |

--- a/culture/telemetry/__init__.py
+++ b/culture/telemetry/__init__.py
@@ -3,7 +3,7 @@
 Public surface re-exported here; call sites import from `culture.telemetry`.
 """
 
-from culture.telemetry.audit import AuditSink, init_audit
+from culture.telemetry.audit import AuditSink, build_audit_record, init_audit
 from culture.telemetry.context import (
     TRACEPARENT_TAG,
     TRACESTATE_TAG,
@@ -22,6 +22,7 @@ __all__ = [
     "MetricsRegistry",
     "TRACEPARENT_TAG",
     "TRACESTATE_TAG",
+    "build_audit_record",
     "context_from_traceparent",
     "current_traceparent",
     "extract_traceparent_from_tags",

--- a/culture/telemetry/__init__.py
+++ b/culture/telemetry/__init__.py
@@ -3,6 +3,7 @@
 Public surface re-exported here; call sites import from `culture.telemetry`.
 """
 
+from culture.telemetry.audit import AuditSink, init_audit
 from culture.telemetry.context import (
     TRACEPARENT_TAG,
     TRACESTATE_TAG,
@@ -16,6 +17,7 @@ from culture.telemetry.metrics import MetricsRegistry, init_metrics
 from culture.telemetry.tracing import init_telemetry
 
 __all__ = [
+    "AuditSink",
     "ExtractResult",
     "MetricsRegistry",
     "TRACEPARENT_TAG",
@@ -23,6 +25,7 @@ __all__ = [
     "context_from_traceparent",
     "current_traceparent",
     "extract_traceparent_from_tags",
+    "init_audit",
     "init_metrics",
     "init_telemetry",
     "inject_traceparent",

--- a/culture/telemetry/__init__.py
+++ b/culture/telemetry/__init__.py
@@ -3,7 +3,7 @@
 Public surface re-exported here; call sites import from `culture.telemetry`.
 """
 
-from culture.telemetry.audit import AuditSink, build_audit_record, init_audit
+from culture.telemetry.audit import AuditSink, build_audit_record, init_audit, utc_iso_timestamp
 from culture.telemetry.context import (
     TRACEPARENT_TAG,
     TRACESTATE_TAG,
@@ -30,4 +30,5 @@ __all__ = [
     "init_metrics",
     "init_telemetry",
     "inject_traceparent",
+    "utc_iso_timestamp",
 ]

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -244,7 +244,7 @@ def _target_for(event: "Event") -> dict[str, str]:
     return {"kind": "", "name": ""}
 
 
-def _build_audit_record(
+def build_audit_record(
     server_name: str,
     event: "Event",
     origin_tag: str | None,

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -229,10 +229,14 @@ class AuditSink:
         self._current_size = existing_size
 
 
-def _utc_iso_timestamp(epoch_seconds: float) -> str:
+def utc_iso_timestamp(epoch_seconds: float) -> str:
     """ISO 8601 UTC with microsecond precision, trailing Z."""
     dt = datetime.fromtimestamp(epoch_seconds, tz=timezone.utc)
     return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond:06d}Z"
+
+
+# Back-compat alias kept for any code written against the private name.
+_utc_iso_timestamp = utc_iso_timestamp
 
 
 def _target_for(event: "Event") -> dict[str, str]:
@@ -268,7 +272,7 @@ def build_audit_record(
     event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
 
     return {
-        "ts": _utc_iso_timestamp(event.timestamp),
+        "ts": utc_iso_timestamp(event.timestamp),
         "server": server_name,
         "event_type": event_type_str,
         "origin": "federated" if origin_tag else "local",

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -1,0 +1,313 @@
+"""Audit JSONL sink for Culture.
+
+`init_audit(config, metrics)` returns an AuditSink. The sink runs a
+dedicated async writer task draining a bounded `asyncio.Queue`. Each
+record is JSON-serialized and appended to a daily-rotated file under
+`config.telemetry.audit_dir`. On queue overflow records are dropped
+(and `culture.audit.writes{outcome=error}` increments) — dropping is
+preferable to blocking the event loop.
+
+Lifecycle is owned by IRCd: __init__ calls init_audit(); start() awaits
+sink.start(); stop() awaits sink.shutdown(). When audit_enabled=False
+sink.submit() is a no-op and start/shutdown do nothing.
+
+Audit is independent of telemetry.enabled — even with OTEL fully off,
+audit_enabled=True still writes to JSONL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from culture.agentirc.config import ServerConfig
+
+if TYPE_CHECKING:
+    from culture.agentirc.skill import Event
+    from culture.telemetry.metrics import MetricsRegistry
+
+logger = logging.getLogger(__name__)
+
+_initialized_for: dict | None = None
+_sink: "AuditSink | None" = None
+
+
+@dataclass
+class AuditSink:
+    """Async-safe JSONL audit sink.
+
+    See culture/protocol/extensions/audit.md for the on-disk record
+    schema and rotation rules.
+
+    Lifecycle:
+        sink = init_audit(config, metrics)        # construct
+        await sink.start()                         # spawn writer task
+        sink.submit({...})                          # non-blocking enqueue
+        await sink.shutdown(drain_timeout=5.0)     # drain + cancel
+
+    When `enabled=False`, all four methods become no-ops; submit drops
+    records silently.
+    """
+
+    server_name: str
+    audit_dir: Path
+    max_file_bytes: int
+    rotate_utc_midnight: bool
+    queue_depth: int
+    enabled: bool
+    metrics: "MetricsRegistry"
+
+    queue: asyncio.Queue | None = field(default=None, init=False)
+    _writer_task: asyncio.Task | None = field(default=None, init=False)
+    _current_path: Path | None = field(default=None, init=False)
+    _current_size: int = field(default=0, init=False)
+    _current_date: str | None = field(default=None, init=False)  # YYYY-MM-DD
+    _current_fd: int = field(default=-1, init=False)
+    _current_suffix: int = field(default=0, init=False)
+
+    def submit(self, record: dict) -> None:
+        """Non-blocking enqueue. Drop on overflow or when disabled."""
+        if not self.enabled or self.queue is None:
+            return
+        try:
+            self.queue.put_nowait(record)
+            self.metrics.audit_queue_depth.add(1)
+        except asyncio.QueueFull:
+            self.metrics.audit_writes.add(1, {"outcome": "error"})
+            print(
+                f"audit queue full (depth={self.queue_depth}); dropped 1 record",
+                file=sys.stderr,
+            )
+
+    async def start(self) -> None:
+        """Create the audit directory if missing, then spawn the writer task.
+
+        Idempotent: calling start() twice is harmless (returns immediately
+        on the second call).
+        """
+        if not self.enabled:
+            return
+        if self._writer_task is not None:
+            return
+        self.audit_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.queue = asyncio.Queue(maxsize=self.queue_depth)
+        self._writer_task = asyncio.create_task(self._writer_loop(), name="audit-writer")
+
+    async def shutdown(self, *, drain_timeout: float = 5.0) -> None:
+        """Drain the queue (bounded by drain_timeout) then cancel writer."""
+        if not self.enabled or self._writer_task is None:
+            return
+        if self.queue is not None:
+            try:
+                await asyncio.wait_for(self.queue.join(), timeout=drain_timeout)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "audit drain timed out after %.1fs; %d records may be lost",
+                    drain_timeout,
+                    self.queue.qsize() if self.queue is not None else 0,
+                )
+        self._writer_task.cancel()
+        try:
+            await self._writer_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        self._writer_task = None
+        if self._current_fd != -1:
+            try:
+                os.close(self._current_fd)
+            except OSError:
+                pass
+            self._current_fd = -1
+
+    async def _writer_loop(self) -> None:
+        """Drain the queue forever, JSON-encoding and appending each record."""
+        assert self.queue is not None
+        while True:
+            record = await self.queue.get()
+            try:
+                line = json.dumps(record, separators=(",", ":")) + "\n"
+                line_bytes = line.encode("utf-8")
+                self._maybe_rotate(len(line_bytes))
+                if self._current_fd != -1:
+                    os.write(self._current_fd, line_bytes)
+                    self._current_size += len(line_bytes)
+                    self.metrics.audit_writes.add(1, {"outcome": "ok"})
+                else:
+                    self.metrics.audit_writes.add(1, {"outcome": "error"})
+            except OSError as exc:
+                self.metrics.audit_writes.add(1, {"outcome": "error"})
+                logger.warning("audit write failed: %s", exc)
+            except Exception:  # noqa: BLE001 - audit must never crash the loop
+                self.metrics.audit_writes.add(1, {"outcome": "error"})
+                logger.exception("audit record serialization failed")
+            finally:
+                self.metrics.audit_queue_depth.add(-1)
+                self.queue.task_done()
+
+    def _maybe_rotate(self, next_record_bytes: int) -> None:
+        """Open a new file if the date rolled or the size cap would be hit.
+
+        Called synchronously from the writer loop. Closes the previous fd
+        if one was open; opens the new one with O_WRONLY|O_APPEND|O_CREAT
+        and mode 0o600.
+        """
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        date_changed = self.rotate_utc_midnight and self._current_date != today
+        size_exceeded = (
+            self._current_fd != -1 and self._current_size + next_record_bytes > self.max_file_bytes
+        )
+        first_open = self._current_fd == -1
+
+        if not (date_changed or size_exceeded or first_open):
+            return  # current file is fine
+
+        if date_changed:
+            self._current_suffix = 0  # new day, reset
+        elif size_exceeded:
+            self._current_suffix += 1  # same day, next slot
+
+        if self._current_fd != -1:
+            try:
+                os.close(self._current_fd)
+            except OSError:
+                pass
+            self._current_fd = -1
+
+        self._current_date = today
+        suffix_part = f".{self._current_suffix}" if self._current_suffix else ""
+        path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
+
+        # If we picked a path that already exists at non-zero size (e.g. server
+        # restart mid-day), respect its existing size for cap accounting.
+        try:
+            existing_size = path.stat().st_size if path.exists() else 0
+        except OSError:
+            existing_size = 0
+
+        # If existing file is already over the cap, bump suffix until we find
+        # a fresh slot. Bounded loop — operators can't realistically have 1000
+        # rotations in one day.
+        while existing_size >= self.max_file_bytes and self._current_suffix < 1000:
+            self._current_suffix += 1
+            suffix_part = f".{self._current_suffix}"
+            path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
+            try:
+                existing_size = path.stat().st_size if path.exists() else 0
+            except OSError:
+                existing_size = 0
+
+        try:
+            self._current_fd = os.open(
+                str(path),
+                os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+                0o600,
+            )
+            self._current_path = path
+            self._current_size = existing_size
+        except OSError as exc:
+            logger.warning("audit open failed for %s: %s", path, exc)
+            self._current_fd = -1
+            self._current_path = None
+            self._current_size = 0
+
+
+def _utc_iso_timestamp(epoch_seconds: float) -> str:
+    """ISO 8601 UTC with microsecond precision, trailing Z."""
+    dt = datetime.fromtimestamp(epoch_seconds, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond:06d}Z"
+
+
+def _target_for(event: "Event") -> dict[str, str]:
+    if event.channel:
+        return {"kind": "channel", "name": event.channel}
+    target_name = event.data.get("target", "") if isinstance(event.data, dict) else ""
+    if target_name:
+        return {"kind": "nick", "name": target_name}
+    return {"kind": "", "name": ""}
+
+
+def _build_audit_record(
+    server_name: str,
+    event: "Event",
+    origin_tag: str | None,
+    trace_id: str,
+    span_id: str,
+    *,
+    actor_kind: str = "human",
+    actor_remote_addr: str = "",
+    extra_tags: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a schema-compliant audit record dict.
+
+    See culture/protocol/extensions/audit.md for the field set.
+    """
+    payload = {k: v for k, v in (event.data or {}).items() if not k.startswith("_")}
+    if event.nick:
+        payload.setdefault("nick", event.nick)
+    if event.channel:
+        payload.setdefault("channel", event.channel)
+
+    event_type_str = event.type.value if hasattr(event.type, "value") else str(event.type)
+
+    return {
+        "ts": _utc_iso_timestamp(event.timestamp),
+        "server": server_name,
+        "event_type": event_type_str,
+        "origin": "federated" if origin_tag else "local",
+        "peer": origin_tag or "",
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "actor": {
+            "nick": event.nick or "",
+            "kind": actor_kind,
+            "remote_addr": actor_remote_addr,
+        },
+        "target": _target_for(event),
+        "payload": payload,
+        "tags": dict(extra_tags) if extra_tags else {},
+    }
+
+
+def init_audit(config: ServerConfig, metrics: "MetricsRegistry") -> AuditSink:
+    """Construct an AuditSink from config. Idempotent.
+
+    NOT gated by `config.telemetry.enabled` — audit fires whenever
+    `audit_enabled=True`, even with OTEL fully off.
+    """
+    global _initialized_for, _sink
+
+    tcfg = config.telemetry
+    snapshot = {"telemetry": asdict(tcfg), "instance": config.name}
+    if _initialized_for == snapshot and _sink is not None:
+        return _sink
+
+    audit_dir = Path(tcfg.audit_dir).expanduser()
+
+    sink = AuditSink(
+        server_name=config.name,
+        audit_dir=audit_dir,
+        max_file_bytes=tcfg.audit_max_file_bytes,
+        rotate_utc_midnight=tcfg.audit_rotate_utc_midnight,
+        queue_depth=tcfg.audit_queue_depth,
+        enabled=tcfg.audit_enabled,
+        metrics=metrics,
+    )
+
+    _sink = sink
+    _initialized_for = snapshot
+    return sink
+
+
+def reset_for_tests() -> None:
+    """Test-only: clear module state. Caller is responsible for shutting
+    down any active sink before calling this."""
+    global _initialized_for, _sink
+    _initialized_for = None
+    _sink = None

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -21,7 +21,6 @@ import asyncio
 import json
 import logging
 import os
-import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -74,17 +73,20 @@ class AuditSink:
 
     def submit(self, record: dict) -> None:
         """Non-blocking enqueue. Drop on overflow or when disabled."""
-        if not self.enabled or self.queue is None:
+        if not self.enabled:
+            return
+        if self.queue is None:
+            # start() not yet called — record cannot be enqueued. Count and
+            # log so this state is observable rather than a silent vanish.
+            self.metrics.audit_writes.add(1, {"outcome": "error"})
+            logger.warning("audit submit called before start(); dropped 1 record")
             return
         try:
             self.queue.put_nowait(record)
             self.metrics.audit_queue_depth.add(1)
         except asyncio.QueueFull:
             self.metrics.audit_writes.add(1, {"outcome": "error"})
-            print(
-                f"audit queue full (depth={self.queue_depth}); dropped 1 record",
-                file=sys.stderr,
-            )
+            logger.warning("audit queue full (depth=%d); dropped 1 record", self.queue_depth)
 
     async def start(self) -> None:
         """Create the audit directory if missing, then spawn the writer task.
@@ -128,7 +130,12 @@ class AuditSink:
 
     async def _writer_loop(self) -> None:
         """Drain the queue forever, JSON-encoding and appending each record."""
-        assert self.queue is not None
+        if self.queue is None:
+            # Should never happen — start() always assigns the queue before
+            # spawning this task — but guard against `python -O` stripping
+            # the assert, which would mask a real bug.
+            logger.error("audit writer task started without a queue; exiting")
+            return
         while True:
             record = await self.queue.get()
             try:
@@ -173,13 +180,6 @@ class AuditSink:
         elif size_exceeded:
             self._current_suffix += 1  # same day, next slot
 
-        if self._current_fd != -1:
-            try:
-                os.close(self._current_fd)
-            except OSError:
-                pass
-            self._current_fd = -1
-
         self._current_date = today
         suffix_part = f".{self._current_suffix}" if self._current_suffix else ""
         path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
@@ -203,19 +203,30 @@ class AuditSink:
             except OSError:
                 existing_size = 0
 
+        old_fd = self._current_fd
         try:
-            self._current_fd = os.open(
+            new_fd = os.open(
                 str(path),
                 os.O_WRONLY | os.O_APPEND | os.O_CREAT,
                 0o600,
             )
-            self._current_path = path
-            self._current_size = existing_size
         except OSError as exc:
-            logger.warning("audit open failed for %s: %s", path, exc)
-            self._current_fd = -1
-            self._current_path = None
-            self._current_size = 0
+            # New open failed — keep the old fd usable so the next record may
+            # still write to the previous file. If old_fd was -1 we degrade to
+            # silent-drop (counter increments via writer-loop OSError branch on
+            # next write attempt — which will retry rotation).
+            logger.error("audit open failed for %s: %s — keeping previous fd open", path, exc)
+            return
+
+        # New fd opened successfully — now close the old one if there was one.
+        if old_fd != -1:
+            try:
+                os.close(old_fd)
+            except OSError:
+                pass
+        self._current_fd = new_fd
+        self._current_path = path
+        self._current_size = existing_size
 
 
 def _utc_iso_timestamp(epoch_seconds: float) -> str:
@@ -288,6 +299,17 @@ def init_audit(config: ServerConfig, metrics: "MetricsRegistry") -> AuditSink:
     if _initialized_for == snapshot and _sink is not None:
         return _sink
 
+    # Reinit: warn the caller that the previous sink is being replaced
+    # without an explicit shutdown. Production callers should call
+    # `await sink.shutdown()` themselves before reinit; this branch
+    # primarily protects test isolation.
+    if _sink is not None and _sink._writer_task is not None:
+        logger.warning(
+            "init_audit called with mutated config but previous sink is still "
+            "running; the old writer task will be orphaned. Caller should "
+            "await sink.shutdown() before reinit."
+        )
+
     audit_dir = Path(tcfg.audit_dir).expanduser()
 
     sink = AuditSink(
@@ -309,5 +331,10 @@ def reset_for_tests() -> None:
     """Test-only: clear module state. Caller is responsible for shutting
     down any active sink before calling this."""
     global _initialized_for, _sink
+    if _sink is not None and _sink._writer_task is not None:
+        logger.warning(
+            "reset_for_tests called while sink writer task still running; "
+            "test should `await sink.shutdown()` before reset_for_tests."
+        )
     _initialized_for = None
     _sink = None

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -38,6 +38,22 @@ _initialized_for: dict | None = None
 _sink: "AuditSink | None" = None
 
 
+def _write_all(fd: int, buf: bytes) -> int:
+    """Write ``buf`` fully to ``fd``, looping over short writes.
+
+    Returns the total bytes written. Raises OSError on hard failure.
+    """
+    written = 0
+    view = memoryview(buf)
+    while written < len(buf):
+        n = os.write(fd, view[written:])
+        if n == 0:
+            # POSIX write should never return 0 unless len(buf) is 0.
+            raise OSError("os.write returned 0 — refusing to spin")
+        written += n
+    return written
+
+
 @dataclass
 class AuditSink:
     """Async-safe JSONL audit sink.
@@ -98,7 +114,7 @@ class AuditSink:
             return
         if self._writer_task is not None:
             return
-        self.audit_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        await asyncio.to_thread(self.audit_dir.mkdir, parents=True, exist_ok=True, mode=0o700)
         self.queue = asyncio.Queue(maxsize=self.queue_depth)
         self._writer_task = asyncio.create_task(self._writer_loop(), name="audit-writer")
 
@@ -139,11 +155,11 @@ class AuditSink:
         while True:
             record = await self.queue.get()
             try:
-                line = json.dumps(record, separators=(",", ":")) + "\n"
+                line = json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n"
                 line_bytes = line.encode("utf-8")
                 self._maybe_rotate(len(line_bytes))
                 if self._current_fd != -1:
-                    os.write(self._current_fd, line_bytes)
+                    _write_all(self._current_fd, line_bytes)
                     self._current_size += len(line_bytes)
                     self.metrics.audit_writes.add(1, {"outcome": "ok"})
                 else:
@@ -158,12 +174,56 @@ class AuditSink:
                 self.metrics.audit_queue_depth.add(-1)
                 self.queue.task_done()
 
+    def _pick_rotation_path(self, today: str) -> tuple[Path, int, int]:
+        """Find the next audit file path for *today* with available capacity.
+
+        Returns (path, suffix, existing_size). The suffix is written back to
+        ``self._current_suffix`` by the caller so subsequent writes continue
+        appending to the same slot.
+        """
+        suffix_part = f".{self._current_suffix}" if self._current_suffix else ""
+        path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
+
+        # Respect existing file size so a mid-day restart honours the cap.
+        try:
+            existing_size = path.stat().st_size if path.exists() else 0
+        except OSError:
+            existing_size = 0
+
+        # Bump suffix until we find a slot below the cap (bounded to 1000).
+        while existing_size >= self.max_file_bytes and self._current_suffix < 1000:
+            self._current_suffix += 1
+            suffix_part = f".{self._current_suffix}"
+            path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
+            try:
+                existing_size = path.stat().st_size if path.exists() else 0
+            except OSError:
+                existing_size = 0
+
+        return path, self._current_suffix, existing_size
+
+    def _open_audit_file(self, path: Path) -> int:
+        """Open *path* for append-write and enforce 0600 permissions.
+
+        Returns the new file descriptor. Raises ``OSError`` on failure.
+        Using ``os.fchmod`` on the open fd avoids a race window between
+        open and a separate ``path.chmod`` call.
+        """
+        new_fd = os.open(
+            str(path),
+            os.O_WRONLY | os.O_APPEND | os.O_CREAT,
+            0o600,
+        )
+        # Enforce 0600 even if the file pre-existed with broader perms.
+        os.fchmod(new_fd, 0o600)
+        return new_fd
+
     def _maybe_rotate(self, next_record_bytes: int) -> None:
         """Open a new file if the date rolled or the size cap would be hit.
 
         Called synchronously from the writer loop. Closes the previous fd
         if one was open; opens the new one with O_WRONLY|O_APPEND|O_CREAT
-        and mode 0o600.
+        and mode 0o600 (enforced via fchmod on the open fd).
         """
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         date_changed = self.rotate_utc_midnight and self._current_date != today
@@ -181,35 +241,11 @@ class AuditSink:
             self._current_suffix += 1  # same day, next slot
 
         self._current_date = today
-        suffix_part = f".{self._current_suffix}" if self._current_suffix else ""
-        path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
-
-        # If we picked a path that already exists at non-zero size (e.g. server
-        # restart mid-day), respect its existing size for cap accounting.
-        try:
-            existing_size = path.stat().st_size if path.exists() else 0
-        except OSError:
-            existing_size = 0
-
-        # If existing file is already over the cap, bump suffix until we find
-        # a fresh slot. Bounded loop — operators can't realistically have 1000
-        # rotations in one day.
-        while existing_size >= self.max_file_bytes and self._current_suffix < 1000:
-            self._current_suffix += 1
-            suffix_part = f".{self._current_suffix}"
-            path = self.audit_dir / f"{self.server_name}-{today}{suffix_part}.jsonl"
-            try:
-                existing_size = path.stat().st_size if path.exists() else 0
-            except OSError:
-                existing_size = 0
+        path, _, existing_size = self._pick_rotation_path(today)
 
         old_fd = self._current_fd
         try:
-            new_fd = os.open(
-                str(path),
-                os.O_WRONLY | os.O_APPEND | os.O_CREAT,
-                0o600,
-            )
+            new_fd = self._open_audit_file(path)
         except OSError as exc:
             # New open failed — keep the old fd usable so the next record may
             # still write to the previous file. If old_fd was -1 we degrade to

--- a/culture/telemetry/metrics.py
+++ b/culture/telemetry/metrics.py
@@ -60,6 +60,9 @@ class MetricsRegistry:
     client_command_duration: Histogram
     # Trace-context hygiene
     trace_inbound: Counter
+    # Audit (Plan 4)
+    audit_writes: Counter
+    audit_queue_depth: UpDownCounter
 
 
 def reset_for_tests() -> None:
@@ -155,6 +158,15 @@ def _build_registry(meter: Meter) -> MetricsRegistry:
         trace_inbound=meter.create_counter(
             "culture.trace.inbound",
             description="Inbound traceparent extraction outcome by result and peer",
+        ),
+        # Audit (Plan 4)
+        audit_writes=meter.create_counter(
+            "culture.audit.writes",
+            description="Audit JSONL write outcomes (ok|error)",
+        ),
+        audit_queue_depth=meter.create_up_down_counter(
+            "culture.audit.queue_depth",
+            description="Audit queue depth (records waiting to flush to disk)",
         ),
     )
 

--- a/docs/agentirc/audit.md
+++ b/docs/agentirc/audit.md
@@ -1,0 +1,141 @@
+---
+layout: default
+title: Audit Log
+parent: AgentIRC
+nav_order: 91
+---
+
+# Audit Log
+
+Every event the server emits — PRIVMSG, NOTICE, JOIN, PART, ROOMCREATE, federated peer events, ROOMARCHIVE, and so on — is appended as a single JSON object to a daily-rotated JSONL file. PARSE_ERROR lines from malformed inbound traffic are also captured. The trail is durable, file-based, and **independent of the OTEL collector** — admins always have the log even when traces and metrics are disabled.
+
+Available since **culture 8.5.0**.
+
+## Where files live
+
+By default: `~/.culture/audit/<server>-<YYYY-MM-DD>.jsonl` (UTC date).
+
+- **File mode:** `0600` (owner read/write only).
+- **Directory mode:** `0700`.
+
+Override via `~/.culture/server.yaml`:
+
+```yaml
+telemetry:
+  audit_enabled: true              # default; set false to disable
+  audit_dir: ~/.culture/audit      # absolute paths also accepted
+  audit_max_file_bytes: 268435456  # 256 MiB; size-cap rotation
+  audit_rotate_utc_midnight: true  # daily rotation
+  audit_queue_depth: 10000         # bounded async queue
+```
+
+`audit_enabled` is **independent of `telemetry.enabled`** — even with OTEL fully off, the JSONL still writes. The audit pillar is "always on by default."
+
+## Inspecting the trail
+
+Tail the live file:
+
+```bash
+tail -f ~/.culture/audit/spark-$(date -u +%F).jsonl | jq
+```
+
+All events for a specific channel:
+
+```bash
+jq -c 'select(.target.kind == "channel" and .target.name == "#general")' \
+  ~/.culture/audit/spark-2026-04-27.jsonl
+```
+
+Federated events from a specific peer:
+
+```bash
+jq -c 'select(.origin == "federated" and .peer == "alpha")' \
+  ~/.culture/audit/spark-*.jsonl
+```
+
+PARSE_ERROR records (malformed inbound):
+
+```bash
+jq -c 'select(.event_type == "PARSE_ERROR")' \
+  ~/.culture/audit/spark-*.jsonl
+```
+
+Replay a single trace across the JSONL — given a trace_id from your tracing backend:
+
+```bash
+jq -c 'select(.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736")' \
+  ~/.culture/audit/spark-*.jsonl
+```
+
+Every record carries `trace_id` / `span_id` from the active `irc.event.emit` span when telemetry is enabled — that's how you bridge from your trace backend (Tempo / Jaeger / Honeycomb) into the audit log for full reconstruction.
+
+## Record schema
+
+See [`culture/protocol/extensions/audit.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/audit.md) for the full schema, field semantics, and stable-contract policy. Quick summary:
+
+| Field | Purpose |
+|-------|---------|
+| `ts` | ISO 8601 UTC with microseconds. |
+| `server` | Local server name. |
+| `event_type` | `EventType.value` (e.g. `message`, `user.join`) or `PARSE_ERROR`. |
+| `origin` | `local` or `federated`. |
+| `peer` | Sending peer name when federated; `""` otherwise. |
+| `trace_id`, `span_id` | OTEL span context for cross-pillar joins; `""` if no active span. |
+| `actor` | `{nick, kind, remote_addr}` where `kind` is one of `human`, `bot`, `harness`. v1 always emits `human`. |
+| `target` | `{kind, name}` where `kind` is `channel`, `nick`, or `""` for global events. |
+| `payload` | `event.data` with underscore-prefix keys stripped (`_origin` etc.). |
+| `tags` | At most `culture.dev/traceparent` derived from the active span. |
+
+The schema is a stable contract: future additions are additive only (new keys); existing keys keep their type and semantics.
+
+## Rotation
+
+Two triggers (whichever fires first):
+
+1. **Daily** — UTC midnight starts a fresh file with the new date.
+2. **Size cap** — at `audit_max_file_bytes` (default 256 MiB), the next record opens a new file with `.1`, `.2`, … suffix.
+
+A single record larger than the size cap is still written — it lands in its own freshly-rotated file.
+
+## Durability tradeoffs
+
+- **Bounded queue.** Records flow through a `asyncio.Queue` of depth `audit_queue_depth`. On overflow the record is dropped and `culture.audit.writes{outcome=error}` increments. A stderr warning is logged.
+- **No `fsync` per record.** Writes hit the page cache; the OS flushes on its own schedule. A hard crash can lose the in-flight record.
+- **Single writer task.** All disk writes go through one async task — atomic per-record append, no interleaving.
+
+The drop-on-overflow choice is deliberate: a brief audit gap during a flood is recoverable; a blocked event loop is catastrophic. If you see frequent `outcome=error` you have a downstream IO problem (slow disk, fsync storm in another process, etc.).
+
+## Disabling audit
+
+```yaml
+telemetry:
+  audit_enabled: false
+```
+
+Restart the server. The audit directory is left untouched; existing files stay where they are.
+
+## Retention
+
+Files are not auto-pruned in 8.5.0 — operators prune manually:
+
+```bash
+find ~/.culture/audit -name 'spark-*.jsonl*' -mtime +30 -delete
+```
+
+A future `audit-prune` CLI is on the roadmap.
+
+## Health metrics
+
+Two metrics surface the audit pipeline's health (collected via the OTEL collector when telemetry is enabled):
+
+- `culture.audit.writes{outcome=ok|error}` — write attempt count. A non-zero `outcome=error` rate indicates dropped records (queue overflow or IO failure).
+- `culture.audit.queue_depth` — currently-queued records waiting to flush. Steady-state should be near zero; a rising trend means the writer task can't keep up.
+
+These appear in Grafana / Prometheus dashboards alongside the rest of the `culture.*` metrics from 8.4.0.
+
+## Known limitations (v1)
+
+- **`actor.kind` is always `human` in 8.5.0.** Plan 5 (harness) and Plan 6 (bots) will refine to `bot`/`harness` based on the connection type.
+- **`actor.remote_addr` is empty for events emitted from server-internal sites** (skills, system bot). Populated for `Client._process_buffer` PARSE_ERRORs.
+- **Federated lifecycle events (JOIN/PART/QUIT) on the receiver side are not yet surfaced** — only federated `message` events produce audit records. Tracking gap in [#296](https://github.com/agentculture/culture/issues/296).
+- **No OTEL Logs export.** JSONL is the source of truth; future plans may add a best-effort duplicate via the OTEL Logs API.

--- a/docs/agentirc/audit.md
+++ b/docs/agentirc/audit.md
@@ -133,6 +133,19 @@ Two metrics surface the audit pipeline's health (collected via the OTEL collecto
 
 These appear in Grafana / Prometheus dashboards alongside the rest of the `culture.*` metrics from 8.4.0.
 
+## Public API
+
+For embedding the audit pipeline in custom code (e.g. an external admin tool that wants to write into the same JSONL), `culture.telemetry` re-exports four symbols:
+
+| Symbol | Purpose |
+|--------|---------|
+| `AuditSink` | The dataclass that owns the queue + writer task + rotation. |
+| `init_audit(config, metrics)` | Idempotent constructor; mirrors `init_metrics` / `init_telemetry`. |
+| `build_audit_record(server_name, event, origin_tag, trace_id, span_id, ...)` | Build a schema-compliant record dict from an `Event`. Used by `IRCd.emit_event`. |
+| `utc_iso_timestamp(epoch_seconds)` | Format a `time.time()` value as the ISO 8601 UTC string the `ts` field expects. Used by `Client._process_buffer` for PARSE_ERROR records. |
+
+PARSE_ERROR records cannot go through `build_audit_record` (no `Event` object) — callers construct the dict inline using `utc_iso_timestamp` for the `ts` field and the schema in [`audit.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/audit.md) for everything else.
+
 ## Known limitations (v1)
 
 - **`actor.kind` is always `human` in 8.5.0.** Plan 5 (harness) and Plan 6 (bots) will refine to `bot`/`harness` based on the connection type.

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -9,7 +9,7 @@ nav_order: 90
 
 Culture ships with first-class OpenTelemetry support: traces for every IRC command and event, W3C trace context carried across federation via a new IRCv3 tag, and a local collector pattern that keeps Culture's surface small.
 
-This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), and the **Metrics Pillar** (culture 8.4.0). Audit, harness instrumentation, and bot instrumentation ship in subsequent releases.
+This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), the **Metrics Pillar** (culture 8.4.0), and the **Audit JSONL Sink** (culture 8.5.0). Harness and bot instrumentation ship in subsequent releases.
 
 ## What you get in 8.2.0
 
@@ -102,6 +102,11 @@ telemetry:
   traces_sampler: parentbased_always_on
   metrics_enabled: true
   metrics_export_interval_ms: 10000
+  audit_enabled: true
+  audit_dir: ~/.culture/audit
+  audit_max_file_bytes: 268435456
+  audit_rotate_utc_midnight: true
+  audit_queue_depth: 10000
 ```
 
 - `enabled: false` (default) → no SDK init, no export, no overhead. Traceparent tags on inbound messages are still parsed and validated (for the future mitigation metric), but no spans are created.
@@ -128,13 +133,34 @@ When telemetry is enabled and a span is active, outbound client messages carry t
 
 Protocol details, length caps, and inbound mitigation rules: see [`tracing.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/tracing.md) (lives under `culture/` in the repo; Jekyll excludes that path from the published site).
 
-## What's not in 8.4.0
+## What you get in 8.5.0
+
+The audit JSONL sink lands: every event flowing through `IRCd.emit_event` (PRIVMSG, JOIN, PART, ROOMCREATE, …) is appended as a single JSON object to `~/.culture/audit/<server>-<YYYY-MM-DD>.jsonl`. Each line carries the full event payload, the active OTEL `trace_id` / `span_id` for cross-pillar joins, the actor (nick + kind + remote_addr), and the target (channel or DM). PARSE_ERROR lines from `Client._process_buffer` are also captured.
+
+Highlights:
+
+- **Always on by default.** `audit_enabled: true` is independent of `telemetry.enabled` — even with OTEL fully off, the JSONL still writes. Set `audit_enabled: false` to disable.
+- **Bounded async queue + dedicated writer task.** `audit_queue_depth: 10000` (configurable). On overflow, the record is dropped and `culture.audit.writes{outcome=error}` increments — dropping is preferable to blocking the event loop.
+- **Daily rotation on UTC midnight + size cap at 256 MiB.** Same-day size rotations get `.1`, `.2`, … suffixes.
+- **`0600` file mode, `0700` directory mode** — admin-only by construction.
+- **Stable schema.** See [`audit.md`](https://github.com/agentculture/culture/blob/main/culture/protocol/extensions/audit.md) for the record format and additive-only compat policy.
+
+New audit metrics (extend the Plan 3 `MetricsRegistry`):
+
+- `culture.audit.writes` — Counter. Labels: `outcome=ok|error`. Increments on every record write attempt.
+- `culture.audit.queue_depth` — UpDownCounter. Currently-queued records waiting to flush.
+
+New operator guide: [`docs/agentirc/audit.md`](audit.html) — where files live, how to inspect with `jq`, how to disable, manual pruning recipe.
+
+## What's not in 8.5.0
 
 The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces ship in later releases:
 
-- Audit JSONL sink + audit metrics (`culture.audit.writes`, `culture.audit.queue_depth`).
 - Harness-side tracing for `claude`/`codex`/`copilot`/`acp` + harness LLM metrics (`culture.harness.llm.*`).
 - Bot webhook HTTP instrumentation + bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`).
-- Outbound `culture.s2s.messages` (8.4.0 records inbound only — outbound needs a clean verb-extraction site without parsing every `send_raw` line).
+- Outbound `culture.s2s.messages` (records inbound only — outbound needs a clean verb-extraction site).
+- OTEL Logs export of audit records (best-effort duplicate; JSONL stays source of truth either way).
+- `audit-prune` CLI for retention; operators prune manually in v1.
+- Federated lifecycle audit (JOIN/PART/QUIT on the receiver side) — gap tracked in [#296](https://github.com/agentculture/culture/issues/296). Federated `message` events DO produce audit records correctly.
 
 Each will get an entry under "What you get in \<version\>" as it lands.

--- a/docs/superpowers/plans/2026-04-27-otel-audit.md
+++ b/docs/superpowers/plans/2026-04-27-otel-audit.md
@@ -1,0 +1,247 @@
+# OTEL Audit JSONL Sink Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the third observability pillar — a durable, file-based JSONL audit log capturing every event the server emits, independent of the OTEL collector. Admin-only "who said what to whom, when" trail.
+
+**Architecture:** New `culture/telemetry/audit.py` with an `AuditSink` (bounded asyncio.Queue + dedicated writer task + file rotation). `IRCd.__init__` constructs the sink via `init_audit(config, metrics)`; `IRCd.start()`/`stop()` own the writer-task lifecycle. `IRCd.emit_event` calls `audit.submit(record)` after the existing span/metrics work. Records follow the schema in `culture/protocol/extensions/audit.md` (a stable contract). Two new metrics extend the Plan-3 `MetricsRegistry`: `culture.audit.writes{outcome}` and `culture.audit.queue_depth`.
+
+**Tech Stack:** Python stdlib `asyncio` + `os.write` for atomic appends; no new dependencies. Reuses Plan-3's `MetricsRegistry` extension pattern.
+
+---
+
+## Context
+
+Plans 1–3 shipped the **traces** and **metrics** pillars of OTEL. Plan 4 adds the **audit JSONL sink** — a separate, durable, file-based "who said what to whom, when" trail. Audit is the spec's third observability question (`docs/superpowers/specs/2026-04-24-otel-observability-design.md` §Context line 5):
+
+- **Trace context** (Plans 1–2) → "where did a flow stall?"
+- **Metrics** (Plan 3) → "is the mesh healthy?"
+- **Audit log** (Plan 4) → "who said what, when, via what path?"
+
+Audit is independent of the OTEL collector — JSONL on local disk, never depends on a running `otelcol-contrib`. After this ships, an admin can `tail ~/.culture/audit/<server>-YYYY-MM-DD.jsonl | jq` and replay every event the server has emitted, including federated ones.
+
+The OTEL Logs export of audit records (spec line 192, "best-effort duplicate") is **deferred** to a future task — Plan 4 is JSONL-only. JSONL is source of truth either way; OTEL log dual-export is a nice-to-have we can layer on once the audit format is stable.
+
+## Critical files to read before implementing
+
+- `docs/superpowers/specs/2026-04-24-otel-observability-design.md:147-192` — audit metrics + audit log section (record schema, durability, rotation, retention).
+- `docs/superpowers/plans/2026-04-26-otel-metrics.md` — Plan 3 reference for the `MetricsRegistry` extension pattern, `init_metrics` shape, fixture pattern.
+- `culture/telemetry/metrics.py` — pattern to mirror (idempotency snapshot, no-op when disabled, extension comment on `MetricsRegistry`).
+- `culture/agentirc/ircd.py:217-241` — `emit_event` (the single audit submit site).
+- `culture/agentirc/client.py:127-160` — `_process_buffer` (the PARSE_ERROR submit site; already has parse-exception compensation as a span event).
+- `culture/agentirc/skill.py:14-44` — `Event`/`EventType` definitions.
+- `culture/agentirc/config.py` — `TelemetryConfig` (extend with audit fields).
+- `culture/protocol/extensions/` — siblings (`tracing.md`, `events.md`, etc.) for tone/format of the new `audit.md`.
+
+## Approach
+
+### 1. Config — extend `TelemetryConfig`
+
+Add to `culture/agentirc/config.py::TelemetryConfig`:
+
+```python
+audit_enabled: bool = True  # independent of `enabled` — audit fires even with telemetry off
+audit_dir: str = "~/.culture/audit"
+audit_max_file_bytes: int = 256 * 1024 * 1024  # 256 MiB
+audit_rotate_utc_midnight: bool = True
+audit_queue_depth: int = 10000
+```
+
+Critically: `audit_enabled` is **not** gated by the parent `enabled`. Audit is the spec's "always-on" property — even with `telemetry.enabled=False`, the JSONL still writes. Default `True` so freshly-installed servers get audit out of the box.
+
+### 2. Protocol extension — `culture/protocol/extensions/audit.md`
+
+New page documenting the JSONL record schema as a stable contract. Sections:
+
+- **File layout**: `~/.culture/audit/<server>-YYYY-MM-DD.jsonl` (UTC date), `0600` file mode, `0700` directory mode, optional rotation suffix `.<n>` when same-day size cap hits twice.
+- **Record schema** verbatim from spec line 172-185 with field descriptions.
+- **Rotation**: daily on UTC midnight + 256 MiB whichever first.
+- **Durability**: bounded queue, async writer, drop-on-overflow with stderr warning.
+- **Retention**: not auto-pruned in v1 (TODO: future `audit-prune` CLI).
+- **Compat**: additive; record-level fields can be added in future versions; downstream consumers must tolerate unknown keys.
+
+### 3. New module `culture/telemetry/audit.py`
+
+```python
+@dataclass
+class AuditSink:
+    """Bounded async queue + dedicated writer task + JSONL file rotation."""
+    config: ServerConfig
+    metrics: MetricsRegistry
+    enabled: bool
+    queue: asyncio.Queue[dict] | None = None
+    writer_task: asyncio.Task | None = None
+    current_path: Path | None = None
+    current_size: int = 0
+    current_date: date | None = None
+
+    def submit(self, record: dict) -> None:
+        """Non-blocking enqueue. On overflow, drop + count error."""
+        ...
+
+    async def start(self) -> None:
+        """Spawn writer task; ensure dir 0700; open current file."""
+        ...
+
+    async def shutdown(self, *, drain_timeout: float = 5.0) -> None:
+        """Drain queue (bounded by timeout) then cancel writer task."""
+        ...
+
+    async def _writer_loop(self) -> None:
+        """json.dumps each record, _maybe_rotate, os.write append."""
+        ...
+
+    def _maybe_rotate(self, next_record_bytes: int) -> None:
+        """Date roll or size cap → open new file with .N suffix."""
+        ...
+
+
+def init_audit(config: ServerConfig, metrics: MetricsRegistry) -> AuditSink:
+    """Idempotent. When disabled, sink.submit() is no-op."""
+    ...
+
+
+def reset_for_tests() -> None:
+    ...
+```
+
+Key implementation details:
+
+- Writer uses `os.open(path, O_WRONLY|O_APPEND|O_CREAT, 0o600)` + `os.write` per record for atomic appends.
+- Directory is created with `mkdir(parents=True, exist_ok=True, mode=0o700)`.
+- `_maybe_rotate` is sync (no awaits inside the writer loop's hot path).
+- `~` in `audit_dir` expanded via `Path(...).expanduser()`.
+- No fsync per record (too slow per spec).
+
+### 4. Extend `MetricsRegistry` — Plan 3 carry-forward
+
+Add to `culture/telemetry/metrics.py::MetricsRegistry` and `_build_registry`:
+
+```python
+audit_writes: Counter
+audit_queue_depth: UpDownCounter
+```
+
+Names per spec: `culture.audit.writes` (labels: `outcome=ok|error`) and `culture.audit.queue_depth`.
+
+### 5. Wire `init_audit` into `IRCd` lifecycle
+
+```python
+# IRCd.__init__
+self.metrics = init_metrics(config)
+self.audit = init_audit(config, self.metrics)
+
+# IRCd.start (early, before listener bind)
+await self.audit.start()
+
+# IRCd.stop (end of teardown)
+await self.audit.shutdown()
+```
+
+### 6. Wire `submit()` into `IRCd.emit_event`
+
+Capture `trace_id`/`span_id` inside the `irc.event.emit` span, build the audit record outside it, call `self.audit.submit(record)`. Helper `_build_audit_record(server_name, event, origin_tag, trace_id, span_id) -> dict` produces the schema-compliant dict with payload (underscore-prefix keys stripped), actor (kind="human" for v1), target, tags (current `traceparent` only).
+
+### 7. PARSE_ERROR records
+
+In `culture/agentirc/client.py::_process_buffer`, the existing `except Exception as exc` handler emits a span event. Add `audit.submit({event_type: "PARSE_ERROR", line_preview, error_type, remote_addr, ...})` alongside.
+
+### 8. Test fixture `audit_dir`
+
+Add to `tests/conftest.py`:
+
+```python
+@pytest_asyncio.fixture
+async def audit_dir(tmp_path):
+    yield tmp_path
+```
+
+Tests build a `ServerConfig` with `telemetry.audit_dir=str(tmp_path)` and inspect file contents.
+
+### 9. Documentation
+
+- New `culture/protocol/extensions/audit.md` — record schema + file layout + rotation + retention.
+- `docs/agentirc/telemetry.md` — new "What you get in 8.5.0" section.
+- `docs/agentirc/audit.md` — operator guide (where files live, jq examples, disable instructions, prune TODO).
+
+### 10. Version bump
+
+`/version-bump minor` → `8.4.0` → `8.5.0`.
+
+## Files to modify / create
+
+**New:**
+
+- `culture/telemetry/audit.py` — `AuditSink`, `init_audit`, `reset_for_tests`, `_build_audit_record` helper.
+- `culture/protocol/extensions/audit.md` — record schema doc.
+- `docs/agentirc/audit.md` — operator guide.
+- `tests/telemetry/test_audit_basic.py`
+- `tests/telemetry/test_audit_rotation.py`
+- `tests/telemetry/test_audit_overflow.py`
+- `tests/telemetry/test_audit_disabled.py`
+- `tests/telemetry/test_audit_parse_error.py`
+- `tests/telemetry/test_audit_federation.py`
+
+**Modified:**
+
+- `culture/agentirc/config.py` — 5 audit fields on `TelemetryConfig`.
+- `culture/telemetry/metrics.py` — `audit_writes` + `audit_queue_depth` on `MetricsRegistry`.
+- `culture/telemetry/__init__.py` — re-export `AuditSink`, `init_audit`.
+- `culture/agentirc/ircd.py` — `__init__` + `start()` + `stop()` + `emit_event` audit submit.
+- `culture/agentirc/client.py` — `_process_buffer` PARSE_ERROR audit submit.
+- `tests/conftest.py` — `audit_dir` fixture.
+- `docs/agentirc/telemetry.md` — "What you get in 8.5.0".
+- `pyproject.toml`, `CHANGELOG.md` — version bump.
+
+## Tests
+
+Per-area tests in `tests/telemetry/test_audit_*.py`:
+
+1. **basic**: emit event → record on disk with right shape (ts, server, event_type, origin, peer, trace_id/span_id, actor, target, payload, tags). Underscore-prefix keys stripped from payload.
+2. **rotation**: monkey-patch the date for daily rotation; monkey-patch `audit_max_file_bytes` to a small value for size rotation. Assert two files with `.0`/`.1` suffix.
+3. **overflow**: queue depth 2; flood 10 submits; assert `outcome=error` counter ≥ 8.
+4. **disabled**: `audit_enabled=False` → no file. `telemetry.enabled=False, audit_enabled=True` → still writes.
+5. **parse_error**: send malformed line via raw bytes → `event_type: "PARSE_ERROR"` in JSONL.
+6. **federation**: `linked_servers` + per-server audit_dir; PRIVMSG from alpha → record on beta has `origin=federated, peer=alpha`.
+
+## Verification
+
+1. `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — full suite green (current baseline 1022).
+2. `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/telemetry/test_audit_*.py` — audit suite green.
+3. Manual: start a server with `audit_enabled=true`; connect weechat; send PRIVMSG/JOIN/PART; `tail ~/.culture/audit/<server>-*.jsonl | jq` — see records.
+4. Manual: start with `telemetry.enabled=false, audit_enabled=true`; verify audit still writes (independence).
+5. `Agent(subagent_type="doc-test-alignment", ...)` before first push.
+6. `Agent(subagent_type="superpowers:code-reviewer", ...)` on staged diff — `audit.py` is a new file with bounded-queue semantics + IO; the kind of choke-point CLAUDE.md calls for pre-push review on.
+7. `bash ~/.claude/skills/pr-review/scripts/pr-status.sh <PR>` after push.
+
+## Out of scope (future plans)
+
+- **OTEL Logs export** of audit records — JSONL is source of truth; OTEL Logs is additive. Defer.
+- **`audit-prune` CLI** — operators prune manually in v1.
+- **Capture inbound IRCv3 tag bag** in the `tags` field — v1 captures only the active span's `traceparent`. Capturing original wire tags would require threading the source `Message` through `emit_event`.
+- **`actor.remote_addr`** for non-Client paths — v1 leaves it empty for emit_event-from-server-internal sites.
+- **`actor.kind`** — defaults `"human"`. Plan 5/6 refines to `bot`/`harness`.
+- **fsync per record** — not in v1.
+
+## Carry-forward notes
+
+- **MetricsRegistry continues to grow.** Plan 5/6 will add `harness_*` / `bot_*` fields. Don't fork the dataclass.
+- **`audit_enabled` is not gated by `enabled`.** Future audit fields should follow the same gating.
+- **Record schema is a stable contract.** Future schema changes are additive only (new keys); existing keys keep their type.
+- **Path expansion.** Resolve `~` once at init; don't store the `~`-form internally.
+- **Writer task lifecycle.** Owned by `IRCd.start()` / `IRCd.stop()`. The shutdown drain is bounded.
+- **Tests use `await sink.queue.join()`** to drain before assertion.
+- **OTEL Logs export deferred** — when added, factor `_build_audit_record` so the same dict feeds both JSONL and the OTEL Logs API.
+
+## Phasing (suggested task breakdown for subagent execution)
+
+1. **Task 1**: TelemetryConfig audit fields + `culture/protocol/extensions/audit.md` schema doc.
+2. **Task 2**: `culture/telemetry/audit.py` — `AuditSink`, `init_audit`, lifecycle, rotation logic, isolated tests.
+3. **Task 3**: extend `MetricsRegistry` with `audit_writes` + `audit_queue_depth`.
+4. **Task 4**: wire `init_audit` + `start()`/`stop()` into `IRCd` lifecycle.
+5. **Task 5**: wire `submit()` into `IRCd.emit_event` (with `_build_audit_record` helper).
+6. **Task 6**: PARSE_ERROR audit records from `Client._process_buffer`.
+7. **Task 7**: integration tests (rotation under live IRCd, federation, disabled, queue overflow).
+8. **Task 8**: `docs/agentirc/telemetry.md` "What you get in 8.5.0" + `docs/agentirc/audit.md` operator guide.
+9. **Task 9**: version bump 8.4.0 → 8.5.0.
+10. **Task 10**: pre-push verification + open PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.4.0"
+version = "8.5.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import asyncio
 from unittest.mock import patch
 
+import pytest
 import pytest_asyncio
 from opentelemetry import metrics as otel_metrics
 from opentelemetry import trace
@@ -12,7 +13,7 @@ from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from culture.agentirc.config import LinkConfig, ServerConfig
+from culture.agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
 from culture.agentirc.ircd import IRCd
 from culture.telemetry.metrics import reset_for_tests as _reset_metrics
 from culture.telemetry.tracing import reset_for_tests as _reset_telemetry
@@ -104,7 +105,13 @@ async def server(tmp_path):
     # never read/write the real ~/.culture/bots/ directory.
     empty_bots = tmp_path / "_bots"
     empty_bots.mkdir()
-    config = ServerConfig(name="testserv", host="127.0.0.1", port=0, webhook_port=0)
+    config = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        webhook_port=0,
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit")),
+    )
     with (
         patch(_BOTS_DIR_MANAGER, empty_bots),
         patch(_BOTS_DIR_CONFIG, empty_bots),
@@ -157,6 +164,7 @@ async def linked_servers(tmp_path):
         port=0,
         webhook_port=0,
         links=[LinkConfig(name="beta", host="127.0.0.1", port=0, password=link_password)],
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit_alpha")),
     )
     config_b = ServerConfig(
         name="beta",
@@ -164,6 +172,7 @@ async def linked_servers(tmp_path):
         port=0,
         webhook_port=0,
         links=[LinkConfig(name="alpha", host="127.0.0.1", port=0, password=link_password)],
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit_beta")),
     )
 
     server_a = IRCd(config_a)
@@ -263,6 +272,7 @@ async def server_welcome_disabled(tmp_path):
         port=0,
         webhook_port=0,
         system_bots={"welcome": {"enabled": False}},
+        telemetry=TelemetryConfig(audit_dir=str(tmp_path / "audit")),
     )
     with (
         patch(_BOTS_DIR_MANAGER, empty_bots),
@@ -367,3 +377,13 @@ async def metrics_reader():
         yield reader
     finally:
         _reset_metrics()
+
+
+@pytest.fixture
+def audit_dir(tmp_path):
+    """Yields a Path for tests to use as `telemetry.audit_dir`.
+
+    Tests build a ServerConfig with `telemetry=TelemetryConfig(audit_dir=str(tmp_path))`
+    and inspect file contents via `Path(audit_dir).glob("*.jsonl*")`.
+    """
+    return tmp_path

--- a/tests/telemetry/test_audit_emit.py
+++ b/tests/telemetry/test_audit_emit.py
@@ -1,0 +1,145 @@
+"""Tests for IRCd.emit_event audit submit wiring.
+
+Verifies a single emit_event produces a JSONL record with the right
+shape (event_type, origin/peer, trace_id/span_id, actor, target,
+payload, tags). Federation, parse_error, and queue overflow live in
+their own test files (Tasks 6/7)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from culture.agentirc.config import ServerConfig, TelemetryConfig
+from culture.agentirc.ircd import IRCd
+from culture.agentirc.skill import Event, EventType
+
+
+def _build_server(audit_dir):
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    return IRCd(cfg)
+
+
+def _read_records(audit_dir, server_name="testserv"):
+    files = sorted(audit_dir.glob(f"{server_name}-*.jsonl*"))
+    out = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_emit_event_writes_audit_record(audit_dir, tracing_exporter):
+    server = _build_server(audit_dir)
+    await server.start()
+    try:
+        await server.emit_event(
+            Event(
+                type=EventType.MESSAGE,
+                channel="#test",
+                nick="testserv-alice",
+                data={"text": "hello world"},
+            )
+        )
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    records = _read_records(audit_dir)
+    # Records: SERVER_WAKE (from start), our MESSAGE, SERVER_SLEEP (from stop).
+    msg_records = [r for r in records if r["event_type"] == "message"]
+    assert len(msg_records) == 1, f"expected 1 message record, got {records}"
+    rec = msg_records[0]
+    assert rec["server"] == "testserv"
+    assert rec["origin"] == "local"
+    assert rec["peer"] == ""
+    assert rec["target"] == {"kind": "channel", "name": "#test"}
+    assert rec["actor"]["nick"] == "testserv-alice"
+    assert rec["actor"]["kind"] == "human"
+    assert rec["payload"]["text"] == "hello world"
+    assert rec["payload"]["nick"] == "testserv-alice"
+    assert rec["payload"]["channel"] == "#test"
+    # ts shape
+    assert "T" in rec["ts"] and rec["ts"].endswith("Z")
+    # trace_id/span_id may be empty if no span context wraps the
+    # caller, but emit_event opens its own span so they MUST be set.
+    assert len(rec["trace_id"]) == 32
+    assert len(rec["span_id"]) == 16
+    assert rec["tags"]["culture.dev/traceparent"].startswith("00-")
+    assert rec["trace_id"] in rec["tags"]["culture.dev/traceparent"]
+
+
+@pytest.mark.asyncio
+async def test_emit_event_strips_underscore_keys_from_payload(audit_dir):
+    server = _build_server(audit_dir)
+    await server.start()
+    try:
+        await server.emit_event(
+            Event(
+                type=EventType.MESSAGE,
+                channel="#test",
+                nick="testserv-bob",
+                data={
+                    "text": "hi",
+                    "_origin": "alpha",
+                    "_internal_state": "x",
+                },
+            )
+        )
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    records = _read_records(audit_dir)
+    msg_records = [r for r in records if r["event_type"] == "message"]
+    assert msg_records, f"expected message record, got {records}"
+    rec = msg_records[0]
+    assert "_origin" not in rec["payload"]
+    assert "_internal_state" not in rec["payload"]
+    # _origin makes the event federated.
+    assert rec["origin"] == "federated"
+    assert rec["peer"] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_emit_event_dm_target(audit_dir):
+    server = _build_server(audit_dir)
+    await server.start()
+    try:
+        await server.emit_event(
+            Event(
+                type=EventType.MESSAGE,
+                channel=None,
+                nick="testserv-alice",
+                data={"text": "secret", "target": "testserv-bob"},
+            )
+        )
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    records = _read_records(audit_dir)
+    msg_records = [r for r in records if r["event_type"] == "message"]
+    assert msg_records
+    rec = msg_records[0]
+    assert rec["target"] == {"kind": "nick", "name": "testserv-bob"}
+
+
+@pytest.mark.asyncio
+async def test_server_wake_and_sleep_appear_in_audit(audit_dir):
+    server = _build_server(audit_dir)
+    await server.start()
+    await server.stop()
+    records = _read_records(audit_dir)
+    types = [r["event_type"] for r in records]
+    assert "server.wake" in types
+    assert "server.sleep" in types

--- a/tests/telemetry/test_audit_federation.py
+++ b/tests/telemetry/test_audit_federation.py
@@ -1,0 +1,132 @@
+"""Federation audit records — federated events land in the receiver's
+audit log with origin=federated, peer=<peer_name>."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _read_records(audit_dir: Path, server_name: str) -> list[dict]:
+    files = sorted(audit_dir.glob(f"{server_name}-*.jsonl*"))
+    out: list[dict] = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_federated_message_event_audit_record(
+    linked_servers, make_client_a, make_client_b, tmp_path
+):
+    """A PRIVMSG that crosses alpha→beta should produce an audit record on
+    BOTH servers: origin=local on alpha, origin=federated peer=alpha on beta."""
+    server_a, server_b = linked_servers
+
+    # Both clients join a shared channel.
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    client_b = await make_client_b(nick="beta-bob", user="bob")
+    await client_a.send("JOIN #fed-audit")
+    await client_a.recv_all(timeout=0.5)
+    await client_b.send("JOIN #fed-audit")
+    await client_b.recv_all(timeout=0.5)
+    # Allow membership burst.
+    await asyncio.sleep(0.3)
+
+    # alpha-alice sends a channel message; it should arrive on beta as
+    # a federated MESSAGE event.
+    await client_a.send("PRIVMSG #fed-audit :hello-from-alpha")
+    await client_a.recv_all(timeout=0.5)
+
+    # Allow propagation + audit drain.
+    await asyncio.sleep(0.5)
+    await asyncio.wait_for(server_a.audit.queue.join(), timeout=2.0)
+    await asyncio.wait_for(server_b.audit.queue.join(), timeout=2.0)
+
+    audit_alpha = tmp_path / "audit_alpha"
+    audit_beta = tmp_path / "audit_beta"
+
+    records_alpha = _read_records(audit_alpha, "alpha")
+    records_beta = _read_records(audit_beta, "beta")
+
+    # On alpha: origin=local, peer="" for the originating MESSAGE.
+    alpha_msgs = [
+        r
+        for r in records_alpha
+        if r["event_type"] == "message" and r.get("payload", {}).get("text") == "hello-from-alpha"
+    ]
+    assert alpha_msgs, (
+        f"expected origin=local message on alpha, got: "
+        f"{[r['event_type'] for r in records_alpha]}"
+    )
+    assert alpha_msgs[0]["origin"] == "local"
+    assert alpha_msgs[0]["peer"] == ""
+    assert alpha_msgs[0]["actor"]["nick"] == "alpha-alice"
+
+    # On beta: origin=federated, peer=alpha for the relayed MESSAGE.
+    beta_msgs = [
+        r
+        for r in records_beta
+        if r["event_type"] == "message" and r.get("payload", {}).get("text") == "hello-from-alpha"
+    ]
+    assert beta_msgs, (
+        f"expected origin=federated message on beta, got: "
+        f"{[(r['event_type'], r.get('origin')) for r in records_beta]}"
+    )
+    assert beta_msgs[0]["origin"] == "federated"
+    assert beta_msgs[0]["peer"] == "alpha"
+    assert beta_msgs[0]["actor"]["nick"] == "alpha-alice"
+
+
+@pytest.mark.asyncio
+async def test_federated_join_no_user_join_audit_on_receiver(
+    linked_servers, make_client_a, tmp_path
+):
+    """Documents current behavior: SJOIN (federated JOIN) does NOT produce a
+    user.join audit record on the receiving server.
+
+    ServerLink._handle_sjoin processes SJOIN wire messages purely at the
+    channel-membership level — it does not call server.emit_event, so no
+    user.join record lands in the receiver's audit log.  Only events relayed
+    via SEVENT (e.g. PRIVMSG → message) flow through emit_event and produce
+    audit records.
+
+    This is a known gap: a future improvement should emit a federated user.join
+    event from _handle_sjoin so the audit is complete.  Until then this test
+    pins the current behavior so a regression is immediately visible if
+    _handle_sjoin is changed to emit the event.
+    """
+    _server_a, server_b = linked_servers
+    client_a = await make_client_a(nick="alpha-alice", user="alice")
+    await client_a.send("JOIN #fed-join")
+    await client_a.recv_all(timeout=0.5)
+    await asyncio.sleep(0.3)
+
+    await asyncio.wait_for(server_b.audit.queue.join(), timeout=2.0)
+
+    audit_beta = tmp_path / "audit_beta"
+    records = _read_records(audit_beta, "beta")
+    event_types = [r["event_type"] for r in records]
+
+    # Confirm the server.link events ARE present (federation link audit works).
+    assert "server.link" in event_types, f"expected server.link records on beta, got: {event_types}"
+
+    # The gap: user.join for the federated client is NOT currently produced.
+    # This assertion documents that and will break loudly if the behavior
+    # changes — at which point the test should be updated to assert
+    # origin=federated + peer=alpha on the new record.
+    join_records = [
+        r
+        for r in records
+        if r["event_type"] == "user.join" and r.get("actor", {}).get("nick") == "alpha-alice"
+    ]
+    assert not join_records, (
+        "SJOIN now emits a user.join audit record on the receiver — "
+        "update this test to assert origin=federated, peer=alpha on that record. "
+        f"Unexpected records: {join_records}"
+    )

--- a/tests/telemetry/test_audit_lifecycle.py
+++ b/tests/telemetry/test_audit_lifecycle.py
@@ -1,0 +1,69 @@
+"""Smoke test for IRCd-managed AuditSink lifecycle.
+
+This test exists to verify the wiring: IRCd.start() actually awaits
+sink.start(), and IRCd.stop() actually awaits sink.shutdown().
+The audit sink itself is exercised in test_audit_module.py; integration
+tests covering submit() during the lifecycle land in Task 5/Task 7."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.agentirc.config import ServerConfig, TelemetryConfig
+from culture.agentirc.ircd import IRCd
+from culture.telemetry.audit import reset_for_tests as _reset_audit
+from culture.telemetry.metrics import reset_for_tests as _reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_metrics()
+    _reset_audit()
+    yield
+    _reset_audit()
+    _reset_metrics()
+
+
+@pytest.mark.asyncio
+async def test_audit_sink_starts_and_shuts_down_with_ircd(audit_dir):
+    """IRCd.start() opens the audit dir and writer task; stop() drains it."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    server = IRCd(cfg)
+    assert server.audit is not None
+    assert server.audit._writer_task is None  # not started yet
+
+    await server.start()
+    try:
+        assert server.audit._writer_task is not None
+        assert audit_dir.exists()
+    finally:
+        await server.stop()
+
+    # After stop, the writer task should be cancelled.
+    assert server.audit._writer_task is None
+
+
+@pytest.mark.asyncio
+async def test_audit_disabled_does_not_create_directory(tmp_path):
+    """audit_enabled=False should not create the audit dir."""
+    audit_dir = tmp_path / "should-not-exist"
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(
+            audit_dir=str(audit_dir),
+            audit_enabled=False,
+        ),
+    )
+    server = IRCd(cfg)
+    await server.start()
+    try:
+        assert not audit_dir.exists(), f"audit_enabled=False but dir was created at {audit_dir}"
+    finally:
+        await server.stop()

--- a/tests/telemetry/test_audit_module.py
+++ b/tests/telemetry/test_audit_module.py
@@ -13,7 +13,8 @@ import pytest
 from culture.agentirc.config import ServerConfig, TelemetryConfig
 from culture.agentirc.skill import Event, EventType
 from culture.telemetry import AuditSink, init_audit
-from culture.telemetry.audit import _build_audit_record, _utc_iso_timestamp
+from culture.telemetry.audit import _utc_iso_timestamp
+from culture.telemetry.audit import build_audit_record as _build_audit_record
 from culture.telemetry.audit import reset_for_tests as _reset_audit
 from culture.telemetry.metrics import init_metrics
 from culture.telemetry.metrics import reset_for_tests as _reset_metrics

--- a/tests/telemetry/test_audit_module.py
+++ b/tests/telemetry/test_audit_module.py
@@ -13,9 +13,9 @@ import pytest
 from culture.agentirc.config import ServerConfig, TelemetryConfig
 from culture.agentirc.skill import Event, EventType
 from culture.telemetry import AuditSink, init_audit
-from culture.telemetry.audit import _utc_iso_timestamp
 from culture.telemetry.audit import build_audit_record as _build_audit_record
 from culture.telemetry.audit import reset_for_tests as _reset_audit
+from culture.telemetry.audit import utc_iso_timestamp as _utc_iso_timestamp
 from culture.telemetry.metrics import init_metrics
 from culture.telemetry.metrics import reset_for_tests as _reset_metrics
 

--- a/tests/telemetry/test_audit_module.py
+++ b/tests/telemetry/test_audit_module.py
@@ -1,0 +1,282 @@
+"""Module-level tests for AuditSink + init_audit + helpers.
+
+Exercises the sink directly without spinning up an IRCd; integration
+tests live in tests/telemetry/test_audit_*.py (Task 7)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from culture.agentirc.config import ServerConfig, TelemetryConfig
+from culture.agentirc.skill import Event, EventType
+from culture.telemetry import AuditSink, init_audit
+from culture.telemetry.audit import _build_audit_record, _utc_iso_timestamp
+from culture.telemetry.audit import reset_for_tests as _reset_audit
+from culture.telemetry.metrics import init_metrics
+from culture.telemetry.metrics import reset_for_tests as _reset_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _reset_metrics()
+    _reset_audit()
+    yield
+    _reset_audit()
+    _reset_metrics()
+
+
+def _build_config(tmp_path, **overrides):
+    tcfg = TelemetryConfig(audit_dir=str(tmp_path), **overrides)
+    return ServerConfig(name="testserv", telemetry=tcfg)
+
+
+# --- _utc_iso_timestamp ---------------------------------------------------
+
+
+def test_iso_timestamp_format():
+    ts = _utc_iso_timestamp(0.0)
+    assert ts == "1970-01-01T00:00:00.000000Z"
+
+
+def test_iso_timestamp_microseconds_padded():
+    ts = _utc_iso_timestamp(0.000005)
+    assert ts.endswith(".000005Z")
+
+
+# --- _build_audit_record --------------------------------------------------
+
+
+def test_record_local_message_event():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel="#general",
+        nick="testserv-alice",
+        data={"text": "hi"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv",
+        event=event,
+        origin_tag=None,
+        trace_id="",
+        span_id="",
+    )
+    assert record["server"] == "testserv"
+    assert record["event_type"] == "message"
+    assert record["origin"] == "local"
+    assert record["peer"] == ""
+    assert record["target"] == {"kind": "channel", "name": "#general"}
+    assert record["actor"]["nick"] == "testserv-alice"
+    assert record["actor"]["kind"] == "human"
+    assert record["payload"]["text"] == "hi"
+    assert record["payload"]["nick"] == "testserv-alice"
+    assert record["payload"]["channel"] == "#general"
+    assert record["tags"] == {}
+
+
+def test_record_federated_strips_underscore_keys():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel="#general",
+        nick="alpha-alice",
+        data={"text": "hi", "_origin": "alpha", "_internal": "x"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv",
+        event=event,
+        origin_tag="alpha",
+        trace_id="4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id="00f067aa0ba902b7",
+    )
+    assert record["origin"] == "federated"
+    assert record["peer"] == "alpha"
+    assert record["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert "_origin" not in record["payload"]
+    assert "_internal" not in record["payload"]
+    assert record["payload"]["text"] == "hi"
+
+
+def test_record_dm_target_kind_nick():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel=None,
+        nick="testserv-alice",
+        data={"text": "hi", "target": "testserv-bob"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv", event=event, origin_tag=None, trace_id="", span_id=""
+    )
+    assert record["target"] == {"kind": "nick", "name": "testserv-bob"}
+
+
+def test_record_unknown_event_type_string():
+    """Federated events sometimes carry event.type as a plain string."""
+    event = Event(
+        type="custom.future_event",  # type: ignore[arg-type]
+        channel=None,
+        nick="alpha-alice",
+        data={"_origin": "alpha"},
+        timestamp=0.0,
+    )
+    record = _build_audit_record(
+        server_name="testserv", event=event, origin_tag="alpha", trace_id="", span_id=""
+    )
+    assert record["event_type"] == "custom.future_event"
+
+
+def test_record_extra_tags_traceparent():
+    event = Event(
+        type=EventType.MESSAGE,
+        channel="#general",
+        nick="testserv-alice",
+        data={"text": "hi"},
+        timestamp=0.0,
+    )
+    tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    record = _build_audit_record(
+        server_name="testserv",
+        event=event,
+        origin_tag=None,
+        trace_id="4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id="00f067aa0ba902b7",
+        extra_tags={"culture.dev/traceparent": tp},
+    )
+    assert record["tags"]["culture.dev/traceparent"] == tp
+
+
+# --- init_audit -----------------------------------------------------------
+
+
+def test_init_audit_returns_sink_when_disabled(tmp_path):
+    cfg = _build_config(tmp_path, audit_enabled=False)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    assert isinstance(sink, AuditSink)
+    assert sink.enabled is False
+    # No-op submit must not raise.
+    sink.submit({"event_type": "test"})
+
+
+def test_init_audit_idempotent_same_config(tmp_path):
+    cfg = _build_config(tmp_path, audit_enabled=False)
+    metrics = init_metrics(cfg)
+    sink1 = init_audit(cfg, metrics)
+    sink2 = init_audit(cfg, metrics)
+    assert sink1 is sink2
+
+
+def test_init_audit_independent_of_telemetry_enabled(tmp_path):
+    """audit_enabled=True should fire even with telemetry.enabled=False."""
+    cfg = _build_config(tmp_path, enabled=False, audit_enabled=True)
+    metrics = init_metrics(cfg)  # no-op proxy meter
+    sink = init_audit(cfg, metrics)
+    assert sink.enabled is True
+
+
+def test_init_audit_expands_tilde(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg = _build_config(tmp_path)
+    cfg.telemetry.audit_dir = "~/audit-test"
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    assert sink.audit_dir == tmp_path / "audit-test"
+
+
+# --- AuditSink lifecycle + write ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sink_start_creates_directory(tmp_path):
+    audit_dir = tmp_path / "audit"
+    cfg = _build_config(audit_dir)
+    cfg.telemetry.audit_dir = str(audit_dir)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        assert audit_dir.exists()
+        assert audit_dir.is_dir()
+    finally:
+        await sink.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_sink_writes_record_to_jsonl(tmp_path):
+    cfg = _build_config(tmp_path)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        sink.submit({"event_type": "test", "n": 1})
+        sink.submit({"event_type": "test", "n": 2})
+        await asyncio.wait_for(sink.queue.join(), timeout=2.0)
+    finally:
+        await sink.shutdown()
+
+    files = list(tmp_path.glob("testserv-*.jsonl"))
+    assert len(files) == 1
+    lines = files[0].read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["n"] == 1
+    assert json.loads(lines[1])["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_sink_disabled_writes_nothing(tmp_path):
+    cfg = _build_config(tmp_path, audit_enabled=False)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        sink.submit({"event_type": "test"})
+        await asyncio.sleep(0.05)
+    finally:
+        await sink.shutdown()
+    assert list(tmp_path.glob("*.jsonl")) == []
+
+
+@pytest.mark.asyncio
+async def test_sink_size_rotation(tmp_path):
+    cfg = _build_config(tmp_path, audit_max_file_bytes=200)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        for i in range(20):
+            sink.submit({"event_type": "test", "i": i, "padding": "x" * 50})
+        await asyncio.wait_for(sink.queue.join(), timeout=2.0)
+    finally:
+        await sink.shutdown()
+
+    files = sorted(tmp_path.glob("testserv-*.jsonl*"))
+    # With 200-byte cap and ~80-byte records, expect at least 2 files.
+    assert len(files) >= 2, f"expected >=2 rotated files, got {[f.name for f in files]}"
+
+
+@pytest.mark.asyncio
+async def test_sink_overflow_drops_records(tmp_path):
+    """Queue depth 2; flood 10. Some must be dropped."""
+    cfg = _build_config(tmp_path, audit_queue_depth=2)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    # Don't await between submits — pile records up before the writer
+    # task can pull them.
+    try:
+        for i in range(10):
+            sink.submit({"event_type": "test", "i": i})
+        # Let writer finish what it can.
+        await asyncio.sleep(0.1)
+    finally:
+        await sink.shutdown()
+    files = list(tmp_path.glob("*.jsonl"))
+    written = files[0].read_text().splitlines() if files else []
+    # Some records should have been dropped — strict equality on count is
+    # racy because the writer may have drained 1 before we filled, so just
+    # assert "less than 10".
+    assert len(written) < 10, f"expected drops, all 10 written: {written}"

--- a/tests/telemetry/test_audit_module.py
+++ b/tests/telemetry/test_audit_module.py
@@ -280,3 +280,26 @@ async def test_sink_overflow_drops_records(tmp_path):
     # racy because the writer may have drained 1 before we filled, so just
     # assert "less than 10".
     assert len(written) < 10, f"expected drops, all 10 written: {written}"
+
+
+@pytest.mark.asyncio
+async def test_sink_writes_oversized_record_into_fresh_file(tmp_path):
+    """A single record larger than audit_max_file_bytes is still written —
+    the cap is a soft ceiling for accumulated bytes, not a hard reject."""
+    cfg = _build_config(tmp_path, audit_max_file_bytes=100)
+    metrics = init_metrics(cfg)
+    sink = init_audit(cfg, metrics)
+    await sink.start()
+    try:
+        big = {"event_type": "test", "padding": "x" * 500}  # ~530 bytes
+        sink.submit(big)
+        sink.submit({"event_type": "test", "n": 2})
+        await asyncio.wait_for(sink.queue.join(), timeout=2.0)
+    finally:
+        await sink.shutdown()
+    files = sorted(tmp_path.glob("testserv-*.jsonl*"))
+    # Oversized record forces rotation; second record forces another.
+    assert len(files) >= 2
+    # The oversized record must be in one of the files.
+    all_lines = "\n".join(f.read_text() for f in files)
+    assert "x" * 500 in all_lines

--- a/tests/telemetry/test_audit_parse_error.py
+++ b/tests/telemetry/test_audit_parse_error.py
@@ -1,0 +1,177 @@
+"""PARSE_ERROR audit records from Client._process_buffer.
+
+Verifies a malformed inbound line produces a PARSE_ERROR JSONL record
+with the right shape: line_preview (truncated to 64 chars), error type,
+remote_addr from peer info, trace_id/span_id from the active
+irc.client.process_buffer span.
+
+NOTE: Message.parse is fully tolerant and never raises for any syntactically
+constructable input. Tests therefore use mock.patch to force a ValueError
+from Message.parse — this is the only reliable way to exercise the
+except-branch in _process_buffer. The unit tests below validate the
+record shape directly via _submit_parse_error_audit, and via a patched
+_process_buffer round-trip against a real IRCd.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+
+from culture.agentirc.client import Client
+from culture.agentirc.config import ServerConfig, TelemetryConfig
+from culture.agentirc.ircd import IRCd
+from culture.protocol.message import Message
+from tests.telemetry._fakes import FakeWriter
+
+# ---------------------------------------------------------------------------
+# Unit-level: _submit_parse_error_audit builds the right record shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_error_audit_record_shape(audit_dir, tracing_exporter):
+    """_submit_parse_error_audit enqueues a well-formed PARSE_ERROR record."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    server = IRCd(cfg)
+    await server.start()
+    try:
+        client = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+        client.nick = "testserv-alice"
+
+        # Call _submit_parse_error_audit directly (no real parse failure needed).
+        client._submit_parse_error_audit("GARBAGE_LINE_THAT_FAILED", ValueError("bad"))
+
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    files = sorted(audit_dir.glob("testserv-*.jsonl*"))
+    records = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                records.append(json.loads(line))
+
+    parse_errors = [r for r in records if r["event_type"] == "PARSE_ERROR"]
+    assert len(parse_errors) == 1, f"expected 1 PARSE_ERROR record, got {records}"
+
+    rec = parse_errors[0]
+    assert rec["server"] == "testserv"
+    assert rec["origin"] == "local"
+    assert rec["peer"] == ""
+    assert rec["target"] == {"kind": "", "name": ""}
+    assert rec["actor"]["nick"] == "testserv-alice"
+    assert rec["actor"]["kind"] == "human"
+    # FakeWriter returns ("testaddr", 12345) for peername.
+    assert rec["actor"]["remote_addr"] == "testaddr:12345"
+    assert rec["payload"]["line_preview"] == "GARBAGE_LINE_THAT_FAILED"
+    assert rec["payload"]["error"] == "ValueError"
+    assert "T" in rec["ts"] and rec["ts"].endswith("Z")
+
+
+@pytest.mark.asyncio
+async def test_submit_parse_error_line_preview_truncated_to_64(audit_dir, tracing_exporter):
+    """line_preview is truncated to 64 characters."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_dir=str(audit_dir)),
+    )
+    server = IRCd(cfg)
+    await server.start()
+    try:
+        client = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+        client.nick = "testserv-bob"
+
+        long_line = "X" * 200
+        client._submit_parse_error_audit(long_line, RuntimeError("too long"))
+
+        await asyncio.wait_for(server.audit.queue.join(), timeout=2.0)
+    finally:
+        await server.stop()
+
+    files = sorted(audit_dir.glob("testserv-*.jsonl*"))
+    records = []
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                records.append(json.loads(line))
+
+    parse_errors = [r for r in records if r["event_type"] == "PARSE_ERROR"]
+    assert parse_errors, "expected a PARSE_ERROR record"
+    rec = parse_errors[0]
+    assert len(rec["payload"]["line_preview"]) == 64
+    assert rec["payload"]["error"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _process_buffer calls _submit_parse_error_audit on exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_buffer_submits_audit_on_parse_exception(audit_dir, tracing_exporter, server):
+    """When Message.parse raises, _process_buffer calls _submit_parse_error_audit."""
+    client_obj = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+    client_obj.nick = "testserv-carol"
+
+    submitted: list[dict] = []
+    original_submit = server.audit.submit
+
+    def _capturing_submit(record):
+        submitted.append(record)
+        original_submit(record)
+
+    server.audit.submit = _capturing_submit  # type: ignore[method-assign]
+
+    def _boom(_line):
+        raise ValueError("deliberate parse failure")
+
+    with patch.object(Message, "parse", side_effect=_boom):
+        await client_obj._process_buffer("BAD LINE\n")
+
+    assert len(submitted) == 1
+    rec = submitted[0]
+    assert rec["event_type"] == "PARSE_ERROR"
+    assert rec["server"] == server.config.name
+    assert rec["payload"]["line_preview"].startswith("BAD LINE")
+    assert rec["payload"]["error"] == "ValueError"
+    assert rec["origin"] == "local"
+    assert rec["peer"] == ""
+    assert rec["target"] == {"kind": "", "name": ""}
+    assert rec["actor"]["kind"] == "human"
+    # trace_id and span_id should be set — process_buffer opens a span.
+    assert len(rec["trace_id"]) == 32
+    assert len(rec["span_id"]) == 16
+    assert rec["tags"]["culture.dev/traceparent"].startswith("00-")
+
+
+@pytest.mark.asyncio
+async def test_process_buffer_audit_disabled_does_not_raise(tracing_exporter):
+    """When audit is disabled, _process_buffer parse errors don't crash."""
+    cfg = ServerConfig(
+        name="testserv",
+        host="127.0.0.1",
+        port=0,
+        telemetry=TelemetryConfig(audit_enabled=False),
+    )
+    server = IRCd(cfg)
+    client_obj = Client(reader=None, writer=FakeWriter(), server=server)  # type: ignore[arg-type]
+    client_obj.nick = "testserv-dave"
+
+    def _boom(_line):
+        raise ValueError("deliberate parse failure")
+
+    with patch.object(Message, "parse", side_effect=_boom):
+        # Should not raise even though audit is disabled (submit is a no-op).
+        await client_obj._process_buffer("BAD LINE\n")

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.4.0"
+version = "8.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Durable, file-based audit log: every `IRCd.emit_event` call appends a single JSON object to `~/.culture/audit/<server>-YYYY-MM-DD.jsonl`. PARSE_ERROR records from `Client._process_buffer` are also captured.
- New `culture/telemetry/audit.py` with `AuditSink` (bounded async queue + dedicated writer task + daily/size rotation + `0600`/`0700` perms). Independent of `telemetry.enabled` — audit fires even with OTEL fully off.
- Two new metrics extend the Plan-3 `MetricsRegistry`: `culture.audit.writes` (Counter, `outcome=ok|error`) and `culture.audit.queue_depth` (UpDownCounter).
- New protocol extension `culture/protocol/extensions/audit.md` (record schema as a stable contract) + new operator guide `docs/agentirc/audit.md`.

This is **Plan 4 of 6** of the OTEL observability initiative ([design spec](https://github.com/agentculture/culture/blob/main/docs/superpowers/specs/2026-04-24-otel-observability-design.md), [plan](https://github.com/agentculture/culture/blob/main/docs/superpowers/plans/2026-04-27-otel-audit.md)). Plans 1–3 shipped traces + metrics in #292 / #293 / #295.

## Cross-pillar joins

Every record carries `trace_id` / `span_id` from the active `irc.event.emit` span when telemetry is enabled. That's how an admin bridges from a trace backend (Tempo / Jaeger) into the JSONL for full reconstruction:

```bash
jq -c 'select(.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736")' \
  ~/.culture/audit/spark-*.jsonl
```

## What changed

- **New module:** `culture/telemetry/audit.py` (`AuditSink`, `init_audit`, `build_audit_record`, `utc_iso_timestamp`, `reset_for_tests`).
- **New protocol page:** `culture/protocol/extensions/audit.md` — record schema, file layout, rotation, durability, retention, compat.
- **New operator guide:** `docs/agentirc/audit.md` — file paths, `jq` recipes, health metrics, known v1 limitations.
- **TelemetryConfig:** five new audit fields. `audit_enabled=True` by default, **independent of** `enabled`.
- **MetricsRegistry:** extended with `audit_writes` + `audit_queue_depth`.
- **`IRCd.__init__`:** constructs the sink. **`IRCd.start()`/`stop()`:** drive the sink lifecycle.
- **`IRCd.emit_event`:** captures `trace_id`/`span_id` inside the span, builds the record after span exit, submits.
- **`Client._process_buffer`:** PARSE_ERROR audit submit alongside the existing parse-error span event.
- **Tests:** 6 new files (~30 tests). Module-level: rotation, overflow, disabled, oversized records. Integration: lifecycle, emit-event shape, payload underscore-strip, DM target, PARSE_ERROR, federation.
- **No new dependencies.**

## Known v1 limitations

- `actor.kind` is always `"human"` — Plan 5 (harness) and Plan 6 (bots) refine.
- `actor.remote_addr` empty for events emitted from server-internal sites.
- Federated lifecycle events (JOIN/PART/QUIT) on the receiver are not yet surfaced — gap tracked in #296. Federated `message` events DO produce audit records correctly.
- No OTEL Logs export (deferred follow-up).
- No `audit-prune` CLI (deferred follow-up).

## Test plan

- [x] `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — 1051 passed.
- [x] `tests/telemetry/test_audit_*.py` — 6 new files cover module-level + IRCd-integration + federation.
- [x] No regression in `tests/test_federation.py`.
- [ ] Manual: start a server with `audit_enabled=true`, weechat → PRIVMSG/JOIN/PART → `tail ~/.culture/audit/spark-*.jsonl | jq`.
- [ ] Manual: `telemetry.enabled=false, audit_enabled=true` → audit still writes (independence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)