### PR TITLE
feat(telemetry): OTEL harness-side tracing & LLM metrics (8.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.6.0] - 2026-04-26
+
+### Added
+
+- Harness-side OTEL: 3 spans (harness.irc.connect, harness.irc.message.handle, harness.llm.call) and 4 LLM metrics (culture.harness.llm.tokens.input/output, call.duration, calls).
+- W3C traceparent injection on outbound IRC + extraction on inbound — single trace_id now spans server, federation, and harness in the cross-process tree.
+- Per-backend telemetry citation across claude/codex/copilot/acp with all-backends parity test (24 tests across 6 dimensions) locking down drift.
+- docs/agentirc/harness-telemetry.md — new operator guide for the harness OTEL pillar.
+
+### Changed
+
+- packages/agent-harness/{telemetry.py,config.py,culture.yaml,irc_transport.py,daemon.py} — reference module for the citation pattern.
+- culture/clients/{claude,codex,copilot,acp}/{telemetry.py,config.py,culture.yaml,irc_transport.py,daemon.py,agent_runner.py} — telemetry citation, harness.llm.call span wrap, record_llm_call invocation.
+- tests/harness/ — 70 new tests (24 parity + 46 module/runner/transport/daemon).
+
+### Fixed
+
+- Code-quality fixes from review: zero-token usage extraction (0 no longer silenced), tracer-name from constant (no hardcoded strings), module-top imports of record_llm_call across all 4 backends.
+
 ## [8.5.0] - 2026-04-25
 
 ### Added

--- a/culture/clients/acp/agent_runner.py
+++ b/culture/clients/acp/agent_runner.py
@@ -12,9 +12,16 @@ import logging
 import os
 import shutil
 import tempfile
-from typing import Any, Awaitable, Callable
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from opentelemetry import trace as _otel_trace
 
 from culture.aio import maybe_await
+from culture.clients.acp.telemetry import _HARNESS_TRACER_NAME, record_llm_call
+
+if TYPE_CHECKING:
+    from culture.clients.acp.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +43,8 @@ class ACPAgentRunner:
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         on_turn_error: Callable[[], Awaitable[None] | None] | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        nick: str = "",
     ) -> None:
         self.model = model
         self.directory = directory
@@ -44,6 +53,8 @@ class ACPAgentRunner:
         self.on_exit = on_exit
         self.on_message = on_message
         self.on_turn_error = on_turn_error
+        self._metrics = metrics
+        self._nick = nick
 
         self._isolated_home: str | None = None
         self._process: asyncio.subprocess.Process | None = None
@@ -431,16 +442,47 @@ class ACPAgentRunner:
 
     async def _execute_single_prompt(self, text: str) -> None:
         """Send one prompt and handle its result, managing the busy flag."""
-        try:
-            self._busy = True
-            resp = await self._send_prompt_with_retry(text)
-            await self._handle_prompt_result(resp)
-        except Exception:
-            logger.exception("ACP turn error")
-            if self.on_turn_error:
-                await maybe_await(self.on_turn_error())
-        finally:
-            self._busy = False
+        start_perf = time.perf_counter()
+        outcome = "success"
+        tracer = _otel_trace.get_tracer(_HARNESS_TRACER_NAME)
+        with tracer.start_as_current_span(
+            "harness.llm.call",
+            attributes={
+                "harness.backend": "acp",
+                "harness.model": self.model,
+                "harness.nick": self._nick,
+            },
+        ):
+            try:
+                self._busy = True
+                resp = await self._send_prompt_with_retry(text)
+                await self._handle_prompt_result(resp)
+            except TimeoutError:  # bubbles from _send_prompt_with_retry's retry-then-fail
+                outcome = "timeout"
+                logger.exception("ACP turn timeout")
+                if self.on_turn_error:
+                    await maybe_await(self.on_turn_error())
+            except Exception:
+                outcome = "error"
+                logger.exception("ACP turn error")
+                if self.on_turn_error:
+                    await maybe_await(self.on_turn_error())
+            finally:
+                self._busy = False
+        duration_ms = (time.perf_counter() - start_perf) * 1000.0
+        if self._metrics is not None:
+            # ACP token usage MAY arrive in session/update stopReason payload;
+            # current implementation does not extract — usage=None for v1.
+            # When we add extraction (per backing agent), thread through here.
+            record_llm_call(
+                self._metrics,
+                backend="acp",
+                model=self.model,
+                nick=self._nick,
+                usage=None,
+                duration_ms=duration_ms,
+                outcome=outcome,
+            )
 
     async def _prompt_loop(self) -> None:
         """Process queued prompts one at a time."""

--- a/culture/clients/acp/config.py
+++ b/culture/clients/acp/config.py
@@ -63,12 +63,34 @@ class AgentConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """OpenTelemetry settings for the agent harness.
+
+    ``enabled: false`` by default so freshly installed harnesses don't
+    try to connect to a non-existent OTLP collector. Flip to ``true``
+    once your collector is running.
+    """
+
+    enabled: bool = False
+    service_name: str = "culture.harness.acp"
+    otlp_endpoint: str = "http://localhost:4317"
+    otlp_protocol: str = "grpc"  # grpc | http/protobuf (only grpc supported initially)
+    otlp_timeout_ms: int = 5000
+    otlp_compression: str = "gzip"
+    traces_enabled: bool = True
+    traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
+
+
+@dataclass
 class DaemonConfig:
     """Top-level daemon configuration."""
 
     server: ServerConnConfig = field(default_factory=ServerConnConfig)
     supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
     webhooks: WebhookConfig = field(default_factory=WebhookConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     buffer_size: int = 500
     poll_interval: int = 60
     sleep_start: str = "23:00"
@@ -91,6 +113,7 @@ def load_config(path: str | Path) -> DaemonConfig:
     supervisor = SupervisorConfig(**raw.get("supervisor", {}))
 
     webhooks = WebhookConfig(**raw.get("webhooks", {}))
+    telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
     known_agent_fields = {f.name for f in AgentConfig.__dataclass_fields__.values()}
@@ -102,6 +125,7 @@ def load_config(path: str | Path) -> DaemonConfig:
         server=server,
         supervisor=supervisor,
         webhooks=webhooks,
+        telemetry=telemetry,
         buffer_size=raw.get("buffer_size", 500),
         poll_interval=raw.get("poll_interval", 60),
         sleep_start=raw.get("sleep_start", "23:00"),

--- a/culture/clients/acp/culture.yaml
+++ b/culture/clients/acp/culture.yaml
@@ -15,3 +15,18 @@ system_prompt: |
 tags:
   - harness
   - acp
+
+# OpenTelemetry configuration for the agent harness.
+# Set enabled: true once your OTLP collector is running.
+# See docs/agentirc/harness-telemetry.md for a setup guide.
+telemetry:
+  enabled: false                          # master switch — flip to true to start exporting
+  service_name: culture.harness.acp       # overridden per-backend (e.g. culture.harness.acp)
+  otlp_endpoint: http://localhost:4317    # OTLP/gRPC receiver endpoint
+  otlp_protocol: grpc                     # grpc or http/protobuf
+  otlp_timeout_ms: 5000                   # export request timeout in milliseconds
+  otlp_compression: gzip                  # gzip | none
+  traces_enabled: true                    # enable distributed tracing
+  traces_sampler: parentbased_always_on   # honor the server's sampling decision
+  metrics_enabled: true                   # enable LLM call metrics export
+  metrics_export_interval_ms: 10000       # how often to push metric batches (ms)

--- a/culture/clients/acp/daemon.py
+++ b/culture/clients/acp/daemon.py
@@ -25,6 +25,7 @@ from culture.clients.acp.irc_transport import IRCTransport
 from culture.clients.acp.message_buffer import MessageBuffer
 from culture.clients.acp.socket_server import SocketServer
 from culture.clients.acp.supervisor import Supervisor, make_sdk_evaluate_fn
+from culture.clients.acp.telemetry import init_harness_telemetry
 from culture.clients.acp.webhook import AlertEvent, WebhookClient
 from culture.pidfile import remove_pid, write_pid
 
@@ -71,6 +72,8 @@ class ACPDaemon:
         self._socket_server: SocketServer | None = None
         self._agent_runner: ACPAgentRunner | None = None
         self._supervisor: Supervisor | None = None
+        self._tracer = None
+        self._metrics = None
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -134,6 +137,9 @@ class ACPDaemon:
         self._pid_name = f"agent-{self.agent.nick}"
         write_pid(self._pid_name, os.getpid())
 
+        # 0.5. OTEL telemetry (if telemetry.enabled, installs SDK providers; else no-op).
+        self._tracer, self._metrics = init_harness_telemetry(self.config)
+
         # 1. Message buffer
         self._buffer = MessageBuffer(max_per_channel=self.config.buffer_size)
 
@@ -148,6 +154,9 @@ class ACPDaemon:
             on_mention=self._on_mention,
             tags=list(self.agent.tags),
             on_roominvite=self._on_roominvite,
+            tracer=self._tracer,
+            metrics=self._metrics,
+            backend="acp",
         )
         await self._transport.connect()
 
@@ -389,6 +398,8 @@ class ACPDaemon:
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
             on_turn_error=self._on_turn_error,
+            metrics=self._metrics,
+            nick=self.agent.nick,
         )
         # Absorb the system prompt response without relaying to IRC
         self._mention_targets.append(None)

--- a/culture/clients/acp/irc_transport.py
+++ b/culture/clients/acp/irc_transport.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
-from typing import Callable
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Callable
 
 from culture.aio import maybe_await
 from culture.clients.acp.message_buffer import MessageBuffer
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
+from culture.telemetry.context import (
+    TRACEPARENT_TAG,
+    context_from_traceparent,
+    current_traceparent,
+    extract_traceparent_from_tags,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
+
+    from culture.clients.acp.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
 
 class IRCTransport:
-    """Async IRC client for the daemon."""
+    """Async IRC client for the daemon.
+
+    Optional kwargs ``tracer``, ``metrics``, and ``backend`` enable OTEL
+    tracing and LLM metrics when an SDK provider is installed. Pass ``None``
+    (the default) for all three to run without instrumentation.
+    """
 
     def __init__(
         self,
@@ -28,6 +46,9 @@ class IRCTransport:
         tags: list[str] | None = None,
         on_roominvite: Callable[[str, str], None] | None = None,
         icon: str | None = None,
+        tracer: Tracer | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        backend: str = "acp",
     ):
         self.host = host
         self.port = port
@@ -39,6 +60,10 @@ class IRCTransport:
         self.tags = tags or []
         self.on_roominvite = on_roominvite
         self.icon = icon
+        self._tracer = tracer
+        # accepted for future per-message metrics (e.g. byte counters); unused in v1
+        self._metrics = metrics
+        self._backend = backend
         self.connected = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -57,23 +82,46 @@ class IRCTransport:
             "332": self._on_numeric_topic,
         }
 
+    def _span(self, name: str, attrs: dict | None = None) -> AbstractContextManager:
+        """Return a real span context manager when tracing is enabled, else a no-op.
+
+        Keeps the no-tracer fast path clean — all callers write the same
+        ``with self._span(...):`` pattern regardless of whether a tracer is
+        configured.
+
+        Does NOT accept a ``context=`` argument; callers that need a span
+        parented to a remote trace context (e.g. inbound message handling in
+        ``_handle``) call ``self._tracer.start_as_current_span`` directly.
+        """
+        if self._tracer is not None:
+            return self._tracer.start_as_current_span(name, attributes=attrs or {})
+        return contextlib.nullcontext()
+
     async def connect(self) -> None:
         self._should_run = True
         await self._do_connect()
 
     async def _do_connect(self) -> None:
-        try:
-            self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
-        except OSError as exc:
-            raise ConnectionError(
-                f"Cannot connect to IRC server at {self.host}:{self.port} "
-                f"- is the server running?"
-            ) from exc
-        await self._send_raw("CAP REQ :message-tags")
-        await self._send_raw(f"NICK {self.nick}")
-        await self._send_raw(f"USER {self.user} 0 * :{self.user}")
-        await self._send_raw("CAP END")
-        self._read_task = asyncio.create_task(self._read_loop())
+        with self._span(
+            "harness.irc.connect",
+            attrs={
+                "harness.backend": self._backend,
+                "harness.nick": self.nick,
+                "harness.server": f"{self.host}:{self.port}",
+            },
+        ):
+            try:
+                self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+            except OSError as exc:
+                raise ConnectionError(
+                    f"Cannot connect to IRC server at {self.host}:{self.port} "
+                    f"- is the server running?"
+                ) from exc
+            await self._send_raw("CAP REQ :message-tags")
+            await self._send_raw(f"NICK {self.nick}")
+            await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+            await self._send_raw("CAP END")
+            self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:
         self._should_run = False
@@ -151,6 +199,14 @@ class IRCTransport:
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
+        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
+        # Only inject when we have a tracer configured (fast-path: no work if
+        # self._tracer is None) and there is no tag block already on the line
+        # (defensive guard — prevents double-tagging if a caller pre-tagged).
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:
@@ -193,9 +249,41 @@ class IRCTransport:
                 delay = min(delay * 2, 60)
 
     async def _handle(self, msg: Message) -> None:
-        handler = self._cmd_handlers.get(msg.command)
-        if handler:
-            await maybe_await(handler(msg))
+        # Extract inbound traceparent before opening any span so the new span
+        # can be correctly parented to the remote trace context.
+        result = extract_traceparent_from_tags(msg, peer=None)
+
+        if self._tracer is not None:
+            if result.status == "valid":
+                ctx = context_from_traceparent(result.traceparent)
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    context=ctx,
+                    attributes={
+                        "irc.command": msg.command,
+                        "irc.client.nick": self.nick,
+                        "culture.trace.origin": "remote",
+                    },
+                )
+            else:
+                attrs = {
+                    "irc.command": msg.command,
+                    "irc.client.nick": self.nick,
+                    "culture.trace.origin": ("local" if result.status == "missing" else "remote"),
+                }
+                if result.status in ("malformed", "too_long"):
+                    attrs["culture.trace.dropped_reason"] = result.status
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    attributes=attrs,
+                )
+        else:
+            span_cm = contextlib.nullcontext()
+
+        with span_cm:
+            handler = self._cmd_handlers.get(msg.command)
+            if handler:
+                await maybe_await(handler(msg))
 
     async def _on_ping(self, msg: Message) -> None:
         token = msg.params[0] if msg.params else ""

--- a/culture/clients/acp/irc_transport.py
+++ b/culture/clients/acp/irc_transport.py
@@ -193,20 +193,23 @@ class IRCTransport:
             await self._send_raw(f"TOPIC {channel}")
 
     async def send_raw(self, line: str) -> None:
-        """Send a raw IRC line. Public for commands like HISTORY."""
+        """Send a raw IRC line. Public for commands like HISTORY.
+
+        When a tracer is configured and a span is active, prepends the W3C
+        ``@culture.dev/traceparent=`` IRCv3 tag so all outbound paths — whether
+        called via the internal ``_send_raw`` helper or directly by daemon code
+        — carry trace context consistently.
+        """
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp is not None:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         if self._writer:
             self._writer.write(f"{line}\r\n".encode())
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
-        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
-        # Only inject when we have a tracer configured (fast-path: no work if
-        # self._tracer is None) and there is no tag block already on the line
-        # (defensive guard — prevents double-tagging if a caller pre-tagged).
-        if self._tracer is not None and not line.startswith("@"):
-            tp = current_traceparent()
-            if tp:
-                line = f"@{TRACEPARENT_TAG}={tp} {line}"
+        """Internal send helper; delegates to send_raw (injection lives there)."""
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:

--- a/culture/clients/acp/telemetry.py
+++ b/culture/clients/acp/telemetry.py
@@ -1,0 +1,318 @@
+"""OpenTelemetry bootstrap for Culture agent harnesses.
+
+Why this file lives in ``packages/agent-harness/``
+---------------------------------------------------
+The culture codebase uses a **cite, don't import** pattern for the per-backend
+agent harnesses in ``culture/clients/{claude,codex,copilot,acp}/``. Each backend
+owns a verbatim copy of this file (with the ``service_name`` default changed to
+``culture.harness.<backend>``). Backend-specific overrides are isolated to those
+two sites; all other logic must stay identical so the all-backends parity test
+(``tests/harness/test_all_backends_parity.py``) passes.
+
+This is the ACP citation of the reference module in
+``packages/agent-harness/telemetry.py``.
+
+Backend-specific edit sites (two, both must be updated on citation)
+--------------------------------------------------------------------
+1. ``TelemetryConfig.service_name`` in ``config.py`` — change the default from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"``.
+2. ``_HARNESS_TRACER_NAME`` constant in this file — change the value from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"`` to match.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.metrics import Counter, Histogram, Meter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    Sampler,
+    TraceIdRatioBased,
+)
+from opentelemetry.trace import Tracer
+
+logger = logging.getLogger(__name__)
+
+# Module-level tracer name — cited backends replace "culture.harness" with
+# "culture.harness.<backend>" to match their service.name.
+_HARNESS_TRACER_NAME = "culture.harness.acp"
+
+# Module-level globals — mirrors the server-side tracing.py / metrics.py pattern.
+_initialized_for: dict | None = None
+_tracer: Tracer | None = None
+_meter_provider: MeterProvider | None = None
+_registry: HarnessMetricsRegistry | None = None
+
+
+@dataclass
+class HarnessMetricsRegistry:
+    """All harness-side LLM instruments, registered once during init_harness_telemetry.
+
+    Parallel to the server's ``MetricsRegistry`` — different process, different
+    provider, different ``service.name``. Plan 6's bot-side metrics follow the
+    same parallel-registry pattern if bots are process-isolated.
+    """
+
+    llm_tokens_input: Counter
+    """Per-LLM-call input token count by backend/model/nick."""
+
+    llm_tokens_output: Counter
+    """Per-LLM-call output token count by backend/model/nick."""
+
+    llm_call_duration: Histogram
+    """Per-LLM-call wall-clock duration in milliseconds."""
+
+    llm_calls: Counter
+    """Per-LLM-call count by backend/model/outcome."""
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only.
+
+    Mirrors ``culture.telemetry.metrics.reset_for_tests`` (MeterProvider
+    shutdown + global clear) and ``culture.telemetry.tracing.reset_for_tests``
+    (trace provider global clear). Both are needed because parallel xdist
+    workers can leak global providers across module boundaries.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        _meter_provider = None
+
+    _initialized_for = None
+    _tracer = None
+    _registry = None
+
+    # Reset the OTEL metrics global — same path as server-side metrics.py.
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    _mi._METER_PROVIDER = None
+    _mi._METER_PROVIDER_SET_ONCE = _mi.Once()
+
+    # Reset the OTEL trace global — same path as server-side tracing.py.
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER_SET_ONCE = trace.Once()  # type: ignore[attr-defined]
+
+
+def _build_sampler(name: str) -> Sampler:
+    """Parse a ``traces_sampler`` string into an OTEL Sampler.
+
+    Mirrors ``culture.telemetry.tracing._build_sampler`` exactly — same
+    string grammar, same fallback warning.
+    """
+    if name == "parentbased_always_on":
+        return ParentBased(ALWAYS_ON)
+    if name.startswith("parentbased_traceidratio:"):
+        ratio = float(name.split(":", 1)[1])
+        return ParentBased(TraceIdRatioBased(ratio))
+    if name == "always_off":
+        return ALWAYS_OFF
+    logger.error(
+        "Unknown telemetry.traces_sampler %r, falling back to parentbased_always_on. "
+        "Valid values: parentbased_always_on, parentbased_traceidratio:<0.0-1.0>, always_off",
+        name,
+    )
+    return ParentBased(ALWAYS_ON)
+
+
+def _build_registry(meter: Meter) -> HarnessMetricsRegistry:
+    """Register all four harness LLM instruments against ``meter``."""
+    return HarnessMetricsRegistry(
+        llm_tokens_input=meter.create_counter(
+            "culture.harness.llm.tokens.input",
+            description="Per-LLM-call input token count by backend/model/nick",
+        ),
+        llm_tokens_output=meter.create_counter(
+            "culture.harness.llm.tokens.output",
+            description="Per-LLM-call output token count by backend/model/nick",
+        ),
+        llm_call_duration=meter.create_histogram(
+            "culture.harness.llm.call.duration",
+            unit="ms",
+            description="Per-LLM-call wall-clock duration in milliseconds",
+        ),
+        llm_calls=meter.create_counter(
+            "culture.harness.llm.calls",
+            description="Per-LLM-call count by backend/model/outcome",
+        ),
+    )
+
+
+def init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]:
+    """Initialize TracerProvider + MeterProvider for the harness. Idempotent.
+
+    Returns a ``(Tracer, HarnessMetricsRegistry)`` pair. When
+    ``telemetry.enabled`` is False the returned tracer is a no-op proxy (no
+    SDK provider installed) and the registry instruments are bound to OTEL's
+    proxy meter — call sites can ``add()`` / ``record()`` unconditionally
+    without ``if`` guards.
+
+    The idempotency snapshot includes both the full ``TelemetryConfig`` dict
+    and the agent identity (nick or daemon server name) so that two daemons
+    with identical config but different nicks get separate providers with the
+    correct ``service.instance.id``.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    tcfg = config.telemetry
+
+    # Build a stable identity string for service.instance.id.
+    if config.agents:
+        nick_identity = "-".join(a.nick for a in config.agents)
+    else:
+        nick_identity = config.server.name
+
+    snapshot = {"telemetry": asdict(tcfg), "nick": nick_identity}
+    if _initialized_for == snapshot and _tracer is not None and _registry is not None:
+        return _tracer, _registry
+
+    # Tear down the previous MeterProvider (has a background export thread).
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown errors must not crash init
+            logger.debug("HarnessMeterProvider shutdown failed", exc_info=True)
+        _meter_provider = None
+
+    # ------------------------------------------------------------------ #
+    # No-op / disabled paths                                               #
+    # ------------------------------------------------------------------ #
+    traces_on = tcfg.enabled and tcfg.traces_enabled
+    metrics_on = tcfg.enabled and tcfg.metrics_enabled
+
+    if not traces_on:
+        # No SDK provider → proxy no-op tracer.
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+
+    if not metrics_on:
+        # Proxy meter — instruments work as stubs; no export thread.
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+
+    if not tcfg.enabled:
+        _initialized_for = snapshot
+        return _tracer, _registry  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------ #
+    # Full SDK init                                                         #
+    # ------------------------------------------------------------------ #
+    resource = Resource.create(
+        {
+            "service.name": tcfg.service_name,
+            "service.instance.id": nick_identity,
+        }
+    )
+    compression_val = None if tcfg.otlp_compression == "none" else tcfg.otlp_compression
+
+    if traces_on:
+        span_exporter = OTLPSpanExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        tracer_provider = TracerProvider(
+            resource=resource,
+            sampler=_build_sampler(tcfg.traces_sampler),
+        )
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+        logger.info(
+            "OTEL harness tracing initialized: service=%s instance=%s endpoint=%s sampler=%s",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.traces_sampler,
+        )
+
+    if metrics_on:
+        metric_exporter = OTLPMetricExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter=metric_exporter,
+            export_interval_millis=tcfg.metrics_export_interval_ms,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        _meter_provider = provider
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+        logger.info(
+            "OTEL harness metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.metrics_export_interval_ms,
+        )
+
+    _initialized_for = snapshot
+    return _tracer, _registry  # type: ignore[return-value]
+
+
+def record_llm_call(
+    registry: HarnessMetricsRegistry,
+    *,
+    backend: str,
+    model: str,
+    nick: str,
+    usage: dict | None,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+    """Record metrics for a single LLM call.
+
+    Always increments ``llm_calls`` and records ``llm_call_duration``,
+    regardless of whether ``usage`` is present.
+
+    ``usage`` contract: may be ``None`` or contain partial keys; missing
+    or ``None``-valued keys silently skip the corresponding token counter.
+    This is intentional — codex (#298) and copilot (#299) do not expose
+    token counts in their current SDK versions. All four backends call this
+    helper; only claude and acp backends may have non-None usage dicts.
+
+    Args:
+        registry: The ``HarnessMetricsRegistry`` returned by
+            ``init_harness_telemetry``.
+        backend: Backend identifier string (e.g. ``"claude"``, ``"codex"``).
+        model: LLM model name (e.g. ``"claude-opus-4-6"``).
+        nick: Agent IRC nick (e.g. ``"spark-claude"``). Used as the
+            ``harness.nick`` label on token counters.
+        usage: Optional dict with optional keys ``tokens_input`` (int) and
+            ``tokens_output`` (int). ``None`` and missing keys are both safe.
+        duration_ms: Wall-clock duration of the LLM call in milliseconds.
+        outcome: One of ``"success"``, ``"error"``, or ``"timeout"``.
+    """
+    call_attrs = {"backend": backend, "model": model, "outcome": outcome}
+    registry.llm_calls.add(1, call_attrs)
+    registry.llm_call_duration.record(duration_ms, call_attrs)
+
+    if usage is not None:
+        tokens_input = usage.get("tokens_input")
+        if isinstance(tokens_input, int):
+            registry.llm_tokens_input.add(
+                tokens_input, {"backend": backend, "model": model, "harness.nick": nick}
+            )
+        tokens_output = usage.get("tokens_output")
+        if isinstance(tokens_output, int):
+            registry.llm_tokens_output.add(
+                tokens_output, {"backend": backend, "model": model, "harness.nick": nick}
+            )

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from claude_agent_sdk import (
     AssistantMessage,
@@ -14,6 +15,9 @@ from claude_agent_sdk import (
     ToolUseBlock,
     query,
 )
+
+if TYPE_CHECKING:
+    from culture.clients.claude.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -46,12 +50,16 @@ class AgentRunner:
         system_prompt: str = "",
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        nick: str = "",
     ) -> None:
         self.model = model
         self.directory = directory
         self.system_prompt = system_prompt
         self.on_exit = on_exit
         self.on_message = on_message
+        self._metrics = metrics
+        self._nick = nick
 
         self._session_id: str | None = None
         self._task: asyncio.Task | None = None
@@ -130,19 +138,59 @@ class AgentRunner:
 
     async def _process_turn(self, prompt: str) -> bool:
         """Run a single conversation turn. Returns False if a fatal error occurred."""
-        try:
-            async for message in query(
-                prompt=prompt,
-                options=self._make_options(),
-            ):
-                if isinstance(message, ResultMessage):
-                    self._handle_result_message(message)
-                elif isinstance(message, AssistantMessage):
-                    await self._handle_assistant_message(message)
-        except Exception:
-            logger.exception("SDK session turn error")
-            if not self._stopping and self.on_exit:
-                await self.on_exit(1)
+        from opentelemetry import trace as _otel_trace
+
+        tracer = _otel_trace.get_tracer("culture.harness.claude")
+        start_perf = time.perf_counter()
+        outcome = "success"
+        usage_dict: dict | None = None
+        failed = False
+        with tracer.start_as_current_span(
+            "harness.llm.call",
+            attributes={
+                "harness.backend": "claude",
+                "harness.model": self.model,
+                "harness.nick": self._nick,
+            },
+        ):
+            try:
+                async for message in query(
+                    prompt=prompt,
+                    options=self._make_options(),
+                ):
+                    if isinstance(message, ResultMessage):
+                        self._handle_result_message(message)
+                        # Extract usage if exposed by SDK; some ResultMessages have it
+                        u = getattr(message, "usage", None)
+                        if u is not None:
+                            usage_dict = {
+                                "tokens_input": getattr(u, "input_tokens", None)
+                                or (u.get("input_tokens") if isinstance(u, dict) else None),
+                                "tokens_output": getattr(u, "output_tokens", None)
+                                or (u.get("output_tokens") if isinstance(u, dict) else None),
+                            }
+                    elif isinstance(message, AssistantMessage):
+                        await self._handle_assistant_message(message)
+            except Exception:
+                outcome = "error"
+                failed = True
+                logger.exception("SDK session turn error")
+                if not self._stopping and self.on_exit:
+                    await self.on_exit(1)
+        duration_ms = (time.perf_counter() - start_perf) * 1000.0
+        if self._metrics is not None:
+            from culture.clients.claude.telemetry import record_llm_call
+
+            record_llm_call(
+                self._metrics,
+                backend="claude",
+                model=self.model,
+                nick=self._nick,
+                usage=usage_dict,
+                duration_ms=duration_ms,
+                outcome=outcome,
+            )
+        if failed:
             return False
         return True
 

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -15,8 +15,9 @@ from claude_agent_sdk import (
     ToolUseBlock,
     query,
 )
+from opentelemetry import trace as _otel_trace
 
-from culture.clients.claude.telemetry import record_llm_call
+from culture.clients.claude.telemetry import _HARNESS_TRACER_NAME, record_llm_call
 
 if TYPE_CHECKING:
     from culture.clients.claude.telemetry import HarnessMetricsRegistry
@@ -155,9 +156,7 @@ class AgentRunner:
 
     async def _process_turn(self, prompt: str) -> bool:
         """Run a single conversation turn. Returns False if a fatal error occurred."""
-        from opentelemetry import trace as _otel_trace
-
-        tracer = _otel_trace.get_tracer("culture.harness.claude")
+        tracer = _otel_trace.get_tracer(_HARNESS_TRACER_NAME)
         start_perf = time.perf_counter()
         outcome = "success"
         usage_dict: dict | None = None

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -16,6 +16,8 @@ from claude_agent_sdk import (
     query,
 )
 
+from culture.clients.claude.telemetry import record_llm_call
+
 if TYPE_CHECKING:
     from culture.clients.claude.telemetry import HarnessMetricsRegistry
 
@@ -33,6 +35,21 @@ def _content_block_to_dict(block: Any) -> dict[str, Any]:
     if isinstance(block, ThinkingBlock):
         return {"type": "thinking", "text": block.thinking}
     return {"type": "unknown", "repr": repr(block)}
+
+
+def _extract_usage(u: Any) -> dict[str, Any]:
+    """Extract token counts from a usage object (dict or attr-style).
+
+    Uses explicit branching so that a legitimate zero-token value is preserved
+    rather than being silenced by the ``or``-fallback pattern.
+    """
+    if isinstance(u, dict):
+        tokens_in = u.get("input_tokens")
+        tokens_out = u.get("output_tokens")
+    else:
+        tokens_in = getattr(u, "input_tokens", None)
+        tokens_out = getattr(u, "output_tokens", None)
+    return {"tokens_input": tokens_in, "tokens_output": tokens_out}
 
 
 class AgentRunner:
@@ -163,12 +180,7 @@ class AgentRunner:
                         # Extract usage if exposed by SDK; some ResultMessages have it
                         u = getattr(message, "usage", None)
                         if u is not None:
-                            usage_dict = {
-                                "tokens_input": getattr(u, "input_tokens", None)
-                                or (u.get("input_tokens") if isinstance(u, dict) else None),
-                                "tokens_output": getattr(u, "output_tokens", None)
-                                or (u.get("output_tokens") if isinstance(u, dict) else None),
-                            }
+                            usage_dict = _extract_usage(u)
                     elif isinstance(message, AssistantMessage):
                         await self._handle_assistant_message(message)
             except Exception:
@@ -179,8 +191,6 @@ class AgentRunner:
                     await self.on_exit(1)
         duration_ms = (time.perf_counter() - start_perf) * 1000.0
         if self._metrics is not None:
-            from culture.clients.claude.telemetry import record_llm_call
-
             record_llm_call(
                 self._metrics,
                 backend="claude",

--- a/culture/clients/claude/config.py
+++ b/culture/clients/claude/config.py
@@ -69,12 +69,34 @@ class AgentConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """OpenTelemetry settings for the agent harness.
+
+    ``enabled: false`` by default so freshly installed harnesses don't
+    try to connect to a non-existent OTLP collector. Flip to ``true``
+    once your collector is running.
+    """
+
+    enabled: bool = False
+    service_name: str = "culture.harness.claude"
+    otlp_endpoint: str = "http://localhost:4317"
+    otlp_protocol: str = "grpc"  # grpc | http/protobuf (only grpc supported initially)
+    otlp_timeout_ms: int = 5000
+    otlp_compression: str = "gzip"
+    traces_enabled: bool = True
+    traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
+
+
+@dataclass
 class DaemonConfig:
     """Top-level daemon configuration."""
 
     server: ServerConnConfig = field(default_factory=ServerConnConfig)
     supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
     webhooks: WebhookConfig = field(default_factory=WebhookConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     buffer_size: int = 500
     poll_interval: int = 60
     sleep_start: str = "23:00"
@@ -97,6 +119,7 @@ def load_config(path: str | Path) -> DaemonConfig:
     supervisor = SupervisorConfig(**raw.get("supervisor", {}))
 
     webhooks = WebhookConfig(**raw.get("webhooks", {}))
+    telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
     known_agent_fields = {f.name for f in AgentConfig.__dataclass_fields__.values()}
@@ -110,6 +133,7 @@ def load_config(path: str | Path) -> DaemonConfig:
         server=server,
         supervisor=supervisor,
         webhooks=webhooks,
+        telemetry=telemetry,
         buffer_size=raw.get("buffer_size", 500),
         poll_interval=raw.get("poll_interval", 60),
         sleep_start=raw.get("sleep_start", "23:00"),

--- a/culture/clients/claude/culture.yaml
+++ b/culture/clients/claude/culture.yaml
@@ -12,3 +12,18 @@ system_prompt: |
 tags:
   - harness
   - claude
+
+# OpenTelemetry configuration for the agent harness.
+# Set enabled: true once your OTLP collector is running.
+# See docs/agentirc/harness-telemetry.md for a setup guide.
+telemetry:
+  enabled: false                          # master switch — flip to true to start exporting
+  service_name: culture.harness.claude    # overridden per-backend (e.g. culture.harness.claude)
+  otlp_endpoint: http://localhost:4317    # OTLP/gRPC receiver endpoint
+  otlp_protocol: grpc                     # grpc or http/protobuf
+  otlp_timeout_ms: 5000                   # export request timeout in milliseconds
+  otlp_compression: gzip                  # gzip | none
+  traces_enabled: true                    # enable distributed tracing
+  traces_sampler: parentbased_always_on   # honor the server's sampling decision
+  metrics_enabled: true                   # enable LLM call metrics export
+  metrics_export_interval_ms: 10000       # how often to push metric batches (ms)

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -15,6 +15,7 @@ from culture.clients.claude.irc_transport import IRCTransport
 from culture.clients.claude.message_buffer import MessageBuffer
 from culture.clients.claude.socket_server import SocketServer
 from culture.clients.claude.supervisor import Supervisor, make_sdk_evaluate_fn
+from culture.clients.claude.telemetry import init_harness_telemetry
 from culture.clients.claude.webhook import AlertEvent, WebhookClient
 from culture.pidfile import remove_pid, write_pid
 
@@ -60,6 +61,8 @@ class AgentDaemon:
         self._socket_server: SocketServer | None = None
         self._agent_runner: AgentRunner | None = None
         self._supervisor: Supervisor | None = None
+        self._tracer = None
+        self._metrics = None
 
         # Crash-recovery state
         self._crash_times: list[float] = []
@@ -115,6 +118,9 @@ class AgentDaemon:
         self._pid_name = f"agent-{self.agent.nick}"
         write_pid(self._pid_name, os.getpid())
 
+        # 0.5. OTEL telemetry (if telemetry.enabled, installs SDK providers; else no-op).
+        self._tracer, self._metrics = init_harness_telemetry(self.config)
+
         # 1. Message buffer
         self._buffer = MessageBuffer(max_per_channel=self.config.buffer_size)
 
@@ -129,6 +135,9 @@ class AgentDaemon:
             on_mention=self._on_mention,
             tags=list(self.agent.tags),
             on_roominvite=self._on_roominvite,
+            tracer=self._tracer,
+            metrics=self._metrics,
+            backend="claude",
         )
         await self._transport.connect()
 
@@ -320,6 +329,8 @@ class AgentDaemon:
             system_prompt=self._build_system_prompt(),
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
+            metrics=self._metrics,
+            nick=self.agent.nick,
         )
         await self._agent_runner.start()
         logger.info("AgentRunner started via SDK for %s", self.agent.nick)

--- a/culture/clients/claude/irc_transport.py
+++ b/culture/clients/claude/irc_transport.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
-from typing import Callable
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Callable
 
 from culture.aio import maybe_await
 from culture.clients.claude.message_buffer import MessageBuffer
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
+from culture.telemetry.context import (
+    TRACEPARENT_TAG,
+    context_from_traceparent,
+    current_traceparent,
+    extract_traceparent_from_tags,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
+
+    from culture.clients.claude.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
 
 class IRCTransport:
-    """Async IRC client for the daemon."""
+    """Async IRC client for the daemon.
+
+    Optional kwargs ``tracer``, ``metrics``, and ``backend`` enable OTEL
+    tracing and LLM metrics when an SDK provider is installed. Pass ``None``
+    (the default) for all three to run without instrumentation.
+    """
 
     def __init__(
         self,
@@ -28,6 +46,9 @@ class IRCTransport:
         tags: list[str] | None = None,
         on_roominvite: Callable[[str, str], None] | None = None,
         icon: str | None = None,
+        tracer: Tracer | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        backend: str = "claude",
     ):
         self.host = host
         self.port = port
@@ -39,6 +60,10 @@ class IRCTransport:
         self.tags = tags or []
         self.on_roominvite = on_roominvite
         self.icon = icon
+        self._tracer = tracer
+        # stored for the daemon to forward to the agent runner; not used in transport
+        self._metrics = metrics
+        self._backend = backend
         self.connected = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -57,23 +82,46 @@ class IRCTransport:
             "332": self._on_numeric_topic,
         }
 
+    def _span(self, name: str, attrs: dict | None = None) -> AbstractContextManager:
+        """Return a real span context manager when tracing is enabled, else a no-op.
+
+        Keeps the no-tracer fast path clean — all callers write the same
+        ``with self._span(...):`` pattern regardless of whether a tracer is
+        configured.
+
+        Does NOT accept a ``context=`` argument; callers that need a span
+        parented to a remote trace context (e.g. inbound message handling in
+        ``_handle``) call ``self._tracer.start_as_current_span`` directly.
+        """
+        if self._tracer is not None:
+            return self._tracer.start_as_current_span(name, attributes=attrs or {})
+        return contextlib.nullcontext()
+
     async def connect(self) -> None:
         self._should_run = True
         await self._do_connect()
 
     async def _do_connect(self) -> None:
-        try:
-            self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
-        except OSError as exc:
-            raise ConnectionError(
-                f"Cannot connect to IRC server at {self.host}:{self.port} "
-                f"- is the server running?"
-            ) from exc
-        await self._send_raw("CAP REQ :message-tags")
-        await self._send_raw(f"NICK {self.nick}")
-        await self._send_raw(f"USER {self.user} 0 * :{self.user}")
-        await self._send_raw("CAP END")
-        self._read_task = asyncio.create_task(self._read_loop())
+        with self._span(
+            "harness.irc.connect",
+            attrs={
+                "harness.backend": self._backend,
+                "harness.nick": self.nick,
+                "harness.server": f"{self.host}:{self.port}",
+            },
+        ):
+            try:
+                self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+            except OSError as exc:
+                raise ConnectionError(
+                    f"Cannot connect to IRC server at {self.host}:{self.port} "
+                    f"- is the server running?"
+                ) from exc
+            await self._send_raw("CAP REQ :message-tags")
+            await self._send_raw(f"NICK {self.nick}")
+            await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+            await self._send_raw("CAP END")
+            self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:
         self._should_run = False
@@ -151,6 +199,14 @@ class IRCTransport:
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
+        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
+        # Only inject when we have a tracer configured (fast-path: no work if
+        # self._tracer is None) and there is no tag block already on the line
+        # (defensive guard — prevents double-tagging if a caller pre-tagged).
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:
@@ -193,9 +249,41 @@ class IRCTransport:
                 delay = min(delay * 2, 60)
 
     async def _handle(self, msg: Message) -> None:
-        handler = self._cmd_handlers.get(msg.command)
-        if handler:
-            await maybe_await(handler(msg))
+        # Extract inbound traceparent before opening any span so the new span
+        # can be correctly parented to the remote trace context.
+        result = extract_traceparent_from_tags(msg, peer=None)
+
+        if self._tracer is not None:
+            if result.status == "valid":
+                ctx = context_from_traceparent(result.traceparent)
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    context=ctx,
+                    attributes={
+                        "irc.command": msg.command,
+                        "irc.client.nick": self.nick,
+                        "culture.trace.origin": "remote",
+                    },
+                )
+            else:
+                attrs = {
+                    "irc.command": msg.command,
+                    "irc.client.nick": self.nick,
+                    "culture.trace.origin": ("local" if result.status == "missing" else "remote"),
+                }
+                if result.status in ("malformed", "too_long"):
+                    attrs["culture.trace.dropped_reason"] = result.status
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    attributes=attrs,
+                )
+        else:
+            span_cm = contextlib.nullcontext()
+
+        with span_cm:
+            handler = self._cmd_handlers.get(msg.command)
+            if handler:
+                await maybe_await(handler(msg))
 
     async def _on_ping(self, msg: Message) -> None:
         token = msg.params[0] if msg.params else ""
@@ -211,23 +299,6 @@ class IRCTransport:
         if self.icon:
             await self._send_raw(f"ICON {self.icon}")
         await self._send_raw(f"MODE {self.nick} +A")
-
-    def _on_privmsg(self, msg: Message) -> None:
-        if len(msg.params) < 2:
-            return
-        target = msg.params[0]
-        text = msg.params[1]
-        sender = msg.prefix.split("!")[0] if msg.prefix else "unknown"
-        if sender == self.nick:
-            return
-        # Filter out server-emitted event notifications from system-<server>.
-        # These are surfaced PRIVMSGs that announce mesh events (user.join,
-        # agent.connect, server.link, etc.) — they are not conversation and
-        # should not enter the agent's message buffer or trigger the poll loop.
-        if sender.startswith(SYSTEM_USER_PREFIX):
-            return
-        self._route_to_buffer(target, sender, text)
-        self._detect_and_fire_mention(target, sender, text)
 
     def _on_topic(self, msg: Message) -> None:
         """Handle TOPIC broadcasts (someone changed the topic)."""
@@ -250,6 +321,23 @@ class IRCTransport:
             self.buffer.add(channel, "server", "* No topic is set")
         elif msg.command == "332" and len(msg.params) >= 3:
             self.buffer.add(channel, "server", f"* Topic: {msg.params[2]}")
+
+    def _on_privmsg(self, msg: Message) -> None:
+        if len(msg.params) < 2:
+            return
+        target = msg.params[0]
+        text = msg.params[1]
+        sender = msg.prefix.split("!")[0] if msg.prefix else "unknown"
+        if sender == self.nick:
+            return
+        # Filter out server-emitted event notifications from system-<server>.
+        # These are surfaced PRIVMSGs that announce mesh events (user.join,
+        # agent.connect, server.link, etc.) — they are not conversation and
+        # should not enter the agent's message buffer or trigger the poll loop.
+        if sender.startswith(SYSTEM_USER_PREFIX):
+            return
+        self._route_to_buffer(target, sender, text)
+        self._detect_and_fire_mention(target, sender, text)
 
     def _route_to_buffer(self, target: str, sender: str, text: str) -> None:
         """Insert the message into the appropriate buffer (channel or DM)."""

--- a/culture/clients/claude/irc_transport.py
+++ b/culture/clients/claude/irc_transport.py
@@ -61,7 +61,7 @@ class IRCTransport:
         self.on_roominvite = on_roominvite
         self.icon = icon
         self._tracer = tracer
-        # stored for the daemon to forward to the agent runner; not used in transport
+        # accepted for future per-message metrics (e.g. byte counters); unused in v1
         self._metrics = metrics
         self._backend = backend
         self.connected = False

--- a/culture/clients/claude/irc_transport.py
+++ b/culture/clients/claude/irc_transport.py
@@ -193,20 +193,23 @@ class IRCTransport:
             await self._send_raw(f"TOPIC {channel}")
 
     async def send_raw(self, line: str) -> None:
-        """Send a raw IRC line. Public for commands like HISTORY."""
+        """Send a raw IRC line. Public for commands like HISTORY.
+
+        When a tracer is configured and a span is active, prepends the W3C
+        ``@culture.dev/traceparent=`` IRCv3 tag so all outbound paths — whether
+        called via the internal ``_send_raw`` helper or directly by daemon code
+        — carry trace context consistently.
+        """
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp is not None:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         if self._writer:
             self._writer.write(f"{line}\r\n".encode())
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
-        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
-        # Only inject when we have a tracer configured (fast-path: no work if
-        # self._tracer is None) and there is no tag block already on the line
-        # (defensive guard — prevents double-tagging if a caller pre-tagged).
-        if self._tracer is not None and not line.startswith("@"):
-            tp = current_traceparent()
-            if tp:
-                line = f"@{TRACEPARENT_TAG}={tp} {line}"
+        """Internal send helper; delegates to send_raw (injection lives there)."""
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:

--- a/culture/clients/claude/telemetry.py
+++ b/culture/clients/claude/telemetry.py
@@ -1,0 +1,318 @@
+"""OpenTelemetry bootstrap for Culture agent harnesses.
+
+Why this file lives in ``packages/agent-harness/``
+---------------------------------------------------
+The culture codebase uses a **cite, don't import** pattern for the per-backend
+agent harnesses in ``culture/clients/{claude,codex,copilot,acp}/``. Each backend
+owns a verbatim copy of this file (with the ``service_name`` default changed to
+``culture.harness.<backend>``). Backend-specific overrides are isolated to those
+two sites; all other logic must stay identical so the all-backends parity test
+(``tests/harness/test_all_backends_parity.py``) passes.
+
+This is the claude citation of the reference module in
+``packages/agent-harness/telemetry.py``.
+
+Backend-specific edit sites (two, both must be updated on citation)
+--------------------------------------------------------------------
+1. ``TelemetryConfig.service_name`` in ``config.py`` — change the default from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"``.
+2. ``_HARNESS_TRACER_NAME`` constant in this file — change the value from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"`` to match.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.metrics import Counter, Histogram, Meter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    Sampler,
+    TraceIdRatioBased,
+)
+from opentelemetry.trace import Tracer
+
+logger = logging.getLogger(__name__)
+
+# Module-level tracer name — cited backends replace "culture.harness" with
+# "culture.harness.<backend>" to match their service.name.
+_HARNESS_TRACER_NAME = "culture.harness.claude"
+
+# Module-level globals — mirrors the server-side tracing.py / metrics.py pattern.
+_initialized_for: dict | None = None
+_tracer: Tracer | None = None
+_meter_provider: MeterProvider | None = None
+_registry: HarnessMetricsRegistry | None = None
+
+
+@dataclass
+class HarnessMetricsRegistry:
+    """All harness-side LLM instruments, registered once during init_harness_telemetry.
+
+    Parallel to the server's ``MetricsRegistry`` — different process, different
+    provider, different ``service.name``. Plan 6's bot-side metrics follow the
+    same parallel-registry pattern if bots are process-isolated.
+    """
+
+    llm_tokens_input: Counter
+    """Per-LLM-call input token count by backend/model/nick."""
+
+    llm_tokens_output: Counter
+    """Per-LLM-call output token count by backend/model/nick."""
+
+    llm_call_duration: Histogram
+    """Per-LLM-call wall-clock duration in milliseconds."""
+
+    llm_calls: Counter
+    """Per-LLM-call count by backend/model/outcome."""
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only.
+
+    Mirrors ``culture.telemetry.metrics.reset_for_tests`` (MeterProvider
+    shutdown + global clear) and ``culture.telemetry.tracing.reset_for_tests``
+    (trace provider global clear). Both are needed because parallel xdist
+    workers can leak global providers across module boundaries.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        _meter_provider = None
+
+    _initialized_for = None
+    _tracer = None
+    _registry = None
+
+    # Reset the OTEL metrics global — same path as server-side metrics.py.
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    _mi._METER_PROVIDER = None
+    _mi._METER_PROVIDER_SET_ONCE = _mi.Once()
+
+    # Reset the OTEL trace global — same path as server-side tracing.py.
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER_SET_ONCE = trace.Once()  # type: ignore[attr-defined]
+
+
+def _build_sampler(name: str) -> Sampler:
+    """Parse a ``traces_sampler`` string into an OTEL Sampler.
+
+    Mirrors ``culture.telemetry.tracing._build_sampler`` exactly — same
+    string grammar, same fallback warning.
+    """
+    if name == "parentbased_always_on":
+        return ParentBased(ALWAYS_ON)
+    if name.startswith("parentbased_traceidratio:"):
+        ratio = float(name.split(":", 1)[1])
+        return ParentBased(TraceIdRatioBased(ratio))
+    if name == "always_off":
+        return ALWAYS_OFF
+    logger.error(
+        "Unknown telemetry.traces_sampler %r, falling back to parentbased_always_on. "
+        "Valid values: parentbased_always_on, parentbased_traceidratio:<0.0-1.0>, always_off",
+        name,
+    )
+    return ParentBased(ALWAYS_ON)
+
+
+def _build_registry(meter: Meter) -> HarnessMetricsRegistry:
+    """Register all four harness LLM instruments against ``meter``."""
+    return HarnessMetricsRegistry(
+        llm_tokens_input=meter.create_counter(
+            "culture.harness.llm.tokens.input",
+            description="Per-LLM-call input token count by backend/model/nick",
+        ),
+        llm_tokens_output=meter.create_counter(
+            "culture.harness.llm.tokens.output",
+            description="Per-LLM-call output token count by backend/model/nick",
+        ),
+        llm_call_duration=meter.create_histogram(
+            "culture.harness.llm.call.duration",
+            unit="ms",
+            description="Per-LLM-call wall-clock duration in milliseconds",
+        ),
+        llm_calls=meter.create_counter(
+            "culture.harness.llm.calls",
+            description="Per-LLM-call count by backend/model/outcome",
+        ),
+    )
+
+
+def init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]:
+    """Initialize TracerProvider + MeterProvider for the harness. Idempotent.
+
+    Returns a ``(Tracer, HarnessMetricsRegistry)`` pair. When
+    ``telemetry.enabled`` is False the returned tracer is a no-op proxy (no
+    SDK provider installed) and the registry instruments are bound to OTEL's
+    proxy meter — call sites can ``add()`` / ``record()`` unconditionally
+    without ``if`` guards.
+
+    The idempotency snapshot includes both the full ``TelemetryConfig`` dict
+    and the agent identity (nick or daemon server name) so that two daemons
+    with identical config but different nicks get separate providers with the
+    correct ``service.instance.id``.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    tcfg = config.telemetry
+
+    # Build a stable identity string for service.instance.id.
+    if config.agents:
+        nick_identity = "-".join(a.nick for a in config.agents)
+    else:
+        nick_identity = config.server.name
+
+    snapshot = {"telemetry": asdict(tcfg), "nick": nick_identity}
+    if _initialized_for == snapshot and _tracer is not None and _registry is not None:
+        return _tracer, _registry
+
+    # Tear down the previous MeterProvider (has a background export thread).
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown errors must not crash init
+            logger.debug("HarnessMeterProvider shutdown failed", exc_info=True)
+        _meter_provider = None
+
+    # ------------------------------------------------------------------ #
+    # No-op / disabled paths                                               #
+    # ------------------------------------------------------------------ #
+    traces_on = tcfg.enabled and tcfg.traces_enabled
+    metrics_on = tcfg.enabled and tcfg.metrics_enabled
+
+    if not traces_on:
+        # No SDK provider → proxy no-op tracer.
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+
+    if not metrics_on:
+        # Proxy meter — instruments work as stubs; no export thread.
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+
+    if not tcfg.enabled:
+        _initialized_for = snapshot
+        return _tracer, _registry  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------ #
+    # Full SDK init                                                         #
+    # ------------------------------------------------------------------ #
+    resource = Resource.create(
+        {
+            "service.name": tcfg.service_name,
+            "service.instance.id": nick_identity,
+        }
+    )
+    compression_val = None if tcfg.otlp_compression == "none" else tcfg.otlp_compression
+
+    if traces_on:
+        span_exporter = OTLPSpanExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        tracer_provider = TracerProvider(
+            resource=resource,
+            sampler=_build_sampler(tcfg.traces_sampler),
+        )
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+        logger.info(
+            "OTEL harness tracing initialized: service=%s instance=%s endpoint=%s sampler=%s",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.traces_sampler,
+        )
+
+    if metrics_on:
+        metric_exporter = OTLPMetricExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter=metric_exporter,
+            export_interval_millis=tcfg.metrics_export_interval_ms,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        _meter_provider = provider
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+        logger.info(
+            "OTEL harness metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.metrics_export_interval_ms,
+        )
+
+    _initialized_for = snapshot
+    return _tracer, _registry  # type: ignore[return-value]
+
+
+def record_llm_call(
+    registry: HarnessMetricsRegistry,
+    *,
+    backend: str,
+    model: str,
+    nick: str,
+    usage: dict | None,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+    """Record metrics for a single LLM call.
+
+    Always increments ``llm_calls`` and records ``llm_call_duration``,
+    regardless of whether ``usage`` is present.
+
+    ``usage`` contract: may be ``None`` or contain partial keys; missing
+    or ``None``-valued keys silently skip the corresponding token counter.
+    This is intentional — codex (#298) and copilot (#299) do not expose
+    token counts in their current SDK versions. All four backends call this
+    helper; only claude and acp backends may have non-None usage dicts.
+
+    Args:
+        registry: The ``HarnessMetricsRegistry`` returned by
+            ``init_harness_telemetry``.
+        backend: Backend identifier string (e.g. ``"claude"``, ``"codex"``).
+        model: LLM model name (e.g. ``"claude-opus-4-6"``).
+        nick: Agent IRC nick (e.g. ``"spark-claude"``). Used as the
+            ``harness.nick`` label on token counters.
+        usage: Optional dict with optional keys ``tokens_input`` (int) and
+            ``tokens_output`` (int). ``None`` and missing keys are both safe.
+        duration_ms: Wall-clock duration of the LLM call in milliseconds.
+        outcome: One of ``"success"``, ``"error"``, or ``"timeout"``.
+    """
+    call_attrs = {"backend": backend, "model": model, "outcome": outcome}
+    registry.llm_calls.add(1, call_attrs)
+    registry.llm_call_duration.record(duration_ms, call_attrs)
+
+    if usage is not None:
+        tokens_input = usage.get("tokens_input")
+        if isinstance(tokens_input, int):
+            registry.llm_tokens_input.add(
+                tokens_input, {"backend": backend, "model": model, "harness.nick": nick}
+            )
+        tokens_output = usage.get("tokens_output")
+        if isinstance(tokens_output, int):
+            registry.llm_tokens_output.add(
+                tokens_output, {"backend": backend, "model": model, "harness.nick": nick}
+            )

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -8,9 +8,16 @@ import logging
 import os
 import shutil
 import tempfile
-from typing import Any, Awaitable, Callable
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from opentelemetry import trace as _otel_trace
 
 from culture.aio import maybe_await
+from culture.clients.codex.telemetry import _HARNESS_TRACER_NAME, record_llm_call
+
+if TYPE_CHECKING:
+    from culture.clients.codex.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +33,8 @@ class CodexAgentRunner:
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         on_turn_error: Callable[[], Awaitable[None] | None] | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        nick: str = "",
     ) -> None:
         self.model = model
         self.directory = directory
@@ -33,6 +42,8 @@ class CodexAgentRunner:
         self.on_exit = on_exit
         self.on_message = on_message
         self.on_turn_error = on_turn_error
+        self._metrics = metrics
+        self._nick = nick
 
         self._isolated_home: str | None = None
         self._process: asyncio.subprocess.Process | None = None
@@ -335,28 +346,55 @@ class CodexAgentRunner:
 
     async def _execute_single_turn(self, text: str) -> None:
         """Send one turn request and wait for completion."""
-        self._turn_done.clear()
-        try:
-            await self._send_request(
-                "turn/start",
-                {
-                    "threadId": self._thread_id,
-                    "input": [{"type": "text", "text": text}],
-                },
+        start_perf = time.perf_counter()
+        outcome = "success"
+        tracer = _otel_trace.get_tracer(_HARNESS_TRACER_NAME)
+        with tracer.start_as_current_span(
+            "harness.llm.call",
+            attributes={
+                "harness.backend": "codex",
+                "harness.model": self.model,
+                "harness.nick": self._nick,
+            },
+        ):
+            self._turn_done.clear()
+            try:
+                await self._send_request(
+                    "turn/start",
+                    {
+                        "threadId": self._thread_id,
+                        "input": [{"type": "text", "text": text}],
+                    },
+                )
+                # Wait for turn/completed notification via the event
+                async with asyncio.timeout(300):
+                    await self._turn_done.wait()
+            except asyncio.TimeoutError:
+                outcome = "timeout"
+                logger.warning("Codex turn timed out after 300s")
+                self._turn_done.set()
+                if self.on_turn_error:
+                    await maybe_await(self.on_turn_error())
+            except Exception:
+                outcome = "error"
+                logger.exception("Codex turn error")
+                self._turn_done.set()
+                if self.on_turn_error:
+                    await maybe_await(self.on_turn_error())
+        duration_ms = (time.perf_counter() - start_perf) * 1000.0
+        if self._metrics is not None:
+            # Codex token usage tracking — issue #298 (currently usage=None;
+            # token counts are not exposed by the codex app-server turn/completed
+            # notification in the current SDK version).
+            record_llm_call(
+                self._metrics,
+                backend="codex",
+                model=self.model,
+                nick=self._nick,
+                usage=None,
+                duration_ms=duration_ms,
+                outcome=outcome,
             )
-            # Wait for turn/completed notification via the event
-            async with asyncio.timeout(300):
-                await self._turn_done.wait()
-        except asyncio.TimeoutError:
-            logger.warning("Codex turn timed out after 300s")
-            self._turn_done.set()
-            if self.on_turn_error:
-                await maybe_await(self.on_turn_error())
-        except Exception:
-            logger.exception("Codex turn error")
-            self._turn_done.set()
-            if self.on_turn_error:
-                await maybe_await(self.on_turn_error())
 
     async def _prompt_loop(self) -> None:
         """Process queued prompts one at a time."""

--- a/culture/clients/codex/config.py
+++ b/culture/clients/codex/config.py
@@ -61,12 +61,34 @@ class AgentConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """OpenTelemetry settings for the agent harness.
+
+    ``enabled: false`` by default so freshly installed harnesses don't
+    try to connect to a non-existent OTLP collector. Flip to ``true``
+    once your collector is running.
+    """
+
+    enabled: bool = False
+    service_name: str = "culture.harness.codex"
+    otlp_endpoint: str = "http://localhost:4317"
+    otlp_protocol: str = "grpc"  # grpc | http/protobuf (only grpc supported initially)
+    otlp_timeout_ms: int = 5000
+    otlp_compression: str = "gzip"
+    traces_enabled: bool = True
+    traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
+
+
+@dataclass
 class DaemonConfig:
     """Top-level daemon configuration."""
 
     server: ServerConnConfig = field(default_factory=ServerConnConfig)
     supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
     webhooks: WebhookConfig = field(default_factory=WebhookConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     buffer_size: int = 500
     poll_interval: int = 60
     sleep_start: str = "23:00"
@@ -89,10 +111,13 @@ def load_config(path: str | Path) -> DaemonConfig:
     supervisor = SupervisorConfig(**raw.get("supervisor", {}))
 
     webhooks = WebhookConfig(**raw.get("webhooks", {}))
+    telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
     known_agent_fields = {f.name for f in AgentConfig.__dataclass_fields__.values()}
     for agent_raw in raw.get("agents", []):
+        # Strip unknown fields (e.g. backend-specific fields from other backends)
+        # so multi-backend configs don't crash on load.
         filtered = {k: v for k, v in agent_raw.items() if k in known_agent_fields}
         agents.append(AgentConfig(**filtered))
 
@@ -100,6 +125,7 @@ def load_config(path: str | Path) -> DaemonConfig:
         server=server,
         supervisor=supervisor,
         webhooks=webhooks,
+        telemetry=telemetry,
         buffer_size=raw.get("buffer_size", 500),
         poll_interval=raw.get("poll_interval", 60),
         sleep_start=raw.get("sleep_start", "23:00"),

--- a/culture/clients/codex/culture.yaml
+++ b/culture/clients/codex/culture.yaml
@@ -12,3 +12,18 @@ system_prompt: |
 tags:
   - harness
   - codex
+
+# OpenTelemetry configuration for the agent harness.
+# Set enabled: true once your OTLP collector is running.
+# See docs/agentirc/harness-telemetry.md for a setup guide.
+telemetry:
+  enabled: false                          # master switch — flip to true to start exporting
+  service_name: culture.harness.codex     # overridden per-backend (e.g. culture.harness.codex)
+  otlp_endpoint: http://localhost:4317    # OTLP/gRPC receiver endpoint
+  otlp_protocol: grpc                     # grpc or http/protobuf
+  otlp_timeout_ms: 5000                   # export request timeout in milliseconds
+  otlp_compression: gzip                  # gzip | none
+  traces_enabled: true                    # enable distributed tracing
+  traces_sampler: parentbased_always_on   # honor the server's sampling decision
+  metrics_enabled: true                   # enable LLM call metrics export
+  metrics_export_interval_ms: 10000       # how often to push metric batches (ms)

--- a/culture/clients/codex/daemon.py
+++ b/culture/clients/codex/daemon.py
@@ -22,6 +22,7 @@ from culture.clients.codex.irc_transport import IRCTransport
 from culture.clients.codex.message_buffer import MessageBuffer
 from culture.clients.codex.socket_server import SocketServer
 from culture.clients.codex.supervisor import CodexSupervisor
+from culture.clients.codex.telemetry import init_harness_telemetry
 from culture.clients.codex.webhook import AlertEvent, WebhookClient
 from culture.pidfile import remove_pid, write_pid
 
@@ -75,6 +76,8 @@ class CodexDaemon:
         self._socket_server: SocketServer | None = None
         self._agent_runner: CodexAgentRunner | None = None
         self._supervisor: CodexSupervisor | None = None
+        self._tracer = None
+        self._metrics = None
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -136,6 +139,9 @@ class CodexDaemon:
         self._pid_name = f"agent-{self.agent.nick}"
         write_pid(self._pid_name, os.getpid())
 
+        # 0.5. OTEL telemetry (if telemetry.enabled, installs SDK providers; else no-op).
+        self._tracer, self._metrics = init_harness_telemetry(self.config)
+
         # 1. Message buffer
         self._buffer = MessageBuffer(max_per_channel=self.config.buffer_size)
 
@@ -150,6 +156,9 @@ class CodexDaemon:
             on_mention=self._on_mention,
             tags=list(self.agent.tags),
             on_roominvite=self._on_roominvite,
+            tracer=self._tracer,
+            metrics=self._metrics,
+            backend="codex",
         )
         await self._transport.connect()
 
@@ -370,6 +379,8 @@ class CodexDaemon:
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
             on_turn_error=self._on_turn_error,
+            metrics=self._metrics,
+            nick=self.agent.nick,
         )
         await self._agent_runner.start()
         logger.info("CodexAgentRunner started for %s", self.agent.nick)

--- a/culture/clients/codex/irc_transport.py
+++ b/culture/clients/codex/irc_transport.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
-from typing import Callable
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Callable
 
 from culture.aio import maybe_await
 from culture.clients.codex.message_buffer import MessageBuffer
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
+from culture.telemetry.context import (
+    TRACEPARENT_TAG,
+    context_from_traceparent,
+    current_traceparent,
+    extract_traceparent_from_tags,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
+
+    from culture.clients.codex.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
 
 class IRCTransport:
-    """Async IRC client for the daemon."""
+    """Async IRC client for the daemon.
+
+    Optional kwargs ``tracer``, ``metrics``, and ``backend`` enable OTEL
+    tracing and LLM metrics when an SDK provider is installed. Pass ``None``
+    (the default) for all three to run without instrumentation.
+    """
 
     def __init__(
         self,
@@ -28,6 +46,9 @@ class IRCTransport:
         tags: list[str] | None = None,
         on_roominvite: Callable[[str, str], None] | None = None,
         icon: str | None = None,
+        tracer: Tracer | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        backend: str = "codex",
     ):
         self.host = host
         self.port = port
@@ -39,6 +60,10 @@ class IRCTransport:
         self.tags = tags or []
         self.on_roominvite = on_roominvite
         self.icon = icon
+        self._tracer = tracer
+        # accepted for future per-message metrics (e.g. byte counters); unused in v1
+        self._metrics = metrics
+        self._backend = backend
         self.connected = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -57,23 +82,46 @@ class IRCTransport:
             "332": self._on_numeric_topic,
         }
 
+    def _span(self, name: str, attrs: dict | None = None) -> AbstractContextManager:
+        """Return a real span context manager when tracing is enabled, else a no-op.
+
+        Keeps the no-tracer fast path clean — all callers write the same
+        ``with self._span(...):`` pattern regardless of whether a tracer is
+        configured.
+
+        Does NOT accept a ``context=`` argument; callers that need a span
+        parented to a remote trace context (e.g. inbound message handling in
+        ``_handle``) call ``self._tracer.start_as_current_span`` directly.
+        """
+        if self._tracer is not None:
+            return self._tracer.start_as_current_span(name, attributes=attrs or {})
+        return contextlib.nullcontext()
+
     async def connect(self) -> None:
         self._should_run = True
         await self._do_connect()
 
     async def _do_connect(self) -> None:
-        try:
-            self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
-        except OSError as exc:
-            raise ConnectionError(
-                f"Cannot connect to IRC server at {self.host}:{self.port} "
-                f"- is the server running?"
-            ) from exc
-        await self._send_raw("CAP REQ :message-tags")
-        await self._send_raw(f"NICK {self.nick}")
-        await self._send_raw(f"USER {self.user} 0 * :{self.user}")
-        await self._send_raw("CAP END")
-        self._read_task = asyncio.create_task(self._read_loop())
+        with self._span(
+            "harness.irc.connect",
+            attrs={
+                "harness.backend": self._backend,
+                "harness.nick": self.nick,
+                "harness.server": f"{self.host}:{self.port}",
+            },
+        ):
+            try:
+                self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+            except OSError as exc:
+                raise ConnectionError(
+                    f"Cannot connect to IRC server at {self.host}:{self.port} "
+                    f"- is the server running?"
+                ) from exc
+            await self._send_raw("CAP REQ :message-tags")
+            await self._send_raw(f"NICK {self.nick}")
+            await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+            await self._send_raw("CAP END")
+            self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:
         self._should_run = False
@@ -151,6 +199,14 @@ class IRCTransport:
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
+        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
+        # Only inject when we have a tracer configured (fast-path: no work if
+        # self._tracer is None) and there is no tag block already on the line
+        # (defensive guard — prevents double-tagging if a caller pre-tagged).
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:
@@ -193,9 +249,41 @@ class IRCTransport:
                 delay = min(delay * 2, 60)
 
     async def _handle(self, msg: Message) -> None:
-        handler = self._cmd_handlers.get(msg.command)
-        if handler:
-            await maybe_await(handler(msg))
+        # Extract inbound traceparent before opening any span so the new span
+        # can be correctly parented to the remote trace context.
+        result = extract_traceparent_from_tags(msg, peer=None)
+
+        if self._tracer is not None:
+            if result.status == "valid":
+                ctx = context_from_traceparent(result.traceparent)
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    context=ctx,
+                    attributes={
+                        "irc.command": msg.command,
+                        "irc.client.nick": self.nick,
+                        "culture.trace.origin": "remote",
+                    },
+                )
+            else:
+                attrs = {
+                    "irc.command": msg.command,
+                    "irc.client.nick": self.nick,
+                    "culture.trace.origin": ("local" if result.status == "missing" else "remote"),
+                }
+                if result.status in ("malformed", "too_long"):
+                    attrs["culture.trace.dropped_reason"] = result.status
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    attributes=attrs,
+                )
+        else:
+            span_cm = contextlib.nullcontext()
+
+        with span_cm:
+            handler = self._cmd_handlers.get(msg.command)
+            if handler:
+                await maybe_await(handler(msg))
 
     async def _on_ping(self, msg: Message) -> None:
         token = msg.params[0] if msg.params else ""

--- a/culture/clients/codex/irc_transport.py
+++ b/culture/clients/codex/irc_transport.py
@@ -193,20 +193,23 @@ class IRCTransport:
             await self._send_raw(f"TOPIC {channel}")
 
     async def send_raw(self, line: str) -> None:
-        """Send a raw IRC line. Public for commands like HISTORY."""
+        """Send a raw IRC line. Public for commands like HISTORY.
+
+        When a tracer is configured and a span is active, prepends the W3C
+        ``@culture.dev/traceparent=`` IRCv3 tag so all outbound paths — whether
+        called via the internal ``_send_raw`` helper or directly by daemon code
+        — carry trace context consistently.
+        """
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp is not None:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         if self._writer:
             self._writer.write(f"{line}\r\n".encode())
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
-        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
-        # Only inject when we have a tracer configured (fast-path: no work if
-        # self._tracer is None) and there is no tag block already on the line
-        # (defensive guard — prevents double-tagging if a caller pre-tagged).
-        if self._tracer is not None and not line.startswith("@"):
-            tp = current_traceparent()
-            if tp:
-                line = f"@{TRACEPARENT_TAG}={tp} {line}"
+        """Internal send helper; delegates to send_raw (injection lives there)."""
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:

--- a/culture/clients/codex/telemetry.py
+++ b/culture/clients/codex/telemetry.py
@@ -1,0 +1,318 @@
+"""OpenTelemetry bootstrap for Culture agent harnesses.
+
+Why this file lives in ``packages/agent-harness/``
+---------------------------------------------------
+The culture codebase uses a **cite, don't import** pattern for the per-backend
+agent harnesses in ``culture/clients/{claude,codex,copilot,acp}/``. Each backend
+owns a verbatim copy of this file (with the ``service_name`` default changed to
+``culture.harness.<backend>``). Backend-specific overrides are isolated to those
+two sites; all other logic must stay identical so the all-backends parity test
+(``tests/harness/test_all_backends_parity.py``) passes.
+
+This is the codex citation of the reference module in
+``packages/agent-harness/telemetry.py``.
+
+Backend-specific edit sites (two, both must be updated on citation)
+--------------------------------------------------------------------
+1. ``TelemetryConfig.service_name`` in ``config.py`` — change the default from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"``.
+2. ``_HARNESS_TRACER_NAME`` constant in this file — change the value from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"`` to match.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.metrics import Counter, Histogram, Meter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    Sampler,
+    TraceIdRatioBased,
+)
+from opentelemetry.trace import Tracer
+
+logger = logging.getLogger(__name__)
+
+# Module-level tracer name — cited backends replace "culture.harness" with
+# "culture.harness.<backend>" to match their service.name.
+_HARNESS_TRACER_NAME = "culture.harness.codex"
+
+# Module-level globals — mirrors the server-side tracing.py / metrics.py pattern.
+_initialized_for: dict | None = None
+_tracer: Tracer | None = None
+_meter_provider: MeterProvider | None = None
+_registry: HarnessMetricsRegistry | None = None
+
+
+@dataclass
+class HarnessMetricsRegistry:
+    """All harness-side LLM instruments, registered once during init_harness_telemetry.
+
+    Parallel to the server's ``MetricsRegistry`` — different process, different
+    provider, different ``service.name``. Plan 6's bot-side metrics follow the
+    same parallel-registry pattern if bots are process-isolated.
+    """
+
+    llm_tokens_input: Counter
+    """Per-LLM-call input token count by backend/model/nick."""
+
+    llm_tokens_output: Counter
+    """Per-LLM-call output token count by backend/model/nick."""
+
+    llm_call_duration: Histogram
+    """Per-LLM-call wall-clock duration in milliseconds."""
+
+    llm_calls: Counter
+    """Per-LLM-call count by backend/model/outcome."""
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only.
+
+    Mirrors ``culture.telemetry.metrics.reset_for_tests`` (MeterProvider
+    shutdown + global clear) and ``culture.telemetry.tracing.reset_for_tests``
+    (trace provider global clear). Both are needed because parallel xdist
+    workers can leak global providers across module boundaries.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        _meter_provider = None
+
+    _initialized_for = None
+    _tracer = None
+    _registry = None
+
+    # Reset the OTEL metrics global — same path as server-side metrics.py.
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    _mi._METER_PROVIDER = None
+    _mi._METER_PROVIDER_SET_ONCE = _mi.Once()
+
+    # Reset the OTEL trace global — same path as server-side tracing.py.
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER_SET_ONCE = trace.Once()  # type: ignore[attr-defined]
+
+
+def _build_sampler(name: str) -> Sampler:
+    """Parse a ``traces_sampler`` string into an OTEL Sampler.
+
+    Mirrors ``culture.telemetry.tracing._build_sampler`` exactly — same
+    string grammar, same fallback warning.
+    """
+    if name == "parentbased_always_on":
+        return ParentBased(ALWAYS_ON)
+    if name.startswith("parentbased_traceidratio:"):
+        ratio = float(name.split(":", 1)[1])
+        return ParentBased(TraceIdRatioBased(ratio))
+    if name == "always_off":
+        return ALWAYS_OFF
+    logger.error(
+        "Unknown telemetry.traces_sampler %r, falling back to parentbased_always_on. "
+        "Valid values: parentbased_always_on, parentbased_traceidratio:<0.0-1.0>, always_off",
+        name,
+    )
+    return ParentBased(ALWAYS_ON)
+
+
+def _build_registry(meter: Meter) -> HarnessMetricsRegistry:
+    """Register all four harness LLM instruments against ``meter``."""
+    return HarnessMetricsRegistry(
+        llm_tokens_input=meter.create_counter(
+            "culture.harness.llm.tokens.input",
+            description="Per-LLM-call input token count by backend/model/nick",
+        ),
+        llm_tokens_output=meter.create_counter(
+            "culture.harness.llm.tokens.output",
+            description="Per-LLM-call output token count by backend/model/nick",
+        ),
+        llm_call_duration=meter.create_histogram(
+            "culture.harness.llm.call.duration",
+            unit="ms",
+            description="Per-LLM-call wall-clock duration in milliseconds",
+        ),
+        llm_calls=meter.create_counter(
+            "culture.harness.llm.calls",
+            description="Per-LLM-call count by backend/model/outcome",
+        ),
+    )
+
+
+def init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]:
+    """Initialize TracerProvider + MeterProvider for the harness. Idempotent.
+
+    Returns a ``(Tracer, HarnessMetricsRegistry)`` pair. When
+    ``telemetry.enabled`` is False the returned tracer is a no-op proxy (no
+    SDK provider installed) and the registry instruments are bound to OTEL's
+    proxy meter — call sites can ``add()`` / ``record()`` unconditionally
+    without ``if`` guards.
+
+    The idempotency snapshot includes both the full ``TelemetryConfig`` dict
+    and the agent identity (nick or daemon server name) so that two daemons
+    with identical config but different nicks get separate providers with the
+    correct ``service.instance.id``.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    tcfg = config.telemetry
+
+    # Build a stable identity string for service.instance.id.
+    if config.agents:
+        nick_identity = "-".join(a.nick for a in config.agents)
+    else:
+        nick_identity = config.server.name
+
+    snapshot = {"telemetry": asdict(tcfg), "nick": nick_identity}
+    if _initialized_for == snapshot and _tracer is not None and _registry is not None:
+        return _tracer, _registry
+
+    # Tear down the previous MeterProvider (has a background export thread).
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown errors must not crash init
+            logger.debug("HarnessMeterProvider shutdown failed", exc_info=True)
+        _meter_provider = None
+
+    # ------------------------------------------------------------------ #
+    # No-op / disabled paths                                               #
+    # ------------------------------------------------------------------ #
+    traces_on = tcfg.enabled and tcfg.traces_enabled
+    metrics_on = tcfg.enabled and tcfg.metrics_enabled
+
+    if not traces_on:
+        # No SDK provider → proxy no-op tracer.
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+
+    if not metrics_on:
+        # Proxy meter — instruments work as stubs; no export thread.
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+
+    if not tcfg.enabled:
+        _initialized_for = snapshot
+        return _tracer, _registry  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------ #
+    # Full SDK init                                                         #
+    # ------------------------------------------------------------------ #
+    resource = Resource.create(
+        {
+            "service.name": tcfg.service_name,
+            "service.instance.id": nick_identity,
+        }
+    )
+    compression_val = None if tcfg.otlp_compression == "none" else tcfg.otlp_compression
+
+    if traces_on:
+        span_exporter = OTLPSpanExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        tracer_provider = TracerProvider(
+            resource=resource,
+            sampler=_build_sampler(tcfg.traces_sampler),
+        )
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+        logger.info(
+            "OTEL harness tracing initialized: service=%s instance=%s endpoint=%s sampler=%s",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.traces_sampler,
+        )
+
+    if metrics_on:
+        metric_exporter = OTLPMetricExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter=metric_exporter,
+            export_interval_millis=tcfg.metrics_export_interval_ms,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        _meter_provider = provider
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+        logger.info(
+            "OTEL harness metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.metrics_export_interval_ms,
+        )
+
+    _initialized_for = snapshot
+    return _tracer, _registry  # type: ignore[return-value]
+
+
+def record_llm_call(
+    registry: HarnessMetricsRegistry,
+    *,
+    backend: str,
+    model: str,
+    nick: str,
+    usage: dict | None,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+    """Record metrics for a single LLM call.
+
+    Always increments ``llm_calls`` and records ``llm_call_duration``,
+    regardless of whether ``usage`` is present.
+
+    ``usage`` contract: may be ``None`` or contain partial keys; missing
+    or ``None``-valued keys silently skip the corresponding token counter.
+    This is intentional — codex (#298) and copilot (#299) do not expose
+    token counts in their current SDK versions. All four backends call this
+    helper; only claude and acp backends may have non-None usage dicts.
+
+    Args:
+        registry: The ``HarnessMetricsRegistry`` returned by
+            ``init_harness_telemetry``.
+        backend: Backend identifier string (e.g. ``"claude"``, ``"codex"``).
+        model: LLM model name (e.g. ``"claude-opus-4-6"``).
+        nick: Agent IRC nick (e.g. ``"spark-claude"``). Used as the
+            ``harness.nick`` label on token counters.
+        usage: Optional dict with optional keys ``tokens_input`` (int) and
+            ``tokens_output`` (int). ``None`` and missing keys are both safe.
+        duration_ms: Wall-clock duration of the LLM call in milliseconds.
+        outcome: One of ``"success"``, ``"error"``, or ``"timeout"``.
+    """
+    call_attrs = {"backend": backend, "model": model, "outcome": outcome}
+    registry.llm_calls.add(1, call_attrs)
+    registry.llm_call_duration.record(duration_ms, call_attrs)
+
+    if usage is not None:
+        tokens_input = usage.get("tokens_input")
+        if isinstance(tokens_input, int):
+            registry.llm_tokens_input.add(
+                tokens_input, {"backend": backend, "model": model, "harness.nick": nick}
+            )
+        tokens_output = usage.get("tokens_output")
+        if isinstance(tokens_output, int):
+            registry.llm_tokens_output.add(
+                tokens_output, {"backend": backend, "model": model, "harness.nick": nick}
+            )

--- a/culture/clients/copilot/agent_runner.py
+++ b/culture/clients/copilot/agent_runner.py
@@ -7,9 +7,16 @@ import logging
 import os
 import shutil
 import tempfile
-from typing import Any, Awaitable, Callable
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from opentelemetry import trace as _otel_trace
 
 from culture.aio import maybe_await
+from culture.clients.copilot.telemetry import _HARNESS_TRACER_NAME, record_llm_call
+
+if TYPE_CHECKING:
+    from culture.clients.copilot.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +33,8 @@ class CopilotAgentRunner:
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         on_turn_error: Callable[[], Awaitable[None] | None] | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        nick: str = "",
     ) -> None:
         self.model = model
         self.directory = directory
@@ -34,6 +43,8 @@ class CopilotAgentRunner:
         self.on_exit = on_exit
         self.on_message = on_message
         self.on_turn_error = on_turn_error
+        self._metrics = metrics
+        self._nick = nick
 
         self._isolated_home: str | None = None
         self._client: Any = None
@@ -171,12 +182,43 @@ class CopilotAgentRunner:
 
         Returns True if the loop should exit due to a fatal error.
         """
+        start_perf = time.perf_counter()
+        outcome = "success"
+        tracer = _otel_trace.get_tracer(_HARNESS_TRACER_NAME)
+        exit_signal = False
         try:
-            response = await self._session.send_and_wait(text, timeout=120.0)
-            await self._handle_turn_response(response)
-        except Exception:
-            return await self._handle_turn_error()
-        return False
+            with tracer.start_as_current_span(
+                "harness.llm.call",
+                attributes={
+                    "harness.backend": "copilot",
+                    "harness.model": self.model,
+                    "harness.nick": self._nick,
+                },
+            ):
+                try:
+                    response = await self._session.send_and_wait(text, timeout=120.0)
+                    await self._handle_turn_response(response)
+                except asyncio.TimeoutError:
+                    outcome = "timeout"
+                    exit_signal = await self._handle_turn_error()
+                except Exception:
+                    outcome = "error"
+                    exit_signal = await self._handle_turn_error()
+        finally:
+            duration_ms = (time.perf_counter() - start_perf) * 1000.0
+            if self._metrics is not None:
+                # Copilot token usage tracking — issue #299 (currently usage=None;
+                # github-copilot-sdk does not expose token counts on responses).
+                record_llm_call(
+                    self._metrics,
+                    backend="copilot",
+                    model=self.model,
+                    nick=self._nick,
+                    usage=None,
+                    duration_ms=duration_ms,
+                    outcome=outcome,
+                )
+        return exit_signal
 
     async def _prompt_loop(self) -> None:
         """Process queued prompts one at a time using send_and_wait."""

--- a/culture/clients/copilot/config.py
+++ b/culture/clients/copilot/config.py
@@ -61,12 +61,34 @@ class AgentConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """OpenTelemetry settings for the agent harness.
+
+    ``enabled: false`` by default so freshly installed harnesses don't
+    try to connect to a non-existent OTLP collector. Flip to ``true``
+    once your collector is running.
+    """
+
+    enabled: bool = False
+    service_name: str = "culture.harness.copilot"
+    otlp_endpoint: str = "http://localhost:4317"
+    otlp_protocol: str = "grpc"  # grpc | http/protobuf (only grpc supported initially)
+    otlp_timeout_ms: int = 5000
+    otlp_compression: str = "gzip"
+    traces_enabled: bool = True
+    traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
+
+
+@dataclass
 class DaemonConfig:
     """Top-level daemon configuration."""
 
     server: ServerConnConfig = field(default_factory=ServerConnConfig)
     supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
     webhooks: WebhookConfig = field(default_factory=WebhookConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     buffer_size: int = 500
     poll_interval: int = 60
     sleep_start: str = "23:00"
@@ -89,6 +111,7 @@ def load_config(path: str | Path) -> DaemonConfig:
     supervisor = SupervisorConfig(**raw.get("supervisor", {}))
 
     webhooks = WebhookConfig(**raw.get("webhooks", {}))
+    telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
     known_agent_fields = {f.name for f in AgentConfig.__dataclass_fields__.values()}
@@ -100,6 +123,7 @@ def load_config(path: str | Path) -> DaemonConfig:
         server=server,
         supervisor=supervisor,
         webhooks=webhooks,
+        telemetry=telemetry,
         buffer_size=raw.get("buffer_size", 500),
         poll_interval=raw.get("poll_interval", 60),
         sleep_start=raw.get("sleep_start", "23:00"),

--- a/culture/clients/copilot/culture.yaml
+++ b/culture/clients/copilot/culture.yaml
@@ -12,3 +12,18 @@ system_prompt: |
 tags:
   - harness
   - copilot
+
+# OpenTelemetry configuration for the agent harness.
+# Set enabled: true once your OTLP collector is running.
+# See docs/agentirc/harness-telemetry.md for a setup guide.
+telemetry:
+  enabled: false                          # master switch — flip to true to start exporting
+  service_name: culture.harness.copilot   # overridden per-backend (e.g. culture.harness.copilot)
+  otlp_endpoint: http://localhost:4317    # OTLP/gRPC receiver endpoint
+  otlp_protocol: grpc                     # grpc or http/protobuf
+  otlp_timeout_ms: 5000                   # export request timeout in milliseconds
+  otlp_compression: gzip                  # gzip | none
+  traces_enabled: true                    # enable distributed tracing
+  traces_sampler: parentbased_always_on   # honor the server's sampling decision
+  metrics_enabled: true                   # enable LLM call metrics export
+  metrics_export_interval_ms: 10000       # how often to push metric batches (ms)

--- a/culture/clients/copilot/daemon.py
+++ b/culture/clients/copilot/daemon.py
@@ -22,6 +22,7 @@ from culture.clients.copilot.irc_transport import IRCTransport
 from culture.clients.copilot.message_buffer import MessageBuffer
 from culture.clients.copilot.socket_server import SocketServer
 from culture.clients.copilot.supervisor import CopilotSupervisor
+from culture.clients.copilot.telemetry import init_harness_telemetry
 from culture.clients.copilot.webhook import AlertEvent, WebhookClient
 from culture.pidfile import remove_pid, write_pid
 
@@ -68,6 +69,8 @@ class CopilotDaemon:
         self._socket_server: SocketServer | None = None
         self._agent_runner: CopilotAgentRunner | None = None
         self._supervisor: CopilotSupervisor | None = None
+        self._tracer = None
+        self._metrics = None
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -129,6 +132,9 @@ class CopilotDaemon:
         self._pid_name = f"agent-{self.agent.nick}"
         write_pid(self._pid_name, os.getpid())
 
+        # 0.5. OTEL telemetry (if telemetry.enabled, installs SDK providers; else no-op).
+        self._tracer, self._metrics = init_harness_telemetry(self.config)
+
         # 1. Message buffer
         self._buffer = MessageBuffer(max_per_channel=self.config.buffer_size)
 
@@ -143,6 +149,9 @@ class CopilotDaemon:
             on_mention=self._on_mention,
             tags=list(self.agent.tags),
             on_roominvite=self._on_roominvite,
+            tracer=self._tracer,
+            metrics=self._metrics,
+            backend="copilot",
         )
         await self._transport.connect()
 
@@ -370,6 +379,8 @@ class CopilotDaemon:
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
             on_turn_error=self._on_turn_error,
+            metrics=self._metrics,
+            nick=self.agent.nick,
         )
         await self._agent_runner.start()
         logger.info("CopilotAgentRunner started for %s", self.agent.nick)

--- a/culture/clients/copilot/irc_transport.py
+++ b/culture/clients/copilot/irc_transport.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
-from typing import Callable
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Callable
 
 from culture.aio import maybe_await
 from culture.clients.copilot.message_buffer import MessageBuffer
 from culture.constants import SYSTEM_USER_PREFIX
 from culture.protocol.message import Message
+from culture.telemetry.context import (
+    TRACEPARENT_TAG,
+    context_from_traceparent,
+    current_traceparent,
+    extract_traceparent_from_tags,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
+
+    from culture.clients.copilot.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
 
 class IRCTransport:
-    """Async IRC client for the daemon."""
+    """Async IRC client for the daemon.
+
+    Optional kwargs ``tracer``, ``metrics``, and ``backend`` enable OTEL
+    tracing and LLM metrics when an SDK provider is installed. Pass ``None``
+    (the default) for all three to run without instrumentation.
+    """
 
     def __init__(
         self,
@@ -28,6 +46,9 @@ class IRCTransport:
         tags: list[str] | None = None,
         on_roominvite: Callable[[str, str], None] | None = None,
         icon: str | None = None,
+        tracer: Tracer | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        backend: str = "copilot",
     ):
         self.host = host
         self.port = port
@@ -39,6 +60,10 @@ class IRCTransport:
         self.tags = tags or []
         self.on_roominvite = on_roominvite
         self.icon = icon
+        self._tracer = tracer
+        # accepted for future per-message metrics (e.g. byte counters); unused in v1
+        self._metrics = metrics
+        self._backend = backend
         self.connected = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -57,23 +82,46 @@ class IRCTransport:
             "332": self._on_numeric_topic,
         }
 
+    def _span(self, name: str, attrs: dict | None = None) -> AbstractContextManager:
+        """Return a real span context manager when tracing is enabled, else a no-op.
+
+        Keeps the no-tracer fast path clean — all callers write the same
+        ``with self._span(...):`` pattern regardless of whether a tracer is
+        configured.
+
+        Does NOT accept a ``context=`` argument; callers that need a span
+        parented to a remote trace context (e.g. inbound message handling in
+        ``_handle``) call ``self._tracer.start_as_current_span`` directly.
+        """
+        if self._tracer is not None:
+            return self._tracer.start_as_current_span(name, attributes=attrs or {})
+        return contextlib.nullcontext()
+
     async def connect(self) -> None:
         self._should_run = True
         await self._do_connect()
 
     async def _do_connect(self) -> None:
-        try:
-            self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
-        except OSError as exc:
-            raise ConnectionError(
-                f"Cannot connect to IRC server at {self.host}:{self.port} "
-                f"- is the server running?"
-            ) from exc
-        await self._send_raw("CAP REQ :message-tags")
-        await self._send_raw(f"NICK {self.nick}")
-        await self._send_raw(f"USER {self.user} 0 * :{self.user}")
-        await self._send_raw("CAP END")
-        self._read_task = asyncio.create_task(self._read_loop())
+        with self._span(
+            "harness.irc.connect",
+            attrs={
+                "harness.backend": self._backend,
+                "harness.nick": self.nick,
+                "harness.server": f"{self.host}:{self.port}",
+            },
+        ):
+            try:
+                self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+            except OSError as exc:
+                raise ConnectionError(
+                    f"Cannot connect to IRC server at {self.host}:{self.port} "
+                    f"- is the server running?"
+                ) from exc
+            await self._send_raw("CAP REQ :message-tags")
+            await self._send_raw(f"NICK {self.nick}")
+            await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+            await self._send_raw("CAP END")
+            self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:
         self._should_run = False
@@ -151,6 +199,14 @@ class IRCTransport:
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
+        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
+        # Only inject when we have a tracer configured (fast-path: no work if
+        # self._tracer is None) and there is no tag block already on the line
+        # (defensive guard — prevents double-tagging if a caller pre-tagged).
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:
@@ -193,9 +249,41 @@ class IRCTransport:
                 delay = min(delay * 2, 60)
 
     async def _handle(self, msg: Message) -> None:
-        handler = self._cmd_handlers.get(msg.command)
-        if handler:
-            await maybe_await(handler(msg))
+        # Extract inbound traceparent before opening any span so the new span
+        # can be correctly parented to the remote trace context.
+        result = extract_traceparent_from_tags(msg, peer=None)
+
+        if self._tracer is not None:
+            if result.status == "valid":
+                ctx = context_from_traceparent(result.traceparent)
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    context=ctx,
+                    attributes={
+                        "irc.command": msg.command,
+                        "irc.client.nick": self.nick,
+                        "culture.trace.origin": "remote",
+                    },
+                )
+            else:
+                attrs = {
+                    "irc.command": msg.command,
+                    "irc.client.nick": self.nick,
+                    "culture.trace.origin": ("local" if result.status == "missing" else "remote"),
+                }
+                if result.status in ("malformed", "too_long"):
+                    attrs["culture.trace.dropped_reason"] = result.status
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    attributes=attrs,
+                )
+        else:
+            span_cm = contextlib.nullcontext()
+
+        with span_cm:
+            handler = self._cmd_handlers.get(msg.command)
+            if handler:
+                await maybe_await(handler(msg))
 
     async def _on_ping(self, msg: Message) -> None:
         token = msg.params[0] if msg.params else ""

--- a/culture/clients/copilot/irc_transport.py
+++ b/culture/clients/copilot/irc_transport.py
@@ -193,20 +193,23 @@ class IRCTransport:
             await self._send_raw(f"TOPIC {channel}")
 
     async def send_raw(self, line: str) -> None:
-        """Send a raw IRC line. Public for commands like HISTORY."""
+        """Send a raw IRC line. Public for commands like HISTORY.
+
+        When a tracer is configured and a span is active, prepends the W3C
+        ``@culture.dev/traceparent=`` IRCv3 tag so all outbound paths — whether
+        called via the internal ``_send_raw`` helper or directly by daemon code
+        — carry trace context consistently.
+        """
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp is not None:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         if self._writer:
             self._writer.write(f"{line}\r\n".encode())
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
-        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
-        # Only inject when we have a tracer configured (fast-path: no work if
-        # self._tracer is None) and there is no tag block already on the line
-        # (defensive guard — prevents double-tagging if a caller pre-tagged).
-        if self._tracer is not None and not line.startswith("@"):
-            tp = current_traceparent()
-            if tp:
-                line = f"@{TRACEPARENT_TAG}={tp} {line}"
+        """Internal send helper; delegates to send_raw (injection lives there)."""
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:

--- a/culture/clients/copilot/telemetry.py
+++ b/culture/clients/copilot/telemetry.py
@@ -1,0 +1,318 @@
+"""OpenTelemetry bootstrap for Culture agent harnesses.
+
+Why this file lives in ``packages/agent-harness/``
+---------------------------------------------------
+The culture codebase uses a **cite, don't import** pattern for the per-backend
+agent harnesses in ``culture/clients/{claude,codex,copilot,acp}/``. Each backend
+owns a verbatim copy of this file (with the ``service_name`` default changed to
+``culture.harness.<backend>``). Backend-specific overrides are isolated to those
+two sites; all other logic must stay identical so the all-backends parity test
+(``tests/harness/test_all_backends_parity.py``) passes.
+
+This is the copilot citation of the reference module in
+``packages/agent-harness/telemetry.py``.
+
+Backend-specific edit sites (two, both must be updated on citation)
+--------------------------------------------------------------------
+1. ``TelemetryConfig.service_name`` in ``config.py`` — change the default from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"``.
+2. ``_HARNESS_TRACER_NAME`` constant in this file — change the value from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"`` to match.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.metrics import Counter, Histogram, Meter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    Sampler,
+    TraceIdRatioBased,
+)
+from opentelemetry.trace import Tracer
+
+logger = logging.getLogger(__name__)
+
+# Module-level tracer name — cited backends replace "culture.harness" with
+# "culture.harness.<backend>" to match their service.name.
+_HARNESS_TRACER_NAME = "culture.harness.copilot"
+
+# Module-level globals — mirrors the server-side tracing.py / metrics.py pattern.
+_initialized_for: dict | None = None
+_tracer: Tracer | None = None
+_meter_provider: MeterProvider | None = None
+_registry: HarnessMetricsRegistry | None = None
+
+
+@dataclass
+class HarnessMetricsRegistry:
+    """All harness-side LLM instruments, registered once during init_harness_telemetry.
+
+    Parallel to the server's ``MetricsRegistry`` — different process, different
+    provider, different ``service.name``. Plan 6's bot-side metrics follow the
+    same parallel-registry pattern if bots are process-isolated.
+    """
+
+    llm_tokens_input: Counter
+    """Per-LLM-call input token count by backend/model/nick."""
+
+    llm_tokens_output: Counter
+    """Per-LLM-call output token count by backend/model/nick."""
+
+    llm_call_duration: Histogram
+    """Per-LLM-call wall-clock duration in milliseconds."""
+
+    llm_calls: Counter
+    """Per-LLM-call count by backend/model/outcome."""
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only.
+
+    Mirrors ``culture.telemetry.metrics.reset_for_tests`` (MeterProvider
+    shutdown + global clear) and ``culture.telemetry.tracing.reset_for_tests``
+    (trace provider global clear). Both are needed because parallel xdist
+    workers can leak global providers across module boundaries.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        _meter_provider = None
+
+    _initialized_for = None
+    _tracer = None
+    _registry = None
+
+    # Reset the OTEL metrics global — same path as server-side metrics.py.
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    _mi._METER_PROVIDER = None
+    _mi._METER_PROVIDER_SET_ONCE = _mi.Once()
+
+    # Reset the OTEL trace global — same path as server-side tracing.py.
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER_SET_ONCE = trace.Once()  # type: ignore[attr-defined]
+
+
+def _build_sampler(name: str) -> Sampler:
+    """Parse a ``traces_sampler`` string into an OTEL Sampler.
+
+    Mirrors ``culture.telemetry.tracing._build_sampler`` exactly — same
+    string grammar, same fallback warning.
+    """
+    if name == "parentbased_always_on":
+        return ParentBased(ALWAYS_ON)
+    if name.startswith("parentbased_traceidratio:"):
+        ratio = float(name.split(":", 1)[1])
+        return ParentBased(TraceIdRatioBased(ratio))
+    if name == "always_off":
+        return ALWAYS_OFF
+    logger.error(
+        "Unknown telemetry.traces_sampler %r, falling back to parentbased_always_on. "
+        "Valid values: parentbased_always_on, parentbased_traceidratio:<0.0-1.0>, always_off",
+        name,
+    )
+    return ParentBased(ALWAYS_ON)
+
+
+def _build_registry(meter: Meter) -> HarnessMetricsRegistry:
+    """Register all four harness LLM instruments against ``meter``."""
+    return HarnessMetricsRegistry(
+        llm_tokens_input=meter.create_counter(
+            "culture.harness.llm.tokens.input",
+            description="Per-LLM-call input token count by backend/model/nick",
+        ),
+        llm_tokens_output=meter.create_counter(
+            "culture.harness.llm.tokens.output",
+            description="Per-LLM-call output token count by backend/model/nick",
+        ),
+        llm_call_duration=meter.create_histogram(
+            "culture.harness.llm.call.duration",
+            unit="ms",
+            description="Per-LLM-call wall-clock duration in milliseconds",
+        ),
+        llm_calls=meter.create_counter(
+            "culture.harness.llm.calls",
+            description="Per-LLM-call count by backend/model/outcome",
+        ),
+    )
+
+
+def init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]:
+    """Initialize TracerProvider + MeterProvider for the harness. Idempotent.
+
+    Returns a ``(Tracer, HarnessMetricsRegistry)`` pair. When
+    ``telemetry.enabled`` is False the returned tracer is a no-op proxy (no
+    SDK provider installed) and the registry instruments are bound to OTEL's
+    proxy meter — call sites can ``add()`` / ``record()`` unconditionally
+    without ``if`` guards.
+
+    The idempotency snapshot includes both the full ``TelemetryConfig`` dict
+    and the agent identity (nick or daemon server name) so that two daemons
+    with identical config but different nicks get separate providers with the
+    correct ``service.instance.id``.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    tcfg = config.telemetry
+
+    # Build a stable identity string for service.instance.id.
+    if config.agents:
+        nick_identity = "-".join(a.nick for a in config.agents)
+    else:
+        nick_identity = config.server.name
+
+    snapshot = {"telemetry": asdict(tcfg), "nick": nick_identity}
+    if _initialized_for == snapshot and _tracer is not None and _registry is not None:
+        return _tracer, _registry
+
+    # Tear down the previous MeterProvider (has a background export thread).
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown errors must not crash init
+            logger.debug("HarnessMeterProvider shutdown failed", exc_info=True)
+        _meter_provider = None
+
+    # ------------------------------------------------------------------ #
+    # No-op / disabled paths                                               #
+    # ------------------------------------------------------------------ #
+    traces_on = tcfg.enabled and tcfg.traces_enabled
+    metrics_on = tcfg.enabled and tcfg.metrics_enabled
+
+    if not traces_on:
+        # No SDK provider → proxy no-op tracer.
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+
+    if not metrics_on:
+        # Proxy meter — instruments work as stubs; no export thread.
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+
+    if not tcfg.enabled:
+        _initialized_for = snapshot
+        return _tracer, _registry  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------ #
+    # Full SDK init                                                         #
+    # ------------------------------------------------------------------ #
+    resource = Resource.create(
+        {
+            "service.name": tcfg.service_name,
+            "service.instance.id": nick_identity,
+        }
+    )
+    compression_val = None if tcfg.otlp_compression == "none" else tcfg.otlp_compression
+
+    if traces_on:
+        span_exporter = OTLPSpanExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        tracer_provider = TracerProvider(
+            resource=resource,
+            sampler=_build_sampler(tcfg.traces_sampler),
+        )
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+        logger.info(
+            "OTEL harness tracing initialized: service=%s instance=%s endpoint=%s sampler=%s",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.traces_sampler,
+        )
+
+    if metrics_on:
+        metric_exporter = OTLPMetricExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter=metric_exporter,
+            export_interval_millis=tcfg.metrics_export_interval_ms,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        _meter_provider = provider
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+        logger.info(
+            "OTEL harness metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.metrics_export_interval_ms,
+        )
+
+    _initialized_for = snapshot
+    return _tracer, _registry  # type: ignore[return-value]
+
+
+def record_llm_call(
+    registry: HarnessMetricsRegistry,
+    *,
+    backend: str,
+    model: str,
+    nick: str,
+    usage: dict | None,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+    """Record metrics for a single LLM call.
+
+    Always increments ``llm_calls`` and records ``llm_call_duration``,
+    regardless of whether ``usage`` is present.
+
+    ``usage`` contract: may be ``None`` or contain partial keys; missing
+    or ``None``-valued keys silently skip the corresponding token counter.
+    This is intentional — codex (#298) and copilot (#299) do not expose
+    token counts in their current SDK versions. All four backends call this
+    helper; only claude and acp backends may have non-None usage dicts.
+
+    Args:
+        registry: The ``HarnessMetricsRegistry`` returned by
+            ``init_harness_telemetry``.
+        backend: Backend identifier string (e.g. ``"claude"``, ``"codex"``).
+        model: LLM model name (e.g. ``"claude-opus-4-6"``).
+        nick: Agent IRC nick (e.g. ``"spark-claude"``). Used as the
+            ``harness.nick`` label on token counters.
+        usage: Optional dict with optional keys ``tokens_input`` (int) and
+            ``tokens_output`` (int). ``None`` and missing keys are both safe.
+        duration_ms: Wall-clock duration of the LLM call in milliseconds.
+        outcome: One of ``"success"``, ``"error"``, or ``"timeout"``.
+    """
+    call_attrs = {"backend": backend, "model": model, "outcome": outcome}
+    registry.llm_calls.add(1, call_attrs)
+    registry.llm_call_duration.record(duration_ms, call_attrs)
+
+    if usage is not None:
+        tokens_input = usage.get("tokens_input")
+        if isinstance(tokens_input, int):
+            registry.llm_tokens_input.add(
+                tokens_input, {"backend": backend, "model": model, "harness.nick": nick}
+            )
+        tokens_output = usage.get("tokens_output")
+        if isinstance(tokens_output, int):
+            registry.llm_tokens_output.add(
+                tokens_output, {"backend": backend, "model": model, "harness.nick": nick}
+            )

--- a/docs/agentirc/harness-telemetry.md
+++ b/docs/agentirc/harness-telemetry.md
@@ -158,6 +158,74 @@ data:
 If you see `culture.harness.llm.tokens.input` flat for codex or copilot, your
 dashboards are not broken — the data is simply not yet available from those SDKs.
 
+## Harness API
+
+The reference implementation lives in `packages/agent-harness/telemetry.py`.
+Each backend owns a cited copy at `culture/clients/<backend>/telemetry.py`
+(the only per-backend edit sites are `_HARNESS_TRACER_NAME` and the
+`service_name` default in `config.py`).
+
+### `init_harness_telemetry`
+
+```python
+def init_harness_telemetry(config: DaemonConfig) -> tuple[Tracer, HarnessMetricsRegistry]:
+```
+
+Call once from `daemon.start()`, before the IRC transport connects. Idempotent —
+calling it a second time with the same config is a no-op that returns the cached
+pair. A changed config (different nick or different `TelemetryConfig` values)
+tears down the old `MeterProvider` and re-initialises cleanly.
+
+When `telemetry.enabled: false`, no SDK provider is installed. The returned
+`Tracer` is OTEL's proxy no-op tracer and the `HarnessMetricsRegistry`
+instruments are bound to OTEL's proxy meter. Call sites can `add()` /
+`record()` unconditionally — no `if telemetry.enabled` guards needed.
+
+### `HarnessMetricsRegistry`
+
+Dataclass that owns the four LLM instruments registered during
+`init_harness_telemetry`. Pass it to `record_llm_call` from `agent_runner.py`.
+
+| Field | Instrument | Metric name |
+|-------|-----------|-------------|
+| `llm_tokens_input` | Counter | `culture.harness.llm.tokens.input` |
+| `llm_tokens_output` | Counter | `culture.harness.llm.tokens.output` |
+| `llm_call_duration` | Histogram | `culture.harness.llm.call.duration` |
+| `llm_calls` | Counter | `culture.harness.llm.calls` |
+
+### `record_llm_call`
+
+```python
+def record_llm_call(
+    registry: HarnessMetricsRegistry,
+    *,
+    backend: str,
+    model: str,
+    nick: str,
+    usage: dict | None,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+```
+
+Record metrics for one LLM call. Parameters:
+
+- `registry` — the `HarnessMetricsRegistry` returned by `init_harness_telemetry`.
+- `backend` — one of `"claude"`, `"codex"`, `"copilot"`, `"acp"`.
+- `model` — model identifier string used as the `model` label
+  (e.g. `"claude-opus-4-6"`).
+- `nick` — agent IRC nick (e.g. `"spark-claude"`); becomes the `harness.nick`
+  label on token counters.
+- `usage` — `dict | None`. Recognised keys: `tokens_input` (`int`) and
+  `tokens_output` (`int`). `None` and missing or non-`int` values are silently
+  skipped. codex (#298) and copilot (#299) currently pass `None`.
+- `duration_ms` — wall-clock call duration in milliseconds (`float`).
+- `outcome` — one of `"success"`, `"error"`, `"timeout"`.
+
+Behavior: always increments `llm_calls` and records `llm_call_duration`.
+Increments `llm_tokens_input` / `llm_tokens_output` only when the
+corresponding key is present in `usage` with an `int` value.
+
 ## What's not in 8.6.0
 
 - **Bot-side OTEL instrumentation** — Plan 6.

--- a/docs/agentirc/harness-telemetry.md
+++ b/docs/agentirc/harness-telemetry.md
@@ -1,0 +1,232 @@
+---
+layout: default
+title: Harness Telemetry
+parent: AgentIRC
+nav_order: 92
+---
+
+# Harness Telemetry
+
+Culture 8.6.0 brings OpenTelemetry across the harness boundary. Every agent
+backend — `claude`, `codex`, `copilot`, and `acp` — now emits three spans that
+extend the server-side trace tree and four LLM-focused metrics that sit alongside
+the server `culture.*` instruments in the same Prometheus / Grafana instance.
+W3C `traceparent` is extracted from inbound IRC messages and injected into
+outbound ones, so a single `trace_id` now flows from `irc.command.PRIVMSG` on
+the originating server all the way through `harness.irc.message.handle` and into
+`harness.llm.call` — a true cross-process trace with no gap at the harness
+boundary.
+
+Available since **culture 8.6.0**.
+
+## What you get in 8.6.0
+
+### Spans
+
+| Span name | Where it opens | Key attributes |
+|-----------|----------------|----------------|
+| `harness.irc.connect` | `IRCTransport._do_connect` | `harness.backend`, `harness.nick`, `harness.server` |
+| `harness.irc.message.handle` | `IRCTransport._handle` (per inbound message) | `irc.command`, `irc.client.nick`, `culture.trace.origin` |
+| `harness.llm.call` | per-backend `agent_runner.py` LLM call site | `harness.backend`, `harness.model`, `outcome` |
+
+`harness.irc.message.handle` is the cross-process join point: if the inbound
+message carries a valid `culture.dev/traceparent` IRCv3 tag, the span is opened
+as a child of the server-side context. On `malformed` or `too_long` input, the
+span starts as a root and carries a `culture.trace.dropped_reason` attribute.
+
+### Metrics
+
+All four instruments are registered per-backend in an independent
+`HarnessMetricsRegistry`. Token counters are skipped (not incremented) when the
+underlying SDK does not expose token counts — see [Token-usage caveats](#token-usage-caveats).
+
+| Metric | Kind | Unit | Labels |
+|--------|------|------|--------|
+| `culture.harness.llm.tokens.input` | Counter | (none) | `backend`, `model`, `harness.nick` |
+| `culture.harness.llm.tokens.output` | Counter | (none) | `backend`, `model`, `harness.nick` |
+| `culture.harness.llm.call.duration` | Histogram | `ms` | `backend`, `model`, `outcome` |
+| `culture.harness.llm.calls` | Counter | (none) | `backend`, `model`, `outcome` |
+
+`outcome` is one of `success`, `error`, or `timeout`.
+
+### Traceparent propagation
+
+- **Inbound** — `IRCTransport._handle` calls `extract_traceparent_from_tags` on
+  every message before opening `harness.irc.message.handle`. A valid traceparent
+  makes the harness span a child of the server's `irc.event.emit` span.
+- **Outbound** — `IRCTransport._send_raw` prepends
+  `@culture.dev/traceparent=<value>` followed by a space to every IRC line
+  while a span is recording. This lets the _next_ peer in the chain continue
+  the trace.
+
+Tracestate injection is not included in 8.6.0 (server-parity-deferred — see
+[What's not in 8.6.0](#whats-not-in-860)).
+
+### All-backends parity
+
+All four backends (`claude`, `codex`, `copilot`, `acp`) carry identical harness
+telemetry code — same span names, same metric names, same `record_llm_call`
+helper — enforced by `tests/harness/test_all_backends_parity.py`. The only
+intentional per-backend difference is `service.name` (see
+[Per-backend telemetry namespaces](#per-backend-telemetry-namespaces)).
+
+## Configuration
+
+Add a `telemetry:` block to the harness `culture.yaml` (the template lives in
+`packages/agent-harness/culture.yaml`; each backend's copy is in
+`culture/clients/<backend>/culture.yaml`):
+
+```yaml
+telemetry:
+  enabled: false                          # master switch — flip to true to start exporting
+  service_name: culture.harness.claude    # set per-backend; see namespaces section
+  otlp_endpoint: http://localhost:4317    # OTLP/gRPC receiver endpoint
+  otlp_protocol: grpc                     # grpc or http/protobuf
+  otlp_timeout_ms: 5000                   # export request timeout in milliseconds
+  otlp_compression: gzip                  # gzip | none
+  traces_enabled: true                    # enable distributed tracing
+  traces_sampler: parentbased_always_on   # honor the server's sampling decision
+  metrics_enabled: true                   # enable LLM call metrics export
+  metrics_export_interval_ms: 10000       # how often to push metric batches (ms)
+```
+
+Field notes:
+
+- **`enabled: false`** is the default. Operators must opt in. When disabled, the
+  SDK is not initialised — no export, no overhead. Traceparent tags on inbound
+  messages are still parsed.
+- **`service_name`** is the value that appears as `service.name` in your tracing
+  backend. Set it to the backend-specific value from the table in
+  [Per-backend telemetry namespaces](#per-backend-telemetry-namespaces) rather
+  than the default `culture.harness` placeholder.
+- **`otlp_endpoint`** / **`otlp_protocol`** point at your collector. The default
+  matches `otelcol-contrib` started with `docs/agentirc/otelcol-template.yaml`.
+- **`traces_sampler: parentbased_always_on`** honours the server's sampling
+  decision: if the server sampled a trace and passed `traceparent` to the harness,
+  the harness samples the child spans too. Alternative values match the server's
+  semantics: `parentbased_traceidratio:0.1` for 10 % sampling, `always_off` to
+  suppress entirely.
+- **`metrics_export_interval_ms`** sets the push cadence. 10 s matches the server
+  default so metric series align in time in Grafana.
+
+Standard OpenTelemetry env vars override YAML: `OTEL_SERVICE_NAME`,
+`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`.
+
+## Per-backend telemetry namespaces
+
+Each harness backend runs as an independent process with its own
+`MeterProvider` and `TracerProvider`. In Grafana / Prometheus they appear as
+separate services:
+
+| Backend | `service.name` | `service.instance.id` |
+|---------|----------------|-----------------------|
+| claude | `culture.harness.claude` | agent nick (e.g. `spark-claude`) |
+| codex | `culture.harness.codex` | agent nick (e.g. `spark-codex`) |
+| copilot | `culture.harness.copilot` | agent nick (e.g. `spark-copilot`) |
+| acp | `culture.harness.acp` | agent nick (e.g. `spark-acp`) |
+
+`service.instance.id` is the agent's IRC nick, derived from the nick(s) in
+`culture.yaml`. If multiple agents share a daemon, the nicks are joined with
+`-`. This lets you distinguish two `culture.harness.claude` processes running
+on different machines (e.g. `spark-claude` vs `thor-claude`) in a single
+Grafana instance.
+
+The tracer name also equals `service.name` (e.g. `culture.harness.claude`) —
+don't mix backends in the same provider.
+
+## Token-usage caveats
+
+`culture.harness.llm.calls{outcome=*}` and `culture.harness.llm.call.duration`
+work for all four backends because they depend only on the LLM call completing
+(or failing), not on token-count data in the response.
+
+Token counters (`culture.harness.llm.tokens.input` and
+`culture.harness.llm.tokens.output`) depend on the backend SDK exposing usage
+data:
+
+- **claude** — `ResultMessage.usage` carries `input_tokens` / `output_tokens`.
+  Both counters increment correctly.
+- **acp** — token counts arrive in the `session/update` `stopReason` payload when
+  the backing agent exposes them. Both counters increment when the data is present.
+- **codex** — the `turn/completed` notification does not currently expose token
+  counts. Both token counters stay at zero. Tracked in
+  [#298](https://github.com/agentculture/culture/issues/298).
+- **copilot** — the current SDK does not expose `input_tokens` / `output_tokens`
+  on the response. Both token counters stay at zero. Tracked in
+  [#299](https://github.com/agentculture/culture/issues/299).
+
+If you see `culture.harness.llm.tokens.input` flat for codex or copilot, your
+dashboards are not broken — the data is simply not yet available from those SDKs.
+
+## What's not in 8.6.0
+
+- **Bot-side OTEL instrumentation** — Plan 6.
+- **Tracestate injection** — server-parity-deferred. Both server-side
+  `client.py` / `server_link.py` and the harness currently pass `tracestate=None`
+  when injecting. A future plan will add `current_tracestate()` to
+  `culture.telemetry.context` and thread it through both sides simultaneously.
+- **`culture.clients.connected{kind}` refinement to `kind=harness`** — still
+  `kind=human` until a server-side detection signal (CAP token, new culture verb,
+  or USER-suffix convention) lands.
+- **Audit `actor.kind` refinement** — same blocker. Stays `"human"` in v1.
+- **Token-usage extraction for codex / copilot** — tracked via
+  [#298](https://github.com/agentculture/culture/issues/298) (codex) and
+  [#299](https://github.com/agentculture/culture/issues/299) (copilot).
+
+## Manual end-to-end test
+
+This recipe walks the full cross-process trace from a PRIVMSG on the originating
+server all the way into a harness LLM call.
+
+**1. Start the collector:**
+
+```bash
+otelcol-contrib --config=docs/agentirc/otelcol-template.yaml
+```
+
+The template uses a `debug` exporter — spans and metrics print to stdout.
+
+**2. Start the server with telemetry enabled:**
+
+```bash
+# ~/.culture/server.yaml must have telemetry.enabled: true
+culture server start --name spark
+```
+
+**3. Start the claude harness with telemetry enabled:**
+
+```bash
+# culture/clients/claude/culture.yaml must have telemetry.enabled: true
+# and service_name: culture.harness.claude
+culture start spark-claude
+```
+
+**4. Send a PRIVMSG that mentions the harness:**
+
+```text
+(in weechat or irssi, connected to spark)
+/msg #general @spark-claude hi
+```
+
+**5. Verify traces in the collector output:**
+
+Look for a single `trace_id` that covers all four spans in parent-child order:
+
+```text
+irc.command.PRIVMSG           (service: culture.agentirc)
+└── irc.event.emit             (service: culture.agentirc)
+    └── harness.irc.message.handle  (service: culture.harness.claude)
+        └── harness.llm.call        (service: culture.harness.claude)
+```
+
+**6. Verify the LLM call counter:**
+
+In the collector metric output, confirm:
+
+```text
+culture.harness.llm.calls{backend="claude", model="...", outcome="success"} 1
+```
+
+Also check that `culture.harness.llm.tokens.input` and
+`culture.harness.llm.tokens.output` carry non-zero values (claude exposes token
+counts via `ResultMessage.usage`).

--- a/docs/agentirc/harness-telemetry.md
+++ b/docs/agentirc/harness-telemetry.md
@@ -109,8 +109,10 @@ Field notes:
 - **`metrics_export_interval_ms`** sets the push cadence. 10 s matches the server
   default so metric series align in time in Grafana.
 
-Standard OpenTelemetry env vars override YAML: `OTEL_SERVICE_NAME`,
-`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`.
+The harness currently uses the values from this YAML block for telemetry
+configuration. Standard OpenTelemetry env vars such as `OTEL_SERVICE_NAME`,
+`OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_TRACES_SAMPLER` do **not** override
+these YAML settings automatically.
 
 ## Per-backend telemetry namespaces
 

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -9,7 +9,7 @@ nav_order: 90
 
 Culture ships with first-class OpenTelemetry support: traces for every IRC command and event, W3C trace context carried across federation via a new IRCv3 tag, and a local collector pattern that keeps Culture's surface small.
 
-This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), the **Metrics Pillar** (culture 8.4.0), and the **Audit JSONL Sink** (culture 8.5.0). Harness and bot instrumentation ship in subsequent releases.
+This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), the **Metrics Pillar** (culture 8.4.0), the **Audit JSONL Sink** (culture 8.5.0), and **Harness-side OTEL** (culture 8.6.0). Bot instrumentation ships in a subsequent release.
 
 ## What you get in 8.2.0
 
@@ -152,11 +152,48 @@ New audit metrics (extend the Plan 3 `MetricsRegistry`):
 
 New operator guide: [`docs/agentirc/audit.md`](audit.html) — where files live, how to inspect with `jq`, how to disable, manual pruning recipe.
 
+## What you get in 8.6.0
+
+Harness-side OTEL lands: every agent backend — `claude`, `codex`, `copilot`, and
+`acp` — now emits three spans and four LLM-focused metrics alongside the
+server-side `culture.*` instruments.
+
+New spans per harness process:
+
+- `harness.irc.connect` — wraps the TCP connect to the IRC server.
+- `harness.irc.message.handle` — wraps each inbound message. If the message
+  carries a valid `culture.dev/traceparent` IRCv3 tag, this span becomes a child
+  of the server's `irc.event.emit` span — closing the cross-process gap.
+- `harness.llm.call` — wraps the backend LLM call. Attributes: `harness.backend`,
+  `harness.model`, `outcome` (`success`/`error`/`timeout`).
+
+New metrics (per-backend `HarnessMetricsRegistry`, independent of the server's
+`MetricsRegistry`):
+
+- `culture.harness.llm.tokens.input` — Counter, labels: `backend`, `model`,
+  `harness.nick`.
+- `culture.harness.llm.tokens.output` — Counter, same labels.
+- `culture.harness.llm.call.duration` — Histogram (`ms`), labels: `backend`,
+  `model`, `outcome`.
+- `culture.harness.llm.calls` — Counter, labels: `backend`, `model`, `outcome`.
+
+Token-usage caveats: codex ([#298](https://github.com/agentculture/culture/issues/298))
+and copilot ([#299](https://github.com/agentculture/culture/issues/299)) do not
+currently expose token counts, so `culture.harness.llm.tokens.input/output` stay
+at zero for those backends. Duration and call-count metrics work for all four.
+
+All four backends are instrumented identically. The parity invariant is enforced
+by `tests/harness/test_all_backends_parity.py`.
+
+For full configuration details, the per-backend `service.name` table, the
+end-to-end test recipe, and a list of what's deferred, see the operator guide at
+[`docs/agentirc/harness-telemetry.html`](harness-telemetry.html).
+
 ## What's not in 8.5.0
 
-The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces ship in later releases:
+The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces shipped in later releases or remain deferred:
 
-- Harness-side tracing for `claude`/`codex`/`copilot`/`acp` + harness LLM metrics (`culture.harness.llm.*`).
+- Harness-side tracing for `claude`/`codex`/`copilot`/`acp` + harness LLM metrics (`culture.harness.llm.*`) — **shipped in 8.6.0**.
 - Bot webhook HTTP instrumentation + bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`).
 - Outbound `culture.s2s.messages` (records inbound only — outbound needs a clean verb-extraction site).
 - OTEL Logs export of audit records (best-effort duplicate; JSONL stays source of truth either way).

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -189,11 +189,10 @@ For full configuration details, the per-backend `service.name` table, the
 end-to-end test recipe, and a list of what's deferred, see the operator guide at
 [`docs/agentirc/harness-telemetry.html`](harness-telemetry.html).
 
-## What's not in 8.5.0
+## What's not in 8.6.0
 
-The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces shipped in later releases or remain deferred:
+The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces remain deferred:
 
-- Harness-side tracing for `claude`/`codex`/`copilot`/`acp` + harness LLM metrics (`culture.harness.llm.*`) — **shipped in 8.6.0**.
 - Bot webhook HTTP instrumentation + bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`).
 - Outbound `culture.s2s.messages` (records inbound only — outbound needs a clean verb-extraction site).
 - OTEL Logs export of audit records (best-effort duplicate; JSONL stays source of truth either way).

--- a/docs/superpowers/plans/2026-04-28-otel-harness.md
+++ b/docs/superpowers/plans/2026-04-28-otel-harness.md
@@ -1,0 +1,270 @@
+# Plan 5 — OTEL Harness-side Tracing & LLM Metrics
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`. Branch `feature/otel-harness`. Tracking issues for token-usage gaps: codex #298, copilot #299.
+
+## Context
+
+Plans 1–4 shipped the **server side** of OTEL: traces (cmd/event/federation spans), the metrics pillar (15 server instruments + audit health), and the audit JSONL sink. Plan 5 crosses the **harness boundary** — the per-backend agent runner that bridges the IRC mesh to an LLM. After this ships, a single `trace_id` flows from `irc.command.PRIVMSG` on the originating server, across federation, into the receiving server's `irc.event.emit`, into the harness's `harness.irc.message.handle`, and finally into `harness.llm.call` — and four new LLM metrics (`culture.harness.llm.tokens.input/output`, `culture.harness.llm.call.duration`, `culture.harness.llm.calls`) appear next to the server-side metrics in the same Grafana / Prometheus instance.
+
+Spec coverage: `docs/superpowers/specs/2026-04-24-otel-observability-design.md`
+
+- :22-44 Architecture (harness telemetry module + per-backend citation)
+- :97-107 Instrumentation points (transport boundary spans + LLM call span)
+- :152-157 Harness LLM metrics catalog (4 instruments, all with `backend`/`model`/`outcome` labels)
+- :230-247 Harness config block (cited into each backend's `culture.yaml` template)
+- :283 All-backends parity test
+
+This is the first plan that touches the **citation pattern** at scale — `packages/agent-harness/` is the reference, and each of `culture/clients/{claude,codex,copilot,acp}/` carries a copy. The CLAUDE.md "all-backends rule" applies in full: a feature in only one backend is a bug.
+
+## Critical files to read before implementing
+
+**Spec:**
+
+- `docs/superpowers/specs/2026-04-24-otel-observability-design.md` lines 22-44, 97-107, 152-157, 230-247, 283.
+
+**Server-side patterns to mirror:**
+
+- `culture/telemetry/tracing.py` — idempotency snapshot, `reset_for_tests`, no-op when disabled. Plan 5's `init_harness_telemetry` mirrors this exactly.
+- `culture/telemetry/metrics.py` — `MetricsRegistry` dataclass + `_build_registry` + `init_metrics`. Plan 5 builds a parallel `HarnessMetricsRegistry` (it is *not* a sub-registry of the server's; harness runs in a separate process with its own provider).
+- `culture/telemetry/context.py` — `extract_traceparent_from_tags`, `inject_traceparent`, `current_traceparent`, `context_from_traceparent`. **Reusable as-is from `culture.telemetry`** — both server and harness import these. Don't duplicate them in `packages/agent-harness/`.
+- `culture/agentirc/ircd.py` — `init_metrics(config)` then `init_audit(config, metrics)` ordering at `__init__`; `metrics_reader` fixture pattern in tests.
+- `culture/agentirc/client.py:127-160` — outbound `_send_raw` injection site; inbound `_process_buffer` extraction site. Pattern to mirror in `IRCTransport`.
+
+**Reference + citations:**
+
+- `packages/agent-harness/irc_transport.py` — reference. `_send_raw` (l. 155) is the injection site; `_read_loop` / `_handle` (l. 158, 197) are the extraction sites; `_do_connect` (l. 66) is the connect-span site.
+- `packages/agent-harness/config.py` — reference `DaemonConfig`. Add `TelemetryConfig` dataclass + field; teach `load_config` to parse `telemetry:`.
+- `packages/agent-harness/culture.yaml` — reference template. Add `telemetry:` block.
+- `packages/agent-harness/daemon.py` — reference `AgentDaemon.start()`. Plan 5 adds an `init_harness_telemetry(config)` call early.
+- `culture/clients/claude/agent_runner.py` — claude backend; LLM call sits inside `query()` async generator at `_process_turn` (l. 131). `ResultMessage.usage` carries token counts.
+- `culture/clients/codex/agent_runner.py` — codex backend; LLM turn sits inside `_send_request("turn/start", ...)` at `_execute_single_turn` (l. 336). Token usage arrives via `turn/completed` notification.
+- `culture/clients/copilot/agent_runner.py` — copilot backend; LLM call is `self._session.send_and_wait(text, timeout=120.0)` at `_execute_single_turn` (l. 169). Response shape: `response.data.content` (no usage exposed in current SDK; see "Out of scope" below).
+- `culture/clients/acp/agent_runner.py` — ACP backend; LLM turn sits inside `_send_request("session/prompt", ...)` at `_send_prompt_with_retry` (l. 399). Token usage arrives in the `session/update` `stopReason` payload (varies by backend).
+
+**Tests:**
+
+- `tests/conftest.py` — `tracing_exporter` and `metrics_reader` fixture pattern. Plan 5's harness fixtures mirror these but install harness-side providers.
+- `tests/telemetry/test_audit_module.py` — Plan 4 isolation pattern: build a small fake without spinning up an IRCd. Mirror this for the harness telemetry module tests.
+
+## Approach
+
+### 1. Reference: `packages/agent-harness/telemetry.py` (new)
+
+A self-contained module with:
+
+- `HarnessMetricsRegistry` — dataclass with 4 fields:
+  - `llm_tokens_input: Counter` (`culture.harness.llm.tokens.input`, no unit, labels `backend`/`model`/`harness.nick`)
+  - `llm_tokens_output: Counter` (`culture.harness.llm.tokens.output`, same labels)
+  - `llm_call_duration: Histogram` (`culture.harness.llm.call.duration`, unit `ms`, labels `backend`/`model`/`outcome`)
+  - `llm_calls: Counter` (`culture.harness.llm.calls`, labels `backend`/`model`/`outcome`)
+- `init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]` — idempotent. Snapshot is `{"telemetry": asdict(tcfg), "nick": <agent.nick or daemon identity>}`. When `enabled: false` returns no-op tracer + proxy-bound registry. When on, installs an SDK TracerProvider + MeterProvider with `service.name=culture.harness.<backend>` and `service.instance.id=<nick>`.
+- `record_llm_call(registry, backend, model, nick, usage, duration_ms, outcome)` — single helper called from each backend's `agent_runner.py`. `usage` is `dict | None` with optional `tokens_input` / `tokens_output` keys; missing keys are skipped (some SDKs don't expose token counts). Always increments `llm_calls` and records `llm_call_duration`.
+- `reset_for_tests()` — mirrors `culture.telemetry.tracing.reset_for_tests` and `culture.telemetry.metrics.reset_for_tests`.
+
+The module imports `extract_traceparent_from_tags`, `inject_traceparent`, `current_traceparent`, `context_from_traceparent`, `TRACEPARENT_TAG`, `TRACESTATE_TAG` from `culture.telemetry` — the harness is in the same Python package install, so a real `from culture.telemetry import …` works (no duplication).
+
+### 2. Reference config: `packages/agent-harness/config.py`
+
+Add a `TelemetryConfig` dataclass mirroring the server's (subset — no audit, since the server owns audit per spec line 250):
+
+```python
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    service_name: str = "culture.harness"
+    otlp_endpoint: str = "http://localhost:4317"
+    otlp_protocol: str = "grpc"
+    otlp_timeout_ms: int = 5000
+    otlp_compression: str = "gzip"
+    traces_enabled: bool = True
+    traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
+```
+
+Attach to `DaemonConfig.telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)`. Teach `load_config` to parse the new `telemetry:` block (defaulting to defaults when absent — backwards compat).
+
+### 3. Reference template: `packages/agent-harness/culture.yaml`
+
+Add a `telemetry:` block at the top level (alongside `suffix:`, `backend:`, etc.) — mostly comments and defaults. Plan 5 ships with `enabled: false` so freshly installed harnesses don't try to talk to a non-existent collector.
+
+### 4. Reference transport: `packages/agent-harness/irc_transport.py`
+
+Three new spans + the inject/extract pair:
+
+- `_do_connect` (l. 66) — wrap in `harness.irc.connect` span. Attrs: `harness.backend` (from caller), `harness.nick` (from `self.nick`), `harness.server` (from `self.host:self.port`).
+- `_send_raw` (l. 155) — when a span is recording, prepend `@culture.dev/traceparent=<value>;culture.dev/tracestate=<value> ` to the line as IRCv3 tag prefix. Stays a string operation — minimal blast radius, matches server-side `client.py`, wire grammar identical (IRCv3 tags are space-prefixed before the prefix or verb). Don't refactor every send-helper to construct `Message` objects.
+- `_handle` (l. 197) — wrap in `harness.irc.message.handle` span. Before opening the span, run `extract_traceparent_from_tags(msg, peer=None)`; if `status="valid"`, parent the span to the extracted context via `context_from_traceparent(tp)`. Attrs: `irc.command`, `irc.client.nick`, `culture.trace.origin=remote|local`. On `malformed`/`too_long`, attach `culture.trace.dropped_reason` and start a root.
+- Per-backend tracer name: `culture.harness.<backend>` matching `service.name`.
+
+`_handle` is async — wrap with `with self._tracer.start_as_current_span(...)` only when `self._tracer is not None`. Tracer is passed in via the constructor (new optional kwarg `tracer: Tracer | None = None`); when absent, all the propagation code is gated `if self._tracer:` and the no-op fast path stays clean. **All four backends pass it from `daemon.py` after `init_harness_telemetry(config)`.**
+
+### 5. Reference daemon: `packages/agent-harness/daemon.py`
+
+Early in `start()` (before constructing `IRCTransport`):
+
+```python
+from culture.clients.BACKEND.telemetry import init_harness_telemetry
+self._tracer, self._metrics = init_harness_telemetry(self.config)
+```
+
+Then pass `self._tracer` and `self._metrics` to `IRCTransport(...)` as kwargs. Leave existing kwargs untouched.
+
+`record_llm_call` is invoked from each `agent_runner.py`, not from `daemon.py` — but `daemon.py` is responsible for stashing the metrics registry on the runner (via constructor injection or a setter) so the runner can call into it.
+
+### 6. Per-backend citations (the all-backends rule)
+
+For each of `claude`, `codex`, `copilot`, `acp`:
+
+1. **`telemetry.py`** — copy `packages/agent-harness/telemetry.py`. Replace `culture.harness` default `service_name` with `culture.harness.<backend>`. **No other diffs.** This is the citation-parity invariant tested in Step 8.
+2. **`config.py`** — add the same `TelemetryConfig` dataclass + field on `DaemonConfig`. Teach `load_config` to parse `telemetry:`.
+3. **`culture.yaml`** — add the `telemetry:` block (commented `enabled: false` by default).
+4. **`irc_transport.py`** — add the constructor `tracer`/`metrics` kwargs + `harness.irc.*` spans + traceparent inject/extract calls.
+5. **`daemon.py`** — call `init_harness_telemetry(config)` in `start()` before `IRCTransport` construction; pass results to transport + agent runner.
+6. **`agent_runner.py`** — wrap LLM call in `harness.llm.call` span. Fire `record_llm_call(...)` after. Backend-specific `usage` extraction:
+   - **claude:** `_handle_result_message` already has `ResultMessage` — check `getattr(msg, "usage", None)` (claude-agent-sdk exposes `{"input_tokens": int, "output_tokens": int}` on ResultMessage).
+   - **codex:** `_handle_notification` on `turn/completed` — params may carry `usage` per the codex app-server protocol (TBD; if absent, record duration + count only with `usage=None`).
+   - **copilot:** `send_and_wait` response — current SDK does not expose token counts; record duration + count only with `usage=None`.
+   - **acp:** `session/update` final notification — `update` may carry token counts depending on the backing agent; record what's available.
+   - **All four:** wrap the LLM call site in a `with self._tracer.start_as_current_span("harness.llm.call", attributes={"harness.backend": ..., "harness.model": self.model})` block. Outcome label: `success` (turn completed), `error` (exception), `timeout` (asyncio.TimeoutError).
+
+Each backend's `agent_runner.py` constructor takes a new `metrics: HarnessMetricsRegistry | None = None` kwarg; when `None`, all metric calls become guarded no-ops.
+
+### 7. Server-side touchpoint (small)
+
+The `culture.clients.connected{kind=...}` label was Plan-3-deferred at `kind=human`. It stays that way for now — refining to `kind=harness` requires the IRCd to detect harness clients via a connection-time signal (a CAP token, USER suffix, or new culture verb). **Defer to a follow-up.** Plan 5 does not change server-side label semantics.
+
+Same applies to the audit `actor.kind` field (Plan 4) — stays `"human"` for v1. Plan 6 (bots) refines to `"bot"`. A future server-side update can refine to `"harness"` once the IRCd has a way to detect.
+
+### 8. All-backends parity test: `tests/harness/test_all_backends_parity.py`
+
+Walks `culture/clients/{claude,codex,copilot,acp}/` and asserts:
+
+- `telemetry.py` exists.
+- The file contents match `packages/agent-harness/telemetry.py` modulo the `service_name` default — diff after stripping the `service_name=...` line should be empty.
+- `config.py` defines a `TelemetryConfig` dataclass with the 10 expected fields.
+- `culture.yaml` parses and has a `telemetry:` block.
+- `agent_runner.py` imports `record_llm_call` (or its module).
+- `irc_transport.py` constructor accepts `tracer` / `metrics` kwargs.
+
+This test fails the build if any backend drifts, enforcing the all-backends rule.
+
+### 9. Other tests
+
+- `tests/harness/test_telemetry_module.py` — unit-test `init_harness_telemetry` (idempotent snapshot, no-op when disabled, real provider when on), `record_llm_call` (4 metrics emitted, missing-`usage`-key paths skip the right counters).
+- `tests/harness/test_irc_transport_propagation.py` — fake `StreamReader`/`StreamWriter`; build an `IRCTransport` with a test tracer; emit a line with `@culture.dev/traceparent=<valid>` prefix; assert `_handle` opens a child span linked to that traceparent. Then assert outbound `send_privmsg` while a span is recording carries `culture.dev/traceparent` in the wire bytes.
+- `tests/harness/test_record_llm_call.py` — fake `HarnessMetricsRegistry`; call `record_llm_call` with various `usage` shapes; assert every code path records the right metrics and labels.
+- `tests/harness/test_agent_runner_<backend>.py` (4 files) — mock the LLM call layer; assert the `harness.llm.call` span opens, `record_llm_call` is invoked with correct `outcome=success|error|timeout`, and `harness.backend` / `harness.model` attrs are present.
+
+### 10. Documentation
+
+- New `docs/agentirc/harness-telemetry.md` — operator guide. Pages parallel to `docs/agentirc/audit.md`: "What you get in 8.6.0" / "Configuring it" / "Per-backend telemetry namespaces" / "What's not in 8.6.0".
+- Extend `docs/agentirc/telemetry.md` with a "What you get in 8.6.0" subsection: harness-side OTEL, 4 LLM metrics, traceparent across the harness boundary, all-backends parity.
+- Extend `packages/agent-harness/README.md` (small) — point at the new telemetry config block in the template.
+
+### 11. Version bump
+
+`/version-bump minor` → `8.5.0` → `8.6.0`. CHANGELOG entry summarizing the 4 new harness metrics + the harness-boundary trace-context propagation.
+
+## Files to modify / create
+
+**New:**
+
+- `packages/agent-harness/telemetry.py` — reference module.
+- `culture/clients/claude/telemetry.py` — citation.
+- `culture/clients/codex/telemetry.py` — citation.
+- `culture/clients/copilot/telemetry.py` — citation.
+- `culture/clients/acp/telemetry.py` — citation.
+- `docs/agentirc/harness-telemetry.md` — operator guide.
+- `tests/harness/__init__.py`
+- `tests/harness/test_telemetry_module.py`
+- `tests/harness/test_irc_transport_propagation.py`
+- `tests/harness/test_record_llm_call.py`
+- `tests/harness/test_all_backends_parity.py`
+- `tests/harness/test_agent_runner_claude.py`
+- `tests/harness/test_agent_runner_codex.py`
+- `tests/harness/test_agent_runner_copilot.py`
+- `tests/harness/test_agent_runner_acp.py`
+
+**Modified:**
+
+- `packages/agent-harness/config.py` — `TelemetryConfig` dataclass + field + load/save.
+- `packages/agent-harness/culture.yaml` — `telemetry:` block.
+- `packages/agent-harness/irc_transport.py` — `tracer`/`metrics` kwargs + `harness.irc.*` spans + traceparent inject/extract.
+- `packages/agent-harness/daemon.py` — `init_harness_telemetry` call + transport/runner wiring.
+- `packages/agent-harness/README.md` — pointer to telemetry block.
+- `culture/clients/{claude,codex,copilot,acp}/config.py` — `TelemetryConfig` mirror.
+- `culture/clients/{claude,codex,copilot,acp}/culture.yaml` — `telemetry:` block.
+- `culture/clients/{claude,codex,copilot,acp}/irc_transport.py` — span/inject mirror.
+- `culture/clients/{claude,codex,copilot,acp}/daemon.py` — init call + wiring mirror.
+- `culture/clients/{claude,codex,copilot,acp}/agent_runner.py` — `harness.llm.call` span + `record_llm_call` invocation.
+- `docs/agentirc/telemetry.md` — "What you get in 8.6.0" subsection.
+- `pyproject.toml`, `CHANGELOG.md` — version bump.
+
+(Server-side `culture/agentirc/`, `culture/telemetry/`, server tests: **not modified**. Plan 5 is harness-only.)
+
+## Tests
+
+`bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/harness/` exercises the new module + all-backends parity. Full-suite run via the same skill.
+
+Test fixtures (added to `tests/conftest.py`):
+
+- `harness_tracing_exporter` — analogous to `tracing_exporter` but installs the harness-side provider (different reset path since `init_harness_telemetry` lives in the harness module).
+- `harness_metrics_reader` — analogous to `metrics_reader`.
+
+Both reset their respective module state between tests.
+
+## Verification
+
+1. `bash ~/.claude/skills/run-tests/scripts/test.sh -p` — full suite green (current baseline 1051).
+2. `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/harness/` — harness suite green.
+3. `Agent(subagent_type="doc-test-alignment", ...)` before first push.
+4. `Agent(subagent_type="superpowers:code-reviewer", ...)` on staged diff — touches transport boundaries (`_send_raw`-style I/O) and the citation pattern across 4 backends, exactly the choke-point CLAUDE.md flags.
+5. **Manual end-to-end** (per spec line 313): start `culture server` with `telemetry.enabled=true`. Start `claude` harness with `telemetry.enabled=true`. Send a PRIVMSG mentioning the harness from weechat. In the otelcol-contrib `debug` exporter output, confirm:
+   - A `trace_id` covers `irc.command.PRIVMSG` (server) → `irc.event.emit` (server) → `harness.irc.message.handle` (harness) → `harness.llm.call` (harness).
+   - `culture.harness.llm.calls{backend=claude, model=…, outcome=success}` increments by 1.
+   - `culture.harness.llm.tokens.input` / `output` carry the SDK-reported token counts.
+6. `bash ~/.claude/skills/sonarclaude/scripts/sonar.sh status` on the branch before declaring PR ready.
+7. `bash ~/.claude/skills/pr-review/scripts/pr-status.sh <PR>` after push.
+
+## Out of scope (future plans / follow-ups)
+
+- **Refining `culture.clients.connected{kind=human}`** to `kind=harness` for harness-originated connections. Requires a server-side detection signal (CAP token, new culture verb, or USER-suffix convention). Track as a follow-up.
+- **Refining audit `actor.kind`** from `"human"` to `"harness"` for harness-originated emit_event paths. Same blocker. Track as a follow-up.
+- **Copilot token-usage metrics** — current `copilot` SDK does not expose `input_tokens` / `output_tokens` on the response. We record duration + call count only; token counters stay at zero for the copilot backend until the SDK exposes the data. Document this in `harness-telemetry.md` so operators don't think their dashboards are broken.
+- **Codex token-usage metrics** — depend on the codex app-server's `turn/completed` notification carrying `usage`. If absent in current versions, treat the same as copilot (duration + count only).
+- **Bot-side OTEL instrumentation** — Plan 6.
+- **Federated-lifecycle audit gap (#296)** — orthogonal, will be addressed in a follow-up that flips the tombstone test in `test_audit_federation.py`.
+- **`audit-prune` CLI** — still deferred from Plan 4.
+- **OTEL Logs export** of audit records — still deferred from Plan 4.
+
+## Carry-forward notes (for future plans / compaction survivors)
+
+- **Reuse `culture.telemetry.context`.** Both server and harness `IRCTransport` import the same `extract_traceparent_from_tags` / `inject_traceparent` helpers — don't duplicate them in the harness reference. The harness Python install includes `culture.telemetry`.
+- **`HarnessMetricsRegistry` is parallel to `MetricsRegistry`, not a subclass.** Different process, different provider, different `service.name`. Plan 6's bot-side metrics (if process-isolated) will follow the same parallel-registry pattern; if bots stay in-process with the IRCd, they extend `MetricsRegistry`.
+- **Citation-parity test is the hard fence.** Drift between `packages/agent-harness/telemetry.py` and any backend's copy fails the test. When updating the reference, update all four citations in the same commit.
+- **Tracer name = `culture.harness.<backend>`** matches `service.name`. Don't mix.
+- **`_send_raw` tag injection is string-prefix.** Don't refactor every send-helper to construct `Message` objects — pre-pending `@culture.dev/traceparent=...;culture.dev/tracestate=... ` to the wire line is wire-grammar valid and minimizes blast radius.
+- **`record_llm_call` accepts `usage=None`** — backends that don't expose token counts still record `llm_calls` + `llm_call_duration`. The Counter for token counts simply doesn't increment. Document this contract on the helper.
+- **Outcome labels: `success`, `error`, `timeout`.** Standardized across backends. `success` = LLM turn completed; `error` = exception caught; `timeout` = `asyncio.TimeoutError` (codex 300s, copilot 120s, acp 300s, claude no explicit timeout — treat any cancellation/timeout as `error`).
+- **Test fixtures must be reset before AND after.** Like the server-side fixtures, harness fixtures call `harness_telemetry.reset_for_tests()` in setup and teardown to avoid global-provider leakage between parallel xdist workers.
+- **The harness has its own MeterProvider.** Don't share with the server in tests — `metrics_reader` and `harness_metrics_reader` install separate providers; tests targeting the harness use the latter.
+
+## Phasing (suggested task breakdown for subagent execution)
+
+1. **Task 1**: `packages/agent-harness/telemetry.py` reference module + `TelemetryConfig` in `packages/agent-harness/config.py` + `culture.yaml` template block. Isolated unit tests (`test_telemetry_module.py`, `test_record_llm_call.py`).
+2. **Task 2**: `packages/agent-harness/irc_transport.py` — tracer kwarg, `harness.irc.*` spans, traceparent inject/extract. Tests (`test_irc_transport_propagation.py`).
+3. **Task 3**: `packages/agent-harness/daemon.py` — `init_harness_telemetry` call + transport/runner wiring.
+4. **Task 4**: Cite into `culture/clients/claude/` (telemetry.py + config.py + culture.yaml + irc_transport.py + daemon.py + agent_runner.py with `harness.llm.call` span + `record_llm_call`). Test (`test_agent_runner_claude.py`).
+5. **Task 5**: Cite into `culture/clients/codex/`. Test (`test_agent_runner_codex.py`).
+6. **Task 6**: Cite into `culture/clients/copilot/`. Test (`test_agent_runner_copilot.py`).
+7. **Task 7**: Cite into `culture/clients/acp/`. Test (`test_agent_runner_acp.py`).
+8. **Task 8**: All-backends parity test (`test_all_backends_parity.py`). Intentionally last — locks down the citation invariant once all four are in.
+9. **Task 9**: Docs — `docs/agentirc/harness-telemetry.md` + extend `docs/agentirc/telemetry.md` "What you get in 8.6.0".
+10. **Task 10**: Version bump 8.5.0 → 8.6.0.
+11. **Task 11**: Pre-push verification (doc-test-alignment, code-reviewer on the multi-backend diff, run-tests, sonar status) + open PR.
+
+## Branch & worktree
+
+- Branch from up-to-date `main`: `git checkout -b feature/otel-harness`.
+- No worktree — same-session subagent-driven execution per the user's preference and the pattern from Plans 1–4.

--- a/docs/superpowers/plans/2026-04-28-otel-harness.md
+++ b/docs/superpowers/plans/2026-04-28-otel-harness.md
@@ -93,7 +93,7 @@ Add a `telemetry:` block at the top level (alongside `suffix:`, `backend:`, etc.
 Three new spans + the inject/extract pair:
 
 - `_do_connect` (l. 66) — wrap in `harness.irc.connect` span. Attrs: `harness.backend` (from caller), `harness.nick` (from `self.nick`), `harness.server` (from `self.host:self.port`).
-- `_send_raw` (l. 155) — when a span is recording, prepend `@culture.dev/traceparent=<value>;culture.dev/tracestate=<value> ` to the line as IRCv3 tag prefix. Stays a string operation — minimal blast radius, matches server-side `client.py`, wire grammar identical (IRCv3 tags are space-prefixed before the prefix or verb). Don't refactor every send-helper to construct `Message` objects.
+- `_send_raw` (l. 155) — when a span is recording, prepend `@culture.dev/traceparent=<value> ` to the line as IRCv3 tag prefix. Stays a string operation — minimal blast radius, matches server-side `client.py`, wire grammar identical (IRCv3 tags are space-prefixed before the prefix or verb). Don't refactor every send-helper to construct `Message` objects. (tracestate injection is NOT in v1 — server-side client.py and server_link.py also currently pass tracestate=None when injecting; matching that behavior keeps harness/server parity. A future plan can add a current_tracestate() helper alongside current_traceparent() in culture/telemetry/context.py and thread it through both sides.)
 - `_handle` (l. 197) — wrap in `harness.irc.message.handle` span. Before opening the span, run `extract_traceparent_from_tags(msg, peer=None)`; if `status="valid"`, parent the span to the extracted context via `context_from_traceparent(tp)`. Attrs: `irc.command`, `irc.client.nick`, `culture.trace.origin=remote|local`. On `malformed`/`too_long`, attach `culture.trace.dropped_reason` and start a root.
 - Per-backend tracer name: `culture.harness.<backend>` matching `service.name`.
 
@@ -233,6 +233,7 @@ Both reset their respective module state between tests.
 - **Refining audit `actor.kind`** from `"human"` to `"harness"` for harness-originated emit_event paths. Same blocker. Track as a follow-up.
 - **Copilot token-usage metrics** — current `copilot` SDK does not expose `input_tokens` / `output_tokens` on the response. We record duration + call count only; token counters stay at zero for the copilot backend until the SDK exposes the data. Document this in `harness-telemetry.md` so operators don't think their dashboards are broken.
 - **Codex token-usage metrics** — depend on the codex app-server's `turn/completed` notification carrying `usage`. If absent in current versions, treat the same as copilot (duration + count only).
+- **Tracestate injection.** Server-side client.py and server_link.py currently pass tracestate=None when injecting (Plans 1–2). Plan 5 matches that behavior. A future plan should add a current_tracestate() helper alongside current_traceparent() in culture/telemetry/context.py and thread it through both server and harness inject sites.
 - **Bot-side OTEL instrumentation** — Plan 6.
 - **Federated-lifecycle audit gap (#296)** — orthogonal, will be addressed in a follow-up that flips the tombstone test in `test_audit_federation.py`.
 - **`audit-prune` CLI** — still deferred from Plan 4.
@@ -246,6 +247,7 @@ Both reset their respective module state between tests.
 - **Tracer name = `culture.harness.<backend>`** matches `service.name`. Don't mix.
 - **`_send_raw` tag injection is string-prefix.** Don't refactor every send-helper to construct `Message` objects — pre-pending `@culture.dev/traceparent=...;culture.dev/tracestate=... ` to the wire line is wire-grammar valid and minimizes blast radius.
 - **`record_llm_call` accepts `usage=None`** — backends that don't expose token counts still record `llm_calls` + `llm_call_duration`. The Counter for token counts simply doesn't increment. Document this contract on the helper.
+- **Tracestate is server-parity-deferred.** Don't add it to the harness ahead of the server. When we plumb it through, do BOTH sides in the same plan to keep the wire grammar consistent.
 - **Outcome labels: `success`, `error`, `timeout`.** Standardized across backends. `success` = LLM turn completed; `error` = exception caught; `timeout` = `asyncio.TimeoutError` (codex 300s, copilot 120s, acp 300s, claude no explicit timeout — treat any cancellation/timeout as `error`).
 - **Test fixtures must be reset before AND after.** Like the server-side fixtures, harness fixtures call `harness_telemetry.reset_for_tests()` in setup and teardown to avoid global-provider leakage between parallel xdist workers.
 - **The harness has its own MeterProvider.** Don't share with the server in tests — `metrics_reader` and `harness_metrics_reader` install separate providers; tests targeting the harness use the latter.

--- a/packages/agent-harness/README.md
+++ b/packages/agent-harness/README.md
@@ -17,6 +17,7 @@ This is the **citation-cli** reference for building new agent backends — copy,
 |------|---------|--------|
 | `daemon.py` | Orchestrates IRC + agent + IPC | Yes — wire up your runner |
 | `irc_transport.py` | IRC client (asyncio, RFC 2812) | Rarely — works as-is |
+| `telemetry.py` | OTEL harness metrics + spans | No — cited per-backend |
 | `message_buffer.py` | Ring buffer for channel messages | No — use as-is |
 | `socket_server.py` | Unix socket for skill IPC | No — use as-is |
 | `ipc.py` | JSON Lines message format | No — use as-is |
@@ -24,6 +25,16 @@ This is the **citation-cli** reference for building new agent backends — copy,
 | `config.py` | YAML config loader | Maybe — add backend-specific fields |
 | `skill/irc_client.py` | CLI for IRC tools | No — use as-is |
 | `skill/SKILL.md` | Agent skill definition | Yes — adapt for your agent |
+
+## Telemetry
+
+The `telemetry:` block in `culture.yaml` controls OpenTelemetry export of LLM
+call metrics (`culture.harness.llm.calls`, `culture.harness.llm.call.duration`,
+`culture.harness.llm.tokens.input/output`) and three spans that extend the
+server-side trace tree across the harness boundary. It is **off by default** —
+set `enabled: true` once your OTLP collector is running. See the operator guide
+at [`docs/agentirc/harness-telemetry.html`](../../docs/agentirc/harness-telemetry.html)
+for full configuration details and an end-to-end test recipe.
 
 ## Citation pattern
 

--- a/packages/agent-harness/config.py
+++ b/packages/agent-harness/config.py
@@ -72,7 +72,7 @@ class TelemetryConfig:
     enabled: bool = False
     service_name: str = "culture.harness"
     otlp_endpoint: str = "http://localhost:4317"
-    otlp_protocol: str = "grpc"
+    otlp_protocol: str = "grpc"  # grpc | http/protobuf (only grpc supported initially)
     otlp_timeout_ms: int = 5000
     otlp_compression: str = "gzip"
     traces_enabled: bool = True

--- a/packages/agent-harness/config.py
+++ b/packages/agent-harness/config.py
@@ -61,12 +61,34 @@ class AgentConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """OpenTelemetry settings for the agent harness.
+
+    ``enabled: false`` by default so freshly installed harnesses don't
+    try to connect to a non-existent OTLP collector. Flip to ``true``
+    once your collector is running.
+    """
+
+    enabled: bool = False
+    service_name: str = "culture.harness"
+    otlp_endpoint: str = "http://localhost:4317"
+    otlp_protocol: str = "grpc"
+    otlp_timeout_ms: int = 5000
+    otlp_compression: str = "gzip"
+    traces_enabled: bool = True
+    traces_sampler: str = "parentbased_always_on"
+    metrics_enabled: bool = True
+    metrics_export_interval_ms: int = 10000
+
+
+@dataclass
 class DaemonConfig:
     """Top-level daemon configuration."""
 
     server: ServerConnConfig = field(default_factory=ServerConnConfig)
     supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
     webhooks: WebhookConfig = field(default_factory=WebhookConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     buffer_size: int = 500
     poll_interval: int = 60
     sleep_start: str = "23:00"
@@ -89,6 +111,7 @@ def load_config(path: str | Path) -> DaemonConfig:
     supervisor = SupervisorConfig(**raw.get("supervisor", {}))
 
     webhooks = WebhookConfig(**raw.get("webhooks", {}))
+    telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
     for agent_raw in raw.get("agents", []):
@@ -98,6 +121,7 @@ def load_config(path: str | Path) -> DaemonConfig:
         server=server,
         supervisor=supervisor,
         webhooks=webhooks,
+        telemetry=telemetry,
         buffer_size=raw.get("buffer_size", 500),
         poll_interval=raw.get("poll_interval", 60),
         sleep_start=raw.get("sleep_start", "23:00"),

--- a/packages/agent-harness/culture.yaml
+++ b/packages/agent-harness/culture.yaml
@@ -11,3 +11,18 @@ system_prompt: |
 tags:
   - harness
   - template
+
+# OpenTelemetry configuration for the agent harness.
+# Set enabled: true once your OTLP collector is running.
+# See docs/agentirc/harness-telemetry.md for a setup guide.
+telemetry:
+  enabled: false                          # master switch — flip to true to start exporting
+  service_name: culture.harness           # overridden per-backend (e.g. culture.harness.claude)
+  otlp_endpoint: http://localhost:4317    # OTLP/gRPC receiver endpoint
+  otlp_protocol: grpc                     # grpc or http/protobuf
+  otlp_timeout_ms: 5000                   # export request timeout in milliseconds
+  otlp_compression: gzip                  # gzip | none
+  traces_enabled: true                    # enable distributed tracing
+  traces_sampler: parentbased_always_on   # honor the server's sampling decision
+  metrics_enabled: true                   # enable LLM call metrics export
+  metrics_export_interval_ms: 10000       # how often to push metric batches (ms)

--- a/packages/agent-harness/daemon.py
+++ b/packages/agent-harness/daemon.py
@@ -27,6 +27,7 @@ from culture.clients.BACKEND.ipc import make_response
 from culture.clients.BACKEND.irc_transport import IRCTransport
 from culture.clients.BACKEND.message_buffer import MessageBuffer
 from culture.clients.BACKEND.socket_server import SocketServer
+from culture.clients.BACKEND.telemetry import init_harness_telemetry
 from culture.clients.BACKEND.webhook import AlertEvent, WebhookClient
 
 MAX_CONSECUTIVE_TURN_FAILURES = 3
@@ -73,6 +74,8 @@ class AgentDaemon:
         self._buffer: MessageBuffer | None = None
         self._socket_server: SocketServer | None = None
         self._webhook: WebhookClient | None = None
+        self._tracer = None
+        self._metrics = None
         self._agent_runner: Any = None
         self._stop_event: asyncio.Event | None = None
 
@@ -128,6 +131,9 @@ class AgentDaemon:
 
     async def start(self) -> None:
         """Start all daemon components."""
+        # 0. OTEL telemetry (if telemetry.enabled, installs SDK providers; else no-op).
+        self._tracer, self._metrics = init_harness_telemetry(self.config)
+
         # 1. Message buffer
         self._buffer = MessageBuffer(max_per_channel=self.config.buffer_size)
 
@@ -140,6 +146,9 @@ class AgentDaemon:
             channels=list(self.agent.channels),
             buffer=self._buffer,
             on_mention=self._on_mention,
+            tracer=self._tracer,
+            metrics=self._metrics,
+            backend="BACKEND",  # Tasks 4–7 will replace this with claude/codex/copilot/acp
         )
         await self._transport.connect()
 
@@ -191,7 +200,10 @@ class AgentDaemon:
         """Start the agent. REPLACE with your backend's agent startup."""
         raise NotImplementedError(
             "Replace _start_agent_runner() with your agent backend's startup logic. "
-            "See culture/clients/claude/daemon.py for the Claude implementation."
+            "See culture/clients/claude/daemon.py for the Claude implementation. "
+            "The agent runner constructor must accept the harness metrics registry as a "
+            "kwarg (e.g. metrics=self._metrics) so it can call "
+            "telemetry.record_llm_call(...) per LLM turn."
         )
 
     def _build_system_prompt(self) -> str:

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -62,7 +62,7 @@ class IRCTransport:
         self.on_roominvite = on_roominvite
         self.icon = icon
         self._tracer = tracer
-        # stored for the daemon to forward to the agent runner; not used in transport
+        # accepted for future per-message metrics (e.g. byte counters); unused in v1
         self._metrics = metrics
         self._backend = backend
         self.connected = False

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -7,6 +7,7 @@ import asyncio
 import contextlib
 import logging
 import re
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Callable
 
 from culture.aio import maybe_await
@@ -27,7 +28,12 @@ logger = logging.getLogger(__name__)
 
 
 class IRCTransport:
-    """Async IRC client for the daemon."""
+    """Async IRC client for the daemon.
+
+    Optional kwargs ``tracer``, ``metrics``, and ``backend`` enable OTEL
+    tracing and LLM metrics when an SDK provider is installed. Pass ``None``
+    (the default) for all three to run without instrumentation.
+    """
 
     def __init__(
         self,
@@ -56,6 +62,7 @@ class IRCTransport:
         self.on_roominvite = on_roominvite
         self.icon = icon
         self._tracer = tracer
+        # stored for the daemon to forward to the agent runner; not used in transport
         self._metrics = metrics
         self._backend = backend
         self.connected = False
@@ -76,12 +83,16 @@ class IRCTransport:
             "332": self._on_numeric_topic,
         }
 
-    def _span(self, name: str, attrs: dict | None = None):
+    def _span(self, name: str, attrs: dict | None = None) -> AbstractContextManager:
         """Return a real span context manager when tracing is enabled, else a no-op.
 
         Keeps the no-tracer fast path clean — all callers write the same
         ``with self._span(...):`` pattern regardless of whether a tracer is
         configured.
+
+        Does NOT accept a ``context=`` argument; callers that need a span
+        parented to a remote trace context (e.g. inbound message handling in
+        ``_handle``) call ``self._tracer.start_as_current_span`` directly.
         """
         if self._tracer is not None:
             return self._tracer.start_as_current_span(name, attributes=attrs or {})

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -4,13 +4,24 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from culture.aio import maybe_await
 from culture.clients.BACKEND.message_buffer import MessageBuffer
 from culture.protocol.message import Message
+from culture.telemetry.context import (
+    TRACEPARENT_TAG,
+    context_from_traceparent,
+    current_traceparent,
+    extract_traceparent_from_tags,
+)
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
+    from telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +41,9 @@ class IRCTransport:
         tags: list[str] | None = None,
         on_roominvite: Callable[[str, str], None] | None = None,
         icon: str | None = None,
+        tracer: Tracer | None = None,
+        metrics: HarnessMetricsRegistry | None = None,
+        backend: str = "harness",
     ):
         self.host = host
         self.port = port
@@ -41,6 +55,9 @@ class IRCTransport:
         self.tags = tags or []
         self.on_roominvite = on_roominvite
         self.icon = icon
+        self._tracer = tracer
+        self._metrics = metrics
+        self._backend = backend
         self.connected = False
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
@@ -59,23 +76,42 @@ class IRCTransport:
             "332": self._on_numeric_topic,
         }
 
+    def _span(self, name: str, attrs: dict | None = None):
+        """Return a real span context manager when tracing is enabled, else a no-op.
+
+        Keeps the no-tracer fast path clean — all callers write the same
+        ``with self._span(...):`` pattern regardless of whether a tracer is
+        configured.
+        """
+        if self._tracer is not None:
+            return self._tracer.start_as_current_span(name, attributes=attrs or {})
+        return contextlib.nullcontext()
+
     async def connect(self) -> None:
         self._should_run = True
         await self._do_connect()
 
     async def _do_connect(self) -> None:
-        try:
-            self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
-        except OSError as exc:
-            raise ConnectionError(
-                f"Cannot connect to IRC server at {self.host}:{self.port} "
-                f"- is the server running?"
-            ) from exc
-        await self._send_raw("CAP REQ :message-tags")
-        await self._send_raw(f"NICK {self.nick}")
-        await self._send_raw(f"USER {self.user} 0 * :{self.user}")
-        await self._send_raw("CAP END")
-        self._read_task = asyncio.create_task(self._read_loop())
+        with self._span(
+            "harness.irc.connect",
+            attrs={
+                "harness.backend": self._backend,
+                "harness.nick": self.nick,
+                "harness.server": f"{self.host}:{self.port}",
+            },
+        ):
+            try:
+                self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+            except OSError as exc:
+                raise ConnectionError(
+                    f"Cannot connect to IRC server at {self.host}:{self.port} "
+                    f"- is the server running?"
+                ) from exc
+            await self._send_raw("CAP REQ :message-tags")
+            await self._send_raw(f"NICK {self.nick}")
+            await self._send_raw(f"USER {self.user} 0 * :{self.user}")
+            await self._send_raw("CAP END")
+            self._read_task = asyncio.create_task(self._read_loop())
 
     async def disconnect(self) -> None:
         self._should_run = False
@@ -153,6 +189,14 @@ class IRCTransport:
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
+        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
+        # Only inject when we have a tracer configured (fast-path: no work if
+        # self._tracer is None) and there is no tag block already on the line
+        # (defensive guard — prevents double-tagging if a caller pre-tagged).
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:
@@ -195,9 +239,41 @@ class IRCTransport:
                 delay = min(delay * 2, 60)
 
     async def _handle(self, msg: Message) -> None:
-        handler = self._cmd_handlers.get(msg.command)
-        if handler:
-            await maybe_await(handler(msg))
+        # Extract inbound traceparent before opening any span so the new span
+        # can be correctly parented to the remote trace context.
+        result = extract_traceparent_from_tags(msg, peer=None)
+
+        if self._tracer is not None:
+            if result.status == "valid":
+                ctx = context_from_traceparent(result.traceparent)
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    context=ctx,
+                    attributes={
+                        "irc.command": msg.command,
+                        "irc.client.nick": self.nick,
+                        "culture.trace.origin": "remote",
+                    },
+                )
+            else:
+                attrs = {
+                    "irc.command": msg.command,
+                    "irc.client.nick": self.nick,
+                    "culture.trace.origin": ("local" if result.status == "missing" else "remote"),
+                }
+                if result.status in ("malformed", "too_long"):
+                    attrs["culture.trace.dropped_reason"] = result.status
+                span_cm = self._tracer.start_as_current_span(
+                    "harness.irc.message.handle",
+                    attributes=attrs,
+                )
+        else:
+            span_cm = contextlib.nullcontext()
+
+        with span_cm:
+            handler = self._cmd_handlers.get(msg.command)
+            if handler:
+                await maybe_await(handler(msg))
 
     async def _on_ping(self, msg: Message) -> None:
         token = msg.params[0] if msg.params else ""

--- a/packages/agent-harness/irc_transport.py
+++ b/packages/agent-harness/irc_transport.py
@@ -194,20 +194,23 @@ class IRCTransport:
             await self._send_raw(f"TOPIC {channel}")
 
     async def send_raw(self, line: str) -> None:
-        """Send a raw IRC line. Public for commands like HISTORY."""
+        """Send a raw IRC line. Public for commands like HISTORY.
+
+        When a tracer is configured and a span is active, prepends the W3C
+        ``@culture.dev/traceparent=`` IRCv3 tag so all outbound paths — whether
+        called via the internal ``_send_raw`` helper or directly by daemon code
+        — carry trace context consistently.
+        """
+        if self._tracer is not None and not line.startswith("@"):
+            tp = current_traceparent()
+            if tp is not None:
+                line = f"@{TRACEPARENT_TAG}={tp} {line}"
         if self._writer:
             self._writer.write(f"{line}\r\n".encode())
             await self._writer.drain()
 
     async def _send_raw(self, line: str) -> None:
-        # Inject W3C traceparent as an IRCv3 tag prefix when a span is active.
-        # Only inject when we have a tracer configured (fast-path: no work if
-        # self._tracer is None) and there is no tag block already on the line
-        # (defensive guard — prevents double-tagging if a caller pre-tagged).
-        if self._tracer is not None and not line.startswith("@"):
-            tp = current_traceparent()
-            if tp:
-                line = f"@{TRACEPARENT_TAG}={tp} {line}"
+        """Internal send helper; delegates to send_raw (injection lives there)."""
         await self.send_raw(line)
 
     async def _read_loop(self) -> None:

--- a/packages/agent-harness/telemetry.py
+++ b/packages/agent-harness/telemetry.py
@@ -5,27 +5,16 @@ Why this file lives in ``packages/agent-harness/``
 The culture codebase uses a **cite, don't import** pattern for the per-backend
 agent harnesses in ``culture/clients/{claude,codex,copilot,acp}/``. Each backend
 owns a verbatim copy of this file (with the ``service_name`` default changed to
-``culture.harness.<backend>``). Backend-specific overrides are isolated to that
-one line; all other logic must stay identical so the all-backends parity test
+``culture.harness.<backend>``). Backend-specific overrides are isolated to those
+two sites; all other logic must stay identical so the all-backends parity test
 (``tests/harness/test_all_backends_parity.py``) passes.
 
-Why ``culture.telemetry.context`` is imported directly
--------------------------------------------------------
-The harness process installs the same ``culture`` Python package as the server.
-The W3C traceparent helpers (``extract_traceparent_from_tags``,
-``inject_traceparent``, ``current_traceparent``, ``context_from_traceparent``,
-``TRACEPARENT_TAG``, ``TRACESTATE_TAG``) are reusable as-is from
-``culture.telemetry`` — duplicating them here would create divergence risk. Both
-the server-side ``IRCd`` and the harness-side ``IRCTransport`` share the same
-wire grammar, so sharing the helpers is correct.
-
-Backend-specific ``service_name`` overrides
--------------------------------------------
-When a backend cites this file into ``culture/clients/<backend>/``, the only
-required edit is replacing the ``service_name: str = "culture.harness"`` default
-in ``TelemetryConfig`` (or more accurately, in the harness-specific
-``config.py``) with ``"culture.harness.<backend>"``. The tracer name passed to
-``get_tracer`` also becomes ``"culture.harness.<backend>"`` to match.
+Backend-specific edit sites (two, both must be updated on citation)
+--------------------------------------------------------------------
+1. ``TelemetryConfig.service_name`` in ``config.py`` — change the default from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"``.
+2. ``_HARNESS_TRACER_NAME`` constant in this file — change the value from
+   ``"culture.harness"`` to ``"culture.harness.<backend>"`` to match.
 """
 
 from __future__ import annotations
@@ -36,7 +25,7 @@ from dataclasses import asdict, dataclass
 from opentelemetry import metrics, trace
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.metrics import Counter, Histogram
+from opentelemetry.metrics import Counter, Histogram, Meter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
@@ -53,7 +42,7 @@ from opentelemetry.trace import Tracer
 
 logger = logging.getLogger(__name__)
 
-# Module-level tracer name — citied backends replace "culture.harness" with
+# Module-level tracer name — cited backends replace "culture.harness" with
 # "culture.harness.<backend>" to match their service.name.
 _HARNESS_TRACER_NAME = "culture.harness"
 
@@ -139,7 +128,7 @@ def _build_sampler(name: str) -> Sampler:
     return ParentBased(ALWAYS_ON)
 
 
-def _build_registry(meter) -> HarnessMetricsRegistry:
+def _build_registry(meter: Meter) -> HarnessMetricsRegistry:
     """Register all four harness LLM instruments against ``meter``."""
     return HarnessMetricsRegistry(
         llm_tokens_input=meter.create_counter(
@@ -207,7 +196,6 @@ def init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]:
     if not traces_on:
         # No SDK provider → proxy no-op tracer.
         _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
-    # else: will be set after provider install below.
 
     if not metrics_on:
         # Proxy meter — instruments work as stubs; no export thread.

--- a/packages/agent-harness/telemetry.py
+++ b/packages/agent-harness/telemetry.py
@@ -1,0 +1,327 @@
+"""OpenTelemetry bootstrap for Culture agent harnesses.
+
+Why this file lives in ``packages/agent-harness/``
+---------------------------------------------------
+The culture codebase uses a **cite, don't import** pattern for the per-backend
+agent harnesses in ``culture/clients/{claude,codex,copilot,acp}/``. Each backend
+owns a verbatim copy of this file (with the ``service_name`` default changed to
+``culture.harness.<backend>``). Backend-specific overrides are isolated to that
+one line; all other logic must stay identical so the all-backends parity test
+(``tests/harness/test_all_backends_parity.py``) passes.
+
+Why ``culture.telemetry.context`` is imported directly
+-------------------------------------------------------
+The harness process installs the same ``culture`` Python package as the server.
+The W3C traceparent helpers (``extract_traceparent_from_tags``,
+``inject_traceparent``, ``current_traceparent``, ``context_from_traceparent``,
+``TRACEPARENT_TAG``, ``TRACESTATE_TAG``) are reusable as-is from
+``culture.telemetry`` — duplicating them here would create divergence risk. Both
+the server-side ``IRCd`` and the harness-side ``IRCTransport`` share the same
+wire grammar, so sharing the helpers is correct.
+
+Backend-specific ``service_name`` overrides
+-------------------------------------------
+When a backend cites this file into ``culture/clients/<backend>/``, the only
+required edit is replacing the ``service_name: str = "culture.harness"`` default
+in ``TelemetryConfig`` (or more accurately, in the harness-specific
+``config.py``) with ``"culture.harness.<backend>"``. The tracer name passed to
+``get_tracer`` also becomes ``"culture.harness.<backend>"`` to match.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.metrics import Counter, Histogram
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    Sampler,
+    TraceIdRatioBased,
+)
+from opentelemetry.trace import Tracer
+
+logger = logging.getLogger(__name__)
+
+# Module-level tracer name — citied backends replace "culture.harness" with
+# "culture.harness.<backend>" to match their service.name.
+_HARNESS_TRACER_NAME = "culture.harness"
+
+# Module-level globals — mirrors the server-side tracing.py / metrics.py pattern.
+_initialized_for: dict | None = None
+_tracer: Tracer | None = None
+_meter_provider: MeterProvider | None = None
+_registry: HarnessMetricsRegistry | None = None
+
+
+@dataclass
+class HarnessMetricsRegistry:
+    """All harness-side LLM instruments, registered once during init_harness_telemetry.
+
+    Parallel to the server's ``MetricsRegistry`` — different process, different
+    provider, different ``service.name``. Plan 6's bot-side metrics follow the
+    same parallel-registry pattern if bots are process-isolated.
+    """
+
+    llm_tokens_input: Counter
+    """Per-LLM-call input token count by backend/model/nick."""
+
+    llm_tokens_output: Counter
+    """Per-LLM-call output token count by backend/model/nick."""
+
+    llm_call_duration: Histogram
+    """Per-LLM-call wall-clock duration in milliseconds."""
+
+    llm_calls: Counter
+    """Per-LLM-call count by backend/model/outcome."""
+
+
+def reset_for_tests() -> None:
+    """Reset module state so each test gets a fresh provider. Test-only.
+
+    Mirrors ``culture.telemetry.metrics.reset_for_tests`` (MeterProvider
+    shutdown + global clear) and ``culture.telemetry.tracing.reset_for_tests``
+    (trace provider global clear). Both are needed because parallel xdist
+    workers can leak global providers across module boundaries.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        _meter_provider = None
+
+    _initialized_for = None
+    _tracer = None
+    _registry = None
+
+    # Reset the OTEL metrics global — same path as server-side metrics.py.
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    _mi._METER_PROVIDER = None
+    _mi._METER_PROVIDER_SET_ONCE = _mi.Once()
+
+    # Reset the OTEL trace global — same path as server-side tracing.py.
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER_SET_ONCE = trace.Once()  # type: ignore[attr-defined]
+
+
+def _build_sampler(name: str) -> Sampler:
+    """Parse a ``traces_sampler`` string into an OTEL Sampler.
+
+    Mirrors ``culture.telemetry.tracing._build_sampler`` exactly — same
+    string grammar, same fallback warning.
+    """
+    if name == "parentbased_always_on":
+        return ParentBased(ALWAYS_ON)
+    if name.startswith("parentbased_traceidratio:"):
+        ratio = float(name.split(":", 1)[1])
+        return ParentBased(TraceIdRatioBased(ratio))
+    if name == "always_off":
+        return ALWAYS_OFF
+    logger.error(
+        "Unknown telemetry.traces_sampler %r, falling back to parentbased_always_on. "
+        "Valid values: parentbased_always_on, parentbased_traceidratio:<0.0-1.0>, always_off",
+        name,
+    )
+    return ParentBased(ALWAYS_ON)
+
+
+def _build_registry(meter) -> HarnessMetricsRegistry:
+    """Register all four harness LLM instruments against ``meter``."""
+    return HarnessMetricsRegistry(
+        llm_tokens_input=meter.create_counter(
+            "culture.harness.llm.tokens.input",
+            description="Per-LLM-call input token count by backend/model/nick",
+        ),
+        llm_tokens_output=meter.create_counter(
+            "culture.harness.llm.tokens.output",
+            description="Per-LLM-call output token count by backend/model/nick",
+        ),
+        llm_call_duration=meter.create_histogram(
+            "culture.harness.llm.call.duration",
+            unit="ms",
+            description="Per-LLM-call wall-clock duration in milliseconds",
+        ),
+        llm_calls=meter.create_counter(
+            "culture.harness.llm.calls",
+            description="Per-LLM-call count by backend/model/outcome",
+        ),
+    )
+
+
+def init_harness_telemetry(config) -> tuple[Tracer, HarnessMetricsRegistry]:
+    """Initialize TracerProvider + MeterProvider for the harness. Idempotent.
+
+    Returns a ``(Tracer, HarnessMetricsRegistry)`` pair. When
+    ``telemetry.enabled`` is False the returned tracer is a no-op proxy (no
+    SDK provider installed) and the registry instruments are bound to OTEL's
+    proxy meter — call sites can ``add()`` / ``record()`` unconditionally
+    without ``if`` guards.
+
+    The idempotency snapshot includes both the full ``TelemetryConfig`` dict
+    and the agent identity (nick or daemon server name) so that two daemons
+    with identical config but different nicks get separate providers with the
+    correct ``service.instance.id``.
+    """
+    global _initialized_for, _tracer, _meter_provider, _registry
+
+    tcfg = config.telemetry
+
+    # Build a stable identity string for service.instance.id.
+    if config.agents:
+        nick_identity = "-".join(a.nick for a in config.agents)
+    else:
+        nick_identity = config.server.name
+
+    snapshot = {"telemetry": asdict(tcfg), "nick": nick_identity}
+    if _initialized_for == snapshot and _tracer is not None and _registry is not None:
+        return _tracer, _registry
+
+    # Tear down the previous MeterProvider (has a background export thread).
+    if _meter_provider is not None:
+        try:
+            _meter_provider.shutdown()
+        except Exception:  # noqa: BLE001 - shutdown errors must not crash init
+            logger.debug("HarnessMeterProvider shutdown failed", exc_info=True)
+        _meter_provider = None
+
+    # ------------------------------------------------------------------ #
+    # No-op / disabled paths                                               #
+    # ------------------------------------------------------------------ #
+    traces_on = tcfg.enabled and tcfg.traces_enabled
+    metrics_on = tcfg.enabled and tcfg.metrics_enabled
+
+    if not traces_on:
+        # No SDK provider → proxy no-op tracer.
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+    # else: will be set after provider install below.
+
+    if not metrics_on:
+        # Proxy meter — instruments work as stubs; no export thread.
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+
+    if not tcfg.enabled:
+        _initialized_for = snapshot
+        return _tracer, _registry  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------ #
+    # Full SDK init                                                         #
+    # ------------------------------------------------------------------ #
+    resource = Resource.create(
+        {
+            "service.name": tcfg.service_name,
+            "service.instance.id": nick_identity,
+        }
+    )
+    compression_val = None if tcfg.otlp_compression == "none" else tcfg.otlp_compression
+
+    if traces_on:
+        span_exporter = OTLPSpanExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        tracer_provider = TracerProvider(
+            resource=resource,
+            sampler=_build_sampler(tcfg.traces_sampler),
+        )
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+        trace.set_tracer_provider(tracer_provider)
+        _tracer = trace.get_tracer(_HARNESS_TRACER_NAME)
+        logger.info(
+            "OTEL harness tracing initialized: service=%s instance=%s endpoint=%s sampler=%s",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.traces_sampler,
+        )
+
+    if metrics_on:
+        metric_exporter = OTLPMetricExporter(
+            endpoint=tcfg.otlp_endpoint,
+            timeout=tcfg.otlp_timeout_ms / 1000.0,
+            compression=compression_val,
+        )
+        reader = PeriodicExportingMetricReader(
+            exporter=metric_exporter,
+            export_interval_millis=tcfg.metrics_export_interval_ms,
+        )
+        provider = MeterProvider(resource=resource, metric_readers=[reader])
+        metrics.set_meter_provider(provider)
+        _meter_provider = provider
+        meter = metrics.get_meter(_HARNESS_TRACER_NAME)
+        _registry = _build_registry(meter)
+        logger.info(
+            "OTEL harness metrics initialized: service=%s instance=%s endpoint=%s interval=%dms",
+            tcfg.service_name,
+            nick_identity,
+            tcfg.otlp_endpoint,
+            tcfg.metrics_export_interval_ms,
+        )
+
+    _initialized_for = snapshot
+    return _tracer, _registry  # type: ignore[return-value]
+
+
+def record_llm_call(
+    registry: HarnessMetricsRegistry,
+    *,
+    backend: str,
+    model: str,
+    nick: str,
+    usage: dict | None,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+    """Record metrics for a single LLM call.
+
+    Always increments ``llm_calls`` and records ``llm_call_duration``,
+    regardless of whether ``usage`` is present.
+
+    ``usage`` contract: may be ``None`` or contain partial keys; missing
+    or ``None``-valued keys silently skip the corresponding token counter.
+    This is intentional — codex (#298) and copilot (#299) do not expose
+    token counts in their current SDK versions. All four backends call this
+    helper; only claude and acp backends may have non-None usage dicts.
+
+    Args:
+        registry: The ``HarnessMetricsRegistry`` returned by
+            ``init_harness_telemetry``.
+        backend: Backend identifier string (e.g. ``"claude"``, ``"codex"``).
+        model: LLM model name (e.g. ``"claude-opus-4-6"``).
+        nick: Agent IRC nick (e.g. ``"spark-claude"``). Used as the
+            ``harness.nick`` label on token counters.
+        usage: Optional dict with optional keys ``tokens_input`` (int) and
+            ``tokens_output`` (int). ``None`` and missing keys are both safe.
+        duration_ms: Wall-clock duration of the LLM call in milliseconds.
+        outcome: One of ``"success"``, ``"error"``, or ``"timeout"``.
+    """
+    call_attrs = {"backend": backend, "model": model, "outcome": outcome}
+    registry.llm_calls.add(1, call_attrs)
+    registry.llm_call_duration.record(duration_ms, call_attrs)
+
+    if usage is not None:
+        tokens_input = usage.get("tokens_input")
+        if isinstance(tokens_input, int):
+            registry.llm_tokens_input.add(
+                tokens_input, {"backend": backend, "model": model, "harness.nick": nick}
+            )
+        tokens_output = usage.get("tokens_output")
+        if isinstance(tokens_output, int):
+            registry.llm_tokens_output.add(
+                tokens_output, {"backend": backend, "model": model, "harness.nick": nick}
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.5.0"
+version = "8.6.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/harness/conftest.py
+++ b/tests/harness/conftest.py
@@ -4,6 +4,12 @@ Adds ``packages/agent-harness/`` to ``sys.path`` so tests can import the
 reference modules (``telemetry``, ``config``) directly. This mirrors how a
 cited backend copy works in practice — each backend owns its copy as a plain
 Python module file, not as part of an installed package.
+
+Shared fixtures:
+- ``harness_metrics_reader`` — InMemoryMetricReader + SdkMeterProvider for
+  harness LLM metrics tests.
+- ``harness_tracing_exporter`` — InMemorySpanExporter + SdkTracerProvider for
+  harness tracing tests.
 """
 
 from __future__ import annotations
@@ -11,9 +17,73 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
 # Insert the agent-harness reference directory so tests can do:
 #   from telemetry import init_harness_telemetry, ...
 #   from config import DaemonConfig, TelemetryConfig, ...
 _HARNESS_REF = str(Path(__file__).parent.parent.parent / "packages" / "agent-harness")
 if _HARNESS_REF not in sys.path:
     sys.path.insert(0, _HARNESS_REF)
+
+# Import reset_for_tests after sys.path is set.
+# pylint: disable=wrong-import-position,import-error
+from telemetry import reset_for_tests as _reset_harness  # noqa: E402
+
+
+@pytest.fixture
+def harness_metrics_reader():
+    """Install an InMemoryMetricReader against a fresh SdkMeterProvider.
+
+    Returns the reader so tests can call ``reader.get_metrics_data()``.
+    Resets harness module state before install and after teardown.
+
+    Shared across test_telemetry_module.py and test_record_llm_call.py — both
+    used to define this inline; this canonical version lives here so future
+    harness tests can reuse it without duplication.
+    """
+    _reset_harness()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-harness"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    yield reader
+    _reset_harness()
+
+
+@pytest.fixture
+def harness_tracing_exporter():
+    """Install an InMemorySpanExporter against a fresh SdkTracerProvider.
+
+    Returns the exporter so tests can call ``exporter.get_finished_spans()``.
+    Resets harness module state before install and after teardown so parallel
+    xdist workers don't leak providers.
+
+    Usage::
+
+        def test_something(harness_tracing_exporter):
+            exporter, tracer_provider = harness_tracing_exporter
+            tracer = tracer_provider.get_tracer("test")
+            # ... use tracer, then:
+            spans = exporter.get_finished_spans()
+    """
+    _reset_harness()
+    exporter = InMemorySpanExporter()
+    provider = SdkTracerProvider(
+        resource=Resource.create({"service.name": "test-harness-tracing"}),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    yield exporter, provider
+    provider.shutdown()
+    _reset_harness()

--- a/tests/harness/conftest.py
+++ b/tests/harness/conftest.py
@@ -1,0 +1,19 @@
+"""Test configuration for tests/harness/.
+
+Adds ``packages/agent-harness/`` to ``sys.path`` so tests can import the
+reference modules (``telemetry``, ``config``) directly. This mirrors how a
+cited backend copy works in practice — each backend owns its copy as a plain
+Python module file, not as part of an installed package.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Insert the agent-harness reference directory so tests can do:
+#   from telemetry import init_harness_telemetry, ...
+#   from config import DaemonConfig, TelemetryConfig, ...
+_HARNESS_REF = str(Path(__file__).parent.parent.parent / "packages" / "agent-harness")
+if _HARNESS_REF not in sys.path:
+    sys.path.insert(0, _HARNESS_REF)

--- a/tests/harness/test_agent_runner_acp.py
+++ b/tests/harness/test_agent_runner_acp.py
@@ -1,0 +1,232 @@
+"""Tests for culture/clients/acp/agent_runner.py OTEL instrumentation.
+
+Tests are isolated — no real ACP process, no IRCd. The JSON-RPC
+``_send_prompt_with_retry`` method is patched directly via
+``unittest.mock.patch.object`` so CI can run without a live ``opencode``
+or ``cline`` binary installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from culture.clients.acp.agent_runner import ACPAgentRunner
+from culture.clients.acp.telemetry import (
+    HarnessMetricsRegistry,
+    _build_registry,
+    reset_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel():
+    """Reset all OTEL globals before and after every test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def metrics_reader():
+    """Install an InMemoryMetricReader and return the reader."""
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-acp-runner"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    return reader
+
+
+@pytest.fixture
+def tracing_exporter():
+    """Install an InMemorySpanExporter and return (exporter, provider)."""
+    exporter = InMemorySpanExporter()
+    provider = SdkTracerProvider(
+        resource=Resource.create({"service.name": "test-acp-runner-tracing"}),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter, provider
+
+
+@pytest.fixture
+def registry(metrics_reader):
+    """Return a real HarnessMetricsRegistry bound to the test meter provider."""
+    from opentelemetry import metrics as _m
+
+    meter = _m.get_meter("culture.harness.acp")
+    return _build_registry(meter)
+
+
+def _make_runner(registry=None, nick="spark-acp", model="anthropic/claude-sonnet-4-6"):
+    """Build a minimal ACPAgentRunner with telemetry wired up."""
+    runner = ACPAgentRunner(
+        model=model,
+        directory="/tmp",
+        metrics=registry,
+        nick=nick,
+    )
+    # Pre-set _session_id so _send_prompt_with_retry doesn't fail on None session
+    runner._session_id = "test-session-id"
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_metric_value(reader, metric_name, attributes=None):
+    """Extract a sum value from the reader for a given metric name + attrs."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return None
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    for dp in m.data.data_points:
+                        if attributes is None:
+                            return dp.value
+                        if all(dp.attributes.get(k) == v for k, v in attributes.items()):
+                            return dp.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_single_prompt_records_success(metrics_reader, tracing_exporter, registry):
+    """Success path: span opened with correct acp attrs, metrics incremented.
+
+    Token counters do NOT increment — ACP v1 defers token extraction.
+    """
+    exporter, _ = tracing_exporter
+    runner = _make_runner(registry=registry, nick="spark-acp", model="anthropic/claude-sonnet-4-6")
+
+    with patch.object(
+        ACPAgentRunner,
+        "_send_prompt_with_retry",
+        new_callable=AsyncMock,
+        return_value={"result": {"stopReason": "end_turn"}},
+    ):
+        with patch.object(ACPAgentRunner, "_handle_prompt_result", new_callable=AsyncMock):
+            await runner._execute_single_prompt("hello")
+
+    # Check span was created with correct attributes
+    spans = exporter.get_finished_spans()
+    llm_spans = [s for s in spans if s.name == "harness.llm.call"]
+    assert len(llm_spans) == 1
+    span = llm_spans[0]
+    assert span.attributes.get("harness.backend") == "acp"
+    assert span.attributes.get("harness.model") == "anthropic/claude-sonnet-4-6"
+    assert span.attributes.get("harness.nick") == "spark-acp"
+
+    # Check llm_calls metric incremented with outcome=success
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {
+            "backend": "acp",
+            "model": "anthropic/claude-sonnet-4-6",
+            "outcome": "success",
+        },
+    )
+    assert calls_val == 1
+
+    # Token counters must NOT be recorded — ACP v1 defers token extraction
+    input_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.input")
+    assert input_val is None
+
+    output_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.output")
+    assert output_val is None
+
+
+@pytest.mark.asyncio
+async def test_execute_single_prompt_records_timeout(metrics_reader, registry):
+    """Timeout path: TimeoutError from retry-exhaustion → outcome=timeout."""
+    runner = _make_runner(registry=registry, nick="spark-acp", model="anthropic/claude-sonnet-4-6")
+
+    with patch.object(
+        ACPAgentRunner,
+        "_send_prompt_with_retry",
+        new_callable=AsyncMock,
+        side_effect=TimeoutError("ACP prompt timed out after retry"),
+    ):
+        await runner._execute_single_prompt("hello")
+
+    # Check outcome=timeout
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {
+            "backend": "acp",
+            "model": "anthropic/claude-sonnet-4-6",
+            "outcome": "timeout",
+        },
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_single_prompt_records_error(metrics_reader, registry):
+    """Error path: RuntimeError → outcome=error increments llm_calls."""
+    runner = _make_runner(registry=registry, nick="spark-acp", model="anthropic/claude-sonnet-4-6")
+
+    with patch.object(
+        ACPAgentRunner,
+        "_send_prompt_with_retry",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("ACP JSON-RPC exploded"),
+    ):
+        await runner._execute_single_prompt("hello")
+
+    # Check outcome=error
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {
+            "backend": "acp",
+            "model": "anthropic/claude-sonnet-4-6",
+            "outcome": "error",
+        },
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_single_prompt_no_metrics_no_recording(metrics_reader):
+    """When metrics=None, no metric data is recorded."""
+    runner = _make_runner(registry=None, nick="spark-acp")
+
+    with patch.object(
+        ACPAgentRunner,
+        "_send_prompt_with_retry",
+        new_callable=AsyncMock,
+        return_value={"result": {"stopReason": "end_turn"}},
+    ):
+        with patch.object(ACPAgentRunner, "_handle_prompt_result", new_callable=AsyncMock):
+            await runner._execute_single_prompt("hello")
+
+    # No metric data should be recorded for llm_calls
+    calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
+    assert calls_val is None

--- a/tests/harness/test_agent_runner_acp.py
+++ b/tests/harness/test_agent_runner_acp.py
@@ -9,6 +9,7 @@ or ``cline`` binary installed.
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -78,7 +79,7 @@ def _make_runner(registry=None, nick="spark-acp", model="anthropic/claude-sonnet
     """Build a minimal ACPAgentRunner with telemetry wired up."""
     runner = ACPAgentRunner(
         model=model,
-        directory="/tmp",
+        directory=tempfile.mkdtemp(prefix="culture-test-acp-"),
         metrics=registry,
         nick=nick,
     )

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -1,0 +1,315 @@
+"""Tests for culture/clients/claude/agent_runner.py OTEL instrumentation.
+
+Tests are isolated — no real Claude SDK, no IRCd. The SDK's ``query()``
+async generator is replaced with a mock so CI can run without ``claude_agent_sdk``
+installed.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+# ---------------------------------------------------------------------------
+# Stub out claude_agent_sdk if not installed so CI can import agent_runner.py
+# ---------------------------------------------------------------------------
+
+
+def _stub_claude_sdk():
+    """Insert minimal stubs for claude_agent_sdk into sys.modules."""
+    if "claude_agent_sdk" in sys.modules:
+        return
+
+    mod = types.ModuleType("claude_agent_sdk")
+
+    class _Base:
+        pass
+
+    class AssistantMessage(_Base):
+        def __init__(self, model="stub-model", content=None):
+            self.model = model
+            self.content = content or []
+
+    class ResultMessage(_Base):
+        def __init__(self, session_id="sid-1", is_error=False, result="", usage=None):
+            self.session_id = session_id
+            self.is_error = is_error
+            self.result = result
+            self.usage = usage
+
+    class ClaudeAgentOptions(_Base):
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class TextBlock(_Base):
+        pass
+
+    class ThinkingBlock(_Base):
+        pass
+
+    class ToolUseBlock(_Base):
+        pass
+
+    class ToolResultBlock(_Base):
+        pass
+
+    async def query(**kwargs):
+        return
+        yield  # make it an async generator
+
+    mod.AssistantMessage = AssistantMessage
+    mod.ResultMessage = ResultMessage
+    mod.ClaudeAgentOptions = ClaudeAgentOptions
+    mod.TextBlock = TextBlock
+    mod.ThinkingBlock = ThinkingBlock
+    mod.ToolUseBlock = ToolUseBlock
+    mod.ToolResultBlock = ToolResultBlock
+    mod.query = query
+
+    sys.modules["claude_agent_sdk"] = mod
+
+
+_stub_claude_sdk()
+
+# Now safe to import
+from culture.clients.claude.agent_runner import AgentRunner  # noqa: E402
+from culture.clients.claude.config import DaemonConfig, TelemetryConfig  # noqa: E402
+from culture.clients.claude.telemetry import (  # noqa: E402
+    HarnessMetricsRegistry,
+    init_harness_telemetry,
+    reset_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel():
+    """Reset all OTEL globals before and after every test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def metrics_reader():
+    """Install an InMemoryMetricReader and return (reader, registry)."""
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-claude-runner"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    return reader
+
+
+@pytest.fixture
+def tracing_exporter():
+    """Install an InMemorySpanExporter and return (exporter, provider)."""
+    exporter = InMemorySpanExporter()
+    provider = SdkTracerProvider(
+        resource=Resource.create({"service.name": "test-claude-runner-tracing"}),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter, provider
+
+
+@pytest.fixture
+def registry(metrics_reader):
+    """Return a real HarnessMetricsRegistry bound to the test meter provider."""
+    from opentelemetry import metrics as _m
+
+    meter = _m.get_meter("culture.harness.claude")
+    from culture.clients.claude.telemetry import _build_registry
+
+    return _build_registry(meter)
+
+
+def _make_runner(registry=None, nick="spark-claude", model="claude-opus-4-6"):
+    """Build a minimal AgentRunner with telemetry wired up."""
+    return AgentRunner(
+        model=model,
+        directory="/tmp",
+        metrics=registry,
+        nick=nick,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_metric_value(reader, metric_name, attributes=None):
+    """Extract a sum value from the reader for a given metric name + attrs."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return None
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    for dp in m.data.data_points:
+                        if attributes is None:
+                            return dp.value
+                        if all(dp.attributes.get(k) == v for k, v in attributes.items()):
+                            return dp.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_turn_records_llm_call_success(metrics_reader, tracing_exporter, registry):
+    """Success path: span opened with correct attrs, metrics incremented."""
+    exporter, _ = tracing_exporter
+    runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
+
+    # Fake ResultMessage with usage dict
+    sdk = sys.modules["claude_agent_sdk"]
+    fake_result = sdk.ResultMessage(
+        session_id="sid-1",
+        is_error=False,
+        usage={"input_tokens": 100, "output_tokens": 200},
+    )
+
+    async def _fake_query(**kwargs):
+        yield fake_result
+
+    with patch("culture.clients.claude.agent_runner.query", _fake_query):
+        result = await runner._process_turn("hello")
+
+    assert result is True
+
+    # Check span
+    spans = exporter.get_finished_spans()
+    llm_spans = [s for s in spans if s.name == "harness.llm.call"]
+    assert len(llm_spans) == 1
+    span = llm_spans[0]
+    assert span.attributes.get("harness.backend") == "claude"
+    assert span.attributes.get("harness.model") == "claude-opus-4-6"
+    assert span.attributes.get("harness.nick") == "spark-claude"
+
+    # Check llm_calls metric
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "claude", "model": "claude-opus-4-6", "outcome": "success"},
+    )
+    assert calls_val == 1
+
+    # Check token counters
+    input_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.tokens.input",
+        {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+    )
+    assert input_val == 100
+
+    output_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.tokens.output",
+        {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+    )
+    assert output_val == 200
+
+
+@pytest.mark.asyncio
+async def test_process_turn_records_error_outcome(metrics_reader, registry):
+    """Error path: outcome=error increments llm_calls{outcome=error}."""
+    runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
+
+    async def _raising_query(**kwargs):
+        raise RuntimeError("SDK exploded")
+        yield  # make it an async generator
+
+    with patch("culture.clients.claude.agent_runner.query", _raising_query):
+        result = await runner._process_turn("hello")
+
+    assert result is False
+
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "claude", "model": "claude-opus-4-6", "outcome": "error"},
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_process_turn_no_metrics_no_recording(metrics_reader):
+    """When metrics=None, no metric data is recorded."""
+    runner = _make_runner(registry=None, nick="spark-claude")
+
+    sdk = sys.modules["claude_agent_sdk"]
+    fake_result = sdk.ResultMessage(
+        session_id="sid-1",
+        is_error=False,
+        usage={"input_tokens": 50, "output_tokens": 75},
+    )
+
+    async def _fake_query(**kwargs):
+        yield fake_result
+
+    with patch("culture.clients.claude.agent_runner.query", _fake_query):
+        result = await runner._process_turn("hello")
+
+    assert result is True
+
+    # No metric data should be recorded for llm_calls
+    calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
+    assert calls_val is None
+
+
+@pytest.mark.asyncio
+async def test_process_turn_no_usage_skips_token_counters(metrics_reader, registry):
+    """When ResultMessage has no usage, llm_calls increments but token counters do not."""
+    runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
+
+    sdk = sys.modules["claude_agent_sdk"]
+    fake_result = sdk.ResultMessage(
+        session_id="sid-1",
+        is_error=False,
+        usage=None,  # No usage
+    )
+
+    async def _fake_query(**kwargs):
+        yield fake_result
+
+    with patch("culture.clients.claude.agent_runner.query", _fake_query):
+        result = await runner._process_turn("hello")
+
+    assert result is True
+
+    # llm_calls should increment
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "claude", "model": "claude-opus-4-6", "outcome": "success"},
+    )
+    assert calls_val == 1
+
+    # Token counters should NOT be recorded
+    input_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.input")
+    assert input_val is None
+
+    output_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.output")
+    assert output_val is None

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -24,6 +24,40 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 # ---------------------------------------------------------------------------
+# Async iterator stubs — replace if-False-yield workarounds (S5797/S3626)
+# ---------------------------------------------------------------------------
+
+
+class _StubAsyncIter:
+    """Async iterator that yields a fixed sequence of pre-built messages."""
+
+    def __init__(self, messages):
+        self._iter = iter(messages)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _RaisingAsyncIter:
+    """Async iterator that raises immediately on iteration."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise self._exc
+
+
+# ---------------------------------------------------------------------------
 # Stub out claude_agent_sdk if not installed so CI can import agent_runner.py
 # ---------------------------------------------------------------------------
 
@@ -67,10 +101,8 @@ def _stub_claude_sdk():
     class ToolResultBlock(_Base):
         pass
 
-    async def query(**kwargs):
-        if False:
-            yield  # marks this as an async generator
-        return
+    def query(**kwargs):
+        return _StubAsyncIter([])
 
     mod.AssistantMessage = AssistantMessage
     mod.ResultMessage = ResultMessage
@@ -240,12 +272,10 @@ async def test_process_turn_records_error_outcome(metrics_reader, registry):
     """Error path: outcome=error increments llm_calls{outcome=error}."""
     runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
 
-    async def _raising_query(**kwargs):
-        if False:
-            yield  # marks this as an async generator
-        raise RuntimeError("SDK exploded")
-
-    with patch("culture.clients.claude.agent_runner.query", _raising_query):
+    with patch(
+        "culture.clients.claude.agent_runner.query",
+        lambda **kw: _RaisingAsyncIter(RuntimeError("SDK exploded")),
+    ):
         result = await runner._process_turn("hello")
 
     assert result is False

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import sys
 import types
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -313,3 +314,103 @@ async def test_process_turn_no_usage_skips_token_counters(metrics_reader, regist
 
     output_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.output")
     assert output_val is None
+
+
+@pytest.mark.asyncio
+async def test_process_turn_records_attr_form_usage(metrics_reader, registry):
+    """Attr-form usage (SimpleNamespace) is correctly extracted and recorded.
+
+    The pre-fix bug affected only the attr path: ``getattr(u, 'input_tokens', None) or rhs``
+    returns the rhs when the attr value is 0 (zero is falsy). This test verifies the
+    explicit-branch fix correctly handles an attr-style usage object.
+    """
+    runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
+
+    sdk = sys.modules["claude_agent_sdk"]
+    # usage is an attribute-style object (not a dict)
+    attr_usage = SimpleNamespace(input_tokens=300, output_tokens=150)
+    fake_result = sdk.ResultMessage(
+        session_id="sid-attr",
+        is_error=False,
+        usage=attr_usage,
+    )
+
+    async def _fake_query(**kwargs):
+        yield fake_result
+
+    with patch("culture.clients.claude.agent_runner.query", _fake_query):
+        result = await runner._process_turn("hello")
+
+    assert result is True
+
+    input_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.tokens.input",
+        {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+    )
+    assert input_val == 300
+
+    output_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.tokens.output",
+        {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+    )
+    assert output_val == 150
+
+
+@pytest.mark.asyncio
+async def test_process_turn_records_zero_token_usage(metrics_reader, registry):
+    """Zero-valued token counts are recorded, not silenced.
+
+    The pre-fix bug: ``getattr(u, 'input_tokens', None) or None`` evaluates to
+    ``None`` when input_tokens==0 (zero is falsy), causing ``record_llm_call``'s
+    ``isinstance(value, int)`` guard to drop the data point entirely. After the fix,
+    ``_extract_usage`` uses explicit branching, so ``0`` survives and a data point
+    with ``value=0`` is emitted.
+    """
+    runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
+
+    sdk = sys.modules["claude_agent_sdk"]
+    fake_result = sdk.ResultMessage(
+        session_id="sid-zero",
+        is_error=False,
+        usage={"input_tokens": 0, "output_tokens": 0},
+    )
+
+    async def _fake_query(**kwargs):
+        yield fake_result
+
+    with patch("culture.clients.claude.agent_runner.query", _fake_query):
+        result = await runner._process_turn("hello")
+
+    assert result is True
+
+    # Both token counters must exist with value 0 — the data point must be present.
+    data = metrics_reader.get_metrics_data()
+    assert data is not None
+
+    def _find_data_points(metric_name):
+        for rm in data.resource_metrics:
+            for sm in rm.scope_metrics:
+                for m in sm.metrics:
+                    if m.name == metric_name:
+                        return list(m.data.data_points)
+        return []
+
+    attrs = {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"}
+
+    input_dps = [
+        dp
+        for dp in _find_data_points("culture.harness.llm.tokens.input")
+        if all(dp.attributes.get(k) == v for k, v in attrs.items())
+    ]
+    assert len(input_dps) == 1, "Expected exactly one data point for tokens.input with zero value"
+    assert input_dps[0].value == 0
+
+    output_dps = [
+        dp
+        for dp in _find_data_points("culture.harness.llm.tokens.output")
+        if all(dp.attributes.get(k) == v for k, v in attrs.items())
+    ]
+    assert len(output_dps) == 1, "Expected exactly one data point for tokens.output with zero value"
+    assert output_dps[0].value == 0

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -8,6 +8,7 @@ installed.
 from __future__ import annotations
 
 import sys
+import tempfile
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -67,8 +68,9 @@ def _stub_claude_sdk():
         pass
 
     async def query(**kwargs):
+        if False:
+            yield  # marks this as an async generator
         return
-        yield  # make it an async generator
 
     mod.AssistantMessage = AssistantMessage
     mod.ResultMessage = ResultMessage
@@ -145,7 +147,7 @@ def _make_runner(registry=None, nick="spark-claude", model="claude-opus-4-6"):
     """Build a minimal AgentRunner with telemetry wired up."""
     return AgentRunner(
         model=model,
-        directory="/tmp",
+        directory=tempfile.mkdtemp(prefix="culture-test-claude-"),
         metrics=registry,
         nick=nick,
     )
@@ -239,8 +241,9 @@ async def test_process_turn_records_error_outcome(metrics_reader, registry):
     runner = _make_runner(registry=registry, nick="spark-claude", model="claude-opus-4-6")
 
     async def _raising_query(**kwargs):
+        if False:
+            yield  # marks this as an async generator
         raise RuntimeError("SDK exploded")
-        yield  # make it an async generator
 
     with patch("culture.clients.claude.agent_runner.query", _raising_query):
         result = await runner._process_turn("hello")

--- a/tests/harness/test_agent_runner_codex.py
+++ b/tests/harness/test_agent_runner_codex.py
@@ -1,0 +1,227 @@
+"""Tests for culture/clients/codex/agent_runner.py OTEL instrumentation.
+
+Tests are isolated — no real Codex process, no IRCd. The JSON-RPC
+``_send_request`` method is patched so CI can run without a live ``codex``
+binary installed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from culture.clients.codex.agent_runner import CodexAgentRunner
+from culture.clients.codex.telemetry import (
+    HarnessMetricsRegistry,
+    _build_registry,
+    reset_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel():
+    """Reset all OTEL globals before and after every test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def metrics_reader():
+    """Install an InMemoryMetricReader and return (reader, registry)."""
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-codex-runner"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    return reader
+
+
+@pytest.fixture
+def tracing_exporter():
+    """Install an InMemorySpanExporter and return (exporter, provider)."""
+    exporter = InMemorySpanExporter()
+    provider = SdkTracerProvider(
+        resource=Resource.create({"service.name": "test-codex-runner-tracing"}),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter, provider
+
+
+@pytest.fixture
+def registry(metrics_reader):
+    """Return a real HarnessMetricsRegistry bound to the test meter provider."""
+    from opentelemetry import metrics as _m
+
+    meter = _m.get_meter("culture.harness.codex")
+    return _build_registry(meter)
+
+
+def _make_runner(registry=None, nick="spark-codex", model="gpt-5.4"):
+    """Build a minimal CodexAgentRunner with telemetry wired up."""
+    runner = CodexAgentRunner(
+        model=model,
+        directory="/tmp",
+        metrics=registry,
+        nick=nick,
+    )
+    # Pre-set _thread_id so _execute_single_turn doesn't fail on None thread
+    runner._thread_id = "test-thread-id"
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_metric_value(reader, metric_name, attributes=None):
+    """Extract a sum value from the reader for a given metric name + attrs."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return None
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    for dp in m.data.data_points:
+                        if attributes is None:
+                            return dp.value
+                        if all(dp.attributes.get(k) == v for k, v in attributes.items()):
+                            return dp.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_records_success(metrics_reader, tracing_exporter, registry):
+    """Success path: span opened with correct codex attrs, metrics incremented.
+
+    Token counters do NOT increment — codex defers token extraction to issue #298.
+    """
+    exporter, _ = tracing_exporter
+    runner = _make_runner(registry=registry, nick="spark-codex", model="gpt-5.4")
+
+    async def _fake_send_request(method, params):
+        # Simulate the turn/completed notification setting the event
+        runner._turn_done.set()
+        return {"result": {}}
+
+    with patch.object(runner, "_send_request", side_effect=_fake_send_request):
+        await runner._execute_single_turn("hello")
+
+    # Check span was created with correct attributes
+    spans = exporter.get_finished_spans()
+    llm_spans = [s for s in spans if s.name == "harness.llm.call"]
+    assert len(llm_spans) == 1
+    span = llm_spans[0]
+    assert span.attributes.get("harness.backend") == "codex"
+    assert span.attributes.get("harness.model") == "gpt-5.4"
+    assert span.attributes.get("harness.nick") == "spark-codex"
+
+    # Check llm_calls metric incremented with outcome=success
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "codex", "model": "gpt-5.4", "outcome": "success"},
+    )
+    assert calls_val == 1
+
+    # Token counters must NOT be recorded — codex defers token extraction (issue #298)
+    input_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.input")
+    assert input_val is None
+
+    output_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.output")
+    assert output_val is None
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_records_timeout(metrics_reader, registry):
+    """Timeout path: asyncio.TimeoutError → outcome=timeout increments llm_calls."""
+    runner = _make_runner(registry=registry, nick="spark-codex", model="gpt-5.4")
+
+    async def _fake_send_request(method, params):
+        # Return without setting _turn_done — this will cause the 300s timeout.
+        # We patch asyncio.timeout to make it expire immediately.
+        return {"result": {}}
+
+    import asyncio
+    from unittest.mock import MagicMock
+
+    # Create a context manager that raises TimeoutError immediately
+    class _ImmediateTimeout:
+        async def __aenter__(self):
+            raise asyncio.TimeoutError()
+
+        async def __aexit__(self, *args):
+            pass
+
+    with patch.object(runner, "_send_request", side_effect=_fake_send_request):
+        with patch(
+            "culture.clients.codex.agent_runner.asyncio.timeout", return_value=_ImmediateTimeout()
+        ):
+            await runner._execute_single_turn("hello")
+
+    # Check outcome=timeout
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "codex", "model": "gpt-5.4", "outcome": "timeout"},
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_records_error(metrics_reader, registry):
+    """Error path: _send_request raises → outcome=error increments llm_calls."""
+    runner = _make_runner(registry=registry, nick="spark-codex", model="gpt-5.4")
+
+    async def _raising_send_request(method, params):
+        raise RuntimeError("JSON-RPC exploded")
+
+    with patch.object(runner, "_send_request", side_effect=_raising_send_request):
+        await runner._execute_single_turn("hello")
+
+    # Check outcome=error
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "codex", "model": "gpt-5.4", "outcome": "error"},
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_no_metrics_no_recording(metrics_reader):
+    """When metrics=None, no metric data is recorded."""
+    runner = _make_runner(registry=None, nick="spark-codex")
+
+    async def _fake_send_request(method, params):
+        runner._turn_done.set()
+        return {"result": {}}
+
+    with patch.object(runner, "_send_request", side_effect=_fake_send_request):
+        await runner._execute_single_turn("hello")
+
+    # No metric data should be recorded for llm_calls
+    calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
+    assert calls_val is None

--- a/tests/harness/test_agent_runner_codex.py
+++ b/tests/harness/test_agent_runner_codex.py
@@ -7,6 +7,7 @@ binary installed.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -163,9 +164,6 @@ async def test_execute_single_turn_records_timeout(metrics_reader, registry):
         # Return without setting _turn_done — this will cause the 300s timeout.
         # We patch asyncio.timeout to make it expire immediately.
         return {"result": {}}
-
-    import asyncio
-    from unittest.mock import MagicMock
 
     # Create a context manager that raises TimeoutError immediately
     class _ImmediateTimeout:

--- a/tests/harness/test_agent_runner_codex.py
+++ b/tests/harness/test_agent_runner_codex.py
@@ -8,6 +8,7 @@ binary installed.
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -77,7 +78,7 @@ def _make_runner(registry=None, nick="spark-codex", model="gpt-5.4"):
     """Build a minimal CodexAgentRunner with telemetry wired up."""
     runner = CodexAgentRunner(
         model=model,
-        directory="/tmp",
+        directory=tempfile.mkdtemp(prefix="culture-test-codex-"),
         metrics=registry,
         nick=nick,
     )
@@ -124,6 +125,7 @@ async def test_execute_single_turn_records_success(metrics_reader, tracing_expor
 
     async def _fake_send_request(method, params):
         # Simulate the turn/completed notification setting the event
+        await asyncio.sleep(0)
         runner._turn_done.set()
         return {"result": {}}
 
@@ -163,6 +165,7 @@ async def test_execute_single_turn_records_timeout(metrics_reader, registry):
     async def _fake_send_request(method, params):
         # Return without setting _turn_done — this will cause the 300s timeout.
         # We patch asyncio.timeout to make it expire immediately.
+        await asyncio.sleep(0)
         return {"result": {}}
 
     # Create a context manager that raises TimeoutError immediately
@@ -171,7 +174,7 @@ async def test_execute_single_turn_records_timeout(metrics_reader, registry):
             raise asyncio.TimeoutError()
 
         async def __aexit__(self, *args):
-            pass
+            """Stub for SDK type."""
 
     with patch.object(runner, "_send_request", side_effect=_fake_send_request):
         with patch(
@@ -214,6 +217,7 @@ async def test_execute_single_turn_no_metrics_no_recording(metrics_reader):
     runner = _make_runner(registry=None, nick="spark-codex")
 
     async def _fake_send_request(method, params):
+        await asyncio.sleep(0)
         runner._turn_done.set()
         return {"result": {}}
 

--- a/tests/harness/test_agent_runner_copilot.py
+++ b/tests/harness/test_agent_runner_copilot.py
@@ -1,0 +1,250 @@
+"""Tests for culture/clients/copilot/agent_runner.py OTEL instrumentation.
+
+Tests are isolated — no real Copilot SDK, no IRCd. The copilot SDK classes
+(``CopilotClient``, ``PermissionHandler``, ``SubprocessConfig``) are stubbed
+via ``sys.modules`` so CI can run without the ``copilot`` package installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+# ---------------------------------------------------------------------------
+# Stub out the copilot SDK if not installed so CI can import agent_runner.py
+# ---------------------------------------------------------------------------
+
+
+def _stub_copilot_sdk():
+    """Insert minimal stubs for the copilot SDK into sys.modules."""
+    if "copilot" in sys.modules:
+        return
+
+    mod = types.ModuleType("copilot")
+
+    class CopilotClient:
+        def __init__(self, config=None):
+            pass
+
+        async def start(self):
+            pass
+
+        async def stop(self):
+            pass
+
+        async def create_session(self, **kwargs):
+            return MagicMock()
+
+    class PermissionHandler:
+        approve_all = staticmethod(lambda req: True)
+
+    class SubprocessConfig:
+        def __init__(self, cwd=None, env=None):
+            self.cwd = cwd
+            self.env = env
+
+    mod.CopilotClient = CopilotClient
+    mod.PermissionHandler = PermissionHandler
+    mod.SubprocessConfig = SubprocessConfig
+
+    sys.modules["copilot"] = mod
+
+
+_stub_copilot_sdk()
+
+# Now safe to import
+from culture.clients.copilot.agent_runner import CopilotAgentRunner  # noqa: E402
+from culture.clients.copilot.telemetry import (  # noqa: E402
+    HarnessMetricsRegistry,
+    _build_registry,
+    reset_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_otel():
+    """Reset all OTEL globals before and after every test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def metrics_reader():
+    """Install an InMemoryMetricReader and return the reader."""
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-copilot-runner"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    return reader
+
+
+@pytest.fixture
+def tracing_exporter():
+    """Install an InMemorySpanExporter and return (exporter, provider)."""
+    exporter = InMemorySpanExporter()
+    provider = SdkTracerProvider(
+        resource=Resource.create({"service.name": "test-copilot-runner-tracing"}),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter, provider
+
+
+@pytest.fixture
+def registry(metrics_reader):
+    """Return a real HarnessMetricsRegistry bound to the test meter provider."""
+    from opentelemetry import metrics as _m
+
+    meter = _m.get_meter("culture.harness.copilot")
+    return _build_registry(meter)
+
+
+def _make_runner(registry=None, nick="spark-copilot", model="gpt-4.1"):
+    """Build a minimal CopilotAgentRunner with telemetry wired up."""
+    runner = CopilotAgentRunner(
+        model=model,
+        directory="/tmp",
+        metrics=registry,
+        nick=nick,
+    )
+    # Pre-wire a mock session so _execute_single_turn can call send_and_wait
+    runner._session = AsyncMock()
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_metric_value(reader, metric_name, attributes=None):
+    """Extract a sum value from the reader for a given metric name + attrs."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return None
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    for dp in m.data.data_points:
+                        if attributes is None:
+                            return dp.value
+                        if all(dp.attributes.get(k) == v for k, v in attributes.items()):
+                            return dp.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_records_success(metrics_reader, tracing_exporter, registry):
+    """Success path: span opened with correct copilot attrs, metrics incremented.
+
+    Token counters do NOT increment — copilot defers token extraction to issue #299.
+    """
+    exporter, _ = tracing_exporter
+    runner = _make_runner(registry=registry, nick="spark-copilot", model="gpt-4.1")
+
+    # Stub send_and_wait to return a fake response with data.content
+    fake_response = SimpleNamespace(data=SimpleNamespace(content="Hello from copilot!"))
+    runner._session.send_and_wait = AsyncMock(return_value=fake_response)
+
+    await runner._execute_single_turn("hello")
+
+    # Check span was created with correct attributes
+    spans = exporter.get_finished_spans()
+    llm_spans = [s for s in spans if s.name == "harness.llm.call"]
+    assert len(llm_spans) == 1
+    span = llm_spans[0]
+    assert span.attributes.get("harness.backend") == "copilot"
+    assert span.attributes.get("harness.model") == "gpt-4.1"
+    assert span.attributes.get("harness.nick") == "spark-copilot"
+
+    # Check llm_calls metric incremented with outcome=success
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "copilot", "model": "gpt-4.1", "outcome": "success"},
+    )
+    assert calls_val == 1
+
+    # Token counters must NOT be recorded — copilot defers token extraction (issue #299)
+    input_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.input")
+    assert input_val is None
+
+    output_val = _get_metric_value(metrics_reader, "culture.harness.llm.tokens.output")
+    assert output_val is None
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_records_timeout(metrics_reader, registry):
+    """Timeout path: asyncio.TimeoutError → outcome=timeout increments llm_calls."""
+    runner = _make_runner(registry=registry, nick="spark-copilot", model="gpt-4.1")
+
+    runner._session.send_and_wait = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    await runner._execute_single_turn("hello")
+
+    # Check outcome=timeout
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "copilot", "model": "gpt-4.1", "outcome": "timeout"},
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_records_error(metrics_reader, registry):
+    """Error path: generic exception → outcome=error increments llm_calls."""
+    runner = _make_runner(registry=registry, nick="spark-copilot", model="gpt-4.1")
+
+    runner._session.send_and_wait = AsyncMock(side_effect=RuntimeError("SDK exploded"))
+
+    await runner._execute_single_turn("hello")
+
+    # Check outcome=error
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "copilot", "model": "gpt-4.1", "outcome": "error"},
+    )
+    assert calls_val == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_no_metrics_no_recording(metrics_reader):
+    """When metrics=None, no metric data is recorded."""
+    runner = _make_runner(registry=None, nick="spark-copilot")
+
+    fake_response = SimpleNamespace(data=SimpleNamespace(content="Hello!"))
+    runner._session.send_and_wait = AsyncMock(return_value=fake_response)
+
+    await runner._execute_single_turn("hello")
+
+    # No metric data should be recorded for llm_calls
+    calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
+    assert calls_val is None

--- a/tests/harness/test_agent_runner_copilot.py
+++ b/tests/harness/test_agent_runner_copilot.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import tempfile
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -36,16 +37,21 @@ def _stub_copilot_sdk():
     mod = types.ModuleType("copilot")
 
     class CopilotClient:
+        """Stub for SDK type."""
+
         def __init__(self, config=None):
-            pass
+            """Stub for SDK type."""
 
         async def start(self):
-            pass
+            """Stub for SDK type."""
+            await asyncio.sleep(0)
 
         async def stop(self):
-            pass
+            """Stub for SDK type."""
+            await asyncio.sleep(0)
 
         async def create_session(self, **kwargs):
+            await asyncio.sleep(0)
             return MagicMock()
 
     class PermissionHandler:
@@ -123,7 +129,7 @@ def _make_runner(registry=None, nick="spark-copilot", model="gpt-4.1"):
     """Build a minimal CopilotAgentRunner with telemetry wired up."""
     runner = CopilotAgentRunner(
         model=model,
-        directory="/tmp",
+        directory=tempfile.mkdtemp(prefix="culture-test-copilot-"),
         metrics=registry,
         nick=nick,
     )

--- a/tests/harness/test_all_backends_parity.py
+++ b/tests/harness/test_all_backends_parity.py
@@ -1,0 +1,398 @@
+"""All-backends citation parity tests (Plan 5 Task 8).
+
+These tests lock down the citation invariant between the reference harness at
+``packages/agent-harness/`` and each of the four cited copies in
+``culture/clients/{claude,codex,copilot,acp}/``.
+
+A test failure means a backend has drifted from the reference — either someone
+edited a cited file beyond the two documented edit sites, or forgot to propagate
+a reference update to all four backends.
+
+No backend modules are imported — all inspection is done via AST (Python files)
+or ``yaml.safe_load`` (YAML files) so that backend-specific SDK requirements
+(claude-agent-sdk, codex-agent-sdk, copilot SDK) cannot break the test runner.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Path helpers — resolved relative to this file so xdist workers all agree.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_HARNESS_REF = _REPO_ROOT / "packages" / "agent-harness"
+_CLIENTS = _REPO_ROOT / "culture" / "clients"
+
+BACKENDS = ["claude", "codex", "copilot", "acp"]
+
+# ---------------------------------------------------------------------------
+# Normalization helpers for test 1
+# ---------------------------------------------------------------------------
+
+_TRACER_NAME_LINE_RE = re.compile(r'^_HARNESS_TRACER_NAME\s*=\s*"culture\.harness(\.\w+)?"')
+_CITATION_LINE_RE = re.compile(r"^This is the \w+ citation of the reference module in$")
+_CITATION_PATH_LINE_RE = re.compile(r"^``packages/agent-harness/telemetry\.py``\.$")
+
+
+def _normalize_telemetry(text: str) -> list[str]:
+    """Return the lines of a telemetry.py source after stripping backend-specific lines.
+
+    Stripped lines:
+    1. The ``_HARNESS_TRACER_NAME = "culture.harness..."`` assignment line.
+    2. The per-backend citation sentence: "This is the X citation of the
+       reference module in" (only present in cited copies).
+    3. The path line that follows it: "``packages/agent-harness/telemetry.py``."
+    4. A blank line that immediately follows lines 2+3 (the blank that separates
+       the citation note from the "Backend-specific edit sites" heading).
+
+    After these four categories of lines are removed, both the reference and any
+    citation should produce an identical line list.
+    """
+    lines = text.splitlines()
+    result: list[str] = []
+    skip_next_blank = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Strip the tracer-name assignment (both reference and citations have it,
+        # but with different values).
+        if _TRACER_NAME_LINE_RE.match(stripped):
+            continue
+
+        # Strip citation-identity lines present only in cited copies.
+        if _CITATION_LINE_RE.match(stripped):
+            skip_next_blank = True
+            continue
+        if _CITATION_PATH_LINE_RE.match(stripped):
+            continue
+
+        # Strip the blank line that follows the citation block inside the docstring.
+        if skip_next_blank and stripped == "":
+            skip_next_blank = False
+            continue
+        skip_next_blank = False
+
+        result.append(line)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Test 1: telemetry.py byte-parity (after normalization)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_telemetry_py_byte_parity(backend: str) -> None:
+    """After stripping the documented edit sites, each citation must equal the reference.
+
+    This test enforces the citation-parity invariant described in Plan 5 §8 and
+    the CLAUDE.md all-backends rule.  Any addition to a backend's telemetry.py
+    beyond the two documented edit sites (``_HARNESS_TRACER_NAME`` and the
+    citation-identifier docstring lines) will cause this test to fail.
+    """
+    ref_path = _HARNESS_REF / "telemetry.py"
+    backend_path = _CLIENTS / backend / "telemetry.py"
+
+    assert ref_path.exists(), f"Reference missing: {ref_path}"
+    assert backend_path.exists(), f"Citation missing for {backend}: {backend_path}"
+
+    ref_lines = _normalize_telemetry(ref_path.read_text(encoding="utf-8"))
+    backend_lines = _normalize_telemetry(backend_path.read_text(encoding="utf-8"))
+
+    if ref_lines != backend_lines:
+        # Build a concise diff to pin down the exact divergence in the failure message.
+        diff_lines: list[str] = []
+        max_lines = max(len(ref_lines), len(backend_lines))
+        for i in range(max_lines):
+            ref_line = ref_lines[i] if i < len(ref_lines) else "<missing>"
+            be_line = backend_lines[i] if i < len(backend_lines) else "<missing>"
+            if ref_line != be_line:
+                diff_lines.append(f"  line {i + 1}:")
+                diff_lines.append(f"    ref:     {ref_line!r}")
+                diff_lines.append(f"    {backend}: {be_line!r}")
+
+        divergence = "\n".join(diff_lines)
+        pytest.fail(
+            f"telemetry.py citation drift detected for backend '{backend}'.\n"
+            f"Normalized text differs from the reference after stripping documented edit sites.\n"
+            f"Diverging lines:\n{divergence}\n\n"
+            f"Fix: update culture/clients/{backend}/telemetry.py to match "
+            f"packages/agent-harness/telemetry.py (keeping only the two documented edit sites)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: config.py defines TelemetryConfig with all 10 expected fields
+# ---------------------------------------------------------------------------
+
+_EXPECTED_TELEMETRY_FIELDS = {
+    "enabled",
+    "service_name",
+    "otlp_endpoint",
+    "otlp_protocol",
+    "otlp_timeout_ms",
+    "otlp_compression",
+    "traces_enabled",
+    "traces_sampler",
+    "metrics_enabled",
+    "metrics_export_interval_ms",
+}
+
+
+def _ast_class_defaults(tree: ast.Module, class_name: str) -> dict[str, object]:
+    """Walk an AST module and return {field_name: default_value} for a dataclass.
+
+    Only handles simple scalar defaults (str, int, bool, None) — which is all
+    ``TelemetryConfig`` uses.  Returns an empty dict if the class is not found.
+    """
+    defaults: dict[str, object] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                    field = item.target.id
+                    if item.value is not None:
+                        val = item.value
+                        if isinstance(val, ast.Constant):
+                            defaults[field] = val.value
+                        # Handle negative ints/floats: UnaryOp(USub, Constant)
+                        elif (
+                            isinstance(val, ast.UnaryOp)
+                            and isinstance(val.op, ast.USub)
+                            and isinstance(val.operand, ast.Constant)
+                        ):
+                            defaults[field] = -val.operand.value
+                    else:
+                        defaults[field] = None
+    return defaults
+
+
+def _ast_daemon_telemetry_field_type(tree: ast.Module) -> str | None:
+    """Return the type annotation string for ``DaemonConfig.telemetry``, or None."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "DaemonConfig":
+            for item in node.body:
+                if (
+                    isinstance(item, ast.AnnAssign)
+                    and isinstance(item.target, ast.Name)
+                    and item.target.id == "telemetry"
+                ):
+                    # Accept both bare Name ("TelemetryConfig") and subscript
+                    ann = item.annotation
+                    if isinstance(ann, ast.Name):
+                        return ann.id
+                    if isinstance(ann, ast.Attribute):
+                        return ann.attr
+    return None
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_config_py_has_telemetry_dataclass(backend: str) -> None:
+    """config.py must define TelemetryConfig with all 10 expected fields.
+
+    Also checks that:
+    - ``service_name`` default is ``"culture.harness.<backend>"``.
+    - ``DaemonConfig`` has a ``telemetry`` field whose annotation resolves to
+      ``TelemetryConfig``.
+
+    Uses AST to avoid importing backend modules (which require backend-specific SDKs).
+    """
+    config_path = _CLIENTS / backend / "config.py"
+    assert config_path.exists(), f"config.py missing for {backend}: {config_path}"
+
+    tree = ast.parse(config_path.read_text(encoding="utf-8"), filename=str(config_path))
+
+    # Check TelemetryConfig class exists and has all 10 fields.
+    telemetry_defaults = _ast_class_defaults(tree, "TelemetryConfig")
+    assert telemetry_defaults, (
+        f"TelemetryConfig class not found in {config_path}. "
+        f"All backends must define TelemetryConfig."
+    )
+
+    missing_fields = _EXPECTED_TELEMETRY_FIELDS - telemetry_defaults.keys()
+    assert not missing_fields, (
+        f"TelemetryConfig in {backend}/config.py is missing fields: {sorted(missing_fields)}. "
+        f"Expected all 10 fields: {sorted(_EXPECTED_TELEMETRY_FIELDS)}."
+    )
+
+    # Check service_name default matches backend.
+    expected_service_name = f"culture.harness.{backend}"
+    actual_service_name = telemetry_defaults.get("service_name")
+    assert actual_service_name == expected_service_name, (
+        f"TelemetryConfig.service_name default mismatch in {backend}/config.py.\n"
+        f"  expected: {expected_service_name!r}\n"
+        f"  got:      {actual_service_name!r}"
+    )
+
+    # Check DaemonConfig.telemetry field type annotation.
+    telemetry_type = _ast_daemon_telemetry_field_type(tree)
+    assert telemetry_type == "TelemetryConfig", (
+        f"DaemonConfig.telemetry field not annotated as TelemetryConfig in {backend}/config.py.\n"
+        f"  got annotation: {telemetry_type!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: culture.yaml has a telemetry block with required keys
+# ---------------------------------------------------------------------------
+
+_REQUIRED_YAML_TELEMETRY_KEYS = {
+    "enabled",
+    "service_name",
+    "otlp_endpoint",
+    "traces_enabled",
+    "metrics_enabled",
+}
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_culture_yaml_has_telemetry_block(backend: str) -> None:
+    """culture.yaml must have a top-level ``telemetry:`` key with 5 minimal sub-keys.
+
+    Also checks that ``service_name`` matches ``"culture.harness.<backend>"``.
+    """
+    yaml_path = _CLIENTS / backend / "culture.yaml"
+    assert yaml_path.exists(), f"culture.yaml missing for {backend}: {yaml_path}"
+
+    data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+    assert (
+        "telemetry" in data
+    ), f"culture.yaml for {backend} is missing the top-level 'telemetry:' key."
+
+    telemetry = data["telemetry"]
+    assert isinstance(
+        telemetry, dict
+    ), f"'telemetry' in {backend}/culture.yaml is not a mapping (got {type(telemetry)!r})."
+
+    missing_keys = _REQUIRED_YAML_TELEMETRY_KEYS - telemetry.keys()
+    assert not missing_keys, (
+        f"culture.yaml for {backend} is missing telemetry sub-keys: {sorted(missing_keys)}. "
+        f"Required: {sorted(_REQUIRED_YAML_TELEMETRY_KEYS)}."
+    )
+
+    expected_service_name = f"culture.harness.{backend}"
+    actual_service_name = telemetry.get("service_name")
+    assert actual_service_name == expected_service_name, (
+        f"culture.yaml for {backend} has wrong telemetry.service_name.\n"
+        f"  expected: {expected_service_name!r}\n"
+        f"  got:      {actual_service_name!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: agent_runner.py imports record_llm_call from the backend's telemetry
+# ---------------------------------------------------------------------------
+
+
+def _ast_finds_import_of(tree: ast.Module, name: str, from_module_suffix: str) -> bool:
+    """Return True if the AST has a top-level ``from X import ... name ...`` statement.
+
+    ``from_module_suffix`` is matched as a suffix of the module path (e.g.
+    ``"telemetry"`` matches ``from culture.clients.claude.telemetry import ...``).
+    ``name`` must appear in the imported names.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.endswith(from_module_suffix):
+                for alias in node.names:
+                    if alias.name == name:
+                        return True
+    return False
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_agent_runner_py_imports_record_llm_call(backend: str) -> None:
+    """agent_runner.py must import ``record_llm_call`` from the backend's telemetry module.
+
+    This test catches backends where someone reverted to a lazy/local import or
+    removed the ``record_llm_call`` import entirely.
+    """
+    runner_path = _CLIENTS / backend / "agent_runner.py"
+    assert runner_path.exists(), f"agent_runner.py missing for {backend}: {runner_path}"
+
+    tree = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
+
+    expected_module = f"culture.clients.{backend}.telemetry"
+    found = _ast_finds_import_of(tree, "record_llm_call", expected_module)
+    assert found, (
+        f"agent_runner.py for {backend} does not import 'record_llm_call' "
+        f"from '{expected_module}'.\n"
+        f"Add: from {expected_module} import record_llm_call"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: agent_runner.py imports _HARNESS_TRACER_NAME from the backend's telemetry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_agent_runner_py_imports_harness_tracer_name(backend: str) -> None:
+    """agent_runner.py must import ``_HARNESS_TRACER_NAME`` from the backend's telemetry module.
+
+    This ensures the agent runner references the backend-specific tracer name
+    constant rather than hard-coding a string literal.
+    """
+    runner_path = _CLIENTS / backend / "agent_runner.py"
+    assert runner_path.exists(), f"agent_runner.py missing for {backend}: {runner_path}"
+
+    tree = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
+
+    expected_module = f"culture.clients.{backend}.telemetry"
+    found = _ast_finds_import_of(tree, "_HARNESS_TRACER_NAME", expected_module)
+    assert found, (
+        f"agent_runner.py for {backend} does not import '_HARNESS_TRACER_NAME' "
+        f"from '{expected_module}'.\n"
+        f"Add: from {expected_module} import _HARNESS_TRACER_NAME"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: irc_transport.py IRCTransport.__init__ accepts tracer, metrics, backend
+# ---------------------------------------------------------------------------
+
+_REQUIRED_TRANSPORT_PARAMS = {"tracer", "metrics", "backend"}
+
+
+def _ast_init_params(tree: ast.Module, class_name: str) -> set[str]:
+    """Return the set of parameter names for ``class_name.__init__``."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                    return {arg.arg for arg in item.args.args}
+    return set()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_irc_transport_py_constructor_accepts_telemetry_kwargs(backend: str) -> None:
+    """IRCTransport.__init__ must accept ``tracer``, ``metrics``, and ``backend`` parameters.
+
+    Presence is required; defaults are not checked (any default is acceptable).
+    This test fails if someone removes these parameters or forgets to add them
+    when creating a new backend.
+    """
+    transport_path = _CLIENTS / backend / "irc_transport.py"
+    assert transport_path.exists(), f"irc_transport.py missing for {backend}: {transport_path}"
+
+    tree = ast.parse(transport_path.read_text(encoding="utf-8"), filename=str(transport_path))
+
+    params = _ast_init_params(tree, "IRCTransport")
+    assert params, f"IRCTransport class or __init__ not found in {backend}/irc_transport.py"
+
+    missing_params = _REQUIRED_TRANSPORT_PARAMS - params
+    assert not missing_params, (
+        f"IRCTransport.__init__ in {backend}/irc_transport.py is missing "
+        f"parameter(s): {sorted(missing_params)}.\n"
+        f"Required: {sorted(_REQUIRED_TRANSPORT_PARAMS)}.\n"
+        f"Found: {sorted(params)}."
+    )

--- a/tests/harness/test_daemon_telemetry.py
+++ b/tests/harness/test_daemon_telemetry.py
@@ -64,12 +64,9 @@ def test_daemon_template_passes_kwargs_to_irc_transport():
 def test_daemon_template_documents_runner_metrics_contract():
     """_start_agent_runner's NotImplementedError must mention the metrics kwarg contract."""
     source = _daemon_source()
-    # Find the NotImplementedError block in _start_agent_runner.
-    assert (
-        "metrics" in source
-    ), "The word 'metrics' must appear in daemon.py (expected in NotImplementedError message)"
-    # More specific: the runner contract description must be present.
-    assert "metrics=self._metrics" in source, (
-        "Expected 'metrics=self._metrics' contract description not found in "
+    # "telemetry.record_llm_call" appears only in the NotImplementedError message,
+    # so this assertion fails correctly if the documentation block is removed.
+    assert "telemetry.record_llm_call" in source, (
+        "Expected 'telemetry.record_llm_call' contract text not found in "
         "_start_agent_runner's NotImplementedError message"
     )

--- a/tests/harness/test_daemon_telemetry.py
+++ b/tests/harness/test_daemon_telemetry.py
@@ -1,0 +1,75 @@
+"""Structural tests for packages/agent-harness/daemon.py OTEL wiring (Plan 5 Task 3).
+
+The reference daemon is a template with BACKEND stub imports and cannot be
+instantiated directly. These tests verify the correct wiring by reading the
+source file as text and asserting the expected patterns are present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Resolve path relative to this test file — robust regardless of cwd.
+_DAEMON_PY = Path(__file__).parent.parent.parent / "packages" / "agent-harness" / "daemon.py"
+
+
+def _daemon_source() -> str:
+    """Return the full source text of the reference daemon.py."""
+    return _DAEMON_PY.read_text(encoding="utf-8")
+
+
+def test_daemon_template_imports_init_harness_telemetry():
+    """daemon.py must import init_harness_telemetry from the BACKEND stub module."""
+    source = _daemon_source()
+    assert "from culture.clients.BACKEND.telemetry import init_harness_telemetry" in source, (
+        "Expected stub import 'from culture.clients.BACKEND.telemetry import "
+        "init_harness_telemetry' not found in daemon.py"
+    )
+
+
+def test_daemon_template_initializes_tracer_metrics_attrs():
+    """__init__ must declare self._tracer = None and self._metrics = None."""
+    source = _daemon_source()
+    assert (
+        "self._tracer = None" in source
+    ), "Expected 'self._tracer = None' attribute initialisation not found in daemon.py"
+    assert (
+        "self._metrics = None" in source
+    ), "Expected 'self._metrics = None' attribute initialisation not found in daemon.py"
+
+
+def test_daemon_template_calls_init_harness_telemetry_in_start():
+    """start() must call init_harness_telemetry(self.config) and unpack into _tracer/_metrics."""
+    source = _daemon_source()
+    assert "self._tracer, self._metrics = init_harness_telemetry(self.config)" in source, (
+        "Expected 'self._tracer, self._metrics = init_harness_telemetry(self.config)' "
+        "call not found in daemon.py start()"
+    )
+
+
+def test_daemon_template_passes_kwargs_to_irc_transport():
+    """IRCTransport construction in start() must pass tracer, metrics, and backend kwargs."""
+    source = _daemon_source()
+    assert (
+        "tracer=self._tracer," in source
+    ), "Expected 'tracer=self._tracer,' kwarg not found in IRCTransport construction"
+    assert (
+        "metrics=self._metrics," in source
+    ), "Expected 'metrics=self._metrics,' kwarg not found in IRCTransport construction"
+    assert (
+        'backend="BACKEND",' in source
+    ), "Expected 'backend=\"BACKEND\",' kwarg not found in IRCTransport construction"
+
+
+def test_daemon_template_documents_runner_metrics_contract():
+    """_start_agent_runner's NotImplementedError must mention the metrics kwarg contract."""
+    source = _daemon_source()
+    # Find the NotImplementedError block in _start_agent_runner.
+    assert (
+        "metrics" in source
+    ), "The word 'metrics' must appear in daemon.py (expected in NotImplementedError message)"
+    # More specific: the runner contract description must be present.
+    assert "metrics=self._metrics" in source, (
+        "Expected 'metrics=self._metrics' contract description not found in "
+        "_start_agent_runner's NotImplementedError message"
+    )

--- a/tests/harness/test_irc_transport_propagation.py
+++ b/tests/harness/test_irc_transport_propagation.py
@@ -1,0 +1,390 @@
+"""Tests for traceparent inject/extract in packages/agent-harness/irc_transport.py.
+
+Verifies:
+- Outbound lines carry @culture.dev/traceparent= when a span is active.
+- Outbound lines are plain (no tag) when no span is active or no tracer.
+- Inbound lines with valid traceparent open a child span.
+- Inbound lines with missing traceparent open a root span with origin=local.
+- Inbound lines with malformed traceparent open a root span with
+  origin=remote and dropped_reason=malformed.
+- Without a tracer, no spans are emitted.
+- _do_connect wraps the connection in harness.irc.connect span with attrs.
+
+Uses a captured-write StreamWriter stub and a queue-based StreamReader stub so
+no real sockets are needed.  All tests are async (pytest-asyncio).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Patch the BACKEND placeholder import before importing irc_transport.
+# The reference module contains ``from culture.clients.BACKEND.message_buffer
+# import MessageBuffer`` — we inject a mock module so the import succeeds.
+# ---------------------------------------------------------------------------
+
+# Build a minimal fake MessageBuffer to satisfy the import.
+_fake_mb_module = types.ModuleType("culture.clients.BACKEND.message_buffer")
+
+
+class _FakeMessageBuffer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def add(self, *args, **kwargs):
+        pass
+
+
+_fake_mb_module.MessageBuffer = _FakeMessageBuffer  # type: ignore[attr-defined]
+
+# Inject into sys.modules BEFORE importing irc_transport.
+sys.modules.setdefault("culture.clients.BACKEND", types.ModuleType("culture.clients.BACKEND"))
+sys.modules.setdefault(
+    "culture.clients.BACKEND.message_buffer",
+    _fake_mb_module,
+)
+
+# Now import irc_transport from the harness reference.
+# conftest.py has already inserted packages/agent-harness into sys.path.
+# pylint: disable=import-error,wrong-import-position
+from irc_transport import IRCTransport  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+class _CaptureWriter:
+    """Minimal StreamWriter stub that captures written bytes."""
+
+    def __init__(self):
+        self.written: list[bytes] = []
+        self._closed = False
+
+    def write(self, data: bytes) -> None:
+        self.written.append(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self._closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+    def get_extra_info(self, key: str, default=None):
+        return default
+
+
+class _QueueReader:
+    """Minimal StreamReader stub backed by an asyncio.Queue."""
+
+    def __init__(self):
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._eof = False
+
+    def feed(self, data: bytes) -> None:
+        self._queue.put_nowait(data)
+
+    def feed_eof(self) -> None:
+        self._queue.put_nowait(b"")
+
+    async def read(self, n: int = -1) -> bytes:
+        if self._eof:
+            return b""
+        chunk = await self._queue.get()
+        if chunk == b"":
+            self._eof = True
+        return chunk
+
+
+def _make_transport(tracer=None):
+    """Build a minimal IRCTransport for testing; injects stub reader/writer."""
+    buf = _FakeMessageBuffer()
+    transport = IRCTransport(
+        host="127.0.0.1",
+        port=6667,
+        nick="test-agent",
+        user="test-agent",
+        channels=["#test"],
+        buffer=buf,
+        tracer=tracer,
+        backend="test",
+    )
+    return transport
+
+
+def _inject_rw(transport):
+    """Replace transport's reader/writer with capture stubs and return them."""
+    reader = _QueueReader()
+    writer = _CaptureWriter()
+    transport._reader = reader
+    transport._writer = writer
+    return reader, writer
+
+
+def _captured_lines(writer: _CaptureWriter) -> list[str]:
+    """Decode all written bytes as lines (split on \\r\\n, strip trailing empties)."""
+    raw = b"".join(writer.written).decode("utf-8")
+    return [line for line in raw.split("\r\n") if line]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (tracer from conftest.py harness_tracing_exporter)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reset_state():
+    """Ensure the harness telemetry module is reset after each test."""
+    from telemetry import reset_for_tests
+
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# test_outbound_carries_traceparent_when_span_active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outbound_carries_traceparent_when_span_active(
+    harness_tracing_exporter, _reset_state
+):
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    _reader, writer = _inject_rw(transport)
+
+    with tracer.start_as_current_span("outer-span"):
+        await transport.send_privmsg("#room", "hello")
+
+    lines = _captured_lines(writer)
+    assert lines, "expected at least one line written"
+    # The first (and only) PRIVMSG line must carry a traceparent tag prefix.
+    privmsg_lines = [l for l in lines if "PRIVMSG" in l]
+    assert privmsg_lines, "no PRIVMSG line found"
+    line = privmsg_lines[0]
+    assert line.startswith(
+        "@culture.dev/traceparent=00-"
+    ), f"Expected @culture.dev/traceparent prefix; got: {line!r}"
+    assert "PRIVMSG #room :hello" in line, f"Expected PRIVMSG body; got: {line!r}"
+
+
+# ---------------------------------------------------------------------------
+# test_outbound_no_tag_when_no_span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outbound_no_tag_when_no_span(harness_tracing_exporter, _reset_state):
+    _exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    _reader, writer = _inject_rw(transport)
+
+    # No active span — current_traceparent() returns None.
+    await transport.send_privmsg("#room", "hello")
+
+    lines = _captured_lines(writer)
+    privmsg_lines = [l for l in lines if "PRIVMSG" in l]
+    assert privmsg_lines, "no PRIVMSG line found"
+    line = privmsg_lines[0]
+    assert not line.startswith("@"), f"Expected plain PRIVMSG; got: {line!r}"
+    assert line == "PRIVMSG #room :hello", f"Unexpected line: {line!r}"
+
+
+# ---------------------------------------------------------------------------
+# test_inbound_with_valid_traceparent_starts_child_span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_with_valid_traceparent_starts_child_span(
+    harness_tracing_exporter, _reset_state
+):
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    reader, _writer = _inject_rw(transport)
+
+    inbound = f"@culture.dev/traceparent={VALID_TRACEPARENT} " ":alice!a@h PRIVMSG #room :hi\r\n"
+    reader.feed(inbound.encode())
+    reader.feed_eof()
+
+    # Drain the read loop.
+    read_task = asyncio.create_task(transport._read_loop())
+    try:
+        await asyncio.wait_for(read_task, timeout=1.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        read_task.cancel()
+        await asyncio.gather(read_task, return_exceptions=True)
+
+    spans = exporter.get_finished_spans()
+    handle_spans = [s for s in spans if s.name == "harness.irc.message.handle"]
+    assert (
+        handle_spans
+    ), f"No harness.irc.message.handle span found; spans: {[s.name for s in spans]}"
+
+    span = handle_spans[0]
+    # The span's parent trace_id must match the traceparent's trace-id.
+    expected_trace_id = int(VALID_TRACEPARENT.split("-")[1], 16)
+    assert (
+        span.context.trace_id == expected_trace_id
+    ), f"Expected trace_id={expected_trace_id:#034x}, got {span.context.trace_id:#034x}"
+
+
+# ---------------------------------------------------------------------------
+# test_inbound_missing_traceparent_starts_root_span
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_missing_traceparent_starts_root_span(harness_tracing_exporter, _reset_state):
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    reader, _writer = _inject_rw(transport)
+
+    inbound = ":alice!a@h PRIVMSG #room :hi\r\n"
+    reader.feed(inbound.encode())
+    reader.feed_eof()
+
+    read_task = asyncio.create_task(transport._read_loop())
+    try:
+        await asyncio.wait_for(read_task, timeout=1.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        read_task.cancel()
+        await asyncio.gather(read_task, return_exceptions=True)
+
+    spans = exporter.get_finished_spans()
+    handle_spans = [s for s in spans if s.name == "harness.irc.message.handle"]
+    assert (
+        handle_spans
+    ), f"No harness.irc.message.handle span found; spans: {[s.name for s in spans]}"
+
+    span = handle_spans[0]
+    attrs = dict(span.attributes)
+    assert attrs.get("culture.trace.origin") == "local", f"Expected origin=local; got attrs={attrs}"
+    assert (
+        "culture.trace.dropped_reason" not in attrs
+    ), f"dropped_reason must not be present on missing traceparent; attrs={attrs}"
+
+
+# ---------------------------------------------------------------------------
+# test_inbound_malformed_traceparent_dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_malformed_traceparent_dropped(harness_tracing_exporter, _reset_state):
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    reader, _writer = _inject_rw(transport)
+
+    inbound = "@culture.dev/traceparent=BAD :alice!a@h PRIVMSG #room :hi\r\n"
+    reader.feed(inbound.encode())
+    reader.feed_eof()
+
+    read_task = asyncio.create_task(transport._read_loop())
+    try:
+        await asyncio.wait_for(read_task, timeout=1.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        read_task.cancel()
+        await asyncio.gather(read_task, return_exceptions=True)
+
+    spans = exporter.get_finished_spans()
+    handle_spans = [s for s in spans if s.name == "harness.irc.message.handle"]
+    assert (
+        handle_spans
+    ), f"No harness.irc.message.handle span found; spans: {[s.name for s in spans]}"
+
+    span = handle_spans[0]
+    attrs = dict(span.attributes)
+    assert (
+        attrs.get("culture.trace.origin") == "remote"
+    ), f"Expected origin=remote for malformed traceparent; got attrs={attrs}"
+    assert (
+        attrs.get("culture.trace.dropped_reason") == "malformed"
+    ), f"Expected dropped_reason=malformed; got attrs={attrs}"
+
+
+# ---------------------------------------------------------------------------
+# test_no_tracer_means_no_spans
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_tracer_means_no_spans(harness_tracing_exporter, _reset_state):
+    exporter, _provider = harness_tracing_exporter
+    # Build transport WITHOUT a tracer.
+    transport = _make_transport(tracer=None)
+    reader, writer = _inject_rw(transport)
+
+    inbound = ":alice!a@h PRIVMSG #room :hi\r\n"
+    reader.feed(inbound.encode())
+    reader.feed_eof()
+
+    read_task = asyncio.create_task(transport._read_loop())
+    try:
+        await asyncio.wait_for(read_task, timeout=1.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        read_task.cancel()
+        await asyncio.gather(read_task, return_exceptions=True)
+
+    await transport.send_privmsg("#room", "hello")
+
+    spans = exporter.get_finished_spans()
+    harness_spans = [s for s in spans if s.name.startswith("harness.")]
+    assert (
+        harness_spans == []
+    ), f"Expected zero harness spans with no tracer; got: {[s.name for s in harness_spans]}"
+
+
+# ---------------------------------------------------------------------------
+# test_connect_span_wraps_do_connect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_span_wraps_do_connect(harness_tracing_exporter, _reset_state):
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+
+    # Patch asyncio.open_connection so _do_connect doesn't need a real server.
+    reader = _QueueReader()
+    writer = _CaptureWriter()
+    # Feed the EOF so the read_loop exits immediately.
+    reader.feed_eof()
+
+    with patch("asyncio.open_connection", new=AsyncMock(return_value=(reader, writer))):
+        # _do_connect calls create_task(_read_loop()) — we cancel that task after.
+        await transport._do_connect()
+
+    # Cancel the read_loop task to avoid dangling coroutine.
+    if transport._read_task is not None:
+        transport._read_task.cancel()
+        await asyncio.gather(transport._read_task, return_exceptions=True)
+
+    spans = exporter.get_finished_spans()
+    connect_spans = [s for s in spans if s.name == "harness.irc.connect"]
+    assert connect_spans, f"Expected harness.irc.connect span; spans: {[s.name for s in spans]}"
+
+    span = connect_spans[0]
+    attrs = dict(span.attributes)
+    assert attrs.get("harness.backend") == "test", f"Missing harness.backend; attrs={attrs}"
+    assert attrs.get("harness.nick") == "test-agent", f"Missing harness.nick; attrs={attrs}"
+    assert attrs.get("harness.server") == "127.0.0.1:6667", f"Missing harness.server; attrs={attrs}"

--- a/tests/harness/test_irc_transport_propagation.py
+++ b/tests/harness/test_irc_transport_propagation.py
@@ -139,29 +139,12 @@ def _captured_lines(writer: _CaptureWriter) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Fixtures (tracer from conftest.py harness_tracing_exporter)
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def _reset_state():
-    """Ensure the harness telemetry module is reset after each test."""
-    from telemetry import reset_for_tests
-
-    reset_for_tests()
-    yield
-    reset_for_tests()
-
-
-# ---------------------------------------------------------------------------
 # test_outbound_carries_traceparent_when_span_active
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_outbound_carries_traceparent_when_span_active(
-    harness_tracing_exporter, _reset_state
-):
+async def test_outbound_carries_traceparent_when_span_active(harness_tracing_exporter):
     exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
@@ -188,7 +171,7 @@ async def test_outbound_carries_traceparent_when_span_active(
 
 
 @pytest.mark.asyncio
-async def test_outbound_no_tag_when_no_span(harness_tracing_exporter, _reset_state):
+async def test_outbound_no_tag_when_no_span(harness_tracing_exporter):
     _exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
@@ -211,9 +194,7 @@ async def test_outbound_no_tag_when_no_span(harness_tracing_exporter, _reset_sta
 
 
 @pytest.mark.asyncio
-async def test_inbound_with_valid_traceparent_starts_child_span(
-    harness_tracing_exporter, _reset_state
-):
+async def test_inbound_with_valid_traceparent_starts_child_span(harness_tracing_exporter):
     exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
@@ -251,7 +232,7 @@ async def test_inbound_with_valid_traceparent_starts_child_span(
 
 
 @pytest.mark.asyncio
-async def test_inbound_missing_traceparent_starts_root_span(harness_tracing_exporter, _reset_state):
+async def test_inbound_missing_traceparent_starts_root_span(harness_tracing_exporter):
     exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
@@ -288,7 +269,7 @@ async def test_inbound_missing_traceparent_starts_root_span(harness_tracing_expo
 
 
 @pytest.mark.asyncio
-async def test_inbound_malformed_traceparent_dropped(harness_tracing_exporter, _reset_state):
+async def test_inbound_malformed_traceparent_dropped(harness_tracing_exporter):
     exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
@@ -327,7 +308,7 @@ async def test_inbound_malformed_traceparent_dropped(harness_tracing_exporter, _
 
 
 @pytest.mark.asyncio
-async def test_inbound_too_long_traceparent_dropped(harness_tracing_exporter, _reset_state):
+async def test_inbound_too_long_traceparent_dropped(harness_tracing_exporter):
     exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
@@ -368,7 +349,7 @@ async def test_inbound_too_long_traceparent_dropped(harness_tracing_exporter, _r
 
 
 @pytest.mark.asyncio
-async def test_no_tracer_means_no_spans(harness_tracing_exporter, _reset_state):
+async def test_no_tracer_means_no_spans(harness_tracing_exporter):
     exporter, _provider = harness_tracing_exporter
     # Build transport WITHOUT a tracer.
     transport = _make_transport(tracer=None)
@@ -400,7 +381,7 @@ async def test_no_tracer_means_no_spans(harness_tracing_exporter, _reset_state):
 
 
 @pytest.mark.asyncio
-async def test_connect_span_wraps_do_connect(harness_tracing_exporter, _reset_state):
+async def test_connect_span_wraps_do_connect(harness_tracing_exporter):
     exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)

--- a/tests/harness/test_irc_transport_propagation.py
+++ b/tests/harness/test_irc_transport_propagation.py
@@ -147,7 +147,7 @@ def _captured_lines(writer: _CaptureWriter) -> list[str]:
 
 @pytest.mark.asyncio
 async def test_outbound_carries_traceparent_when_span_active(harness_tracing_exporter):
-    exporter, provider = harness_tracing_exporter
+    _exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
     _reader, writer = _inject_rw(transport)
@@ -355,7 +355,7 @@ async def test_no_tracer_means_no_spans(harness_tracing_exporter):
     exporter, _provider = harness_tracing_exporter
     # Build transport WITHOUT a tracer.
     transport = _make_transport(tracer=None)
-    reader, writer = _inject_rw(transport)
+    reader, _writer = _inject_rw(transport)
 
     inbound = ":alice!a@h PRIVMSG #room :hi\r\n"
     reader.feed(inbound.encode())
@@ -429,7 +429,7 @@ async def test_send_raw_direct_carries_traceparent(harness_tracing_exporter):
     _send_raw() — callers that bypassed it (e.g. daemon HISTORY commands)
     silently lost trace context.
     """
-    exporter, provider = harness_tracing_exporter
+    _exporter, provider = harness_tracing_exporter
     tracer = provider.get_tracer("test")
     transport = _make_transport(tracer=tracer)
     _reader, writer = _inject_rw(transport)

--- a/tests/harness/test_irc_transport_propagation.py
+++ b/tests/harness/test_irc_transport_propagation.py
@@ -322,6 +322,47 @@ async def test_inbound_malformed_traceparent_dropped(harness_tracing_exporter, _
 
 
 # ---------------------------------------------------------------------------
+# test_inbound_too_long_traceparent_dropped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_too_long_traceparent_dropped(harness_tracing_exporter, _reset_state):
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    reader, _writer = _inject_rw(transport)
+
+    # A traceparent longer than 55 chars triggers the too_long path.
+    too_long_tp = VALID_TRACEPARENT + "extra-garbage-that-makes-it-too-long"
+    inbound = f"@culture.dev/traceparent={too_long_tp} :alice!a@h PRIVMSG #room :hi\r\n"
+    reader.feed(inbound.encode())
+    reader.feed_eof()
+
+    read_task = asyncio.create_task(transport._read_loop())
+    try:
+        await asyncio.wait_for(read_task, timeout=1.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        read_task.cancel()
+        await asyncio.gather(read_task, return_exceptions=True)
+
+    spans = exporter.get_finished_spans()
+    handle_spans = [s for s in spans if s.name == "harness.irc.message.handle"]
+    assert (
+        handle_spans
+    ), f"No harness.irc.message.handle span found; spans: {[s.name for s in spans]}"
+
+    span = handle_spans[0]
+    attrs = dict(span.attributes)
+    assert (
+        attrs.get("culture.trace.origin") == "remote"
+    ), f"Expected origin=remote for too_long traceparent; got attrs={attrs}"
+    assert (
+        attrs.get("culture.trace.dropped_reason") == "too_long"
+    ), f"Expected dropped_reason=too_long; got attrs={attrs}"
+
+
+# ---------------------------------------------------------------------------
 # test_no_tracer_means_no_spans
 # ---------------------------------------------------------------------------
 

--- a/tests/harness/test_irc_transport_propagation.py
+++ b/tests/harness/test_irc_transport_propagation.py
@@ -34,11 +34,13 @@ _fake_mb_module = types.ModuleType("culture.clients.BACKEND.message_buffer")
 
 
 class _FakeMessageBuffer:
+    """Stub MessageBuffer for testing — discards all writes."""
+
     def __init__(self, *args, **kwargs):
-        pass
+        """Stub for SDK type."""
 
     def add(self, *args, **kwargs):
-        pass
+        """Stub for SDK type."""
 
 
 _fake_mb_module.MessageBuffer = _FakeMessageBuffer  # type: ignore[attr-defined]
@@ -73,13 +75,13 @@ class _CaptureWriter:
         self.written.append(data)
 
     async def drain(self) -> None:
-        pass
+        """Stub for SDK type."""
 
     def close(self) -> None:
         self._closed = True
 
     async def wait_closed(self) -> None:
-        pass
+        """Stub for SDK type."""
 
     def get_extra_info(self, key: str, default=None):
         return default
@@ -410,3 +412,36 @@ async def test_connect_span_wraps_do_connect(harness_tracing_exporter):
     assert attrs.get("harness.backend") == "test", f"Missing harness.backend; attrs={attrs}"
     assert attrs.get("harness.nick") == "test-agent", f"Missing harness.nick; attrs={attrs}"
     assert attrs.get("harness.server") == "127.0.0.1:6667", f"Missing harness.server; attrs={attrs}"
+
+
+# ---------------------------------------------------------------------------
+# test_send_raw_direct_carries_traceparent
+# Regression test for the send_raw injection bypass bug: callers that use
+# send_raw() directly (not via _send_raw) must also get the traceparent tag.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_raw_direct_carries_traceparent(harness_tracing_exporter):
+    """send_raw() called directly must inject traceparent when a span is active.
+
+    This is the regression test for the bug where injection lived only in
+    _send_raw() — callers that bypassed it (e.g. daemon HISTORY commands)
+    silently lost trace context.
+    """
+    exporter, provider = harness_tracing_exporter
+    tracer = provider.get_tracer("test")
+    transport = _make_transport(tracer=tracer)
+    _reader, writer = _inject_rw(transport)
+
+    with tracer.start_as_current_span("outer-span"):
+        # Call send_raw directly — NOT via _send_raw or send_privmsg.
+        await transport.send_raw("PRIVMSG #x :hi")
+
+    lines = _captured_lines(writer)
+    assert lines, "expected at least one line written"
+    line = lines[0]
+    assert line.startswith(
+        "@culture.dev/traceparent=00-"
+    ), f"send_raw() direct call must inject traceparent; got: {line!r}"
+    assert "PRIVMSG #x :hi" in line, f"Expected PRIVMSG body preserved; got: {line!r}"

--- a/tests/harness/test_record_llm_call.py
+++ b/tests/harness/test_record_llm_call.py
@@ -108,11 +108,11 @@ def test_records_calls_counter_and_duration_histogram_unconditionally(
         outcome="success",
     )
 
-    assert _get_counter_sum(reader, "culture.harness.llm.calls") == 1.0
+    assert _get_counter_sum(reader, "culture.harness.llm.calls") == pytest.approx(1.0)
     assert _get_histogram_count(reader, "culture.harness.llm.call.duration") == 1
     # Token counters must NOT have been touched.
-    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == 0.0
-    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == pytest.approx(0.0)
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == pytest.approx(0.0)
 
 
 def test_skips_missing_usage_keys(harness_metrics_reader_with_registry):
@@ -129,8 +129,8 @@ def test_skips_missing_usage_keys(harness_metrics_reader_with_registry):
         outcome="success",
     )
 
-    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == 100.0
-    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == pytest.approx(100.0)
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == pytest.approx(0.0)
 
 
 def test_records_both_token_counters_when_present(harness_metrics_reader_with_registry):
@@ -147,22 +147,16 @@ def test_records_both_token_counters_when_present(harness_metrics_reader_with_re
         outcome="success",
     )
 
-    assert (
-        _get_counter_sum(
-            reader,
-            "culture.harness.llm.tokens.input",
-            {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
-        )
-        == 50.0
-    )
-    assert (
-        _get_counter_sum(
-            reader,
-            "culture.harness.llm.tokens.output",
-            {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
-        )
-        == 200.0
-    )
+    assert _get_counter_sum(
+        reader,
+        "culture.harness.llm.tokens.input",
+        {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+    ) == pytest.approx(50.0)
+    assert _get_counter_sum(
+        reader,
+        "culture.harness.llm.tokens.output",
+        {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+    ) == pytest.approx(200.0)
 
 
 def test_outcome_label_propagates(harness_metrics_reader_with_registry):
@@ -179,12 +173,9 @@ def test_outcome_label_propagates(harness_metrics_reader_with_registry):
         outcome="error",
     )
 
-    assert (
-        _get_counter_sum(
-            reader, "culture.harness.llm.calls", {"backend": "acp", "outcome": "error"}
-        )
-        == 1.0
-    )
+    assert _get_counter_sum(
+        reader, "culture.harness.llm.calls", {"backend": "acp", "outcome": "error"}
+    ) == pytest.approx(1.0)
     assert (
         _get_histogram_count(
             reader,
@@ -210,7 +201,7 @@ def test_multiple_calls_accumulate(harness_metrics_reader_with_registry):
             outcome="success",
         )
 
-    assert _get_counter_sum(reader, "culture.harness.llm.calls") == 3.0
+    assert _get_counter_sum(reader, "culture.harness.llm.calls") == pytest.approx(3.0)
 
 
 def test_none_valued_usage_keys_are_skipped(harness_metrics_reader_with_registry):
@@ -228,10 +219,10 @@ def test_none_valued_usage_keys_are_skipped(harness_metrics_reader_with_registry
     )
 
     # None values must not add to the token counters.
-    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == 0.0
-    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == pytest.approx(0.0)
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == pytest.approx(0.0)
     # But calls and duration still record.
-    assert _get_counter_sum(reader, "culture.harness.llm.calls") == 1.0
+    assert _get_counter_sum(reader, "culture.harness.llm.calls") == pytest.approx(1.0)
     assert _get_histogram_count(reader, "culture.harness.llm.call.duration") == 1
 
 
@@ -249,4 +240,6 @@ def test_timeout_outcome(harness_metrics_reader_with_registry):
         outcome="timeout",
     )
 
-    assert _get_counter_sum(reader, "culture.harness.llm.calls", {"outcome": "timeout"}) == 1.0
+    assert _get_counter_sum(
+        reader, "culture.harness.llm.calls", {"outcome": "timeout"}
+    ) == pytest.approx(1.0)

--- a/tests/harness/test_record_llm_call.py
+++ b/tests/harness/test_record_llm_call.py
@@ -12,10 +12,6 @@ import pytest
 # Imported via sys.path set in conftest.py
 # pylint: disable=import-error
 from config import DaemonConfig
-from opentelemetry import metrics as otel_metrics
-from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
-from opentelemetry.sdk.metrics.export import InMemoryMetricReader
-from opentelemetry.sdk.resources import Resource
 from telemetry import (
     init_harness_telemetry,
     record_llm_call,
@@ -36,25 +32,17 @@ def _reset_state():
 
 
 @pytest.fixture
-def harness_metrics_reader():
-    """Install an InMemoryMetricReader and return a (reader, registry) pair.
+def harness_metrics_reader_with_registry(harness_metrics_reader):
+    """Extend the shared harness_metrics_reader fixture with a registry.
 
-    The registry is built from the proxy meter that points at the just-installed
-    real MeterProvider — so ``record_llm_call`` writes to the in-memory store.
+    Builds a registry from the proxy meter that points at the pre-installed
+    real MeterProvider so ``record_llm_call`` writes to the in-memory store.
+
+    Returns a (reader, registry) pair — tests that need both use this fixture.
     """
-    reset_for_tests()
-    reader = InMemoryMetricReader()
-    provider = SdkMeterProvider(
-        resource=Resource.create({"service.name": "test-harness"}),
-        metric_readers=[reader],
-    )
-    otel_metrics.set_meter_provider(provider)
-    # Build registry from the proxy meter (disabled init uses proxy → points at
-    # the SDK provider we just installed).
     config = DaemonConfig()
     _, registry = init_harness_telemetry(config)
-    yield reader, registry
-    reset_for_tests()
+    return harness_metrics_reader, registry
 
 
 # ---------------------------------------------------------------------------
@@ -104,9 +92,11 @@ def _get_histogram_count(reader, metric_name: str, attrs: dict | None = None) ->
 # ---------------------------------------------------------------------------
 
 
-def test_records_calls_counter_and_duration_histogram_unconditionally(harness_metrics_reader):
+def test_records_calls_counter_and_duration_histogram_unconditionally(
+    harness_metrics_reader_with_registry,
+):
     """llm_calls and llm_call_duration always record even when usage is None."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     record_llm_call(
         registry,
@@ -125,9 +115,9 @@ def test_records_calls_counter_and_duration_histogram_unconditionally(harness_me
     assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
 
 
-def test_skips_missing_usage_keys(harness_metrics_reader):
+def test_skips_missing_usage_keys(harness_metrics_reader_with_registry):
     """Partial usage dict: only present non-None int keys record."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     record_llm_call(
         registry,
@@ -143,9 +133,9 @@ def test_skips_missing_usage_keys(harness_metrics_reader):
     assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
 
 
-def test_records_both_token_counters_when_present(harness_metrics_reader):
+def test_records_both_token_counters_when_present(harness_metrics_reader_with_registry):
     """Full usage dict: both token counters record with harness.nick label."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     record_llm_call(
         registry,
@@ -175,9 +165,9 @@ def test_records_both_token_counters_when_present(harness_metrics_reader):
     )
 
 
-def test_outcome_label_propagates(harness_metrics_reader):
+def test_outcome_label_propagates(harness_metrics_reader_with_registry):
     """outcome=error must appear on llm_calls and llm_call_duration."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     record_llm_call(
         registry,
@@ -205,9 +195,9 @@ def test_outcome_label_propagates(harness_metrics_reader):
     )
 
 
-def test_multiple_calls_accumulate(harness_metrics_reader):
+def test_multiple_calls_accumulate(harness_metrics_reader_with_registry):
     """Multiple calls accumulate in the counter."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     for _ in range(3):
         record_llm_call(
@@ -223,9 +213,9 @@ def test_multiple_calls_accumulate(harness_metrics_reader):
     assert _get_counter_sum(reader, "culture.harness.llm.calls") == 3.0
 
 
-def test_none_valued_usage_keys_are_skipped(harness_metrics_reader):
+def test_none_valued_usage_keys_are_skipped(harness_metrics_reader_with_registry):
     """usage keys present but set to None are silently skipped (not 0)."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     record_llm_call(
         registry,
@@ -245,9 +235,9 @@ def test_none_valued_usage_keys_are_skipped(harness_metrics_reader):
     assert _get_histogram_count(reader, "culture.harness.llm.call.duration") == 1
 
 
-def test_timeout_outcome(harness_metrics_reader):
+def test_timeout_outcome(harness_metrics_reader_with_registry):
     """outcome=timeout is valid and records correctly."""
-    reader, registry = harness_metrics_reader
+    reader, registry = harness_metrics_reader_with_registry
 
     record_llm_call(
         registry,

--- a/tests/harness/test_record_llm_call.py
+++ b/tests/harness/test_record_llm_call.py
@@ -1,0 +1,262 @@
+"""Tests for record_llm_call() in packages/agent-harness/telemetry.py.
+
+Exercises all usage-dict shapes: None, partial, full, and verifies that
+``llm_calls`` and ``llm_call_duration`` always record regardless of usage,
+while token counters only record when non-None int values are present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Imported via sys.path set in conftest.py
+# pylint: disable=import-error
+from config import DaemonConfig
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from telemetry import (
+    init_harness_telemetry,
+    record_llm_call,
+    reset_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset OTEL globals before and after every test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def harness_metrics_reader():
+    """Install an InMemoryMetricReader and return a (reader, registry) pair.
+
+    The registry is built from the proxy meter that points at the just-installed
+    real MeterProvider — so ``record_llm_call`` writes to the in-memory store.
+    """
+    reset_for_tests()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-harness"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    # Build registry from the proxy meter (disabled init uses proxy → points at
+    # the SDK provider we just installed).
+    config = DaemonConfig()
+    _, registry = init_harness_telemetry(config)
+    yield reader, registry
+    reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _attrs_match(point_attrs, expected: dict | None) -> bool:
+    """Return True if all expected key/value pairs appear in point_attrs."""
+    if not expected:
+        return True
+    return all(dict(point_attrs).get(k) == v for k, v in expected.items())
+
+
+def _walk_data_points(reader, metric_name: str):
+    """Yield every data point for ``metric_name`` across all resource/scope metrics."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    yield from m.data.data_points
+
+
+def _get_counter_sum(reader, metric_name: str, attrs: dict | None = None) -> float:
+    """Sum counter data point values for ``metric_name``, optionally filtered by attrs."""
+    return sum(
+        dp.value
+        for dp in _walk_data_points(reader, metric_name)
+        if _attrs_match(dp.attributes, attrs)
+    )
+
+
+def _get_histogram_count(reader, metric_name: str, attrs: dict | None = None) -> int:
+    """Count histogram recordings for ``metric_name``, optionally filtered by attrs."""
+    return sum(
+        dp.count
+        for dp in _walk_data_points(reader, metric_name)
+        if _attrs_match(dp.attributes, attrs)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_records_calls_counter_and_duration_histogram_unconditionally(harness_metrics_reader):
+    """llm_calls and llm_call_duration always record even when usage is None."""
+    reader, registry = harness_metrics_reader
+
+    record_llm_call(
+        registry,
+        backend="codex",
+        model="gpt-4o",
+        nick="spark-codex",
+        usage=None,
+        duration_ms=99.5,
+        outcome="success",
+    )
+
+    assert _get_counter_sum(reader, "culture.harness.llm.calls") == 1.0
+    assert _get_histogram_count(reader, "culture.harness.llm.call.duration") == 1
+    # Token counters must NOT have been touched.
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == 0.0
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
+
+
+def test_skips_missing_usage_keys(harness_metrics_reader):
+    """Partial usage dict: only present non-None int keys record."""
+    reader, registry = harness_metrics_reader
+
+    record_llm_call(
+        registry,
+        backend="claude",
+        model="claude-opus-4-6",
+        nick="spark-claude",
+        usage={"tokens_input": 100},  # tokens_output absent
+        duration_ms=50.0,
+        outcome="success",
+    )
+
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == 100.0
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
+
+
+def test_records_both_token_counters_when_present(harness_metrics_reader):
+    """Full usage dict: both token counters record with harness.nick label."""
+    reader, registry = harness_metrics_reader
+
+    record_llm_call(
+        registry,
+        backend="claude",
+        model="claude-opus-4-6",
+        nick="spark-claude",
+        usage={"tokens_input": 50, "tokens_output": 200},
+        duration_ms=120.0,
+        outcome="success",
+    )
+
+    assert (
+        _get_counter_sum(
+            reader,
+            "culture.harness.llm.tokens.input",
+            {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+        )
+        == 50.0
+    )
+    assert (
+        _get_counter_sum(
+            reader,
+            "culture.harness.llm.tokens.output",
+            {"backend": "claude", "model": "claude-opus-4-6", "harness.nick": "spark-claude"},
+        )
+        == 200.0
+    )
+
+
+def test_outcome_label_propagates(harness_metrics_reader):
+    """outcome=error must appear on llm_calls and llm_call_duration."""
+    reader, registry = harness_metrics_reader
+
+    record_llm_call(
+        registry,
+        backend="acp",
+        model="my-model",
+        nick="spark-acp",
+        usage=None,
+        duration_ms=5.0,
+        outcome="error",
+    )
+
+    assert (
+        _get_counter_sum(
+            reader, "culture.harness.llm.calls", {"backend": "acp", "outcome": "error"}
+        )
+        == 1.0
+    )
+    assert (
+        _get_histogram_count(
+            reader,
+            "culture.harness.llm.call.duration",
+            {"backend": "acp", "outcome": "error"},
+        )
+        == 1
+    )
+
+
+def test_multiple_calls_accumulate(harness_metrics_reader):
+    """Multiple calls accumulate in the counter."""
+    reader, registry = harness_metrics_reader
+
+    for _ in range(3):
+        record_llm_call(
+            registry,
+            backend="copilot",
+            model="gpt-4o",
+            nick="spark-copilot",
+            usage=None,
+            duration_ms=10.0,
+            outcome="success",
+        )
+
+    assert _get_counter_sum(reader, "culture.harness.llm.calls") == 3.0
+
+
+def test_none_valued_usage_keys_are_skipped(harness_metrics_reader):
+    """usage keys present but set to None are silently skipped (not 0)."""
+    reader, registry = harness_metrics_reader
+
+    record_llm_call(
+        registry,
+        backend="claude",
+        model="claude-haiku",
+        nick="spark-claude",
+        usage={"tokens_input": None, "tokens_output": None},
+        duration_ms=8.0,
+        outcome="success",
+    )
+
+    # None values must not add to the token counters.
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.input") == 0.0
+    assert _get_counter_sum(reader, "culture.harness.llm.tokens.output") == 0.0
+    # But calls and duration still record.
+    assert _get_counter_sum(reader, "culture.harness.llm.calls") == 1.0
+    assert _get_histogram_count(reader, "culture.harness.llm.call.duration") == 1
+
+
+def test_timeout_outcome(harness_metrics_reader):
+    """outcome=timeout is valid and records correctly."""
+    reader, registry = harness_metrics_reader
+
+    record_llm_call(
+        registry,
+        backend="codex",
+        model="gpt-4o",
+        nick="spark-codex",
+        usage=None,
+        duration_ms=300000.0,
+        outcome="timeout",
+    )
+
+    assert _get_counter_sum(reader, "culture.harness.llm.calls", {"outcome": "timeout"}) == 1.0

--- a/tests/harness/test_telemetry_module.py
+++ b/tests/harness/test_telemetry_module.py
@@ -45,24 +45,6 @@ def disabled_config():
     return DaemonConfig()
 
 
-@pytest.fixture
-def harness_metrics_reader():
-    """Install an InMemoryMetricReader against a fresh SdkMeterProvider.
-
-    Returns the reader so tests can call ``reader.get_metrics_data()``.
-    Resets harness module state before install and after teardown.
-    """
-    reset_for_tests()
-    reader = InMemoryMetricReader()
-    provider = SdkMeterProvider(
-        resource=Resource.create({"service.name": "test-harness"}),
-        metric_readers=[reader],
-    )
-    otel_metrics.set_meter_provider(provider)
-    yield reader
-    reset_for_tests()
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/harness/test_telemetry_module.py
+++ b/tests/harness/test_telemetry_module.py
@@ -116,12 +116,12 @@ def test_init_reinit_on_config_change():
     tcfg = TelemetryConfig(enabled=False)
     config = DaemonConfig(telemetry=tcfg)
 
-    tracer1, registry1 = init_harness_telemetry(config)
+    _tracer1, registry1 = init_harness_telemetry(config)
 
     # Mutate config — snapshot diff should force reinit.
     tcfg.metrics_export_interval_ms = 1000
 
-    tracer2, registry2 = init_harness_telemetry(config)
+    _tracer2, registry2 = init_harness_telemetry(config)
     assert registry1 is not registry2
 
 
@@ -204,7 +204,9 @@ def test_init_with_metrics_reader_records_calls(harness_metrics_reader):
         outcome="success",
     )
 
-    assert _get_counter_sum(harness_metrics_reader, "culture.harness.llm.calls") == 1.0
+    assert _get_counter_sum(harness_metrics_reader, "culture.harness.llm.calls") == pytest.approx(
+        1.0
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harness/test_telemetry_module.py
+++ b/tests/harness/test_telemetry_module.py
@@ -7,6 +7,8 @@ parallel xdist workers don't leak providers.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 # Imported via sys.path set in conftest.py
@@ -139,6 +141,63 @@ def test_init_reinit_on_config_change():
 
     tracer2, registry2 = init_harness_telemetry(config)
     assert registry1 is not registry2
+
+
+# ---------------------------------------------------------------------------
+# test_init_reinit_with_real_provider_shuts_down_old
+# ---------------------------------------------------------------------------
+
+
+def test_init_reinit_with_real_provider_shuts_down_old():
+    """Reinit with changed config shuts down the previous real MeterProvider.
+
+    First call installs a real SdkMeterProvider (enabled=True, metrics_on).
+    A config mutation then triggers reinit, which must call shutdown() on the
+    old provider.  We patch MeterProvider.shutdown to record invocations so
+    the assertion is deterministic without touching live exporters.
+    """
+    reader = InMemoryMetricReader()
+    first_provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-harness-reinit"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(first_provider)
+
+    import telemetry as _tel_module
+
+    _tel_module._meter_provider = first_provider
+
+    shutdown_calls = []
+    original_shutdown = SdkMeterProvider.shutdown
+
+    def _record_shutdown(self, *args, **kwargs):
+        shutdown_calls.append(self)
+        return original_shutdown(self, *args, **kwargs)
+
+    tcfg = TelemetryConfig(enabled=False)
+    config = DaemonConfig(telemetry=tcfg)
+    _tel_module._initialized_for = {
+        "telemetry": {
+            "enabled": False,
+            "service_name": "culture.harness",
+            "otlp_endpoint": "http://localhost:4317",
+            "otlp_protocol": "grpc",
+            "otlp_timeout_ms": 5000,
+            "otlp_compression": "gzip",
+            "traces_enabled": True,
+            "traces_sampler": "parentbased_always_on",
+            "metrics_enabled": True,
+            "metrics_export_interval_ms": 10000,
+        },
+        "nick": "culture",
+    }
+
+    with patch.object(SdkMeterProvider, "shutdown", _record_shutdown):
+        tcfg.metrics_export_interval_ms = 5000
+        init_harness_telemetry(config)
+
+    assert shutdown_calls, "expected old MeterProvider.shutdown() to be called on reinit"
+    assert shutdown_calls[0] is first_provider
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harness/test_telemetry_module.py
+++ b/tests/harness/test_telemetry_module.py
@@ -1,0 +1,221 @@
+"""Unit tests for packages/agent-harness/telemetry.py.
+
+Tests are isolated — no IRCd, no real OTLP exporter. Each test resets all
+global OTEL provider state via ``reset_for_tests()`` before and after so
+parallel xdist workers don't leak providers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Imported via sys.path set in conftest.py
+# pylint: disable=import-error
+from config import AgentConfig, DaemonConfig, ServerConnConfig, TelemetryConfig
+from opentelemetry import metrics as otel_metrics
+from opentelemetry import trace
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.resources import Resource
+from telemetry import (
+    HarnessMetricsRegistry,
+    init_harness_telemetry,
+    record_llm_call,
+    reset_for_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset all OTEL globals before and after every test."""
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+@pytest.fixture
+def disabled_config():
+    """DaemonConfig with telemetry disabled (default)."""
+    return DaemonConfig()
+
+
+@pytest.fixture
+def harness_metrics_reader():
+    """Install an InMemoryMetricReader against a fresh SdkMeterProvider.
+
+    Returns the reader so tests can call ``reader.get_metrics_data()``.
+    Resets harness module state before install and after teardown.
+    """
+    reset_for_tests()
+    reader = InMemoryMetricReader()
+    provider = SdkMeterProvider(
+        resource=Resource.create({"service.name": "test-harness"}),
+        metric_readers=[reader],
+    )
+    otel_metrics.set_meter_provider(provider)
+    yield reader
+    reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_counter_sum(reader, metric_name: str) -> float:
+    """Sum all data point values for a counter metric across all attributes."""
+    data = reader.get_metrics_data()
+    if data is None:
+        return 0.0
+    total = 0.0
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for m in sm.metrics:
+                if m.name == metric_name:
+                    for dp in m.data.data_points:
+                        total += dp.value
+    return total
+
+
+# ---------------------------------------------------------------------------
+# test_init_disabled_returns_noop_tracer_and_proxy_registry
+# ---------------------------------------------------------------------------
+
+
+def test_init_disabled_returns_noop_tracer_and_proxy_registry(disabled_config):
+    """Disabled telemetry yields a no-op tracer and a registry that doesn't raise."""
+    tracer, registry = init_harness_telemetry(disabled_config)
+
+    # Tracer should be a proxy / no-op — starting a span yields a NonRecordingSpan.
+    with tracer.start_as_current_span("test-span") as span:
+        assert not span.is_recording()
+
+    # All 4 instruments present on the registry.
+    assert isinstance(registry, HarnessMetricsRegistry)
+    assert registry.llm_tokens_input is not None
+    assert registry.llm_tokens_output is not None
+    assert registry.llm_call_duration is not None
+    assert registry.llm_calls is not None
+
+    # Calls on proxy instruments must not raise.
+    registry.llm_calls.add(1, {"backend": "test", "model": "m", "outcome": "success"})
+    registry.llm_call_duration.record(10.0, {"backend": "test", "model": "m", "outcome": "success"})
+    registry.llm_tokens_input.add(5, {"backend": "test", "model": "m", "harness.nick": "n"})
+    registry.llm_tokens_output.add(3, {"backend": "test", "model": "m", "harness.nick": "n"})
+
+
+# ---------------------------------------------------------------------------
+# test_init_idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_init_idempotent(disabled_config):
+    """Calling init twice with same config returns the same tracer + registry."""
+    tracer1, registry1 = init_harness_telemetry(disabled_config)
+    tracer2, registry2 = init_harness_telemetry(disabled_config)
+
+    assert tracer1 is tracer2
+    assert registry1 is registry2
+
+
+# ---------------------------------------------------------------------------
+# test_init_reinit_on_config_change
+# ---------------------------------------------------------------------------
+
+
+def test_init_reinit_on_config_change():
+    """Mutating TelemetryConfig triggers fresh provider install on next call."""
+    tcfg = TelemetryConfig(enabled=False)
+    config = DaemonConfig(telemetry=tcfg)
+
+    tracer1, registry1 = init_harness_telemetry(config)
+
+    # Mutate config — snapshot diff should force reinit.
+    tcfg.metrics_export_interval_ms = 1000
+
+    tracer2, registry2 = init_harness_telemetry(config)
+    assert registry1 is not registry2
+
+
+# ---------------------------------------------------------------------------
+# test_init_with_metrics_reader_records_calls
+# ---------------------------------------------------------------------------
+
+
+def test_init_with_metrics_reader_records_calls(harness_metrics_reader):
+    """When a real MeterProvider is pre-installed, record_llm_call records data."""
+    # Build a config that would be disabled so init_harness_telemetry uses the
+    # proxy meter pointing at the already-installed test MeterProvider.
+    config = DaemonConfig()
+    _tracer_obj, registry = init_harness_telemetry(config)
+
+    record_llm_call(
+        registry,
+        backend="claude",
+        model="claude-opus-4-6",
+        nick="spark-claude",
+        usage=None,
+        duration_ms=42.0,
+        outcome="success",
+    )
+
+    assert _get_counter_sum(harness_metrics_reader, "culture.harness.llm.calls") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# test_reset_for_tests_clears_globals
+# ---------------------------------------------------------------------------
+
+
+def test_reset_for_tests_clears_globals(disabled_config):
+    """After reset_for_tests() all module globals are None and OTEL unset."""
+    import telemetry as _tel_module
+
+    init_harness_telemetry(disabled_config)
+
+    # After reset: module globals cleared.
+    reset_for_tests()
+    assert _tel_module._initialized_for is None
+    assert _tel_module._tracer is None
+    assert _tel_module._meter_provider is None
+    assert _tel_module._registry is None
+
+    # OTEL trace provider unset.
+    assert trace._TRACER_PROVIDER is None  # type: ignore[attr-defined]
+
+    # OTEL metrics provider unset.
+    import opentelemetry.metrics._internal as _mi  # type: ignore[attr-defined]
+
+    assert _mi._METER_PROVIDER is None
+
+
+# ---------------------------------------------------------------------------
+# test_nick_identity_from_agents
+# ---------------------------------------------------------------------------
+
+
+def test_nick_identity_from_agents():
+    """When agents list is non-empty, identity is built from agent nicks."""
+    config = DaemonConfig(
+        agents=[AgentConfig(nick="spark-claude"), AgentConfig(nick="spark-daria")],
+    )
+    tracer, registry = init_harness_telemetry(config)
+    assert tracer is not None
+    assert registry is not None
+
+
+# ---------------------------------------------------------------------------
+# test_nick_identity_from_server_name
+# ---------------------------------------------------------------------------
+
+
+def test_nick_identity_from_server_name():
+    """When agents list is empty, identity falls back to server.name."""
+    config = DaemonConfig(server=ServerConnConfig(name="mytestserver"))
+    tracer, registry = init_harness_telemetry(config)
+    assert tracer is not None
+    assert registry is not None

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.5.0"
+version = "8.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Plan 5 of the OTEL initiative: harness-side tracing & LLM metrics. The harness boundary is now part of the cross-process trace tree, and per-backend LLM metrics surface alongside the server-side metrics from Plans 1–4.

After this lands, a single `trace_id` flows: `irc.command.PRIVMSG` (server) → `irc.event.emit` (server) → `harness.irc.message.handle` (harness) → `harness.llm.call` (harness). And four new metrics light up: `culture.harness.llm.tokens.input/output`, `culture.harness.llm.call.duration`, `culture.harness.llm.calls`.

- New reference module `packages/agent-harness/telemetry.py` (`HarnessMetricsRegistry`, `init_harness_telemetry`, `record_llm_call`, `reset_for_tests`).
- Cited verbatim into all 4 agent backends (`claude`, `codex`, `copilot`, `acp`) — only `_HARNESS_TRACER_NAME` differs. Locked down by 24 all-backends parity tests in `tests/harness/test_all_backends_parity.py`.
- W3C traceparent injection on outbound IRC + extraction on inbound (matching server-side parity; tracestate stays server-parity-deferred per the plan body).
- Operator guide: new `docs/agentirc/harness-telemetry.md` + "What you get in 8.6.0" subsection in `docs/agentirc/telemetry.md`.

Test count: 1121 → 1191 (70 new in `tests/harness/`). All pre-commit hooks clean.

## Token-usage caveats (tracked separately)

- Codex token usage: #298 — `usage=None` for now; `llm_calls` and `llm_call_duration` still populate.
- Copilot token usage: #299 — same; SDK doesn't expose token counts on responses today.

Documented in `harness-telemetry.md` so operator dashboards aren't surprising.

## Plan + spec

- Plan: `docs/superpowers/plans/2026-04-28-otel-harness.md`
- Spec: `docs/superpowers/specs/2026-04-24-otel-observability-design.md` (lines 22-44, 97-107, 152-157, 230-247, 283)

## Test plan

- [ ] CI green across the matrix (test, version-check, build-docs, CodeQL, SonarCloud, Cloudflare Pages preview).
- [ ] `bash ~/.claude/skills/run-tests/scripts/test.sh -p tests/harness/` — 70 tests (4× `test_agent_runner_<backend>` + parity + module + transport + record_llm_call + daemon).
- [ ] Manual end-to-end (per `docs/agentirc/harness-telemetry.md` "Manual end-to-end test"): server + claude harness with `telemetry.enabled=true`, otelcol-contrib running, weechat sends `@spark-claude hi`, confirm single `trace_id` covers all four span sites + `culture.harness.llm.calls{outcome=success}` increments.
- [ ] SonarCloud Quality Gate.
- [ ] Cloudflare Pages preview renders the new operator guide correctly.

- Claude