### PR TITLE
feat(telemetry): OTEL bot instrumentation (Plan 7, 8.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.7.0] - 2026-04-26
+
+### Added
+
+- OTEL bot instrumentation (Plan 7): bot.event.dispatch and bot.run spans, culture.bot.invocations counter, culture.bot.webhook.duration histogram, aiohttp-server auto-instrumentation on the webhook listener.
+
+### Changed
+
+- docs/agentirc/telemetry.md updated with the 8.7.0 section; harness-telemetry.md cross-link updated.
+
 ## [8.6.0] - 2026-04-26
 
 ### Added

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -127,9 +127,9 @@ class Bot:
 
         Returns the rendered message text.
         """
-        # Span opens before the active-check so a misrouted dispatch (inactive
-        # bot reached via webhook) still surfaces in tracing with ERROR status
-        # and bot.name set, instead of silently raising.
+        # Span opens before the active-check so, if handle() is invoked for an
+        # inactive bot, the failure still surfaces in tracing with ERROR
+        # status and bot.name set instead of only raising.
         with _otel_trace.get_tracer("culture.agentirc").start_as_current_span(
             "bot.run",
             attributes={"bot.name": self.config.name},

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -8,6 +8,8 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from opentelemetry import trace as _otel_trace
+
 from culture.agentirc.skill import Event, EventType
 from culture.bots.config import BOTS_DIR, BotConfig
 from culture.bots.template_engine import render_fallback, render_template
@@ -125,19 +127,28 @@ class Bot:
 
         Returns the rendered message text.
         """
-        if not self.active or not self.virtual_client:
-            raise RuntimeError(f"Bot {self.config.name} is not active")
+        # Span opens before the active-check so a misrouted dispatch (inactive
+        # bot reached via webhook) still surfaces in tracing with ERROR status
+        # and bot.name set, instead of silently raising.
+        with _otel_trace.get_tracer("culture.agentirc").start_as_current_span(
+            "bot.run",
+            attributes={"bot.name": self.config.name},
+        ) as span:
+            if not self.active or not self.virtual_client:
+                span.set_status(_otel_trace.StatusCode.ERROR, "bot not active")
+                raise RuntimeError(f"Bot {self.config.name} is not active")
 
-        message = await self._resolve_message(payload)
-        if not message:
-            return ""
+            message = await self._resolve_message(payload)
+            if not message:
+                span.set_attribute("bot.run.empty_message", True)
+                return ""
 
-        if self.config.mention:
-            message = f"@{self.config.mention} {message}"
+            if self.config.mention:
+                message = f"@{self.config.mention} {message}"
 
-        await self._deliver(message, payload)
-        await self._maybe_fire_event(payload)
-        return message
+            await self._deliver(message, payload)
+            await self._maybe_fire_event(payload)
+            return message
 
     async def _resolve_message(self, payload: dict) -> str:
         """Render the message from custom handler or template."""

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -91,51 +91,58 @@ class BotManager:
     async def on_event(self, event) -> None:
         """Evaluate event-triggered bots against an event and dispatch matches."""
         # Snapshot: handle() may call emit_event() which re-enters on_event().
-        bots_snapshot = list(self.bots.values())
-        for bot in bots_snapshot:
-            cfg = bot.config
-            if cfg.trigger_type != "event":
-                continue
-            compiled = getattr(cfg, "_compiled_filter", None)
-            if compiled is None:
-                continue
-            ctx = {
-                "type": event.type.value if hasattr(event.type, "value") else str(event.type),
-                "channel": event.channel,
-                "nick": event.nick,
-                "data": dict(event.data),
-            }
+        ctx = {
+            "type": event.type.value if hasattr(event.type, "value") else str(event.type),
+            "channel": event.channel,
+            "nick": event.nick,
+            "data": dict(event.data),
+        }
+        for bot in list(self.bots.values()):
+            if self._matches_event(bot, ctx):
+                await self._dispatch_to_bot(bot, ctx)
+
+    def _matches_event(self, bot: Bot, ctx: dict) -> bool:
+        """True iff `bot` is event-triggered and its filter accepts `ctx`."""
+        cfg = bot.config
+        if cfg.trigger_type != "event":
+            return False
+        compiled = getattr(cfg, "_compiled_filter", None)
+        if compiled is None:
+            return False
+        try:
+            return bool(evaluate(compiled, ctx))
+        except Exception:
+            logger.exception("Filter evaluation failed for bot %s", cfg.name)
+            return False
+
+    async def _dispatch_to_bot(self, bot: Bot, ctx: dict) -> None:
+        """Lazily start the bot and run handle() inside a bot.event.dispatch span."""
+        if not await self._try_start_bot(bot):
+            return
+        cfg = bot.config
+        event_type_str = ctx["type"]
+        with _otel_trace.get_tracer("culture.agentirc").start_as_current_span(
+            "bot.event.dispatch",
+            attributes={"bot.name": cfg.name, "event.type": event_type_str},
+        ) as span:
+            outcome = "success"
             try:
-                if not evaluate(compiled, ctx):
-                    continue
-            except Exception:
-                logger.exception("Filter evaluation failed for bot %s", cfg.name)
-                continue
-            if not await self._try_start_bot(bot):
-                continue
-            event_type_str = ctx["type"]
-            with _otel_trace.get_tracer("culture.agentirc").start_as_current_span(
-                "bot.event.dispatch",
-                attributes={"bot.name": cfg.name, "event.type": event_type_str},
-            ) as span:
-                outcome = "success"
-                try:
-                    await bot.handle({"event": ctx})
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:
-                    outcome = "error"
-                    span.set_status(_otel_trace.StatusCode.ERROR, str(exc))
-                    logger.exception("Bot %s handle() failed for event %s", cfg.name, event.type)
-                finally:
-                    self.server.metrics.bot_invocations.add(
-                        1,
-                        {
-                            "bot": cfg.name,
-                            "event.type": event_type_str,
-                            "outcome": outcome,
-                        },
-                    )
+                await bot.handle({"event": ctx})
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                outcome = "error"
+                span.set_status(_otel_trace.StatusCode.ERROR, str(exc))
+                logger.exception("Bot %s handle() failed for event %s", cfg.name, ctx["type"])
+            finally:
+                self.server.metrics.bot_invocations.add(
+                    1,
+                    {
+                        "bot": cfg.name,
+                        "event.type": event_type_str,
+                        "outcome": outcome,
+                    },
+                )
 
     def load_system_bots(self) -> None:
         """Discover and register system bots from the package."""

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from opentelemetry import trace as _otel_trace
+
 from culture.bots.bot import Bot
 from culture.bots.config import (
     BOT_CONFIG_FILE,
@@ -110,10 +112,27 @@ class BotManager:
                 continue
             if not await self._try_start_bot(bot):
                 continue
-            try:
-                await bot.handle({"event": ctx})
-            except Exception:
-                logger.exception("Bot %s handle() failed for event %s", cfg.name, event.type)
+            event_type_str = ctx["type"]
+            with _otel_trace.get_tracer("culture.agentirc").start_as_current_span(
+                "bot.event.dispatch",
+                attributes={"bot.name": cfg.name, "event.type": event_type_str},
+            ) as span:
+                outcome = "success"
+                try:
+                    await bot.handle({"event": ctx})
+                except Exception as exc:
+                    outcome = "error"
+                    span.set_status(_otel_trace.StatusCode.ERROR, str(exc))
+                    logger.exception("Bot %s handle() failed for event %s", cfg.name, event.type)
+                finally:
+                    self.server.metrics.bot_invocations.add(
+                        1,
+                        {
+                            "bot": cfg.name,
+                            "event.type": event_type_str,
+                            "outcome": outcome,
+                        },
+                    )
 
     def load_system_bots(self) -> None:
         """Discover and register system bots from the package."""

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -120,6 +121,8 @@ class BotManager:
                 outcome = "success"
                 try:
                     await bot.handle({"event": ctx})
+                except asyncio.CancelledError:
+                    raise
                 except Exception as exc:
                     outcome = "error"
                     span.set_status(_otel_trace.StatusCode.ERROR, str(exc))

--- a/culture/bots/http_listener.py
+++ b/culture/bots/http_listener.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from aiohttp import web
+from opentelemetry.instrumentation.aiohttp_server import AioHttpServerInstrumentor
 
 if TYPE_CHECKING:
     from culture.bots.bot_manager import BotManager
@@ -25,7 +27,16 @@ class HttpListener:
         self._runner: web.AppRunner | None = None
 
     async def start(self) -> None:
-        self._app = web.Application()
+        # Patch aiohttp.web.Application to auto-inject the OTEL server
+        # middleware. Deferred from import time so just importing this module
+        # has no side effect. Re-instrument each start() so the captured
+        # tracer/meter rebinds to the *current* TracerProvider — important for
+        # tests that swap providers between runs, harmless in production.
+        instrumentor = AioHttpServerInstrumentor()
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+        instrumentor.instrument()
+        self._app = web.Application(middlewares=[self._record_webhook_duration])
         self._app.router.add_get("/health", self._handle_health)
         self._app.router.add_post("/{bot_name}", self._handle_webhook)
 
@@ -40,6 +51,29 @@ class HttpListener:
             await self._runner.cleanup()
             self._runner = None
             self._app = None
+
+    @web.middleware
+    async def _record_webhook_duration(self, request, handler):
+        """Record per-request duration into culture.bot.webhook.duration."""
+        bot_name = request.match_info.get("bot_name") or "_unrouted"
+        start = time.perf_counter()
+        # Default for the "handler raised a non-HTTPException" path: aiohttp
+        # converts unhandled exceptions to 500 responses outside this
+        # middleware, so the histogram should report 5xx for them.
+        status_class = "5xx"
+        try:
+            response = await handler(request)
+            status_class = f"{response.status // 100}xx"
+            return response
+        except web.HTTPException as exc:
+            status_class = f"{exc.status // 100}xx"
+            raise
+        finally:
+            duration = time.perf_counter() - start
+            self.bot_manager.server.metrics.bot_webhook_duration.record(
+                duration,
+                {"bot": bot_name, "status_class": status_class},
+            )
 
     async def _handle_health(self, request: web.Request) -> web.Response:
         return web.json_response({"status": "ok"})

--- a/culture/telemetry/metrics.py
+++ b/culture/telemetry/metrics.py
@@ -63,6 +63,9 @@ class MetricsRegistry:
     # Audit (Plan 4)
     audit_writes: Counter
     audit_queue_depth: UpDownCounter
+    # Bots (Plan 7)
+    bot_invocations: Counter
+    bot_webhook_duration: Histogram
 
 
 def reset_for_tests() -> None:
@@ -167,6 +170,16 @@ def _build_registry(meter: Meter) -> MetricsRegistry:
         audit_queue_depth=meter.create_up_down_counter(
             "culture.audit.queue_depth",
             description="Audit queue depth (records waiting to flush to disk)",
+        ),
+        # Bots (Plan 7)
+        bot_invocations=meter.create_counter(
+            "culture.bot.invocations",
+            description="Bot dispatch invocations by bot, event.type, outcome=success|error",
+        ),
+        bot_webhook_duration=meter.create_histogram(
+            "culture.bot.webhook.duration",
+            unit="s",
+            description="Webhook request handler duration by bot and status_class=2xx|3xx|4xx|5xx",
         ),
     )
 

--- a/docs/agentirc/harness-telemetry.md
+++ b/docs/agentirc/harness-telemetry.md
@@ -230,7 +230,7 @@ corresponding key is present in `usage` with an `int` value.
 
 ## What's not in 8.6.0
 
-- **Bot-side OTEL instrumentation** — Plan 6.
+- **Bot-side OTEL instrumentation** — shipped in 8.7.0 (Plan 7). See [`telemetry.md`](telemetry.html#what-you-get-in-870).
 - **Tracestate injection** — server-parity-deferred. Both server-side
   `client.py` / `server_link.py` and the harness currently pass `tracestate=None`
   when injecting. A future plan will add `current_tracestate()` to

--- a/docs/agentirc/telemetry.md
+++ b/docs/agentirc/telemetry.md
@@ -9,7 +9,7 @@ nav_order: 90
 
 Culture ships with first-class OpenTelemetry support: traces for every IRC command and event, W3C trace context carried across federation via a new IRCv3 tag, and a local collector pattern that keeps Culture's surface small.
 
-This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), the **Metrics Pillar** (culture 8.4.0), the **Audit JSONL Sink** (culture 8.5.0), and **Harness-side OTEL** (culture 8.6.0). Bot instrumentation ships in a subsequent release.
+This page covers the **Foundation + Server Tracing** release (culture 8.2.0), **Federation Trace-Context Relay** (culture 8.3.0), the **Metrics Pillar** (culture 8.4.0), the **Audit JSONL Sink** (culture 8.5.0), **Harness-side OTEL** (culture 8.6.0), and **Bot Instrumentation** (culture 8.7.0).
 
 ## What you get in 8.2.0
 
@@ -189,11 +189,47 @@ For full configuration details, the per-backend `service.name` table, the
 end-to-end test recipe, and a list of what's deferred, see the operator guide at
 [`docs/agentirc/harness-telemetry.html`](harness-telemetry.html).
 
-## What's not in 8.6.0
+## What you get in 8.7.0
+
+Bot instrumentation lands. Event-triggered dispatch and webhook-triggered dispatch each get their own span tree, both stitched into the same trace as the upstream client/server activity that triggered them.
+
+Event-trigger path:
+
+```text
+irc.command.PRIVMSG (or any event-emitting verb)
+└── irc.event.emit
+    └── bot.event.dispatch  (one per matched bot)
+        └── bot.run         (Bot.handle body)
+            └── irc.privmsg.deliver.channel | .dm
+```
+
+Webhook path:
+
+```text
+HTTP POST /<bot_name>      (auto-instrumented inbound span)
+└── bot.run                (Bot.handle body)
+    └── irc.privmsg.deliver.*
+```
+
+New spans:
+
+- `bot.event.dispatch` — one per matched bot inside `BotManager.on_event`. Attributes: `bot.name`, `event.type`. Status `ERROR` if `Bot.handle` raises.
+- `bot.run` — wraps `Bot.handle` for both event and webhook paths. Attributes: `bot.name`, optional `bot.run.empty_message=True` if the rendered message is empty.
+
+The webhook HTTP server is auto-instrumented via [`opentelemetry-instrumentation-aiohttp-server`](https://pypi.org/project/opentelemetry-instrumentation-aiohttp-server/). Each request produces an inbound HTTP server span (verb + path + status code) that becomes the parent of `bot.run`. If the caller sends a `traceparent` header, the request joins their existing trace.
+
+New metrics:
+
+- `culture.bot.invocations` — Counter. Labels: `bot`, `event.type`, `outcome=success|error`. Increments only after the bot has matched the filter and been started — filter rejections and startup failures are logged but not counted.
+- `culture.bot.webhook.duration` — Histogram, `s`. Labels: `bot`, `status_class=2xx|3xx|4xx|5xx`. Recorded by a per-request middleware on the webhook listener. `bot=_unrouted` is used for `/health` and other non-bot paths so the histogram never silently mis-attributes.
+
+Bots add no new wire protocol surface. Trace context flows in via the existing IRCv3 `culture.dev/traceparent` tag for events and via the standard W3C `traceparent` HTTP header for webhooks.
+
+## What's not in 8.7.0
 
 The design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md` covers the full three-pillar scope. These pieces remain deferred:
 
-- Bot webhook HTTP instrumentation + bot metrics (`culture.bot.invocations`, `culture.bot.webhook.duration`).
+- Outbound webhook delivery instrumentation (`opentelemetry-instrumentation-aiohttp-client`) — bots currently make no outbound HTTP calls; will be added when that feature lands.
 - Outbound `culture.s2s.messages` (records inbound only — outbound needs a clean verb-extraction site).
 - OTEL Logs export of audit records (best-effort duplicate; JSONL stays source of truth either way).
 - `audit-prune` CLI for retention; operators prune manually in v1.

--- a/docs/superpowers/specs/2026-04-24-otel-observability-design.md
+++ b/docs/superpowers/specs/2026-04-24-otel-observability-design.md
@@ -91,7 +91,7 @@ Documents the audit JSONL schema and file layout as a stable contract.
 ### `culture/bots/`
 
 - `BotManager.on_event` — span `bot.event.dispatch` per matched bot, attrs `bot.name`, `event.type`. Metric `culture.bot.invocations{bot, event.type, outcome}`.
-- `http_listener` webhook sender — enable `opentelemetry-instrumentation-aiohttp-client`. Outbound HTTP becomes child spans with traceparent sent as HTTP header automatically. Post-span hook maps status to `status_class` label for `culture.bot.webhook.duration` histogram.
+- `http_listener` webhook receiver — enable `opentelemetry-instrumentation-aiohttp-server`. Inbound HTTP becomes a server span that parents `bot.run`; W3C `traceparent` headers from callers stitch incoming webhooks into their existing trace. A local middleware records the `culture.bot.webhook.duration` histogram (unit `s`) with `{bot, status_class}` labels. **Note (Phase 7, 8.7.0):** the originally-specified outbound `aiohttp-client` instrumentation is deferred — bots make no outbound HTTP calls today; will be added when that feature lands.
 - `Bot` execution — span `bot.run`.
 
 ### `packages/agent-harness/irc_transport.py` (reference, cited into each backend)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.6.0"
+version = "8.7.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -26,6 +26,7 @@ dependencies = [
     "opentelemetry-sdk>=1.25",
     "opentelemetry-exporter-otlp-proto-grpc>=1.25",
     "opentelemetry-semantic-conventions>=0.46b0",
+    "opentelemetry-instrumentation-aiohttp-server>=0.46b0",
 ]
 
 [project.urls]

--- a/tests/telemetry/_metrics_helpers.py
+++ b/tests/telemetry/_metrics_helpers.py
@@ -64,3 +64,12 @@ def get_histogram_count(reader, name: str, attrs: dict | None = None) -> int:
         if _attrs_match(dict(point.attributes), attrs):
             total += point.count
     return total
+
+
+def get_histogram_sum(reader, name: str, attrs: dict | None = None) -> float:
+    """Sum of recorded values for histogram points matching `attrs`. 0.0 if absent."""
+    total = 0.0
+    for point in _walk_data_points(reader, name):
+        if _attrs_match(dict(point.attributes), attrs):
+            total += point.sum
+    return total

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for telemetry integration tests."""
+
+from __future__ import annotations
+
+import pytest_asyncio
+
+from culture.bots.bot_manager import BotManager
+from culture.bots.http_listener import HttpListener
+
+
+@pytest_asyncio.fixture
+async def webhook_server(server, tmp_path, monkeypatch):
+    """IRCd + BotManager + running HttpListener on a random local port.
+
+    Yields ``(server, mgr, port)``. The HttpListener is torn down and all
+    bots stopped at the end of the test.
+    """
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot_manager.BOTS_DIR", tmp_path)
+
+    mgr = BotManager(server)
+    server.bot_manager = mgr
+
+    listener = HttpListener(mgr, "127.0.0.1", 0)
+    await listener.start()
+    site = next(iter(listener._runner._sites))
+    port = site._server.sockets[0].getsockname()[1]
+
+    yield server, mgr, port
+
+    await listener.stop()
+    await mgr.stop_all()

--- a/tests/telemetry/test_bot_event_dispatch_span.py
+++ b/tests/telemetry/test_bot_event_dispatch_span.py
@@ -1,0 +1,138 @@
+"""Spans for BotManager.on_event — bot.event.dispatch (Plan 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_bot_event_dispatch_span_per_match(tracing_exporter, server_with_bot):
+    """A matched event-triggered bot produces one bot.event.dispatch span with attrs."""
+    server, _ = server_with_bot(
+        bot_name="testserv-watcher",
+        trigger_type="event",
+        event_filter="type == 'topic'",
+        channels=["#general"],
+        template="hi {event.nick}",
+    )
+
+    await server.emit_event(
+        Event(
+            type=EventType.TOPIC,
+            channel="#general",
+            nick="testserv-newcomer",
+            data={"body": "hi"},
+        )
+    )
+
+    spans = tracing_exporter.get_finished_spans()
+    dispatch_spans = [
+        s
+        for s in spans
+        if s.name == "bot.event.dispatch" and s.attributes.get("bot.name") == "testserv-watcher"
+    ]
+    assert len(dispatch_spans) == 1, [s.name for s in spans]
+    span = dispatch_spans[0]
+    assert span.attributes["bot.name"] == "testserv-watcher"
+    assert span.attributes["event.type"] == "topic"
+
+    # Parented under irc.event.emit (contextvars-propagated).
+    emit_spans = [s for s in spans if s.name == "irc.event.emit"]
+    assert span.parent is not None
+    assert any(span.parent.span_id == e.context.span_id for e in emit_spans)
+
+
+@pytest.mark.asyncio
+async def test_bot_event_dispatch_span_one_per_matched_bot(tracing_exporter, server_with_bots):
+    """Two bots match the same event → two bot.event.dispatch spans, one per bot."""
+    server, _ = server_with_bots(
+        [
+            {
+                "bot_name": "testserv-a",
+                "trigger_type": "event",
+                "event_filter": "type == 'topic'",
+                "channels": ["#x"],
+                "template": "a",
+            },
+            {
+                "bot_name": "testserv-b",
+                "trigger_type": "event",
+                "event_filter": "type == 'topic'",
+                "channels": ["#x"],
+                "template": "b",
+            },
+        ]
+    )
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#x", nick="testserv-z", data={"body": "y"})
+    )
+
+    dispatch_spans = [
+        s
+        for s in tracing_exporter.get_finished_spans()
+        if s.name == "bot.event.dispatch"
+        and s.attributes.get("bot.name") in {"testserv-a", "testserv-b"}
+    ]
+    bot_names = sorted(s.attributes["bot.name"] for s in dispatch_spans)
+    assert bot_names == ["testserv-a", "testserv-b"]
+
+
+@pytest.mark.asyncio
+async def test_no_dispatch_span_when_filter_rejects(tracing_exporter, server_with_bot):
+    """Filter rejection produces no bot.event.dispatch span for that bot."""
+    server, _ = server_with_bot(
+        bot_name="testserv-silent",
+        trigger_type="event",
+        event_filter="channel == '#never'",
+        channels=["#general"],
+        template="x",
+    )
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#other", nick="testserv-q", data={"body": "x"})
+    )
+
+    dispatch_spans = [
+        s
+        for s in tracing_exporter.get_finished_spans()
+        if s.name == "bot.event.dispatch" and s.attributes.get("bot.name") == "testserv-silent"
+    ]
+    assert dispatch_spans == []
+
+
+@pytest.mark.asyncio
+async def test_bot_event_dispatch_span_error_status_on_handle_raise(
+    tracing_exporter, server_with_bot, monkeypatch
+):
+    """When Bot.handle raises, the dispatch span carries StatusCode.ERROR."""
+    from opentelemetry.trace import StatusCode
+
+    server, _ = server_with_bot(
+        bot_name="testserv-broken",
+        trigger_type="event",
+        event_filter="type == 'topic'",
+        channels=["#err"],
+        template="x",
+    )
+    bot = server.bot_manager.bots["testserv-broken"]
+
+    async def boom(payload):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(bot, "handle", boom)
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#err", nick="testserv-x", data={"body": "x"})
+    )
+
+    dispatch_spans = [
+        s
+        for s in tracing_exporter.get_finished_spans()
+        if s.name == "bot.event.dispatch" and s.attributes.get("bot.name") == "testserv-broken"
+    ]
+    assert len(dispatch_spans) == 1
+    assert dispatch_spans[0].status.status_code == StatusCode.ERROR
+    assert "kaboom" in (dispatch_spans[0].status.description or "")

--- a/tests/telemetry/test_bot_run_span.py
+++ b/tests/telemetry/test_bot_run_span.py
@@ -44,12 +44,14 @@ async def test_bot_run_span_parented_under_dispatch(tracing_exporter, server_wit
 @pytest.mark.asyncio
 async def test_bot_run_span_marks_empty_message(tracing_exporter, server_with_bot):
     """Empty rendered message sets bot.run.empty_message=True."""
+    # Whitespace-only template strips to "" inside Bot._render_message,
+    # forcing the empty-message branch deterministically.
     server, _ = server_with_bot(
         bot_name="testserv-empty",
         trigger_type="event",
         event_filter="type == 'topic'",
         channels=["#z"],
-        template=None,
+        template="   ",
     )
 
     await server.emit_event(
@@ -62,9 +64,7 @@ async def test_bot_run_span_marks_empty_message(tracing_exporter, server_with_bo
         if s.name == "bot.run" and s.attributes.get("bot.name") == "testserv-empty"
     ]
     assert len(run_spans) == 1
-    if not run_spans[0].attributes.get("bot.run.empty_message"):
-        pytest.skip("template fallback produced non-empty message; not the path under test")
-    assert run_spans[0].attributes["bot.run.empty_message"] is True
+    assert run_spans[0].attributes.get("bot.run.empty_message") is True
 
 
 @pytest.mark.asyncio

--- a/tests/telemetry/test_bot_run_span.py
+++ b/tests/telemetry/test_bot_run_span.py
@@ -1,0 +1,91 @@
+"""Spans for Bot.handle — bot.run (Plan 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+
+
+@pytest.mark.asyncio
+async def test_bot_run_span_parented_under_dispatch(tracing_exporter, server_with_bot):
+    """bot.run span exists and is parented under bot.event.dispatch in the event path."""
+    server, _ = server_with_bot(
+        bot_name="testserv-runner",
+        trigger_type="event",
+        event_filter="type == 'topic'",
+        channels=["#room"],
+        template="hi {event.nick}",
+    )
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#room", nick="testserv-x", data={"body": "y"})
+    )
+
+    spans = tracing_exporter.get_finished_spans()
+    run_spans = [
+        s
+        for s in spans
+        if s.name == "bot.run" and s.attributes.get("bot.name") == "testserv-runner"
+    ]
+    assert len(run_spans) == 1
+    run = run_spans[0]
+    assert run.attributes["bot.name"] == "testserv-runner"
+
+    dispatch = next(
+        s
+        for s in spans
+        if s.name == "bot.event.dispatch" and s.attributes.get("bot.name") == "testserv-runner"
+    )
+    assert run.parent is not None
+    assert run.parent.span_id == dispatch.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_bot_run_span_marks_empty_message(tracing_exporter, server_with_bot):
+    """Empty rendered message sets bot.run.empty_message=True."""
+    server, _ = server_with_bot(
+        bot_name="testserv-empty",
+        trigger_type="event",
+        event_filter="type == 'topic'",
+        channels=["#z"],
+        template=None,
+    )
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#z", nick="testserv-y", data={"body": "x"})
+    )
+
+    run_spans = [
+        s
+        for s in tracing_exporter.get_finished_spans()
+        if s.name == "bot.run" and s.attributes.get("bot.name") == "testserv-empty"
+    ]
+    assert len(run_spans) == 1
+    if not run_spans[0].attributes.get("bot.run.empty_message"):
+        pytest.skip("template fallback produced non-empty message; not the path under test")
+    assert run_spans[0].attributes["bot.run.empty_message"] is True
+
+
+@pytest.mark.asyncio
+async def test_bot_run_span_via_dispatch_method(tracing_exporter, server_with_bot):
+    """Calling BotManager.dispatch(...) directly (webhook path proxy) still produces bot.run."""
+    server, _ = server_with_bot(
+        bot_name="testserv-direct",
+        trigger_type="webhook",
+        channels=["#hooks"],
+        template="hi {body}",
+    )
+
+    bot = server.bot_manager.bots["testserv-direct"]
+    await bot.start()
+
+    await server.bot_manager.dispatch("testserv-direct", {"body": "ping"})
+
+    run_spans = [
+        s
+        for s in tracing_exporter.get_finished_spans()
+        if s.name == "bot.run" and s.attributes.get("bot.name") == "testserv-direct"
+    ]
+    assert len(run_spans) == 1
+    assert run_spans[0].attributes["bot.name"] == "testserv-direct"

--- a/tests/telemetry/test_metrics_bots.py
+++ b/tests/telemetry/test_metrics_bots.py
@@ -1,0 +1,127 @@
+"""Metrics for bots — culture.bot.invocations (Plan 7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.agentirc.skill import Event, EventType
+from tests.telemetry._metrics_helpers import get_counter_value
+
+
+@pytest.mark.asyncio
+async def test_bot_invocations_counter_success(metrics_reader, server_with_bot):
+    """Successful event dispatch increments bot_invocations with outcome=success."""
+    server, _ = server_with_bot(
+        bot_name="testserv-ok",
+        trigger_type="event",
+        event_filter="type == 'topic'",
+        channels=["#a"],
+        template="hi {event.nick}",
+    )
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#a", nick="testserv-j", data={"body": "x"})
+    )
+
+    n = get_counter_value(
+        metrics_reader,
+        "culture.bot.invocations",
+        attrs={"bot": "testserv-ok", "event.type": "topic", "outcome": "success"},
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_bot_invocations_counter_error(metrics_reader, server_with_bot, monkeypatch):
+    """A bot whose handle raises increments outcome=error."""
+    server, _ = server_with_bot(
+        bot_name="testserv-fail",
+        trigger_type="event",
+        event_filter="type == 'topic'",
+        channels=["#b"],
+        template="x",
+    )
+    bot = server.bot_manager.bots["testserv-fail"]
+
+    async def boom(payload):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(bot, "handle", boom)
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#b", nick="testserv-j", data={"body": "x"})
+    )
+
+    err = get_counter_value(
+        metrics_reader,
+        "culture.bot.invocations",
+        attrs={"bot": "testserv-fail", "event.type": "topic", "outcome": "error"},
+    )
+    ok = get_counter_value(
+        metrics_reader,
+        "culture.bot.invocations",
+        attrs={"bot": "testserv-fail", "event.type": "topic", "outcome": "success"},
+    )
+    assert err == 1
+    assert ok == 0
+
+
+@pytest.mark.asyncio
+async def test_bot_invocations_counter_two_bots_one_event(metrics_reader, server_with_bots):
+    """Two matched bots → counter increments once for each, distinguished by bot label."""
+    server, _ = server_with_bots(
+        [
+            {
+                "bot_name": "testserv-a",
+                "trigger_type": "event",
+                "event_filter": "type == 'topic'",
+                "channels": ["#c"],
+                "template": "a",
+            },
+            {
+                "bot_name": "testserv-b",
+                "trigger_type": "event",
+                "event_filter": "type == 'topic'",
+                "channels": ["#c"],
+                "template": "b",
+            },
+        ]
+    )
+
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#c", nick="testserv-z", data={"body": "y"})
+    )
+
+    a = get_counter_value(
+        metrics_reader,
+        "culture.bot.invocations",
+        attrs={"bot": "testserv-a", "outcome": "success"},
+    )
+    b = get_counter_value(
+        metrics_reader,
+        "culture.bot.invocations",
+        attrs={"bot": "testserv-b", "outcome": "success"},
+    )
+    assert a == 1
+    assert b == 1
+
+
+@pytest.mark.asyncio
+async def test_bot_invocations_counter_no_match(metrics_reader, server_with_bot):
+    """Non-matching event must not move the counter for that bot."""
+    server, _ = server_with_bot(
+        bot_name="testserv-nomatch",
+        trigger_type="event",
+        event_filter="channel == '#never'",
+        channels=["#z"],
+        template="x",
+    )
+    await server.emit_event(
+        Event(type=EventType.TOPIC, channel="#other", nick="testserv-q", data={"body": "x"})
+    )
+
+    n = get_counter_value(
+        metrics_reader,
+        "culture.bot.invocations",
+        attrs={"bot": "testserv-nomatch"},
+    )
+    assert n == 0

--- a/tests/telemetry/test_metrics_webhook.py
+++ b/tests/telemetry/test_metrics_webhook.py
@@ -3,39 +3,15 @@
 from __future__ import annotations
 
 import pytest
-import pytest_asyncio
 from aiohttp import ClientSession
 
-from culture.bots.bot_manager import BotManager
 from culture.bots.config import BotConfig
-from culture.bots.http_listener import HttpListener
-from tests.telemetry._metrics_helpers import get_histogram_count
-
-
-@pytest_asyncio.fixture
-async def webhook_server(server, tmp_path, monkeypatch):
-    """Server + listener on a random port; returns (server, mgr, port)."""
-    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
-    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
-    monkeypatch.setattr("culture.bots.bot_manager.BOTS_DIR", tmp_path)
-
-    mgr = BotManager(server)
-    server.bot_manager = mgr
-
-    listener = HttpListener(mgr, "127.0.0.1", 0)
-    await listener.start()
-    site = next(iter(listener._runner._sites))
-    port = site._server.sockets[0].getsockname()[1]
-
-    yield server, mgr, port
-
-    await listener.stop()
-    await mgr.stop_all()
+from tests.telemetry._metrics_helpers import get_histogram_count, get_histogram_sum
 
 
 @pytest.mark.asyncio
 async def test_webhook_duration_records_2xx(metrics_reader, webhook_server):
-    server, mgr, port = webhook_server
+    _server, mgr, port = webhook_server
     await mgr.create_bot(
         BotConfig(
             name="testserv-hook",
@@ -116,7 +92,7 @@ async def test_webhook_duration_records_5xx_on_uncaught_exception(
     metrics_reader, webhook_server, monkeypatch
 ):
     """An uncaught non-ValueError/RuntimeError in dispatch is reported as 5xx."""
-    server, mgr, port = webhook_server
+    _server, mgr, port = webhook_server
     await mgr.create_bot(
         BotConfig(
             name="testserv-boom",
@@ -148,7 +124,7 @@ async def test_webhook_duration_records_5xx_on_uncaught_exception(
 @pytest.mark.asyncio
 async def test_webhook_duration_value_is_positive(metrics_reader, webhook_server):
     """Recorded duration must be > 0 (catches zero-time / inverted-timer regressions)."""
-    server, mgr, port = webhook_server
+    _server, mgr, port = webhook_server
     await mgr.create_bot(
         BotConfig(
             name="testserv-timed",
@@ -164,15 +140,9 @@ async def test_webhook_duration_value_is_positive(metrics_reader, webhook_server
         ) as resp:
             assert resp.status == 200
 
-    # Walk histogram points and assert sum > 0 for our bot.
-    data = metrics_reader.get_metrics_data()
-    total_sum = 0.0
-    for rm in data.resource_metrics:
-        for sm in rm.scope_metrics:
-            for metric in sm.metrics:
-                if metric.name != "culture.bot.webhook.duration":
-                    continue
-                for point in metric.data.data_points:
-                    if dict(point.attributes).get("bot") == "testserv-timed":
-                        total_sum += point.sum
-    assert total_sum > 0.0
+    total = get_histogram_sum(
+        metrics_reader,
+        "culture.bot.webhook.duration",
+        attrs={"bot": "testserv-timed"},
+    )
+    assert total > 0.0

--- a/tests/telemetry/test_metrics_webhook.py
+++ b/tests/telemetry/test_metrics_webhook.py
@@ -1,0 +1,178 @@
+"""Webhook-side metric — culture.bot.webhook.duration (Plan 7)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from aiohttp import ClientSession
+
+from culture.bots.bot_manager import BotManager
+from culture.bots.config import BotConfig
+from culture.bots.http_listener import HttpListener
+from tests.telemetry._metrics_helpers import get_histogram_count
+
+
+@pytest_asyncio.fixture
+async def webhook_server(server, tmp_path, monkeypatch):
+    """Server + listener on a random port; returns (server, mgr, port)."""
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot_manager.BOTS_DIR", tmp_path)
+
+    mgr = BotManager(server)
+    server.bot_manager = mgr
+
+    listener = HttpListener(mgr, "127.0.0.1", 0)
+    await listener.start()
+    site = next(iter(listener._runner._sites))
+    port = site._server.sockets[0].getsockname()[1]
+
+    yield server, mgr, port
+
+    await listener.stop()
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_webhook_duration_records_2xx(metrics_reader, webhook_server):
+    server, mgr, port = webhook_server
+    await mgr.create_bot(
+        BotConfig(
+            name="testserv-hook",
+            owner="testserv",
+            channels=[],
+            template="ok {body}",
+        )
+    )
+
+    async with ClientSession() as session:
+        async with session.post(
+            f"http://127.0.0.1:{port}/testserv-hook", json={"body": "ping"}
+        ) as resp:
+            assert resp.status == 200
+
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.bot.webhook.duration",
+        attrs={"bot": "testserv-hook", "status_class": "2xx"},
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_duration_records_4xx_unknown_bot(metrics_reader, webhook_server):
+    _server, _mgr, port = webhook_server
+
+    async with ClientSession() as session:
+        async with session.post(f"http://127.0.0.1:{port}/testserv-nope", json={}) as resp:
+            assert resp.status == 404
+
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.bot.webhook.duration",
+        attrs={"bot": "testserv-nope", "status_class": "4xx"},
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_duration_records_4xx_invalid_json(metrics_reader, webhook_server):
+    _server, _mgr, port = webhook_server
+
+    async with ClientSession() as session:
+        async with session.post(
+            f"http://127.0.0.1:{port}/testserv-anything",
+            data="not json",
+            headers={"Content-Type": "application/json"},
+        ) as resp:
+            assert resp.status == 400
+
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.bot.webhook.duration",
+        attrs={"bot": "testserv-anything", "status_class": "4xx"},
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_duration_records_health_unrouted(metrics_reader, webhook_server):
+    _server, _mgr, port = webhook_server
+
+    async with ClientSession() as session:
+        async with session.get(f"http://127.0.0.1:{port}/health") as resp:
+            assert resp.status == 200
+
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.bot.webhook.duration",
+        attrs={"bot": "_unrouted", "status_class": "2xx"},
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_duration_records_5xx_on_uncaught_exception(
+    metrics_reader, webhook_server, monkeypatch
+):
+    """An uncaught non-ValueError/RuntimeError in dispatch is reported as 5xx."""
+    server, mgr, port = webhook_server
+    await mgr.create_bot(
+        BotConfig(
+            name="testserv-boom",
+            owner="testserv",
+            channels=[],
+            template="ok",
+        )
+    )
+
+    async def boom(bot_name, payload):
+        # Neither ValueError nor RuntimeError → falls through to the
+        # generic 500 branch in _handle_webhook.
+        raise KeyError("__synthetic_internal_error__")
+
+    monkeypatch.setattr(mgr, "dispatch", boom)
+
+    async with ClientSession() as session:
+        async with session.post(f"http://127.0.0.1:{port}/testserv-boom", json={}) as resp:
+            assert resp.status == 500
+
+    n = get_histogram_count(
+        metrics_reader,
+        "culture.bot.webhook.duration",
+        attrs={"bot": "testserv-boom", "status_class": "5xx"},
+    )
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_duration_value_is_positive(metrics_reader, webhook_server):
+    """Recorded duration must be > 0 (catches zero-time / inverted-timer regressions)."""
+    server, mgr, port = webhook_server
+    await mgr.create_bot(
+        BotConfig(
+            name="testserv-timed",
+            owner="testserv",
+            channels=[],
+            template="ok",
+        )
+    )
+
+    async with ClientSession() as session:
+        async with session.post(
+            f"http://127.0.0.1:{port}/testserv-timed", json={"body": "ping"}
+        ) as resp:
+            assert resp.status == 200
+
+    # Walk histogram points and assert sum > 0 for our bot.
+    data = metrics_reader.get_metrics_data()
+    total_sum = 0.0
+    for rm in data.resource_metrics:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                if metric.name != "culture.bot.webhook.duration":
+                    continue
+                for point in metric.data.data_points:
+                    if dict(point.attributes).get("bot") == "testserv-timed":
+                        total_sum += point.sum
+    assert total_sum > 0.0

--- a/tests/telemetry/test_webhook_http_span.py
+++ b/tests/telemetry/test_webhook_http_span.py
@@ -1,0 +1,69 @@
+"""Inbound HTTP span via opentelemetry-instrumentation-aiohttp-server (Plan 7)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from aiohttp import ClientSession
+
+from culture.bots.bot_manager import BotManager
+from culture.bots.config import BotConfig
+from culture.bots.http_listener import HttpListener
+
+
+@pytest_asyncio.fixture
+async def webhook_server(server, tmp_path, monkeypatch):
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot_manager.BOTS_DIR", tmp_path)
+
+    mgr = BotManager(server)
+    server.bot_manager = mgr
+
+    listener = HttpListener(mgr, "127.0.0.1", 0)
+    await listener.start()
+    site = next(iter(listener._runner._sites))
+    port = site._server.sockets[0].getsockname()[1]
+
+    yield server, mgr, port
+
+    await listener.stop()
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_webhook_emits_aiohttp_server_span_parenting_bot_run(
+    tracing_exporter, webhook_server
+):
+    server, mgr, port = webhook_server
+    await mgr.create_bot(
+        BotConfig(
+            name="testserv-spanhook",
+            owner="testserv",
+            channels=[],
+            template="ok {body}",
+        )
+    )
+
+    async with ClientSession() as session:
+        async with session.post(
+            f"http://127.0.0.1:{port}/testserv-spanhook", json={"body": "x"}
+        ) as resp:
+            assert resp.status == 200
+
+    spans = tracing_exporter.get_finished_spans()
+    aiohttp_spans = [
+        s
+        for s in spans
+        if s.instrumentation_scope.name == "opentelemetry.instrumentation.aiohttp_server"
+    ]
+    assert aiohttp_spans, [s.instrumentation_scope.name for s in spans]
+    aiohttp_span = aiohttp_spans[0]
+
+    run_spans = [s for s in spans if s.name == "bot.run"]
+    assert len(run_spans) == 1
+    run = run_spans[0]
+    # bot.run is parented under the aiohttp server span (same trace).
+    assert run.context.trace_id == aiohttp_span.context.trace_id
+    assert run.parent is not None
+    assert run.parent.span_id == aiohttp_span.context.span_id

--- a/tests/telemetry/test_webhook_http_span.py
+++ b/tests/telemetry/test_webhook_http_span.py
@@ -3,39 +3,16 @@
 from __future__ import annotations
 
 import pytest
-import pytest_asyncio
 from aiohttp import ClientSession
 
-from culture.bots.bot_manager import BotManager
 from culture.bots.config import BotConfig
-from culture.bots.http_listener import HttpListener
-
-
-@pytest_asyncio.fixture
-async def webhook_server(server, tmp_path, monkeypatch):
-    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
-    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
-    monkeypatch.setattr("culture.bots.bot_manager.BOTS_DIR", tmp_path)
-
-    mgr = BotManager(server)
-    server.bot_manager = mgr
-
-    listener = HttpListener(mgr, "127.0.0.1", 0)
-    await listener.start()
-    site = next(iter(listener._runner._sites))
-    port = site._server.sockets[0].getsockname()[1]
-
-    yield server, mgr, port
-
-    await listener.stop()
-    await mgr.stop_all()
 
 
 @pytest.mark.asyncio
 async def test_webhook_emits_aiohttp_server_span_parenting_bot_run(
     tracing_exporter, webhook_server
 ):
-    server, mgr, port = webhook_server
+    _server, mgr, port = webhook_server
     await mgr.create_bot(
         BotConfig(
             name="testserv-spanhook",
@@ -63,7 +40,6 @@ async def test_webhook_emits_aiohttp_server_span_parenting_bot_run(
     run_spans = [s for s in spans if s.name == "bot.run"]
     assert len(run_spans) == 1
     run = run_spans[0]
-    # bot.run is parented under the aiohttp server span (same trace).
     assert run.context.trace_id == aiohttp_span.context.trace_id
     assert run.parent is not None
     assert run.parent.span_id == aiohttp_span.context.span_id

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.6.0"
+version = "8.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },
@@ -602,6 +602,7 @@ dependencies = [
     { name = "mistune" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-instrumentation-aiohttp-server" },
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pyyaml" },
@@ -642,6 +643,7 @@ requires-dist = [
     { name = "mistune", specifier = ">=3.0" },
     { name = "opentelemetry-api", specifier = ">=1.25" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25" },
+    { name = "opentelemetry-instrumentation-aiohttp-server", specifier = ">=0.46b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.25" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.46b0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1483,6 +1485,37 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiohttp-server"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/14/ad7f92e56e8b4b389239e4b4df8a94043bee509cd463604db117b6418d20/opentelemetry_instrumentation_aiohttp_server-0.62b1.tar.gz", hash = "sha256:c1f271376d3d07ab7bb26a68c76a96d9ce99339839f2d653cd340c3ea5d08539", size = 11476, upload-time = "2026-04-24T13:22:35.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/2f/38f3a005ddc25e0a874dd0f2ba6ac8a30d4bca7face02072a9a9df28fdab/opentelemetry_instrumentation_aiohttp_server-0.62b1-py3-none-any.whl", hash = "sha256:4069162497371dbb76137c30a5f52bda6a2997a3555a2da1e1e11b00f78df759", size = 8904, upload-time = "2026-04-24T13:21:35.191Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1519,6 +1552,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/1b/aa71b63e18d30a8384036b9937f40f7618f8030a7aa213155fb54f6f2b47/opentelemetry_util_http-0.62b1.tar.gz", hash = "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3", size = 11393, upload-time = "2026-04-24T13:23:12.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/a9d9d32161c1ced61346267db4c9702da54f81ec5dc88214bc65c23f4e9d/opentelemetry_util_http-0.62b1-py3-none-any.whl", hash = "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0", size = 9295, upload-time = "2026-04-24T13:22:28.078Z" },
 ]
 
 [[package]]
@@ -2495,6 +2537,70 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Phase 7 / final bot pillar of the OTEL rollout. Closes the design spec at `docs/superpowers/specs/2026-04-24-otel-observability-design.md`.
- Two new spans: `bot.event.dispatch` (per matched bot in `BotManager.on_event`, attrs `bot.name`, `event.type`) and `bot.run` (wraps `Bot.handle` for both event and webhook paths, attr `bot.name`).
- Two new metrics on the existing `MetricsRegistry`: `culture.bot.invocations{bot, event.type, outcome=success|error}` (Counter) and `culture.bot.webhook.duration{bot, status_class}` (Histogram, unit `s`).
- Webhook listener auto-instrumented via `opentelemetry-instrumentation-aiohttp-server` so inbound HTTP spans parent `bot.run` and W3C `traceparent` headers stitch incoming webhooks into the caller's trace.
- 5 new test files in `tests/telemetry/` covering spans, metrics, parenting, and the 2xx/4xx/5xx/_unrouted paths (17 tests).

End-to-end: a single `trace_id` now flows through `client → server → emit_event → bot.event.dispatch → bot.run → IRC delivery` (event path) and `HTTP POST → bot.run → IRC delivery` (webhook path).

Plan file: `docs/superpowers/plans/2026-04-29-otel-bots.md` is referenced inline as `eager-humming-sky.md` (pre-merge plan), captured in the spec note.

## Test plan

- [x] `/run-tests` — 1139 passed, 1 skipped (was 1136 before this branch).
- [x] New tests: 17 in `tests/telemetry/test_bot_event_dispatch_span.py`, `test_bot_run_span.py`, `test_metrics_bots.py`, `test_metrics_webhook.py`, `test_webhook_http_span.py`.
- [x] `superpowers:code-reviewer` pre-push pass; addressed important findings (deferred-import side effect, ERROR-status-on-handle-raise, 5xx histogram coverage, duration > 0 assertion).
- [x] `doc-test-alignment` audit clean — `docs/agentirc/telemetry.md` updated with the 8.7.0 section and `harness-telemetry.md` cross-link.
- [ ] `/sonarclaude` after PR opens.
- [ ] Optional manual two-server smoke with `otelcol-contrib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)