### PR TITLE
Phase A1: consume agentirc-cli for config dataclasses (Track A)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,27 +58,10 @@ jobs:
           uv build
           uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
 
-      - name: Build and publish agentirc-cli alias to TestPyPI
-        run: |
-          sed -i 's/^name = "culture"/name = "agentirc-cli"/' pyproject.toml
-          sed -i 's/^description = .*/description = "Legacy alias for culture — install culture instead"/' pyproject.toml
-          rm -rf dist
-          uv build
-          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
-
-      - name: Build and publish agentirc alias to TestPyPI
-        run: |
-          sed -i 's/^name = "agentirc-cli"/name = "agentirc"/' pyproject.toml
-          sed -i 's/^name = "culture"/name = "agentirc"/' pyproject.toml
-          rm -rf dist
-          uv build
-          uv publish --publish-url https://test.pypi.org/legacy/ --trusted-publishing always --check-url https://test.pypi.org/simple/
-
       - name: Print install commands
         if: always()
         run: |
           echo "::notice::Test with: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ culture==${DEV_VERSION}"
-          echo "::warning::agentirc on TestPyPI is not intended for production use — install culture instead"
 
   publish:
     if: github.event_name == 'push'
@@ -99,13 +82,5 @@ jobs:
 
       - name: Build and publish culture to PyPI
         run: |
-          uv build
-          uv publish --trusted-publishing always --check-url https://pypi.org/simple/
-
-      - name: Build and publish agentirc-cli alias to PyPI
-        run: |
-          sed -i 's/^name = "culture"/name = "agentirc-cli"/' pyproject.toml
-          sed -i 's/^description = .*/description = "Legacy alias for culture — install culture instead"/' pyproject.toml
-          rm -rf dist
           uv build
           uv publish --trusted-publishing always --check-url https://pypi.org/simple/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.8.0] - 2026-05-01
+
+### Added
+
+- `agentirc-cli>=9.4,<10` runtime dependency — the IRCd config dataclasses (`ServerConfig`, `LinkConfig`, `TelemetryConfig`) are now sourced from the published `agentirc.config` PyPI package instead of culture's local copy. First step of the Track A cutover described in [agentculture/culture#308](https://github.com/agentculture/culture/issues/308).
+
+### Changed
+
+- `culture/agentirc/config.py` is now a re-export shim over `agentirc.config` — `from culture.agentirc.config import ServerConfig` continues to work and resolves to the same class as `from agentirc.config import ServerConfig` (no parallel-dataclass identity hazard). The shim will be deleted alongside the rest of `culture/agentirc/` in Phase A3 once the bot-runtime story is settled (see agentculture/agentirc#15).
+- Canonical call sites retargeted to import directly from `agentirc.config`: `culture/cli/shared/mesh.py`, `culture/config.py`, `culture/telemetry/{metrics,tracing,audit}.py`, `tests/conftest.py`. Bot-runtime call sites (`culture/bots/*`, `culture/agentirc/ircd.py`, `culture/cli/server.py:_run_server`, `culture/clients/*/daemon.py`) intentionally retain their `culture.agentirc.*` imports — those reach internal IRCd/Event/parse_room_meta surfaces that are not yet exposed in agentirc's public API.
+
 ## [8.7.1] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- `agentirc-cli>=9.4,<10` runtime dependency — the IRCd config dataclasses (`ServerConfig`, `LinkConfig`, `TelemetryConfig`) are now sourced from the published `agentirc.config` PyPI package instead of culture's local copy. First step of the Track A cutover described in [agentculture/culture#308](https://github.com/agentculture/culture/issues/308).
+- `agentirc-cli>=9.4,<10` runtime dependency — the IRCd config dataclasses (`ServerConfig`, `LinkConfig`, `TelemetryConfig`) are now sourced from the published `agentirc-cli` PyPI distribution (imported as `agentirc.config`) instead of culture's local copy. First step of the Track A cutover described in [agentculture/culture#308](https://github.com/agentculture/culture/issues/308).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - `culture/agentirc/config.py` is now a re-export shim over `agentirc.config` — `from culture.agentirc.config import ServerConfig` continues to work and resolves to the same class as `from agentirc.config import ServerConfig` (no parallel-dataclass identity hazard). The shim will be deleted alongside the rest of `culture/agentirc/` in Phase A3 once the bot-runtime story is settled (see agentculture/agentirc#15).
 - Canonical call sites retargeted to import directly from `agentirc.config`: `culture/cli/shared/mesh.py`, `culture/config.py`, `culture/telemetry/{metrics,tracing,audit}.py`, `tests/conftest.py`. Bot-runtime call sites (`culture/bots/*`, `culture/agentirc/ircd.py`, `culture/cli/server.py:_run_server`, `culture/clients/*/daemon.py`) intentionally retain their `culture.agentirc.*` imports — those reach internal IRCd/Event/parse_room_meta surfaces that are not yet exposed in agentirc's public API.
 
+### Removed
+
+- Bootstrap-era `agentirc-cli` and `agentirc` alias publish steps from `.github/workflows/publish.yml`. `agentirc-cli` is now owned by [agentculture/agentirc](https://github.com/agentculture/agentirc) and published from there; culture's TestPyPI/PyPI workflow no longer co-publishes itself under those names (the OIDC trust policy was transferred along with the package). Culture continues to publish itself as `culture` on both indices.
+- `agentirc-cli` / `agentirc` fallback chain in `culture/__init__.py` `__version__` resolution. The fallback would silently report agentirc's installed version as culture's version now that the alias names refer to a separate package.
+
 ## [8.7.1] - 2026-04-27
 
 ### Added

--- a/culture/__init__.py
+++ b/culture/__init__.py
@@ -4,10 +4,4 @@ from importlib.metadata import version as _v
 try:
     __version__ = _v("culture")
 except PackageNotFoundError:
-    try:
-        __version__ = _v("agentirc-cli")
-    except PackageNotFoundError:
-        try:
-            __version__ = _v("agentirc")
-        except PackageNotFoundError:
-            __version__ = "0.0.0-dev"
+    __version__ = "0.0.0-dev"

--- a/culture/agentirc/CLAUDE.md
+++ b/culture/agentirc/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 AgentIRC is a custom async Python IRCd (IRC server) built from scratch for AI agent collaboration. It is **not** a wrapper around existing IRC servers. ~4,300 lines of pure async Python (asyncio). Located at `culture/agentirc/` within the culture project.
 
+**Extraction in progress (Track A).** As of culture 8.8.0, the canonical config dataclasses (`ServerConfig`, `LinkConfig`, `TelemetryConfig`) live in the published `agentirc-cli` PyPI package, not here. `culture/agentirc/config.py` is a re-export shim — `from culture.agentirc.config import ServerConfig` resolves to the same class as `from agentirc.config import ServerConfig`. The shim and the rest of `culture/agentirc/{ircd,client,remote_client,channel,events,server_link,room_store,thread_store,history_store,skill,skills/}.py` will be deleted in Phase A3 once the bot-runtime story is settled (tracking: agentculture/culture#308, agentculture/agentirc#15). Until then, the IRCd here remains the in-process host for `culture/bots/*`.
+
 ## Running
 
 ```bash

--- a/culture/agentirc/config.py
+++ b/culture/agentirc/config.py
@@ -1,49 +1,14 @@
-from dataclasses import dataclass, field
+"""Re-export shim for the IRCd config dataclasses.
 
+The dataclass definitions live in `agentirc.config` (the published
+`agentirc-cli` PyPI package). This module re-exports them so
+existing `from culture.agentirc.config import ...` call sites keep
+working during the Track A migration. New code should import from
+`agentirc.config` directly.
 
-@dataclass
-class LinkConfig:
-    """Configuration for a server-to-server link."""
+Removed alongside the rest of `culture/agentirc/` in Phase A3.
+"""
 
-    name: str
-    host: str
-    port: int
-    password: str
-    trust: str = "full"  # "full" or "restricted"
+from agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
 
-
-@dataclass
-class TelemetryConfig:
-    """OpenTelemetry settings. Mirrors server.yaml `telemetry:` block."""
-
-    enabled: bool = False
-    service_name: str = "culture.agentirc"
-    otlp_endpoint: str = "http://localhost:4317"
-    otlp_protocol: str = "grpc"  # grpc | http/protobuf (only grpc supported initially)
-    otlp_timeout_ms: int = 5000
-    otlp_compression: str = "gzip"  # gzip | none
-    traces_enabled: bool = True
-    traces_sampler: str = "parentbased_always_on"
-    metrics_enabled: bool = True
-    metrics_export_interval_ms: int = 10000
-    # Audit JSONL sink (Plan 4). Independent of `enabled` — audit fires
-    # even when telemetry is off so admins always have the trail.
-    audit_enabled: bool = True
-    audit_dir: str = "~/.culture/audit"
-    audit_max_file_bytes: int = 256 * 1024 * 1024  # 256 MiB
-    audit_rotate_utc_midnight: bool = True
-    audit_queue_depth: int = 10000
-
-
-@dataclass
-class ServerConfig:
-    """Configuration for a culture server instance."""
-
-    name: str = "culture"
-    host: str = "0.0.0.0"
-    port: int = 6667
-    webhook_port: int = 7680
-    data_dir: str = ""
-    links: list[LinkConfig] = field(default_factory=list)
-    system_bots: dict = field(default_factory=dict)
-    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
+__all__ = ["LinkConfig", "ServerConfig", "TelemetryConfig"]

--- a/culture/cli/shared/mesh.py
+++ b/culture/cli/shared/mesh.py
@@ -20,7 +20,7 @@ def parse_link(value: str):
     Trust is extracted from the end if it matches a known value.
     This allows passwords containing colons.
     """
-    from culture.agentirc.config import LinkConfig
+    from agentirc.config import LinkConfig
 
     trust = "full"
     if value.endswith(":full") or value.endswith(":restricted"):
@@ -41,7 +41,8 @@ def parse_link(value: str):
 
 def resolve_links_from_mesh(mesh_config_path: str) -> list:
     """Load link configs from mesh.yaml, looking up passwords from OS keyring."""
-    from culture.agentirc.config import LinkConfig
+    from agentirc.config import LinkConfig
+
     from culture.credentials import lookup_credential
     from culture.mesh_config import load_mesh_config
 

--- a/culture/config.py
+++ b/culture/config.py
@@ -14,8 +14,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import yaml
-
-from culture.agentirc.config import TelemetryConfig
+from agentirc.config import TelemetryConfig
 
 logger = logging.getLogger("culture")
 

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -26,7 +26,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from culture.agentirc.config import ServerConfig
+from agentirc.config import ServerConfig
 
 if TYPE_CHECKING:
     from culture.agentirc.skill import Event

--- a/culture/telemetry/metrics.py
+++ b/culture/telemetry/metrics.py
@@ -15,14 +15,13 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict, dataclass
 
+from agentirc.config import ServerConfig
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.metrics import Counter, Histogram, Meter, UpDownCounter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
-
-from culture.agentirc.config import ServerConfig
 
 logger = logging.getLogger(__name__)
 

--- a/culture/telemetry/tracing.py
+++ b/culture/telemetry/tracing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict
 
+from agentirc.config import ServerConfig, TelemetryConfig
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
@@ -24,8 +25,6 @@ from opentelemetry.sdk.trace.sampling import (
     TraceIdRatioBased,
 )
 from opentelemetry.trace import Tracer
-
-from culture.agentirc.config import ServerConfig, TelemetryConfig
 
 logger = logging.getLogger(__name__)
 

--- a/docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md
+++ b/docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md
@@ -4,7 +4,7 @@
 
 **Goal:** Cut over culture to consume the `agentirc-cli` PyPI package: delete the in-tree IRCd, relocate the client transport to `culture/transport/`, install a 1:1 passthrough shim at `culture server <verb>`, and ship a major version bump.
 
-**Architecture:** Single PR off `main`. Adds `agentirc-cli>=0.1,<0.2` as a runtime dep. Replaces `culture/cli/server.py` with a thin argparse-`REMAINDER` passthrough into `agentirc.cli.dispatch(argv) -> int`. Moves `culture/agentirc/{client,remote_client}.py` to `culture/transport/` (git mv to preserve blame). Deletes `culture/agentirc/` and `protocol/extensions/` wholesale. Adds one shim parity test and one cross-repo smoke test.
+**Architecture:** Single PR off `main`. Adds `agentirc-cli>=9.0,<10.0` as a runtime dep. Replaces `culture/cli/server.py` with a thin argparse-`REMAINDER` passthrough into `agentirc.cli.dispatch(argv) -> int`. Moves `culture/agentirc/{client,remote_client}.py` to `culture/transport/` (git mv to preserve blame). Deletes `culture/agentirc/` and `protocol/extensions/` wholesale. Adds one shim parity test and one cross-repo smoke test.
 
 **Tech Stack:** Python 3.x, uv (deps + lockfile), argparse, pytest + pytest-asyncio + pytest-xdist, pre-commit (black + isort + flake8 + pylint + bandit + markdownlint).
 
@@ -14,8 +14,7 @@
 
 ## Preconditions (do not start until all are true)
 
-- `agentirc-cli==<VERSION>` is published to PyPI (Track B is merged in `agentculture/agentirc` and the agentirc agent has tagged + released).
-- The exact version string the engineer will pin is known. Throughout this plan, **`<VERSION>`** is a placeholder for that version (e.g., `0.1.0`). Replace it everywhere before executing.
+- `agentirc-cli==9.0.0` is published to PyPI (verified at plan-write time on 2026-04-30; Track B merged in `agentculture/agentirc` and tagged 9.0.0). If a newer 9.0.x patch exists by execution time, prefer it; the dependency pin range `>=9.0,<10.0` accepts any 9.x.y.
 - Working tree on `main` is clean: `git status` shows no staged or unstaged changes inside `culture/agentirc/`, `culture/cli/server.py`, `culture/cli/shared/mesh.py`, `culture/bots/`, `culture/clients/`, or `protocol/extensions/`.
 - Pre-existing untracked changes elsewhere are fine but should be stashed if they could interfere with `/version-bump` or `git mv`.
 
@@ -27,7 +26,7 @@ If any precondition fails, stop and resolve it before continuing.
 
 | Path | Action | Notes |
 |---|---|---|
-| `pyproject.toml` | Modify | Add `agentirc-cli>=0.1,<0.2` to runtime deps. |
+| `pyproject.toml` | Modify | Add `agentirc-cli>=9.0,<10.0` to runtime deps. |
 | `uv.lock` | Modify | Regenerate via `uv lock`. |
 | `culture/agentirc/` | Delete (whole directory) | All ~3,600 LOC, including `__main__.py` and `skills/`. |
 | `culture/agentirc/client.py` | `git mv` → `culture/transport/client.py` | Preserves blame. |
@@ -53,15 +52,15 @@ If any precondition fails, stop and resolve it before continuing.
 - [ ] **Step 1.1:** Confirm the published version.
 
 ```bash
-uv pip install --dry-run "agentirc-cli==<VERSION>" 2>&1 | tail -5
+uv pip install --dry-run "agentirc-cli==9.0.0" 2>&1 | tail -5
 ```
 
-Expected: a line like `Would install agentirc-cli==<VERSION>`. If you see `Could not find a version that satisfies the requirement`, agentirc-cli isn't on PyPI yet — STOP. Do not start the cutover.
+Expected: a line like `Would install agentirc-cli==9.0.0`. If you see `Could not find a version that satisfies the requirement`, agentirc-cli isn't on PyPI yet — STOP. Do not start the cutover.
 
 - [ ] **Step 1.2:** Smoke-test the binary in a clean throwaway venv.
 
 ```bash
-cd /tmp && uv venv check-agentirc && uv pip install --python check-agentirc/bin/python "agentirc-cli==<VERSION>" >/dev/null && check-agentirc/bin/agentirc --help && rm -rf check-agentirc
+cd /tmp && uv venv check-agentirc && uv pip install --python check-agentirc/bin/python "agentirc-cli==9.0.0" >/dev/null && check-agentirc/bin/agentirc --help && rm -rf check-agentirc
 ```
 
 Expected: `agentirc --help` lists subcommands `serve start stop restart status link logs version` (or a superset). Confirms the binary is wired up.
@@ -69,7 +68,7 @@ Expected: `agentirc --help` lists subcommands `serve start stop restart status l
 - [ ] **Step 1.3:** Inspect the public API surface.
 
 ```bash
-cd /tmp && uv run --with "agentirc-cli==<VERSION>" python -c "
+cd /tmp && uv run --with "agentirc-cli==9.0.0" python -c "
 import agentirc.config, agentirc.cli, agentirc.protocol
 print('config:', sorted(n for n in dir(agentirc.config) if not n.startswith('_')))
 print('cli:', sorted(n for n in dir(agentirc.cli) if not n.startswith('_')))
@@ -97,7 +96,7 @@ Expected: branch created and checked out.
 
 - [ ] **Step 2.2:** Add `agentirc-cli` to runtime dependencies.
 
-Open `pyproject.toml` and add `"agentirc-cli>=0.1,<0.2"` to the `[project] dependencies` list. Keep the list alphabetised if culture's existing entries are alphabetised; otherwise append.
+Open `pyproject.toml` and add `"agentirc-cli>=9.0,<10.0"` to the `[project] dependencies` list. Keep the list alphabetised if culture's existing entries are alphabetised; otherwise append.
 
 - [ ] **Step 2.3:** Regenerate the lockfile.
 
@@ -693,7 +692,7 @@ Open `CHANGELOG.md`. Replace the auto-generated stub for the new version with a 
 
 ### Changed (breaking)
 
-- The IRCd has been extracted into a separate package, `agentirc-cli`. Culture now depends on `agentirc-cli>=0.1,<0.2`.
+- The IRCd has been extracted into a separate package, `agentirc-cli`. Culture now depends on `agentirc-cli>=9.0,<10.0`.
 - `culture server <verb>` is now a 1:1 passthrough into `agentirc.cli.dispatch`. All existing verbs continue to work; their flags, output, and exit codes come from `agentirc-cli`.
 - `culture/agentirc/` has been deleted. Code that imported `culture.agentirc.*` must update:
   - `culture.agentirc.client` / `culture.agentirc.remote_client` → `culture.transport.client` / `culture.transport.remote_client`
@@ -819,7 +818,7 @@ git push -u origin agentirc-extraction-cutover
 gh pr create --base main --title "feat: extract IRCd to agentirc-cli; culture server becomes passthrough" --body "$(cat <<'EOF'
 ## Summary
 
-- Cuts culture over to consume `agentirc-cli>=0.1,<0.2` from PyPI.
+- Cuts culture over to consume `agentirc-cli>=9.0,<10.0` from PyPI.
 - Deletes `culture/agentirc/` (~3,600 LOC); moves client transport to `culture/transport/`; replaces `culture/cli/server.py` with a 1:1 argparse-`REMAINDER` passthrough into `agentirc.cli.dispatch`.
 - Deletes `protocol/extensions/` (it lives in agentirc's repo now).
 - Major version bump.
@@ -863,4 +862,4 @@ After this PR merges and a culture release is published:
 - Confirm `culture server status` and `agentirc status` produce byte-identical output.
 - Confirm an existing peer link still establishes.
 
-If anything misbehaves on a real deployment, file follow-up issues; do not roll back unless behavior is broken (the dependency pin `agentirc-cli>=0.1,<0.2` already protects against accidental 0.2 upgrades).
+If anything misbehaves on a real deployment, file follow-up issues; do not roll back unless behavior is broken (the dependency pin `agentirc-cli>=9.0,<10.0` already protects against accidental 10.0 upgrades).

--- a/docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md
+++ b/docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md
@@ -1,0 +1,866 @@
+# AgentIRC Extraction — Track A (Culture-Side Cutover) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut over culture to consume the `agentirc-cli` PyPI package: delete the in-tree IRCd, relocate the client transport to `culture/transport/`, install a 1:1 passthrough shim at `culture server <verb>`, and ship a major version bump.
+
+**Architecture:** Single PR off `main`. Adds `agentirc-cli>=0.1,<0.2` as a runtime dep. Replaces `culture/cli/server.py` with a thin argparse-`REMAINDER` passthrough into `agentirc.cli.dispatch(argv) -> int`. Moves `culture/agentirc/{client,remote_client}.py` to `culture/transport/` (git mv to preserve blame). Deletes `culture/agentirc/` and `protocol/extensions/` wholesale. Adds one shim parity test and one cross-repo smoke test.
+
+**Tech Stack:** Python 3.x, uv (deps + lockfile), argparse, pytest + pytest-asyncio + pytest-xdist, pre-commit (black + isort + flake8 + pylint + bandit + markdownlint).
+
+**Companion spec:** `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`
+
+---
+
+## Preconditions (do not start until all are true)
+
+- `agentirc-cli==<VERSION>` is published to PyPI (Track B is merged in `agentculture/agentirc` and the agentirc agent has tagged + released).
+- The exact version string the engineer will pin is known. Throughout this plan, **`<VERSION>`** is a placeholder for that version (e.g., `0.1.0`). Replace it everywhere before executing.
+- Working tree on `main` is clean: `git status` shows no staged or unstaged changes inside `culture/agentirc/`, `culture/cli/server.py`, `culture/cli/shared/mesh.py`, `culture/bots/`, `culture/clients/`, or `protocol/extensions/`.
+- Pre-existing untracked changes elsewhere are fine but should be stashed if they could interfere with `/version-bump` or `git mv`.
+
+If any precondition fails, stop and resolve it before continuing.
+
+---
+
+## File Structure (what changes in this PR)
+
+| Path | Action | Notes |
+|---|---|---|
+| `pyproject.toml` | Modify | Add `agentirc-cli>=0.1,<0.2` to runtime deps. |
+| `uv.lock` | Modify | Regenerate via `uv lock`. |
+| `culture/agentirc/` | Delete (whole directory) | All ~3,600 LOC, including `__main__.py` and `skills/`. |
+| `culture/agentirc/client.py` | `git mv` → `culture/transport/client.py` | Preserves blame. |
+| `culture/agentirc/remote_client.py` | `git mv` → `culture/transport/remote_client.py` | Preserves blame. |
+| `culture/transport/__init__.py` | Create | Re-exports the public class names from `client.py` and `remote_client.py`. |
+| `culture/cli/server.py` | Rewrite | ~25 lines. Argparse `REMAINDER` passthrough into `agentirc.cli.dispatch`. |
+| `culture/cli/shared/mesh.py` | Modify | Replace `from culture.agentirc.config import LinkConfig` with `from agentirc.config import LinkConfig`. |
+| `culture/bots/`, `culture/clients/*/daemon.py` | Modify (imports only) | `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`. |
+| `culture/transport/client.py` | Modify (imports only) | Replace any IRC-verb / numeric / extension-tag string literals with `agentirc.protocol.*`. |
+| `protocol/extensions/` | Delete (whole directory) | Lives in agentirc now. |
+| `tests/test_*` for IRCd internals | Delete | They live in agentirc's repo now. |
+| `tests/test_server_shim.py` | Create | Asserts every verb in `agentirc --help` is reachable via `culture server <verb> --help`. |
+| `tests/test_agentirc_smoke.py` | Create | Boots `agentirc serve` as a subprocess, connects a culture transport client, exchanges one message. |
+| `culture/__init__.py` (or `pyproject.toml`) | Modify | Version bumped via `/version-bump major`. |
+| `CHANGELOG.md` | Modify | New section at top via `/version-bump major`. |
+
+---
+
+## Task 1 — Verify the precondition: agentirc-cli is on PyPI
+
+**Files:** none (verification only).
+
+- [ ] **Step 1.1:** Confirm the published version.
+
+```bash
+uv pip install --dry-run "agentirc-cli==<VERSION>" 2>&1 | tail -5
+```
+
+Expected: a line like `Would install agentirc-cli==<VERSION>`. If you see `Could not find a version that satisfies the requirement`, agentirc-cli isn't on PyPI yet — STOP. Do not start the cutover.
+
+- [ ] **Step 1.2:** Smoke-test the binary in a clean throwaway venv.
+
+```bash
+cd /tmp && uv venv check-agentirc && uv pip install --python check-agentirc/bin/python "agentirc-cli==<VERSION>" >/dev/null && check-agentirc/bin/agentirc --help && rm -rf check-agentirc
+```
+
+Expected: `agentirc --help` lists subcommands `serve start stop restart status link logs version` (or a superset). Confirms the binary is wired up.
+
+- [ ] **Step 1.3:** Inspect the public API surface.
+
+```bash
+cd /tmp && uv run --with "agentirc-cli==<VERSION>" python -c "
+import agentirc.config, agentirc.cli, agentirc.protocol
+print('config:', sorted(n for n in dir(agentirc.config) if not n.startswith('_')))
+print('cli:', sorted(n for n in dir(agentirc.cli) if not n.startswith('_')))
+print('protocol:', sorted(n for n in dir(agentirc.protocol) if not n.startswith('_')))
+"
+```
+
+Expected: `config` lists at least `LinkConfig`, `PeerSpec`, `ServerConfig`. `cli` lists at least `dispatch`, `main`. `protocol` lists verb names (e.g., `JOIN`, `PRIVMSG`, `THREAD`, `ROOM`) as constants. **Save the protocol output** — Task 5 needs it.
+
+---
+
+## Task 2 — Branch and add the dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+
+- [ ] **Step 2.1:** Cut a branch off `main`.
+
+```bash
+cd /home/spark/git/culture && git switch main && git pull --ff-only && git switch -c agentirc-extraction-cutover
+```
+
+Expected: branch created and checked out.
+
+- [ ] **Step 2.2:** Add `agentirc-cli` to runtime dependencies.
+
+Open `pyproject.toml` and add `"agentirc-cli>=0.1,<0.2"` to the `[project] dependencies` list. Keep the list alphabetised if culture's existing entries are alphabetised; otherwise append.
+
+- [ ] **Step 2.3:** Regenerate the lockfile.
+
+```bash
+uv lock
+```
+
+Expected: `uv.lock` is updated; `agentirc-cli` and any of its transitive deps appear.
+
+- [ ] **Step 2.4:** Smoke-import inside the project venv.
+
+```bash
+uv run python -c "import agentirc.config, agentirc.cli, agentirc.protocol; print('OK')"
+```
+
+Expected: `OK`. If `ModuleNotFoundError`, the lock didn't take — re-run `uv sync`.
+
+- [ ] **Step 2.5:** Commit.
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat(deps): add agentirc-cli runtime dependency"
+```
+
+---
+
+## Task 3 — Relocate client transport to culture/transport/
+
+**Files:**
+- `git mv` `culture/agentirc/client.py` → `culture/transport/client.py`
+- `git mv` `culture/agentirc/remote_client.py` → `culture/transport/remote_client.py`
+- Create: `culture/transport/__init__.py`
+
+- [ ] **Step 3.1:** Create the destination package directory.
+
+```bash
+mkdir -p culture/transport
+```
+
+- [ ] **Step 3.2:** Move the two files (preserves git blame).
+
+```bash
+git mv culture/agentirc/client.py culture/transport/client.py
+git mv culture/agentirc/remote_client.py culture/transport/remote_client.py
+```
+
+- [ ] **Step 3.3:** Discover the public symbols to re-export.
+
+```bash
+grep -nE "^class |^def " culture/transport/client.py culture/transport/remote_client.py | grep -v "^.*: *def _" | head -20
+```
+
+Expected output: lists the top-level classes/functions in each file. Note the public class names (e.g., `Client`, `RemoteClient`, plus any helper classes that today are imported from `culture.agentirc.client` directly).
+
+- [ ] **Step 3.4:** Write `culture/transport/__init__.py` re-exporting the public symbols.
+
+```python
+"""Culture's IRC client transport, separated from the IRCd (which lives in agentirc-cli)."""
+
+from culture.transport.client import *  # noqa: F401,F403  -- re-export public surface
+from culture.transport.remote_client import *  # noqa: F401,F403
+```
+
+Then narrow the wildcards: open each module, check whether it defines `__all__`. If yes, the wildcard is bounded; keep it. If no, replace `*` with explicit names from Step 3.3 to avoid leaking helpers.
+
+Final form (typical):
+
+```python
+"""Culture's IRC client transport, separated from the IRCd (which lives in agentirc-cli)."""
+
+from culture.transport.client import Client  # plus any other public names
+from culture.transport.remote_client import RemoteClient
+
+__all__ = ["Client", "RemoteClient"]
+```
+
+- [ ] **Step 3.5:** Update every importer in the repo.
+
+```bash
+grep -rln "from culture\.agentirc\.\(client\|remote_client\)\|import culture\.agentirc\.\(client\|remote_client\)" culture tests | sort -u
+```
+
+Expected output: a list of files. For each, run a sed-style replace:
+
+```bash
+grep -rln "culture\.agentirc\.client" culture tests | xargs sed -i 's|culture\.agentirc\.client|culture.transport.client|g'
+grep -rln "culture\.agentirc\.remote_client" culture tests | xargs sed -i 's|culture\.agentirc\.remote_client|culture.transport.remote_client|g'
+```
+
+Verify nothing was missed:
+
+```bash
+grep -rn "culture\.agentirc\.\(client\|remote_client\)" culture tests
+```
+
+Expected: no output.
+
+- [ ] **Step 3.6:** Run the test suite.
+
+```bash
+/run-tests
+```
+
+Expected: tests that depend on transport pass; tests that depend on the (still-present) `culture/agentirc/` IRCd internals also pass for now (we haven't deleted yet). Any failures here mean an importer was missed; go back to 3.5.
+
+- [ ] **Step 3.7:** Commit.
+
+```bash
+git add -A
+git commit -m "refactor: relocate IRC client transport to culture/transport/"
+```
+
+---
+
+## Task 4 — Switch mesh config to agentirc.config
+
+**Files:**
+- Modify: `culture/cli/shared/mesh.py`
+
+- [ ] **Step 4.1:** Inspect current imports.
+
+```bash
+grep -n "from culture\.agentirc\.config\|import culture\.agentirc\.config" culture/cli/shared/mesh.py
+```
+
+Expected: two matches (lines 23 and 44 per the spec).
+
+- [ ] **Step 4.2:** Rewrite the imports.
+
+```bash
+sed -i 's|from culture\.agentirc\.config import|from agentirc.config import|g' culture/cli/shared/mesh.py
+```
+
+Verify:
+
+```bash
+grep -n "agentirc\.config\|culture\.agentirc\.config" culture/cli/shared/mesh.py
+```
+
+Expected: only `from agentirc.config import …` matches; no `culture.agentirc.config` references remain.
+
+- [ ] **Step 4.3:** Run mesh-related tests.
+
+```bash
+/run-tests tests/test_mesh*.py tests/test_culture_link*.py
+```
+
+(If those test files don't exist, run the full suite: `/run-tests`.)
+
+Expected: pass. The dataclasses in `agentirc.config` are byte-equivalent to what was at `culture/agentirc/config.py`, so behaviour is unchanged.
+
+- [ ] **Step 4.4:** Commit.
+
+```bash
+git add culture/cli/shared/mesh.py
+git commit -m "refactor(mesh): import LinkConfig/PeerSpec from agentirc.config"
+```
+
+---
+
+## Task 5 — Replace protocol-constant string literals with agentirc.protocol
+
+**Files:**
+- Modify: `culture/transport/client.py`
+- Possibly: `culture/transport/remote_client.py`, `culture/bots/*.py`
+
+- [ ] **Step 5.1:** Recall the protocol constants you saved in Step 1.3. List them again:
+
+```bash
+uv run python -c "
+import agentirc.protocol as p
+for name in sorted(n for n in dir(p) if not n.startswith('_')):
+    print(name, '=', repr(getattr(p, name)))
+"
+```
+
+Expected: a list like `JOIN = 'JOIN'`, `PRIVMSG = 'PRIVMSG'`, `THREAD = 'THREAD'`, `ROOM = 'ROOM'`, plus numerics and extension tag names.
+
+- [ ] **Step 5.2:** Find candidate string-literal usages in culture's transport.
+
+```bash
+grep -nE '"[A-Z]{3,}"|'\''[A-Z]{3,}'\''' culture/transport/client.py culture/transport/remote_client.py | head -40
+```
+
+Expected: lines where IRC verb names appear as bare uppercase string literals (e.g., `"PRIVMSG"`, `"JOIN"`, `"THREAD"`).
+
+- [ ] **Step 5.3:** Replace each verb literal with the matching `agentirc.protocol` constant.
+
+Open `culture/transport/client.py`. Add at the top of the imports section:
+
+```python
+from agentirc import protocol as _proto
+```
+
+Then for each verb literal you found in Step 5.2 that has a matching constant in Step 5.1, replace `"PRIVMSG"` with `_proto.PRIVMSG`, etc. **Do not replace** verbs that aren't in `agentirc.protocol` — those may be culture-only protocol additions that haven't been promoted to the shared module yet; leave them as literals and note them in the PR description.
+
+If `remote_client.py` has the same pattern, repeat there.
+
+- [ ] **Step 5.4:** Verify nothing reads as a now-undefined constant.
+
+```bash
+uv run python -c "import culture.transport.client, culture.transport.remote_client; print('OK')"
+```
+
+Expected: `OK`. An `AttributeError: module 'agentirc.protocol' has no attribute 'X'` means you replaced a literal that doesn't have a constant — revert that one.
+
+- [ ] **Step 5.5:** Run transport tests.
+
+```bash
+/run-tests tests/test_connection.py tests/test_console_*.py
+```
+
+Expected: pass.
+
+- [ ] **Step 5.6:** Commit.
+
+```bash
+git add culture/transport/
+git commit -m "refactor(transport): use agentirc.protocol constants instead of string literals"
+```
+
+---
+
+## Task 6 — Replace culture/cli/server.py with the passthrough shim (TDD)
+
+**Files:**
+- Create: `tests/test_server_shim.py`
+- Rewrite: `culture/cli/server.py`
+
+- [ ] **Step 6.1: Write the failing test.**
+
+Create `tests/test_server_shim.py`:
+
+```python
+"""Verify culture server <verb> is a 1:1 passthrough into agentirc.cli.dispatch."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "culture", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _agentirc_run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "agentirc", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _agentirc_verbs() -> set[str]:
+    """Parse `agentirc --help` and extract the verb names from its subcommands list."""
+    result = _agentirc_run("--help")
+    assert result.returncode == 0, result.stderr
+    verbs: set[str] = set()
+    in_subcommands = False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            in_subcommands = False
+            continue
+        if stripped.lower().startswith(("subcommands", "commands", "positional arguments")):
+            in_subcommands = True
+            continue
+        if in_subcommands and line.startswith(("    ", "\t")):
+            token = stripped.split(None, 1)[0]
+            if token and token[0].isalpha() and not token.startswith("-"):
+                verbs.add(token)
+    assert verbs, f"no verbs parsed from agentirc --help:\n{result.stdout}"
+    return verbs
+
+
+def test_culture_server_help_succeeds():
+    """culture server --help must exit 0."""
+    result = _run("server", "--help")
+    assert result.returncode == 0, result.stderr
+
+
+def test_every_agentirc_verb_is_reachable_via_culture_server():
+    """For every verb agentirc lists, culture server <verb> --help must succeed."""
+    for verb in _agentirc_verbs():
+        result = _run("server", verb, "--help")
+        assert result.returncode == 0, f"culture server {verb} --help failed: {result.stderr}"
+
+
+def test_culture_server_unknown_verb_returns_agentirc_error():
+    """Unknown verbs are routed to agentirc, which returns its own error (nonzero exit)."""
+    result = _run("server", "this-verb-does-not-exist")
+    assert result.returncode != 0
+```
+
+- [ ] **Step 6.2: Run the test; verify it fails.**
+
+```bash
+/run-tests tests/test_server_shim.py
+```
+
+Expected: the first two tests probably *pass* against today's `culture/cli/server.py` because culture's server group already accepts `--help`. The third test (`test_every_agentirc_verb_is_reachable_via_culture_server`) **fails**, because today `culture server <verb>` only knows the verbs culture's argparse registered (start/stop/status/...), not the full agentirc verb set (which includes `serve`, `link`, `logs`, `version`).
+
+- [ ] **Step 6.3: Replace `culture/cli/server.py` with the shim.**
+
+Overwrite `culture/cli/server.py` with this content (entire file):
+
+```python
+"""culture server <verb> ... — 1:1 in-process passthrough into agentirc.cli.dispatch.
+
+Culture does not parse, validate, or rename any flag past `server`. Every flag,
+verb, and exit code below this layer comes from agentirc-cli. Adding a verb in
+agentirc makes it reachable here automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agentirc.cli import dispatch as _agentirc_dispatch
+
+NAME = "server"  # culture's CLI dispatcher routes args.command == NAME → dispatch(args)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    """Register the `server` subparser as a transparent passthrough."""
+    parser = subparsers.add_parser(
+        NAME,
+        help="Manage the IRC server (passthrough to agentirc-cli)",
+        add_help=False,  # let agentirc handle --help so users see agentirc's verbs
+    )
+    parser.add_argument("agentirc_args", nargs=argparse.REMAINDER)
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    """Forward residual argv to agentirc.cli.dispatch and exit with its code."""
+    rc = _agentirc_dispatch(list(args.agentirc_args))
+    sys.exit(int(rc) if rc is not None else 0)
+```
+
+The `NAME = "server"` constant matches culture's group-module convention (see `culture/cli/agent.py`, `culture/cli/bot.py`, etc.). Culture's top-level dispatcher iterates groups and invokes `group.dispatch(args)` for the group whose `NAME` (or `NAMES`) matches `args.command`.
+
+- [ ] **Step 6.4: Audit for orphaned references.**
+
+The deleted server.py had ~400 LOC referencing `culture.pidfile`, `.shared.constants`, `.shared.mesh.parse_link`, etc. Some of those modules may have been used *only* by `culture/cli/server.py`. Check:
+
+```bash
+grep -rln "from culture\.pidfile\|import culture\.pidfile" culture tests
+```
+
+Expected: at least one match outside `culture/cli/server.py` (bots/agents may also use the pidfile machinery). If `culture/pidfile.py` has zero remaining importers, it's orphaned — leave it for now and flag it in the PR description; cleanup is out of scope for this cutover.
+
+Repeat for `culture/cli/shared/constants.py` and any other helper that the deleted server.py was a primary consumer of.
+
+- [ ] **Step 6.5: Run the shim test.**
+
+```bash
+/run-tests tests/test_server_shim.py
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 6.6: Run the full suite.**
+
+```bash
+/run-tests
+```
+
+Expected: pass. Failures here are likely tests that imported now-deleted symbols from `culture.cli.server` (e.g., `_resolve_server_name`). Track them down — they belong to Task 7 (deleting `culture/agentirc/`) or are stale tests that should be removed.
+
+- [ ] **Step 6.7: Commit.**
+
+```bash
+git add culture/cli/server.py tests/test_server_shim.py
+git commit -m "feat(cli): culture server is now a passthrough into agentirc.cli.dispatch"
+```
+
+---
+
+## Task 7 — Delete culture/agentirc/ and protocol/extensions/
+
+**Files:**
+- Delete: `culture/agentirc/` (entire directory)
+- Delete: `protocol/extensions/` (entire directory)
+
+- [ ] **Step 7.1: Confirm no remaining importers of `culture.agentirc.*`.**
+
+```bash
+grep -rn "from culture\.agentirc\|import culture\.agentirc" culture tests
+```
+
+Expected: no output. If anything matches, it's an importer Tasks 3-6 missed; fix it before deleting.
+
+- [ ] **Step 7.2: Delete `culture/agentirc/`.**
+
+```bash
+git rm -r culture/agentirc/
+```
+
+Expected: dozens of files staged for deletion.
+
+- [ ] **Step 7.3: Delete `protocol/extensions/`.**
+
+```bash
+git rm -r protocol/extensions/
+```
+
+Expected: protocol-extension `.md` files staged for deletion.
+
+- [ ] **Step 7.4: Sweep tests for now-broken imports.**
+
+```bash
+grep -rln "culture\.agentirc" tests
+```
+
+Expected: no output. If anything matches, those are tests that exercised the IRCd directly (now in agentirc's repo). Delete them:
+
+```bash
+git rm <each-broken-test-file>
+```
+
+- [ ] **Step 7.5: Run the full suite.**
+
+```bash
+/run-tests
+```
+
+Expected: pass. If a test fails because a fixture imported `culture.agentirc.X`, either the fixture is a transport helper (rewrite to import from `culture.transport`) or it's an IRCd-internal helper (delete the test).
+
+- [ ] **Step 7.6: Commit.**
+
+```bash
+git add -A
+git commit -m "refactor: delete culture/agentirc/ and protocol/extensions/ (moved to agentirc-cli)"
+```
+
+---
+
+## Task 8 — Cross-repo smoke test
+
+**Files:**
+- Create: `tests/test_agentirc_smoke.py`
+
+- [ ] **Step 8.1: Write the smoke test.**
+
+Create `tests/test_agentirc_smoke.py`:
+
+```python
+"""End-to-end smoke: boot `agentirc serve` as a subprocess, connect a culture transport client.
+
+This is the only cross-repo integration test in culture. It imports nothing from
+agentirc internals — it treats agentirc-cli as a black-box binary, the way an
+external user would.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(host: str, port: int, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def agentirc_server(tmp_path: Path):
+    """Boot an agentirc daemon in a tmp dir; yield (host, port); tear down."""
+    if shutil.which("agentirc") is None:
+        pytest.skip("agentirc binary not on PATH (agentirc-cli not installed?)")
+
+    port = _free_port()
+    config = tmp_path / "server.yaml"
+    config.write_text(
+        f"server:\n"
+        f"  host: 127.0.0.1\n"
+        f"  port: {port}\n"
+        f"  name: smoke-test\n"
+    )
+
+    proc = subprocess.Popen(
+        ["agentirc", "serve", "--config", str(config)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        if not _wait_for_port("127.0.0.1", port):
+            proc.kill()
+            stdout, stderr = proc.communicate(timeout=2)
+            pytest.fail(
+                f"agentirc serve did not bind {port} within 10s.\n"
+                f"stdout:\n{stdout.decode(errors='replace')}\n"
+                f"stderr:\n{stderr.decode(errors='replace')}"
+            )
+        yield "127.0.0.1", port
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_culture_transport_can_connect_to_agentirc(agentirc_server):
+    """A raw TCP connect to agentirc serve succeeds; that's the floor."""
+    host, port = agentirc_server
+    with socket.create_connection((host, port), timeout=2) as sock:
+        # A bare TCP accept is enough for this smoke. Deeper protocol-level
+        # exchange is covered by transport unit tests against a fake server.
+        assert sock.fileno() != -1
+```
+
+The test minimally proves `agentirc serve` boots from the installed binary and accepts TCP. Deeper protocol-level testing stays in transport unit tests against a fake server (those are fast and don't need a subprocess).
+
+- [ ] **Step 8.2: Adjust the config schema if needed.**
+
+The config keys above (`server: {host, port, name}`) match what `agentirc.config.ServerConfig` expects. Verify by running:
+
+```bash
+uv run python -c "
+import agentirc.config, dataclasses
+for f in dataclasses.fields(agentirc.config.ServerConfig):
+    print(f.name, f.type)
+"
+```
+
+Expected: a list of fields. If the actual schema differs (e.g., the top-level key isn't `server:` or fields are differently named), adjust `config.write_text(...)` to match the real schema.
+
+- [ ] **Step 8.3: Run the smoke test.**
+
+```bash
+/run-tests tests/test_agentirc_smoke.py -v
+```
+
+Expected: 1 test passes. If it skips with "agentirc binary not on PATH," your venv didn't install the script — re-run `uv sync` and try again.
+
+- [ ] **Step 8.4: Commit.**
+
+```bash
+git add tests/test_agentirc_smoke.py
+git commit -m "test: cross-repo smoke test boots agentirc serve and connects"
+```
+
+---
+
+## Task 9 — Version bump (major)
+
+**Files:**
+- `culture/__init__.py` (or wherever `__version__` lives)
+- `pyproject.toml`
+- `CHANGELOG.md`
+
+- [ ] **Step 9.1: Run the bump.**
+
+```bash
+/version-bump major
+```
+
+Expected: a new major version section in `CHANGELOG.md`, version updated in `pyproject.toml` and `culture/__init__.py` (or equivalent), `uv.lock` regenerated. Single staged commit prepared by the skill.
+
+- [ ] **Step 9.2: Edit the new CHANGELOG section.**
+
+Open `CHANGELOG.md`. Replace the auto-generated stub for the new version with a hand-written entry. Suggested content:
+
+```markdown
+## [<NEW-MAJOR-VERSION>] - 2026-04-30
+
+### Changed (breaking)
+
+- The IRCd has been extracted into a separate package, `agentirc-cli`. Culture now depends on `agentirc-cli>=0.1,<0.2`.
+- `culture server <verb>` is now a 1:1 passthrough into `agentirc.cli.dispatch`. All existing verbs continue to work; their flags, output, and exit codes come from `agentirc-cli`.
+- `culture/agentirc/` has been deleted. Code that imported `culture.agentirc.*` must update:
+  - `culture.agentirc.client` / `culture.agentirc.remote_client` → `culture.transport.client` / `culture.transport.remote_client`
+  - `culture.agentirc.config` → `agentirc.config`
+  - Other internals (e.g., `culture.agentirc.ircd`, `culture.agentirc.server_link`) are not part of the public API and have no replacement.
+- `python -m culture.agentirc` is removed. Use `agentirc` (CLI) or `python -m agentirc`.
+
+### Notes
+
+- On-disk footprint is unchanged: default config path, socket paths, log paths, and `culture-*` systemd unit names are preserved. Existing deployments require no migration.
+- `protocol/extensions/` documentation has moved to the agentirc repo.
+```
+
+- [ ] **Step 9.3: Verify the bump took.**
+
+```bash
+grep -E "^version|__version__" pyproject.toml culture/__init__.py 2>/dev/null
+```
+
+Expected: version is the new major. If `culture/__init__.py` doesn't have `__version__`, check culture's actual version-source-of-truth (per project CLAUDE.md).
+
+- [ ] **Step 9.4: Commit (or amend the bump's commit).**
+
+If `/version-bump` already created a commit, amend the CHANGELOG hand-edits onto it:
+
+```bash
+git add CHANGELOG.md
+git commit --amend --no-edit
+```
+
+Otherwise:
+
+```bash
+git add CHANGELOG.md pyproject.toml culture/__init__.py uv.lock
+git commit -m "chore: bump major version for agentirc extraction cutover"
+```
+
+---
+
+## Task 10 — Doc-test alignment audit
+
+**Files:** docs across the tree (audit only; fixes inline if needed).
+
+- [ ] **Step 10.1: Invoke the doc-test-alignment subagent.**
+
+Per culture's CLAUDE.md, this audit runs before the first push when public API surface changes. Invoke:
+
+```
+Agent(subagent_type="doc-test-alignment", description="Audit cutover branch", prompt="Audit the staged diff on this branch for new public API surface and report whether docs/ and protocol/extensions/ mention them. Specifically check: (1) culture/transport/ — new module path, replaces culture.agentirc.{client,remote_client}; (2) culture/cli/server.py — now a passthrough into agentirc.cli.dispatch; (3) culture/agentirc/ deletion — any doc that says `culture server` runs in-process or imports IRCd internals is now wrong; (4) protocol/extensions/ deletion — culture's docs that pointed at protocol/extensions/ need updating to point at agentirc's repo; (5) python -m culture.agentirc removal. Report missing or now-wrong docs. Do not write fixes.")
+```
+
+- [ ] **Step 10.2: Address the report.**
+
+For each gap the audit flags, update the docs in this PR:
+
+- A doc that explained "culture's IRCd lives in `culture/agentirc/`" → rewrite to "culture's IRC server is provided by the `agentirc-cli` package; `culture server` is a passthrough."
+- A doc that linked to `protocol/extensions/<file>.md` → repoint at `https://github.com/agentculture/agentirc/blob/main/protocol/extensions/<file>.md`.
+- A doc that documented `python -m culture.agentirc` → remove or replace with `agentirc` / `python -m agentirc`.
+
+Be surgical — do not rewrite docs beyond the gaps the audit names.
+
+- [ ] **Step 10.3: Commit doc fixes (if any).**
+
+```bash
+git add docs/ README.md  # or whatever paths the audit touched
+git commit -m "docs: update references for agentirc extraction"
+```
+
+---
+
+## Task 11 — Final verification, push, and PR
+
+**Files:** none (workflow only).
+
+- [ ] **Step 11.1: Format-before-commit safety net.**
+
+```bash
+uv run black culture tests
+uv run isort culture tests
+```
+
+If either reformats anything, stage and amend the most recent commit:
+
+```bash
+git status --short
+git add -A
+git commit --amend --no-edit
+```
+
+- [ ] **Step 11.2: Run the full test suite, parallel.**
+
+```bash
+/run-tests
+```
+
+Expected: all green. Address any failures before continuing.
+
+- [ ] **Step 11.3: Run pre-commit on all changes.**
+
+```bash
+uv run pre-commit run --files $(git diff --name-only main...HEAD)
+```
+
+Expected: all hooks pass. Fix any flake8/pylint/bandit/markdownlint complaints inline; amend onto the most recent commit.
+
+- [ ] **Step 11.4: Final coupling sweep.**
+
+```bash
+grep -rn "culture\.agentirc\|protocol/extensions" culture tests docs
+```
+
+Expected: no output (except possibly in `CHANGELOG.md`, where references like `culture.agentirc.client` legitimately appear in the breaking-changes notes — those are fine).
+
+- [ ] **Step 11.5: Push the branch.**
+
+```bash
+git push -u origin agentirc-extraction-cutover
+```
+
+- [ ] **Step 11.6: Open the PR.**
+
+```bash
+gh pr create --base main --title "feat: extract IRCd to agentirc-cli; culture server becomes passthrough" --body "$(cat <<'EOF'
+## Summary
+
+- Cuts culture over to consume `agentirc-cli>=0.1,<0.2` from PyPI.
+- Deletes `culture/agentirc/` (~3,600 LOC); moves client transport to `culture/transport/`; replaces `culture/cli/server.py` with a 1:1 argparse-`REMAINDER` passthrough into `agentirc.cli.dispatch`.
+- Deletes `protocol/extensions/` (it lives in agentirc's repo now).
+- Major version bump.
+
+User-visible behavior is unchanged: every `culture server <verb> <args>` invocation continues to work, with flags, output, and exit codes coming from `agentirc-cli`. On-disk footprint (config path, sockets, systemd units, logs) is unchanged.
+
+Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (Track A).
+
+## Test plan
+
+- [x] Existing test suite passes (`/run-tests`).
+- [x] New `tests/test_server_shim.py` asserts every verb in `agentirc --help` is reachable via `culture server <verb> --help`.
+- [x] New `tests/test_agentirc_smoke.py` boots `agentirc serve` as a subprocess and TCP-connects to it.
+- [ ] Post-merge: verify on the spark host that `culture-agent-spark-culture.service` restarts cleanly with the new dependency, and that `culture server status` and `agentirc status` produce identical output (Track C).
+
+- Claude
+EOF
+)"
+```
+
+Expected: PR URL printed. Confirm the PR is open and CI starts.
+
+- [ ] **Step 11.7: Wait for CI and reviewers.**
+
+After CI runs:
+
+```bash
+gh pr checks
+```
+
+If anything fails, fix inline, push, and use `/sonarclaude` before declaring ready (per culture's CLAUDE.md). Use `/pr-review` to handle automated reviewer comments.
+
+---
+
+## Post-merge (Track C — out of scope for this plan, but on the to-do list)
+
+After this PR merges and a culture release is published:
+
+- `pip install -U culture` on the host running `culture-agent-spark-culture.service`.
+- Confirm the service restarts cleanly with the new `agentirc-cli` dependency.
+- Confirm `culture server status` and `agentirc status` produce byte-identical output.
+- Confirm an existing peer link still establishes.
+
+If anything misbehaves on a real deployment, file follow-up issues; do not roll back unless behavior is broken (the dependency pin `agentirc-cli>=0.1,<0.2` already protects against accidental 0.2 upgrades).

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -1,0 +1,305 @@
+# AgentIRC Extraction Design
+
+**Status:** Proposed
+**Date:** 2026-04-30
+**Owner:** Ori Nachum
+
+## Summary
+
+Extract the IRCd in `culture/agentirc/` into a standalone repo at `../agentirc`, published as the `agentirc-cli` PyPI package (import name `agentirc`, CLI binary `agentirc`). Culture consumes it as an external dependency. The user-visible CLI surface is preserved: `culture server <verb>` becomes a transparent passthrough into `agentirc.cli.dispatch`.
+
+### Naming (called out, because three names appear)
+
+| Role | Name |
+|---|---|
+| PyPI distribution name | `agentirc-cli` (TestPyPI also has the squatted `agentirc`; we use `agentirc-cli` everywhere) |
+| Python import package | `agentirc` |
+| CLI binary | `agentirc` |
+| Repo path | `../agentirc` |
+
+This is the first of several planned splits — `culture-agent` and `culture-bot` will follow the same pattern in subsequent refactors. The seam established here is the template.
+
+## Motivation
+
+`culture/agentirc/` is ~3,600 lines of self-contained IRCd code (RFC 2812 base, server-to-server linking, channels, persistence, server-side skill plugins). Today it lives inside the culture repo and is launched in-process by `culture server start`. Three things make extraction useful now:
+
+1. **Independent reuse.** Other projects could run an AgentIRC daemon without pulling in culture's bot/agent runtime.
+2. **Sharper boundaries.** Today culture's CLI server module imports the IRCd directly and reaches into its internals. A package boundary forces a small, documented API surface (`agentirc.config`, `agentirc.cli`, `agentirc.protocol`).
+3. **Pattern for future splits.** Culture-agent and culture-bot will be peeled off the same way. Doing agentirc first establishes the dependency model, the CLI passthrough idiom, and the testing strategy.
+
+## Goals
+
+- agentirc lives in `../agentirc` as an independently versioned package on PyPI (distribution name `agentirc-cli`, import name `agentirc`), with its own CLI binary `agentirc`.
+- Culture consumes it as a normal dependency (`agentirc-cli>=0.1,<0.2`).
+- `culture server <verb> <args>` continues to work for every existing verb, with identical flags, output, and exit codes — implemented as a 1:1 passthrough into `agentirc.cli.dispatch`.
+- On-disk footprint stays culture-named: `~/.culture/server.yaml`, current socket paths, `culture-agent-*.service` systemd units, current log paths. Existing deployments need zero migration.
+- The IRCd's protocol surface (`protocol/extensions/`) lives in agentirc, where it belongs.
+
+## Non-Goals
+
+- **Splitting the client transport.** `client.py` and `remote_client.py` stay in culture (relocated to `culture/transport/`). Only the server core moves.
+- **Splitting bots/agents in this refactor.** Those splits are planned but separate.
+- **Preserving git history.** Approach 2 was chosen: agentirc gets a synthetic "initial import" commit. Anyone wanting historical context for a line uses `git log` in culture before the deletion SHA.
+- **Renaming on-disk artifacts.** Config paths, sockets, systemd units stay culture-named — see Goals.
+- **Backwards compatibility for `python -m culture.agentirc`.** That entrypoint is removed (no known callers). Use `agentirc` (CLI) or `python -m agentirc` instead.
+
+## Boundary
+
+### What moves to `../agentirc`
+
+| File / dir | Source path |
+|---|---|
+| `agentirc/ircd.py` | `culture/agentirc/ircd.py` |
+| `agentirc/server_link.py` | `culture/agentirc/server_link.py` |
+| `agentirc/channel.py` | `culture/agentirc/channel.py` |
+| `agentirc/config.py` | `culture/agentirc/config.py` |
+| `agentirc/events.py` | `culture/agentirc/events.py` |
+| `agentirc/room_store.py` | `culture/agentirc/room_store.py` |
+| `agentirc/thread_store.py` | `culture/agentirc/thread_store.py` |
+| `agentirc/history_store.py` | `culture/agentirc/history_store.py` |
+| `agentirc/rooms_util.py` | `culture/agentirc/rooms_util.py` |
+| `agentirc/skill.py` | `culture/agentirc/skill.py` |
+| `agentirc/skills/` | `culture/agentirc/skills/` |
+| `agentirc/cli.py` | new — extracted from culture's `cli/server.py` server lifecycle code |
+| `agentirc/protocol.py` | new — verb names, numerics, extension tags pulled from string-literals in `client.py` and `ircd.py` |
+| `protocol/extensions/` | `protocol/extensions/` (moved wholesale) |
+| `tests/` | tests under culture's `tests/` that import `culture.agentirc.*` and aren't transport-focused |
+
+### What stays in culture
+
+| File / dir | New path | Why |
+|---|---|---|
+| `culture/transport/client.py` | from `culture/agentirc/client.py` | Culture's bots and backend daemons are the only consumers. |
+| `culture/transport/remote_client.py` | from `culture/agentirc/remote_client.py` | Same. |
+| `culture/cli/server.py` | rewritten as 1-function passthrough | See "CLI surface" below. |
+| `culture/cli/shared/mesh.py` | imports `LinkConfig`, `PeerSpec` from `agentirc.config` | Mesh manifest read/write stays culture-side. |
+| `culture/bots/`, `culture/clients/*/daemon.py` | imports updated to `culture.transport` | Transport ownership unchanged from the consumer's POV. |
+| `packages/agent-harness/` | unchanged | Agent backend citation reference is culture's concern. |
+
+### What is deleted from culture
+
+- `culture/agentirc/` — the entire directory.
+- `culture/agentirc/__main__.py` (no replacement; `python -m culture.agentirc` is gone).
+
+## Architecture
+
+### Repo layout — `../agentirc`
+
+```
+agentirc/
+├── pyproject.toml          # name = "agentirc-cli"; scripts = { agentirc = "agentirc.cli:main" }
+├── CHANGELOG.md            # starts at 0.1.0
+├── README.md
+├── LICENSE
+├── agentirc/
+│   ├── __init__.py
+│   ├── __main__.py         # python -m agentirc
+│   ├── cli.py              # main(), dispatch(argv)
+│   ├── protocol.py         # verb names, numerics, extension tags
+│   ├── config.py           # ServerConfig, LinkConfig, PeerSpec (public)
+│   ├── ircd.py
+│   ├── server_link.py
+│   ├── channel.py
+│   ├── events.py
+│   ├── room_store.py
+│   ├── thread_store.py
+│   ├── history_store.py
+│   ├── rooms_util.py
+│   ├── skill.py
+│   └── skills/
+│       ├── rooms.py
+│       ├── threads.py
+│       ├── history.py
+│       └── icon.py
+├── protocol/
+│   └── extensions/         # moved from culture
+├── tests/
+└── docs/
+    ├── api-stability.md    # documents the public surface culture depends on
+    ├── cli.md
+    └── deployment.md
+```
+
+### Repo layout — culture (delta only)
+
+```
+culture/
+├── pyproject.toml          # adds: agentirc-cli>=0.1,<0.2
+├── uv.lock                 # regenerated
+├── culture/
+│   ├── agentirc/           # DELETED
+│   ├── transport/          # NEW
+│   │   ├── __init__.py     # re-exports Client, RemoteClient for back-compat
+│   │   ├── client.py       # from culture/agentirc/client.py
+│   │   └── remote_client.py
+│   ├── cli/server.py       # passthrough shim (see below)
+│   ├── cli/shared/mesh.py  # imports from agentirc.config
+│   ├── bots/               # imports updated
+│   └── clients/            # imports updated
+├── tests/                  # IRCd tests removed; transport + shim + mesh tests stay
+└── protocol/extensions/    # MOVED to agentirc
+```
+
+## CLI surface
+
+### `agentirc` subcommands (1:1 with what `culture server …` does today)
+
+| Command | Replaces | Notes |
+|---|---|---|
+| `agentirc serve [--config PATH]` | in-process IRCd launch from `cli/server.py:421` | Default `--config` path: `~/.culture/server.yaml`. |
+| `agentirc start [--name NAME]` | `culture server start` | Same systemd / supervisor handoff. |
+| `agentirc stop [--name NAME]` | `culture server stop` | |
+| `agentirc restart [--name NAME]` | `culture server restart` | |
+| `agentirc status [--name NAME]` | `culture server status` | |
+| `agentirc link <peer> [...]` | `culture server link` | Mesh link registration. |
+| `agentirc logs [--name NAME] [-f]` | `culture server logs` | |
+| `agentirc version` | — | Reports agentirc version. |
+
+Default behaviors that preserve transparency:
+
+- `--config` defaults to `~/.culture/server.yaml`.
+- Socket paths, log paths, systemd unit names: unchanged from current culture defaults.
+- Exit codes and stderr formatting are inherited from the moved code (no rewrites in this refactor).
+
+### `culture server` passthrough
+
+`culture/cli/server.py` reduces to a single forwarding function:
+
+```python
+# culture/cli/server.py
+from agentirc.cli import dispatch as _agentirc_dispatch
+
+def server(argv: list[str]) -> int:
+    """culture server <verb> <args> → agentirc <verb> <args>, in-process."""
+    return _agentirc_dispatch(argv)
+```
+
+Properties of the passthrough:
+
+- **Pure forwarding.** Culture does not parse, validate, or rename any flag. It does not enumerate verbs. New verbs added in agentirc are reachable via `culture server <new-verb>` automatically.
+- **In-process.** No subprocess fork; same Python interpreter, same env. Faster and easier to debug than `subprocess.run`.
+- **Single source of truth.** Help text, error messages, exit codes — all come from agentirc.
+
+### `python -m culture.agentirc` removed
+
+There are no known callers. Anyone running it gets an `ImportError` after upgrade. The migration path is `agentirc` (binary) or `python -m agentirc`.
+
+## Import contract
+
+The public surface of agentirc — what culture (and any third-party consumer) is allowed to import:
+
+| Module | Members | Stability |
+|---|---|---|
+| `agentirc.config` | `ServerConfig`, `LinkConfig`, `PeerSpec`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
+| `agentirc.cli` | `main()`, `dispatch(argv) -> int` | Public, semver-tracked. |
+| `agentirc.protocol` | Verb name constants, numeric reply codes, extension tag names | Public, semver-tracked. |
+
+Everything else — `agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`, the stores, the skills — is internal. Agentirc may refactor freely without breaking culture. Documented in `agentirc/docs/api-stability.md`.
+
+### Where culture imports from agentirc
+
+| Culture module | Imports |
+|---|---|
+| `culture/cli/server.py` | `agentirc.cli.dispatch` |
+| `culture/cli/shared/mesh.py` | `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec` |
+| `culture/transport/client.py` | `agentirc.protocol.*` (verb / numeric / tag constants) |
+| `culture/bots/*`, `culture/clients/*/daemon.py` | nothing — they import `culture.transport` |
+
+## Configuration & on-disk footprint
+
+Unchanged from today. `agentirc` reads the same files culture reads now:
+
+- Default config path: `~/.culture/server.yaml`.
+- Socket paths: same as current culture defaults.
+- systemd units: `culture-agent-<name>.service` (unchanged).
+- Log paths: unchanged.
+
+Standalone (non-culture) users of agentirc can override the config path via `agentirc serve --config /path/to/their.yaml`.
+
+## Migration mechanics
+
+### Order of operations
+
+1. **Bootstrap agentirc** (in `../agentirc`):
+   - Copy server-core files from `culture/agentirc/` (excluding `client.py`, `remote_client.py`, `__main__.py`) into `../agentirc/agentirc/`.
+   - Copy `protocol/extensions/` into `../agentirc/protocol/extensions/`.
+   - Copy IRCd-specific tests from culture's `tests/`.
+   - Add `pyproject.toml` (`name = "agentirc-cli"`, `version = "0.1.0"`, scripts `agentirc = "agentirc.cli:main"`).
+   - Rewrite imports in the new tree: `from culture.agentirc.X` → `from agentirc.X`.
+   - Add new modules `agentirc/cli.py` (extracted from `culture/cli/server.py` server-lifecycle code) and `agentirc/protocol.py` (verb / numeric / tag constants pulled from string-literals in `client.py` and `ircd.py`).
+   - First commit: `Initial import from culture@<sha>` — single synthetic commit pointing at the source SHA.
+   - CI mirrors culture's: pytest + black + isort + flake8 + bandit + markdownlint, plus version-check.
+   - Tag `v0.1.0`, publish to PyPI (publishing is already set up).
+2. **Culture-side cutover PR** (single PR, branch out per culture's standard workflow):
+   - `pyproject.toml`: add `agentirc-cli>=0.1,<0.2`. Regenerate `uv.lock`.
+   - Delete `culture/agentirc/` entirely.
+   - Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.
+   - Replace `culture/cli/server.py` with the passthrough shim.
+   - Update imports across culture: `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`; `culture.agentirc.config` → `agentirc.config`; protocol-constant string-literals → `agentirc.protocol`.
+   - Move `protocol/extensions/` out (lives in agentirc now).
+   - Move IRCd-targeted tests out of culture; keep transport / shim / mesh / bot / backend tests.
+   - Add `tests/test_server_shim.py`: invokes `culture server --help`, asserts it matches `agentirc --help` output to prove the passthrough.
+   - `/version-bump major` on culture (deleting the in-tree IRCd is a structural change, even if user-visible CLI is unchanged).
+   - `doc-test-alignment` audit before first push (per culture's CLAUDE.md).
+3. **Verification on a real deployment:**
+   - `pip install -U culture` on a host running `culture-agent-spark-culture.service`.
+   - Confirm the service restarts cleanly with the new agentirc dependency.
+   - Confirm `culture server status` and `agentirc status` produce identical output.
+   - Confirm an existing peer link still establishes (server-link tests in agentirc's CI cover the protocol; this is the in-prod sanity check).
+
+### Distribution
+
+- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=0.1,<0.2`.
+- TestPyPI carries both `agentirc-cli` and a squatted `agentirc`; only `agentirc-cli` is the canonical name. Anything publishing or installing should use `agentirc-cli`.
+- agentirc adopts culture's version workflow (`/version-bump`, CHANGELOG, version-check CI).
+- All-backends rule still applies: changes that cross the agentirc / culture-transport boundary must be reflected across all four backends in culture (`claude`, `codex`, `copilot`, `acp`).
+
+### Rollback
+
+If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=0.1,<0.2` means culture cannot accidentally pick up an incompatible 0.2.0 release.
+
+## Testing strategy
+
+### Coverage split
+
+- **agentirc CI** owns:
+  - IRCd integration tests (real TCP, real IRC clients).
+  - Server-link tests (peer-to-peer mesh).
+  - Channel / store / skill unit tests.
+  - CLI dispatch tests (argv → handler).
+- **Culture CI** owns:
+  - Transport tests (`culture/transport/`).
+  - Bot tests, backend daemon tests.
+  - Mesh manifest tests (`culture/cli/shared/mesh.py`).
+  - The shim parity test (`tests/test_server_shim.py`).
+  - One end-to-end smoke test that spins up `agentirc serve` from the installed package and connects a culture transport client to it. This is the only cross-repo integration test in culture; it imports nothing from agentirc internals.
+
+### Test-suite migration
+
+Tests under culture's `tests/` are sorted into three buckets at copy time:
+
+1. Imports `culture.agentirc.X` only → moves to `../agentirc/tests/`.
+2. Imports `culture.agentirc.client` / `remote_client` only → stays in culture (transport-focused).
+3. Imports both → split into two tests, one per repo. If the test is genuinely cross-cutting (a bot connecting to an IRCd in the same process), it stays in culture and is rewritten to use `agentirc serve` as a subprocess fixture rather than importing `IRCd` directly.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Hidden coupling — culture imports something from `culture.agentirc` we missed. | Pre-cutover, `grep -rn 'culture\.agentirc' culture/ tests/` and review every match. The cutover PR includes an explicit checklist of every importer file. |
+| Protocol constants drift between agentirc (server) and culture/transport (client). | `agentirc.protocol` is the single source. Both sides import from there; tests on either side fail fast on missing constants. |
+| Existing deployment breaks because something on disk is unexpectedly named. | Goals/Non-Goals: nothing on disk is renamed. The verification step on a real deployment catches anything we missed. |
+| `culture server --help` output diverges from `agentirc --help` over time. | The shim parity test asserts byte-equality of the help text. CI fails if drift appears. |
+| First PyPI release of agentirc is broken; culture cutover PR can't merge. | Culture pins `agentirc-cli>=0.1,<0.2`. Patches go out as `0.1.1`, `0.1.2`. Culture's PR can wait or pin to a specific known-good `==0.1.X`. |
+| Future changes touch both repos at once and become hard to coordinate. | All-backends rule already requires multi-backend coordination; the same discipline extends to multi-repo coordination. Significant cross-repo work pairs an agentirc PR with a culture PR that bumps the floor pin. |
+
+## Open questions
+
+None blocking. Design is ready for implementation planning.
+
+## Future work (out of scope)
+
+- Same pattern applied to `culture-agent` (extract backend daemons into their own repo).
+- Same pattern applied to `culture-bot` (extract bot runtime).
+- Whether `culture/transport/` should also become a separate distribution (e.g. `agentirc-client`) once two or more independent consumers exist. Not now.
+- Publishing agentirc reference docs / protocol extensions on a public docs site.

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -1,8 +1,30 @@
 # AgentIRC Extraction Design
 
-**Status:** Proposed
+**Status:** In progress — Phase A1 landed in culture 8.8.0 (2026-05-01); Phase A3 blocked on agentculture/agentirc#15
 **Date:** 2026-04-30
 **Owner:** Ori Nachum
+
+## Implementation status (added 2026-05-01)
+
+Track A on the culture side is split into phases because the literal
+"delete `culture/agentirc/{ircd, ...}.py` and shim `culture server start`"
+described below cannot land in one PR — culture's bots
+(`culture/bots/*`) hold an in-process `IRCd` reference and call
+`server.emit_event`/`server.channels`/`server.get_or_create_channel`
+directly. agentirc's published public API (see
+`docs/api-stability.md` in agentirc) exposes no out-of-process bot
+hook, and `Event`/`EventType` are explicitly internal.
+
+| Phase | Scope | Status |
+|---|---|---|
+| **B** (agentirc bootstrap) | `agentirc-cli==9.4.1` published, public API stable, on-disk layout preserved | ✅ done (see culture#308) |
+| **A1** (culture-side public-API migration) | Pin `agentirc-cli>=9.4,<10`; `culture/agentirc/config.py` becomes a re-export shim over `agentirc.config`; canonical call sites (telemetry, mesh CLI, conftest) retarget; minor bump 8.7.1 → 8.8.0 | ✅ done 2026-05-01 |
+| **A2** (decide bot-runtime story) | agentirc to add a documented out-of-process bot extension API (event-stream verb, public Event/EventType, silent-bot connection convention); culture/bots/* rewritten against it | ⏸ blocked on agentculture/agentirc#15 |
+| **A3** (final cutover) | Delete `culture/agentirc/{ircd,server_link,channel,config,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` + `culture/agentirc/skills/`; drop `culture/agentirc/` from wheel packages; replace `culture/cli/server.py:_run_server` with `subprocess.run(["agentirc", *argv])` (or `agentirc.cli.dispatch`); keep culture-only verbs `default`/`rename`/`archive`/`unarchive`; major bump | ⏸ depends on A2 |
+
+The Boundary / Plan sections below describe the A3 end state. They
+remain the target; the phased approach is purely about how culture
+gets there without breaking bots in flight.
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -30,7 +30,7 @@ This is the first of several planned splits — `culture-agent` and `culture-bot
 ## Goals
 
 - agentirc lives in `../agentirc` as an independently versioned package on PyPI (distribution name `agentirc-cli`, import name `agentirc`), with its own CLI binary `agentirc`.
-- Culture consumes it as a normal dependency (`agentirc-cli>=0.1,<0.2`).
+- Culture consumes it as a normal dependency (`agentirc-cli>=9.0,<10.0`).
 - `culture server <verb> <args>` continues to work for every existing verb, with identical flags, output, and exit codes — implemented as a 1:1 passthrough into `agentirc.cli.dispatch`.
 - On-disk footprint stays culture-named: `~/.culture/server.yaml`, current socket paths, `culture-agent-*.service` systemd units, current log paths. Existing deployments need zero migration.
 - The IRCd's protocol surface (`protocol/extensions/`) lives in agentirc, where it belongs.
@@ -88,7 +88,7 @@ This is the first of several planned splits — `culture-agent` and `culture-bot
 ```
 agentirc/
 ├── pyproject.toml          # name = "agentirc-cli"; scripts = { agentirc = "agentirc.cli:main" }
-├── CHANGELOG.md            # starts at 0.1.0
+├── CHANGELOG.md            # starts at 9.0.0 (aligned with culture's version stream)
 ├── README.md
 ├── LICENSE
 ├── agentirc/
@@ -124,7 +124,7 @@ agentirc/
 
 ```
 culture/
-├── pyproject.toml          # adds: agentirc-cli>=0.1,<0.2
+├── pyproject.toml          # adds: agentirc-cli>=9.0,<10.0
 ├── uv.lock                 # regenerated
 ├── culture/
 │   ├── agentirc/           # DELETED
@@ -224,7 +224,7 @@ The migration runs in **two tracks** owned by two different agents. The culture-
 
 A single PR off `main`, following culture's standard workflow.
 
-1. `pyproject.toml`: add `agentirc-cli>=0.1,<0.2`. Regenerate `uv.lock`.
+1. `pyproject.toml`: add `agentirc-cli>=9.0,<10.0`. Regenerate `uv.lock`.
 2. Delete `culture/agentirc/` entirely.
 3. Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.
 4. Replace `culture/cli/server.py` with the passthrough shim (see "CLI surface" above).
@@ -243,7 +243,7 @@ A single PR off `main`, following culture's standard workflow.
 
 This block is the deliverable. It is **handed to the agent working in `../agentirc`** and is intended to be self-contained — the receiving agent should not need culture-side context to act on it.
 
-**Goal:** Bootstrap `../agentirc` as a publishable Python package called `agentirc-cli` (import name `agentirc`, CLI binary `agentirc`) carrying the IRCd server core extracted from culture, plus a new CLI dispatch module and protocol-constants module. Tag `v0.1.0` and publish to PyPI.
+**Goal:** Bootstrap `../agentirc` as a publishable Python package called `agentirc-cli` (import name `agentirc`, CLI binary `agentirc`) carrying the IRCd server core extracted from culture, plus a new CLI dispatch module and protocol-constants module. Tag `v9.0.0` and publish to PyPI.
 
 **Inputs:**
 
@@ -267,12 +267,12 @@ This block is the deliverable. It is **handed to the agent working in `../agenti
    - `--config` defaults to `~/.culture/server.yaml`.
 7. Create `agentirc/protocol.py`. Pull verb names, numeric reply codes, and extension tags out of string-literals in `ircd.py` (and in culture's `client.py` — read it for reference but do **not** copy the file). Export them as named constants.
 8. Create `agentirc/__main__.py` so `python -m agentirc` works (delegates to `agentirc.cli:main`).
-9. Write `pyproject.toml`: `name = "agentirc-cli"`, `version = "0.1.0"`, scripts `agentirc = "agentirc.cli:main"`. Mirror culture's dev-dep set (pytest, pytest-asyncio, pytest-xdist, black, isort, flake8, pylint, bandit, markdownlint).
-10. Mirror culture's pre-commit, CI, and `/version-bump`/CHANGELOG workflow. Start CHANGELOG at `0.1.0`.
+9. Write `pyproject.toml`: `name = "agentirc-cli"`, `version = "9.0.0"` (aligned with culture's version stream — agentirc-cli prior history runs through 8.7.1; 9.0.0 is the first release of the extracted IRCd), scripts `agentirc = "agentirc.cli:main"`. Mirror culture's dev-dep set (pytest, pytest-asyncio, pytest-xdist, black, isort, flake8, pylint, bandit, markdownlint).
+10. Mirror culture's pre-commit, CI, and `/version-bump`/CHANGELOG workflow. CHANGELOG starts at `9.0.0`.
 11. Write `docs/api-stability.md` documenting the public surface culture pins on: `agentirc.config`, `agentirc.cli`, `agentirc.protocol`. Mark everything else internal.
 12. First commit message: `Initial import from culture@<SHA>` (where `<SHA>` is the culture commit ID provided by the caller).
 13. Run the full test suite — it must pass before tagging.
-14. Tag `v0.1.0`, push, publish to PyPI as `agentirc-cli`. (PyPI publishing is already set up.)
+14. Tag `v9.0.0`, push, publish to PyPI as `agentirc-cli`. (PyPI publishing is already set up.)
 15. Report back the published version + git SHA so culture's Track A PR can pin against it.
 
 **Out of scope for Track B:**
@@ -284,7 +284,7 @@ This block is the deliverable. It is **handed to the agent working in `../agenti
 
 **Acceptance criteria:**
 
-- `pip install agentirc-cli==0.1.0` from PyPI produces a working `agentirc` binary.
+- `pip install agentirc-cli==9.0.0` from PyPI produces a working `agentirc` binary.
 - `agentirc serve --config ~/.culture/server.yaml` starts an IRCd indistinguishable from today's `culture server start`.
 - `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec`, `agentirc.cli.dispatch`, and `agentirc.protocol.*` are importable.
 - All tests in `../agentirc/tests/` pass under `pytest -n auto`.
@@ -301,14 +301,14 @@ After Track A merges and culture is released:
 
 ### Distribution
 
-- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=0.1,<0.2`.
+- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=9.0,<10.0`.
 - TestPyPI carries both `agentirc-cli` and a squatted `agentirc`; only `agentirc-cli` is the canonical name. Anything publishing or installing should use `agentirc-cli`.
 - agentirc adopts culture's version workflow (`/version-bump`, CHANGELOG, version-check CI).
 - All-backends rule still applies: changes that cross the agentirc / culture-transport boundary must be reflected across all four backends in culture (`claude`, `codex`, `copilot`, `acp`).
 
 ### Rollback
 
-If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=0.1,<0.2` means culture cannot accidentally pick up an incompatible 0.2.0 release.
+If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=9.0,<10.0` means culture cannot accidentally pick up an incompatible 10.0.0 release.
 
 ## Testing strategy
 
@@ -342,7 +342,7 @@ Tests under culture's `tests/` are sorted into three buckets at copy time:
 | Protocol constants drift between agentirc (server) and culture/transport (client). | `agentirc.protocol` is the single source. Both sides import from there; tests on either side fail fast on missing constants. |
 | Existing deployment breaks because something on disk is unexpectedly named. | Goals/Non-Goals: nothing on disk is renamed. The verification step on a real deployment catches anything we missed. |
 | `culture server --help` output diverges from `agentirc --help` over time. | The shim parity test asserts byte-equality of the help text. CI fails if drift appears. |
-| First PyPI release of agentirc is broken; culture cutover PR can't merge. | Culture pins `agentirc-cli>=0.1,<0.2`. Patches go out as `0.1.1`, `0.1.2`. Culture's PR can wait or pin to a specific known-good `==0.1.X`. |
+| First PyPI release of agentirc is broken; culture cutover PR can't merge. | Culture pins `agentirc-cli>=9.0,<10.0`. Patches go out as `9.0.1`, `9.0.2`. Culture's PR can wait or pin to a specific known-good `==9.0.X`. |
 | Future changes touch both repos at once and become hard to coordinate. | All-backends rule already requires multi-backend coordination; the same discipline extends to multi-repo coordination. Significant cross-repo work pairs an agentirc PR with a culture PR that bumps the floor pin. |
 
 ## Open questions

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -218,34 +218,86 @@ Standalone (non-culture) users of agentirc can override the config path via `age
 
 ## Migration mechanics
 
-### Order of operations
+The migration runs in **two tracks** owned by two different agents. The culture-side agent (this work) implements only Track A and produces the brief in Track B as a deliverable; the brief is then handed to the agent working in `../agentirc`. The culture-side cutover PR (Track A) **waits** on the agentirc release that Track B produces.
 
-1. **Bootstrap agentirc** (in `../agentirc`):
-   - Copy server-core files from `culture/agentirc/` (excluding `client.py`, `remote_client.py`, `__main__.py`) into `../agentirc/agentirc/`.
-   - Copy `protocol/extensions/` into `../agentirc/protocol/extensions/`.
-   - Copy IRCd-specific tests from culture's `tests/`.
-   - Add `pyproject.toml` (`name = "agentirc-cli"`, `version = "0.1.0"`, scripts `agentirc = "agentirc.cli:main"`).
-   - Rewrite imports in the new tree: `from culture.agentirc.X` → `from agentirc.X`.
-   - Add new modules `agentirc/cli.py` (extracted from `culture/cli/server.py` server-lifecycle code) and `agentirc/protocol.py` (verb / numeric / tag constants pulled from string-literals in `client.py` and `ircd.py`).
-   - First commit: `Initial import from culture@<sha>` — single synthetic commit pointing at the source SHA.
-   - CI mirrors culture's: pytest + black + isort + flake8 + bandit + markdownlint, plus version-check.
-   - Tag `v0.1.0`, publish to PyPI (publishing is already set up).
-2. **Culture-side cutover PR** (single PR, branch out per culture's standard workflow):
-   - `pyproject.toml`: add `agentirc-cli>=0.1,<0.2`. Regenerate `uv.lock`.
-   - Delete `culture/agentirc/` entirely.
-   - Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.
-   - Replace `culture/cli/server.py` with the passthrough shim.
-   - Update imports across culture: `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`; `culture.agentirc.config` → `agentirc.config`; protocol-constant string-literals → `agentirc.protocol`.
-   - Move `protocol/extensions/` out (lives in agentirc now).
-   - Move IRCd-targeted tests out of culture; keep transport / shim / mesh / bot / backend tests.
-   - Add `tests/test_server_shim.py`: invokes `culture server --help`, asserts it matches `agentirc --help` output to prove the passthrough.
-   - `/version-bump major` on culture (deleting the in-tree IRCd is a structural change, even if user-visible CLI is unchanged).
-   - `doc-test-alignment` audit before first push (per culture's CLAUDE.md).
-3. **Verification on a real deployment:**
-   - `pip install -U culture` on a host running `culture-agent-spark-culture.service`.
-   - Confirm the service restarts cleanly with the new agentirc dependency.
-   - Confirm `culture server status` and `agentirc status` produce identical output.
-   - Confirm an existing peer link still establishes (server-link tests in agentirc's CI cover the protocol; this is the in-prod sanity check).
+### Track A — culture-side (implemented in this repo)
+
+A single PR off `main`, following culture's standard workflow.
+
+1. `pyproject.toml`: add `agentirc-cli>=0.1,<0.2`. Regenerate `uv.lock`.
+2. Delete `culture/agentirc/` entirely.
+3. Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.
+4. Replace `culture/cli/server.py` with the passthrough shim (see "CLI surface" above).
+5. Update imports across culture:
+   - `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`
+   - `culture.agentirc.config` → `agentirc.config`
+   - Protocol-constant string-literals in `culture/transport/client.py` → `agentirc.protocol.*`
+6. Move `protocol/extensions/` out of culture (it lives in agentirc now).
+7. Move IRCd-targeted tests out of culture (they live in agentirc now); keep transport / shim / mesh / bot / backend tests.
+8. Add `tests/test_server_shim.py`: invokes `culture server --help` and asserts it matches `agentirc --help` output to prove the passthrough is byte-faithful.
+9. `/version-bump major` on culture (deleting the in-tree IRCd is a structural change even though user-visible CLI is unchanged).
+10. Run the `doc-test-alignment` subagent before the first push (per culture's CLAUDE.md).
+11. CI must be green and `agentirc-cli==<chosen pin>` must be installable from PyPI before merge.
+
+### Track B — hand-off brief for the agentirc agent
+
+This block is the deliverable. It is **handed to the agent working in `../agentirc`** and is intended to be self-contained — the receiving agent should not need culture-side context to act on it.
+
+**Goal:** Bootstrap `../agentirc` as a publishable Python package called `agentirc-cli` (import name `agentirc`, CLI binary `agentirc`) carrying the IRCd server core extracted from culture, plus a new CLI dispatch module and protocol-constants module. Tag `v0.1.0` and publish to PyPI.
+
+**Inputs:**
+
+- `../culture/culture/agentirc/` — server-core source, *minus* `client.py`, `remote_client.py`, `__main__.py` (those stay in culture).
+- `../culture/protocol/extensions/` — protocol docs, moved wholesale.
+- `../culture/tests/` — any test that imports `culture.agentirc.*` and is *not* transport-focused; sort per "Test-suite migration" below.
+- `../culture/culture/cli/server.py` — current server-lifecycle CLI dispatch; the new `agentirc/cli.py` is extracted from this.
+- The source-of-truth culture commit SHA at the time of copy (caller will provide).
+
+**Tasks:**
+
+1. Create the package layout under `../agentirc/agentirc/` exactly as specified in "Repo layout — `../agentirc`" earlier in this spec.
+2. Copy each server-core file from culture into `../agentirc/agentirc/` per the "What moves to `../agentirc`" table.
+3. Copy `protocol/extensions/` from culture into `../agentirc/protocol/extensions/`.
+4. Sort the relevant tests from culture's `tests/` into `../agentirc/tests/` per the "Test-suite migration" rules in this spec's Testing section.
+5. Rewrite imports inside the new tree: `from culture.agentirc.X` → `from agentirc.X`. There must be no remaining `culture.` imports in agentirc.
+6. Create `agentirc/cli.py` from culture's `cli/server.py` server-lifecycle code. Expose:
+   - `main()` — entrypoint for the `agentirc` console script.
+   - `dispatch(argv: list[str]) -> int` — the function culture's shim will call. Same flag set, same exit codes, same output as the CLI binary.
+   - Subcommands per the "CLI surface" table (`serve`, `start`, `stop`, `restart`, `status`, `link`, `logs`, `version`).
+   - `--config` defaults to `~/.culture/server.yaml`.
+7. Create `agentirc/protocol.py`. Pull verb names, numeric reply codes, and extension tags out of string-literals in `ircd.py` (and in culture's `client.py` — read it for reference but do **not** copy the file). Export them as named constants.
+8. Create `agentirc/__main__.py` so `python -m agentirc` works (delegates to `agentirc.cli:main`).
+9. Write `pyproject.toml`: `name = "agentirc-cli"`, `version = "0.1.0"`, scripts `agentirc = "agentirc.cli:main"`. Mirror culture's dev-dep set (pytest, pytest-asyncio, pytest-xdist, black, isort, flake8, pylint, bandit, markdownlint).
+10. Mirror culture's pre-commit, CI, and `/version-bump`/CHANGELOG workflow. Start CHANGELOG at `0.1.0`.
+11. Write `docs/api-stability.md` documenting the public surface culture pins on: `agentirc.config`, `agentirc.cli`, `agentirc.protocol`. Mark everything else internal.
+12. First commit message: `Initial import from culture@<SHA>` (where `<SHA>` is the culture commit ID provided by the caller).
+13. Run the full test suite — it must pass before tagging.
+14. Tag `v0.1.0`, push, publish to PyPI as `agentirc-cli`. (PyPI publishing is already set up.)
+15. Report back the published version + git SHA so culture's Track A PR can pin against it.
+
+**Out of scope for Track B:**
+
+- Editing culture. Track B touches `../agentirc` only.
+- Rewriting any of the moved code beyond import-path adjustments and the new `cli.py`/`protocol.py` modules. The IRCd, stores, channels, server-link, and skills are copied as-is.
+- Renaming on-disk artifacts (config paths, sockets, systemd unit names) — they stay culture-named per the Configuration section.
+- Publishing protocol/extensions docs externally.
+
+**Acceptance criteria:**
+
+- `pip install agentirc-cli==0.1.0` from PyPI produces a working `agentirc` binary.
+- `agentirc serve --config ~/.culture/server.yaml` starts an IRCd indistinguishable from today's `culture server start`.
+- `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec`, `agentirc.cli.dispatch`, and `agentirc.protocol.*` are importable.
+- All tests in `../agentirc/tests/` pass under `pytest -n auto`.
+- `git grep -E '^(from|import) culture' agentirc/ tests/` returns nothing.
+
+### Track C — verification on a real deployment
+
+After Track A merges and culture is released:
+
+- `pip install -U culture` on a host running `culture-agent-spark-culture.service`.
+- Confirm the service restarts cleanly with the new `agentirc-cli` dependency.
+- Confirm `culture server status` and `agentirc status` produce byte-identical output.
+- Confirm an existing peer link still establishes (server-link tests in agentirc's CI cover the protocol; this is the in-prod sanity check).
 
 ### Distribution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.7.1"
+version = "8.8.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -15,6 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0",
+    "agentirc-cli>=9.4,<10",
     "anthropic>=0.40",
     "claude-agent-sdk>=0.1",
     "mistune>=3.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
+from agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
 from opentelemetry import metrics as otel_metrics
 from opentelemetry import trace
 from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
@@ -13,7 +14,6 @@ from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from culture.agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
 from culture.agentirc.ircd import IRCd
 from culture.telemetry.metrics import reset_for_tests as _reset_metrics
 from culture.telemetry.tracing import reset_for_tests as _reset_telemetry

--- a/tests/test_agentirc_config_shim.py
+++ b/tests/test_agentirc_config_shim.py
@@ -1,0 +1,23 @@
+"""Pin the culture.agentirc.config → agentirc.config re-export shim.
+
+`culture/agentirc/config.py` re-exports the three config dataclasses
+from the published `agentirc-cli` PyPI package so that legacy
+`from culture.agentirc.config import ...` call sites resolve to the
+same class objects as `from agentirc.config import ...`. Identity
+collapse is what lets the in-process IRCd at `culture/agentirc/ircd.py`
+keep working unchanged while telemetry/CLI/conftest call sites import
+directly from `agentirc.config`.
+
+Delete this test alongside the shim in Phase A3 (see
+`agentculture/culture#308`).
+"""
+
+import agentirc.config as upstream
+
+from culture.agentirc import config as shim
+
+
+def test_shim_is_identity():
+    assert shim.ServerConfig is upstream.ServerConfig
+    assert shim.LinkConfig is upstream.LinkConfig
+    assert shim.TelemetryConfig is upstream.TelemetryConfig

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,21 @@ wheels = [
 ]
 
 [[package]]
+name = "agentirc-cli"
+version = "9.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a2/8b634f282dee305914bc7981b9078e974807b2dfaa86cf703a34fed0f260/agentirc_cli-9.4.1.tar.gz", hash = "sha256:cee4f94485cd005c8db4a0314b40b090258b5f0a655b3407772ff0db9594495b", size = 203722, upload-time = "2026-05-01T16:07:52.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/b7/330842c7791663945658b1c42f4f63038e463f925c55cdc891d0374ec9dc/agentirc_cli-9.4.1-py3-none-any.whl", hash = "sha256:12c0db88541f30f443910b139bb897f06c99024f49cc3b0ded26c0bb2b1365c5", size = 92046, upload-time = "2026-05-01T16:07:53.473Z" },
+]
+
+[[package]]
 name = "agex-cli"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -591,10 +606,11 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.7.1"
+version = "8.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },
+    { name = "agentirc-cli" },
     { name = "agex-cli" },
     { name = "aiohttp" },
     { name = "anthropic" },
@@ -635,6 +651,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "afi-cli", specifier = ">=0.3,<1.0" },
+    { name = "agentirc-cli", specifier = ">=9.4,<10" },
     { name = "agex-cli", specifier = ">=0.13,<1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", specifier = ">=0.40" },


### PR DESCRIPTION
## Summary

- Pin `agentirc-cli>=9.4,<10` and source `ServerConfig` / `LinkConfig` / `TelemetryConfig` from the published `agentirc.config` instead of culture's local copy. First culture-side step of the Track A cutover from #308.
- `culture/agentirc/config.py` becomes a re-export shim — existing `from culture.agentirc.config import ...` call sites resolve to the same class as `from agentirc.config import ...` (verified by `tests/test_agentirc_config_shim.py`). Identity collapse keeps the in-process IRCd, `culture/cli/server.py:_run_server`, and `culture/agentirc/__main__.py` working unchanged.
- Canonical call sites retargeted to `agentirc.config` directly: `culture/cli/shared/mesh.py`, `culture/config.py`, `culture/telemetry/{metrics,tracing,audit}.py`, `tests/conftest.py`.
- `8.7.1 → 8.8.0` (minor — additive, no public-API removal).

## Phasing & blocker

Issue #308 outlined a single PR that deletes `culture/agentirc/{ircd, ...}.py` and shims `culture server start` to `subprocess.run(["agentirc", *argv])`. That can't land today: culture's bots (`culture/bots/*`) hold an in-process `IRCd` reference and reach into `server.emit_event` / `server.channels` / `server.get_or_create_channel` directly, and agentirc's public API ([`docs/api-stability.md`](https://github.com/agentculture/agentirc/blob/main/docs/api-stability.md)) exposes no out-of-process bot extension hook (`Event` / `EventType` are explicitly internal). I filed [agentculture/agentirc#15](https://github.com/agentculture/agentirc/issues/15) requesting a documented bot extension API. This PR is the part of Track A that's safe to land independently — the spec at `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` now carries an A1/A2/A3 phase breakdown reflecting that.

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` — 1153 tests pass (~57s)
- [x] `tests/test_agentirc_config_shim.py::test_shim_is_identity` — pins the load-bearing identity invariant
- [x] Field-by-field compat audit — `agentirc.config.{ServerConfig,LinkConfig,TelemetryConfig}` matches culture's prior local definitions exactly (verified via `__dataclass_fields__` introspection)
- [x] Pre-commit hooks (black, isort, flake8, pylint, bandit, markdownlint) all green

Out of scope here (Phase A2 / A3): bot rewrite, deletion of `culture/agentirc/{ircd, server_link, channel, ...}.py`, subprocess shim for `culture server start`, dropping `culture/agentirc/` from the wheel, major bump. All depend on agentculture/agentirc#15 closing.

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)