### PR TITLE
docs: split agentirc extraction into A2 + A3 plans

### DIFF
--- a/docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md
+++ b/docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md
@@ -1,5 +1,13 @@
 # AgentIRC Extraction — Track A (Culture-Side Cutover) Implementation Plan
 
+> **⚠ Superseded (2026-05-02).** This plan drafted A1+A2+A3 as a single PR. Phasing forced a split:
+>
+> - **A1** (config dataclasses) shipped in culture#309 (8.8.0, 2026-05-01).
+> - **A2** (bot framework rewrite against agentirc-cli 9.5 public extension API) — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`.
+> - **A3** (delete bundled IRCd + subprocess shim + major bump) — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.
+>
+> This file is kept for historical context; do not execute it. Companion spec (still authoritative): `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Cut over culture to consume the `agentirc-cli` PyPI package: delete the in-tree IRCd, relocate the client transport to `culture/transport/`, install a 1:1 passthrough shim at `culture server <verb>`, and ship a major version bump.

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
@@ -217,7 +217,7 @@ This is the heart of A2. `VirtualClient` today is a duck-typed in-process bot th
   - DM: just send `PRIVMSG <nick> :<text>`. The server resolves the nick.
   - Mention: parse mentions out of incoming `EVENT` payloads; for each mention, send `NOTICE <nick> :<mention-text>`. No client lookup needed.
 
-- [ ] **Step 4.5:** Replace `server.config.name` (line 36) with the bot's own configured server identity, read from `~/.culture/server.yaml` via `agentirc.config.ServerConfig`. The system-nick prefix is a culture-side concept; keep the prefix logic in `culture/bots/virtual_client.py` and source the server name from culture's own config loader, not from a server reference.
+- [ ] **Step 4.5:** Replace `server.config.name` (line 36) with the bot's own configured server identity, read from `~/.culture/server.yaml` via culture's own loader (`culture.config.load_server_config(path)` → `culture.config.ServerConfig`). The `~/.culture/server.yaml` schema is culture's nested format and is parsed by `culture.config.ServerConfig`, **not** by `agentirc.config.ServerConfig` (which is the IRCd's flat config dataclass and would fail to parse the nested file). The system-nick prefix is a culture-side concept; keep the prefix logic in `culture/bots/virtual_client.py` and source the server name from `culture.config.ServerConfig.name` (and `webhook_port` from the same instance for Tasks 5 and 7), not from a server reference.
 
 - [ ] **Step 4.6:** Add `EVENTSUB` subscription registration in `VirtualClient.__init__` or `start`. The bot's filter is whatever the bot's `BotConfig.trigger_type == "event"` filter compiles to (see `culture/bots/filter_dsl.py`). For non-event-triggered bots (webhook only), no subscription is needed.
 
@@ -275,7 +275,7 @@ Bot composes `BotConfig` + `VirtualClient` + `IRCd` ref today. The IRCd ref is u
 
 - [ ] **Step 6.3:** Remove the `IRCd` reference from `BotManager.__init__`. The manager constructs:
   - `culture.telemetry.metrics` (module import).
-  - `agentirc.config.ServerConfig` (loaded from `~/.culture/server.yaml`).
+  - `culture.config.ServerConfig` (loaded from `~/.culture/server.yaml` via `culture.config.load_server_config`). The nested `~/.culture/server.yaml` schema is culture's, not agentirc's — see Step 4.5 above.
   - A `VirtualClient` per bot (per Task 4), each with its own `EVENTSUB` subscription if event-triggered.
 
 - [ ] **Step 6.4:** Update `BotManager.dispatch(bot_name, payload)` (line 215) to no longer assume an IRCd is local — webhook payloads come in via `http_listener.py` and just route to the bot's `handle()` method, same as today.

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
@@ -1,0 +1,546 @@
+# AgentIRC Extraction — Track A2 (Bot Framework Rewrite) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite culture's bot framework against the public bot extension API in `agentirc-cli==9.5.0` (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, canonical 5-field envelope in `agentirc.protocol`). After this lands, `culture/bots/*` no longer holds an in-process `IRCd` reference and no longer reaches into `server.emit_event`/`server.channels`/`server.get_or_create_channel`/`server.get_client`/`server.config`/`server.metrics`. This unblocks Track A3 — the deletion of `culture/agentirc/{ircd,server_link,channel,…}` and the subprocess shim at `culture server`.
+
+**Architecture:** Single PR off `main`. Bumps the dep floor to `agentirc-cli>=9.5,<10`. Rewrites `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` and `culture/bots/system/__init__.py`. Culture takes ownership of the `webhook_port` HTTP listener (agentirc 9.5 no longer binds it). Bot tests stay; the harness shifts from "construct an IRCd, hand it to BotManager" to "spin up an IRCd, connect a CAP-bot to it." Minor bump 8.8.0 → 8.9.0.
+
+**Tech Stack:** Python 3.x, uv (deps + lockfile), aiohttp (existing webhook listener), pytest + pytest-asyncio + pytest-xdist, pre-commit (black + isort + flake8 + pylint + bandit + markdownlint).
+
+**Companion spec:** `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (see "Implementation status" table for A2 row, "Federation interop during the migration window" for the optional sniff patch).
+
+---
+
+## Preconditions (do not start until all are true)
+
+- `agentirc-cli==9.5.0` (or any later 9.5.x patch) is installable from PyPI:
+
+  ```bash
+  uv pip install --dry-run "agentirc-cli>=9.5,<10" 2>&1 | tail -5
+  ```
+
+  Expected: a line like `Would install agentirc-cli==9.5.0`.
+
+- The public surface culture will pin against is reachable:
+
+  ```bash
+  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "
+  from agentirc.protocol import Event, EventType, EVENT_TYPE_RE
+  from agentirc.protocol import EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB
+  print('envelope fields:', sorted(Event.__dataclass_fields__))
+  print('verbs:', EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB)
+  "
+  ```
+
+  Expected: `envelope fields: ['channel', 'data', 'nick', 'timestamp', 'type']`. If `agentirc.protocol` doesn't export these, **stop** — the floor was bumped past a release that doesn't actually carry the surface.
+
+- `agentirc.io/bot` CAP is advertised by **both** the in-tree bundled IRCd and a freshly-installed `agentirc serve`:
+
+  ```bash
+  # Bundled IRCd (still in tree until A3):
+  python -c "from culture.agentirc.ircd import IRCd; from agentirc.config import ServerConfig; print('bundled CAP', IRCd(ServerConfig(name='t')).advertised_caps)"
+
+  # Installed agentirc:
+  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "from agentirc.ircd import IRCd; from agentirc.config import ServerConfig; print('installed CAP', IRCd(ServerConfig(name='t')).advertised_caps)"
+  ```
+
+  Both must list `agentirc.io/bot`. If the bundled IRCd doesn't yet, **stop** — A2 lands before A3 with the bundled IRCd still hosting bots, so the bundled IRCd must speak the CAP. If only the bundled IRCd is missing, the simplest fix is to merge the bot CAP support upstream (forward-port from agentirc 9.5 into `culture/agentirc/`) before continuing — that's a separate small PR, see the "Bundled-IRCd CAP backport" precondition note below.
+
+- Working tree on `main` is clean. `git status` shows no staged/unstaged changes inside `culture/bots/`, `culture/agentirc/`, `culture/cli/server.py`, or `tests/test_*bot*.py`.
+
+### Bundled-IRCd CAP backport (separate small PR if needed)
+
+If the bundled IRCd in `culture/agentirc/` doesn't yet advertise `agentirc.io/bot` or handle `EVENTSUB`/`EVENTPUB`, ship a minimal backport as a standalone patch PR (8.8.0 → 8.8.1 patch — pure compat, no public-API change). Cherry-pick the relevant changes from agentirc PR #20 into `culture/agentirc/{ircd.py,server_link.py,protocol.py}`. Independent of this plan; a hard precondition for it. The simpler alternative is to skip A2 in-tree testing entirely and run A2 + A3 in the same release window — but that loses the safety of landing A2 against the still-bundled IRCd.
+
+---
+
+## File Structure (what changes in this PR)
+
+| Path | Action | Notes |
+|---|---|---|
+| `pyproject.toml` | Modify | Bump `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.5,<10`. |
+| `uv.lock` | Modify | Regenerate via `uv lock`. |
+| `culture/bots/virtual_client.py` | Rewrite | Drop `server` reference; become a CAP-bot client (see Task 4 decision point). |
+| `culture/bots/bot.py` | Modify | Replace `server.get_client`/`server.channels.get`/`server.emit_event`/`server.config.webhook_port` with `EVENTPUB` + bot-client helpers. |
+| `culture/bots/bot_manager.py` | Modify | Replace in-process `on_event` hook with an `EVENTSUB` subscription. Telemetry handle moves to `culture.telemetry.metrics` directly. |
+| `culture/bots/http_listener.py` | Modify | Listener owned by `BotManager`, not by `IRCd`. Route handlers unchanged. |
+| `culture/bots/system/__init__.py` | Modify | `discover_system_bots` no longer needs an `IRCd` reference. |
+| `culture/agentirc/ircd.py` | Modify | Stop instantiating `BotManager`/`HttpListener` here. Bots are external CAP clients now. (Lines ~92-122 today.) |
+| `culture/agentirc/CLAUDE.md` | Modify | Note: bots no longer depend on the in-process IRCd; only `culture/cli/server.py:_run_server` still imports `culture.agentirc.{ircd,server_link,channel}`. |
+| `tests/test_*bot*.py`, `tests/test_virtual_client.py`, `tests/test_events_bot_*.py`, `tests/test_welcome_bot.py`, `tests/test_http_listener.py` | Modify (harness) | Where tests construct an `IRCd` and pass it to `BotManager`, switch to constructing an `IRCd` and starting a separate `BotManager` that connects to it as a CAP client. Test assertions about behavior stay. |
+| `tests/conftest.py` | Modify (fixtures) | Add a `cap_bot_client` fixture that wraps `agentirc.protocol.Event` decoding for tests. |
+| `culture/__init__.py`, `pyproject.toml`, `CHANGELOG.md` | Modify | `/version-bump minor` (8.8.0 → 8.9.0). |
+
+---
+
+## Task 1 — Verify preconditions
+
+**Files:** none (verification only).
+
+- [ ] **Step 1.1:** Confirm 9.5.0 is on PyPI.
+
+  ```bash
+  uv pip install --dry-run "agentirc-cli>=9.5,<10" 2>&1 | tail -5
+  ```
+
+- [ ] **Step 1.2:** Confirm the public surface.
+
+  Run the `agentirc.protocol` snippet from "Preconditions" above. **Save the output** — Tasks 4-6 reference these symbol names.
+
+- [ ] **Step 1.3:** Confirm both IRCds advertise `agentirc.io/bot`.
+
+  Run both CAP-advertise snippets from "Preconditions". If only the bundled one is missing, branch out and ship the cherry-pick PR (see "Bundled-IRCd CAP backport"); merge it before continuing.
+
+- [ ] **Step 1.4:** Smoke-test an `EVENTSUB` round-trip against a freshly-installed `agentirc serve`.
+
+  ```bash
+  cd /tmp && uv venv eventsub-check && uv pip install --python eventsub-check/bin/python "agentirc-cli>=9.5,<10" >/dev/null
+  eventsub-check/bin/agentirc serve --config /tmp/test-server.yaml &
+  AGENTIRC_PID=$!
+  sleep 2
+  # connect a raw client, NICK/USER, CAP REQ agentirc.io/bot, EVENTSUB 1, JOIN #room from another client, expect EVENT 1 :<base64-json>
+  # (full snippet in agentirc/docs/cli.md)
+  kill $AGENTIRC_PID
+  ```
+
+  Smoke test only — full integration coverage comes from the rewritten bot tests in Task 9.
+
+---
+
+## Task 2 — Branch and bump the dependency
+
+**Files:** `pyproject.toml`, `uv.lock`.
+
+- [ ] **Step 2.1:** Branch out.
+
+  ```bash
+  git checkout main && git pull
+  git checkout -b feat/bots-public-extension-api
+  ```
+
+- [ ] **Step 2.2:** Bump the floor in `pyproject.toml`.
+
+  Locate the `dependencies = [...]` block and change `"agentirc-cli>=9.4,<10"` → `"agentirc-cli>=9.5,<10"`.
+
+- [ ] **Step 2.3:** Regenerate the lockfile.
+
+  ```bash
+  uv lock
+  ```
+
+  Stage both files together (per culture's CLAUDE.md "always stage uv.lock with pyproject.toml" rule).
+
+- [ ] **Step 2.4:** Sanity check — the existing test suite still passes against 9.5 with the bot framework unchanged.
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_bots_integration.py tests/test_virtual_client.py
+  ```
+
+  Expected: green. The dep bump alone shouldn't change behavior; A1's config shim absorbs any 9.4 → 9.5 dataclass-field additions.
+
+---
+
+## Task 3 — Retarget `Event`/`EventType` imports to `agentirc.protocol`
+
+**Files:** `culture/bots/virtual_client.py`, anywhere else culture imports `Event`/`EventType`.
+
+The transitional re-exports at `agentirc.skill.{Event, EventType}` work through 9.5.x and disappear in 10.0.0. Pin to `agentirc.protocol` directly.
+
+- [ ] **Step 3.1:** Find every site that imports `Event` or `EventType` from `culture.agentirc.skill` or `agentirc.skill`.
+
+  ```bash
+  grep -rn 'from culture\.agentirc\.skill import\|from agentirc\.skill import' culture/ tests/
+  ```
+
+  Survey-time hit list (verify on the current main):
+  - `culture/bots/virtual_client.py:8`
+
+  Expect this to be the only match. If there are more, add them to the change set.
+
+- [ ] **Step 3.2:** Replace each import:
+
+  ```python
+  # before
+  from culture.agentirc.skill import Event, EventType
+  # after
+  from agentirc.protocol import Event, EventType
+  ```
+
+- [ ] **Step 3.3:** Run a focused test pass to confirm no behavior change.
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_virtual_client.py tests/test_events_bot_trigger.py tests/test_events_bot_chain.py
+  ```
+
+  Expected: green. This step is purely a renamed import.
+
+---
+
+## Task 4 — Rewrite `culture/bots/virtual_client.py` against the public extension API
+
+**Files:** `culture/bots/virtual_client.py`.
+
+This is the heart of A2. `VirtualClient` today is a duck-typed in-process bot that holds an `IRCd` reference (`self.server`) and uses it for: (a) emitting events, (b) reading/writing channel state, (c) resolving nicks, (d) reading server config. Each of these has a public-API equivalent in 9.5.
+
+- [ ] **Step 4.1: Decision point — connection model.** Before writing code, decide:
+
+  - **Option A: TCP CAP-bot client.** `VirtualClient` opens a real connection to `127.0.0.1:<irc_port>` (the same port humans use), `CAP REQ agentirc.io/bot`, and uses standard IRC verbs + the new `EVENT*` verbs for all bot operations.
+  - **Option B: In-process Python API.** If `agentirc-cli==9.5` exposes a class like `agentirc.bot.Bot` or `agentirc.bot.Client` for in-process bot hosting, use that.
+
+  Verify which option agentirc 9.5 supports:
+
+  ```bash
+  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "
+  import agentirc
+  print(sorted(n for n in dir(agentirc) if not n.startswith('_')))
+  try:
+      import agentirc.bot
+      print('bot module:', sorted(n for n in dir(agentirc.bot) if not n.startswith('_')))
+  except ImportError:
+      print('no agentirc.bot module — Option A required')
+  "
+  ```
+
+  **Record the decision in this task before continuing.** Recommendation: prefer Option B if available (matches the in-process pattern agentirc's own `VirtualClient` uses for the system bot, per agentirc#15 closing comment); fall back to Option A.
+
+- [ ] **Step 4.2:** Replace the four `server.emit_event(Event(...))` call sites (current lines 76, 95, 136, 158) with `EVENTPUB`. The wire form is `EVENTPUB <type> <channel-or-*> :<base64-json-data>`. Under Option B, the API call is the agentirc-provided `bot.emit(type, channel, data)`. Under Option A, the call is the bot client's own `send_eventpub(type, channel, data_dict)`. The 5-field envelope (`type`/`channel`/`nick`/`data`/`timestamp`) is constructed server-side; the bot only supplies `type`, `channel`, and `data` (`nick` is the bot's own nick; `timestamp` is server-set).
+
+- [ ] **Step 4.3:** Replace the four `server.channels.get(name)`/`del` accesses (lines 82, 109, 121, 144) and the `server.get_or_create_channel(name)` access (line 56). These are used today for: pre-checking JOIN, post-PART cleanup, broadcast membership walk, mention recipient walk.
+
+  - For JOIN/PART: rely on the IRC `JOIN` verb (server tracks membership; bot doesn't need to).
+  - For broadcast and mention walks: use the inbound `EVENT` envelopes plus the existing IRC `NAMES` / `WHO` paths the harness uses for any human-facing client. Do not maintain a duplicate channel registry inside the bot process.
+  - If a piece of state (e.g., "is this user opt-in for this channel") is genuinely needed, surface it via an `EVENT` filter instead of polling state.
+
+- [ ] **Step 4.4:** Replace the two `server.get_client(nick)` lookups (lines 175, 212). These are for DM target resolution and `@`-mention recipient lookup. Equivalents:
+
+  - DM: just send `PRIVMSG <nick> :<text>`. The server resolves the nick.
+  - Mention: parse mentions out of incoming `EVENT` payloads; for each mention, send `NOTICE <nick> :<mention-text>`. No client lookup needed.
+
+- [ ] **Step 4.5:** Replace `server.config.name` (line 36) with the bot's own configured server identity, read from `~/.culture/server.yaml` via `agentirc.config.ServerConfig`. The system-nick prefix is a culture-side concept; keep the prefix logic in `culture/bots/virtual_client.py` and source the server name from culture's own config loader, not from a server reference.
+
+- [ ] **Step 4.6:** Add `EVENTSUB` subscription registration in `VirtualClient.__init__` or `start`. The bot's filter is whatever the bot's `BotConfig.trigger_type == "event"` filter compiles to (see `culture/bots/filter_dsl.py`). For non-event-triggered bots (webhook only), no subscription is needed.
+
+- [ ] **Step 4.7:** Run the focused tests:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_virtual_client.py
+  ```
+
+  Expected: green. Anything that fails here is a behavioral mismatch in the rewrite — fix it now, not later.
+
+---
+
+## Task 5 — Refactor `culture/bots/bot.py`
+
+**Files:** `culture/bots/bot.py`.
+
+Bot composes `BotConfig` + `VirtualClient` + `IRCd` ref today. The IRCd ref is used at four sites:
+
+- [ ] **Step 5.1:** `bot.py:98` (`server.get_client` for nick collision check at start). Replace with a `WHO <nick>` query against the bot's own connection (Option A) or a public helper (Option B).
+
+- [ ] **Step 5.2:** `bot.py:168` (`server.channels.get` for dynamic-join channel check). Replace with a `LIST <channel>` or remove entirely if the JOIN itself is sufficient (server returns an error if the channel doesn't exist and the bot's not allowed to create it).
+
+- [ ] **Step 5.3:** `bot.py:211` (`server.emit_event` for `fires_event`). Replace with `EVENTPUB`. The `fires_event` semantics — bot triggers downstream bots — survive unchanged because `EVENTPUB` reuses `IRCd.emit_event` server-side and federation/skill-hooks/`#system` surfacing all happen on the same path (per agentirc#15 closing comment, "Decision E").
+
+- [ ] **Step 5.4:** `bot.py:89-90` (`server.config.webhook_port` for URL construction). Read directly from culture's own `ServerConfig` instance (the one `BotManager` constructs in Task 6).
+
+- [ ] **Step 5.5:** Remove the `server: IRCd` field from `Bot.__init__`. The bot composes `BotConfig` + `VirtualClient` + culture's own `ServerConfig`; that's all it needs.
+
+- [ ] **Step 5.6:** Run the focused tests:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_bot.py tests/test_bot_config_fires_event_toplevel.py
+  ```
+
+---
+
+## Task 6 — Refactor `culture/bots/bot_manager.py`
+
+**Files:** `culture/bots/bot_manager.py`.
+
+`BotManager.on_event` is hooked by `IRCd._dispatch_to_bots` today. After the cutover, the IRCd doesn't dispatch to bots — bots subscribe to events themselves via `EVENTSUB`. The manager becomes a coordinator of bot subscriptions, not an event sink.
+
+- [ ] **Step 6.1:** Replace the `on_event(self, event: Event)` method with a per-bot `EVENTSUB` registration that runs at bot start. For event-triggered bots, the manager (or each bot's `VirtualClient`) sends `EVENTSUB <id> [type=…] [channel=…] [nick=…]`; the filter is compiled from `BotConfig` via `filter_dsl.py` (already exists).
+
+- [ ] **Step 6.2:** Telemetry. The four `server.metrics.bot_invocations.add()` call sites (lines 138-145) and `bot_manager.server.metrics.bot_webhook_duration.record()` in `http_listener.py:73-76` switch to importing the meters directly:
+
+  ```python
+  from culture.telemetry import metrics as telemetry_metrics
+  telemetry_metrics.bot_invocations.add(1, attributes={...})
+  telemetry_metrics.bot_webhook_duration.record(elapsed, attributes={...})
+  ```
+
+  The OTEL instruments are already module-level in `culture/telemetry/metrics.py` (per A1's audit); no need to route through the server.
+
+- [ ] **Step 6.3:** Remove the `IRCd` reference from `BotManager.__init__`. The manager constructs:
+  - `culture.telemetry.metrics` (module import).
+  - `agentirc.config.ServerConfig` (loaded from `~/.culture/server.yaml`).
+  - A `VirtualClient` per bot (per Task 4), each with its own `EVENTSUB` subscription if event-triggered.
+
+- [ ] **Step 6.4:** Update `BotManager.dispatch(bot_name, payload)` (line 215) to no longer assume an IRCd is local — webhook payloads come in via `http_listener.py` and just route to the bot's `handle()` method, same as today.
+
+- [ ] **Step 6.5:** Run the focused tests:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_bot_manager.py tests/test_events_bot_trigger.py tests/test_events_bot_chain.py
+  ```
+
+---
+
+## Task 7 — Move webhook listener ownership from IRCd to BotManager
+
+**Files:** `culture/bots/http_listener.py`, `culture/agentirc/ircd.py`.
+
+agentirc 9.5 stops binding `webhook_port` (per agentirc#15 closing comment, "Webhook ownership"). `webhook_port` stays in `ServerConfig` for backward compat, but the listener moves to culture.
+
+- [ ] **Step 7.1:** Move the listener startup. Today (`culture/agentirc/ircd.py:112-116`):
+
+  ```python
+  self._http_listener = HttpListener(bot_manager, "127.0.0.1", webhook_port)
+  ```
+
+  Move this into `BotManager.start()`:
+
+  ```python
+  self._http_listener = HttpListener(self, "127.0.0.1", self.config.webhook_port)
+  await self._http_listener.start()
+  ```
+
+  Move the corresponding shutdown call (somewhere around `ircd.py:122` today) into `BotManager.stop()`.
+
+- [ ] **Step 7.2:** Delete the listener instantiation from `culture/agentirc/ircd.py`. After A2 lands, the bundled IRCd is bot-free — it's just an IRC server. (A3 will then delete the bundled IRCd entirely.)
+
+- [ ] **Step 7.3:** `HttpListener.__init__` already takes `bot_manager`; no signature change. Confirm `_handle_webhook` (line 81) still calls `bot_manager.dispatch(bot_name, payload)` — that path is unchanged.
+
+- [ ] **Step 7.4:** Run the focused tests:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_http_listener.py
+  ```
+
+  The `/health` endpoint test, success/failure POST tests, and 404/503 error code tests should all pass unchanged — they assert HTTP behavior, not who owns the listener.
+
+---
+
+## Task 8 — System bot loading without an IRCd reference
+
+**Files:** `culture/bots/system/__init__.py`, `culture/bots/bot_manager.py`.
+
+`BotManager.load_system_bots()` (line 147) currently calls `discover_system_bots()` and passes its `IRCd` reference. After A2, system bots are just normal bots that happen to ship in the wheel; they connect via the same CAP-bot path as user bots.
+
+- [ ] **Step 8.1:** Update `discover_system_bots(server_name: str)` signature — take a server name string, not an `IRCd`. The function scans `culture/bots/system/<subdir>/bot.yaml` and prefixes each name with `system-{server_name}-`.
+
+- [ ] **Step 8.2:** Update `BotManager.load_system_bots()` to pass `self.config.name` instead of an IRCd reference.
+
+- [ ] **Step 8.3:** Run the focused test:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_welcome_bot.py
+  ```
+
+---
+
+## Task 9 — Test harness migration
+
+**Files:** all `tests/test_*bot*.py`, `tests/test_virtual_client.py`, `tests/test_events_bot_*.py`, `tests/test_welcome_bot.py`, `tests/test_http_listener.py`, `tests/conftest.py`.
+
+The tests assert bot behavior — webhook → IRC flow, event filter matching, fires_event chains, system bot rendering, virtual-client JOIN/PART. These behaviors are unchanged; only the harness for setting up "an IRCd plus some bots" changes.
+
+- [ ] **Step 9.1:** Add a `cap_bot_client` fixture to `tests/conftest.py`:
+
+  ```python
+  @pytest.fixture
+  async def cap_bot_client(ircd):
+      """Connect a CAP-bot client to the running IRCd. Returns a helper with .send(), .recv(), .eventsub(), .eventpub()."""
+      # ... establish connection, NICK/USER, CAP REQ agentirc.io/bot, ACK
+  ```
+
+  The fixture is the testing-side analog of `VirtualClient` — it mirrors the verb sequence but exposes assertion-friendly helpers.
+
+- [ ] **Step 9.2:** For each test file, replace the "construct IRCd, hand to BotManager, manipulate bots in-process" pattern with "construct IRCd, start BotManager, BotManager opens CAP-bot connections to IRCd". Most tests need at most a few lines changed in the setup; assertions stay.
+
+- [ ] **Step 9.3:** Special cases:
+  - `tests/test_events_bot_chain.py` — bot fires event, second bot triggers. After A2, both bots are CAP clients; the chain runs over the wire (`EVENTPUB` → server `emit_event` → reflexive `EVENT` to subscribed bots). Expected to work unchanged in observable behavior.
+  - `tests/test_bots_integration.py` — full webhook → IRC flow. Webhook listener is now in `BotManager`; the `POST /<bot>` URL is unchanged (`http://127.0.0.1:<webhook_port>/<bot>`).
+  - `tests/test_virtual_client.py` — was unit-testing the in-process `VirtualClient`. Rename helper assertions if internal method names change; behavioral assertions stay.
+
+- [ ] **Step 9.4:** Run the full test suite:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q
+  ```
+
+  Expected: all green. If anything fails, fix before continuing — don't push broken tests to CI.
+
+---
+
+## Task 10 — `culture/agentirc/CLAUDE.md` note
+
+**Files:** `culture/agentirc/CLAUDE.md`.
+
+- [ ] **Step 10.1:** Append a paragraph noting that bots are no longer in-process consumers of this directory:
+
+  ```markdown
+  ## Status (after A2, 2026-05-XX)
+
+  After Phase A2 (`feat/bots-public-extension-api`), `culture/bots/*` no
+  longer holds an in-process `IRCd` reference. Bots connect to the IRCd
+  via the public `agentirc.io/bot` CAP and use `EVENTSUB`/`EVENTPUB`
+  instead of `server.emit_event` and `server.channels`. The only
+  remaining culture-side consumer of `culture/agentirc/{ircd, server_link,
+  channel, ...}` internals is `culture/cli/server.py:_run_server`. A3
+  deletes the bundled IRCd and replaces that import with a subprocess
+  shim into the installed `agentirc` binary.
+  ```
+
+---
+
+## Task 11 — Pre-push reviewer + doc audit
+
+**Files:** none (audits only).
+
+- [ ] **Step 11.1:** Stage all changes and run the code reviewer agent on the diff:
+
+  ```bash
+  git add -p   # selective; or git add for everything in the change set
+  ```
+
+  Then invoke `superpowers:code-reviewer` per culture/CLAUDE.md's "Pre-push review for library/protocol code" rule. A2 touches transport (CAP negotiation, EVENT verb wire format) and protocol parsers — exactly the choke points the rule targets.
+
+- [ ] **Step 11.2:** Run the `doc-test-alignment` subagent:
+
+  ```bash
+  Agent(subagent_type="doc-test-alignment", prompt="Audit the staged diff on feat/bots-public-extension-api for new public surface (CLI commands, config fields, IRC verbs, exceptions, public functions) and report missing docs/ or protocol/extensions/ coverage.")
+  ```
+
+  A2 is mostly internal rewrite, but the change in webhook ownership and the `agentirc.io/bot` CAP usage may need updates in `docs/` (search for `webhook_port`, `bot_manager`, `webhook listener`).
+
+- [ ] **Step 11.3:** Address any findings — fix docs, re-stage, repeat until both audits are clean.
+
+---
+
+## Task 12 — Version bump, push, PR
+
+**Files:** `culture/__init__.py`, `pyproject.toml`, `CHANGELOG.md`.
+
+- [ ] **Step 12.1:** `/version-bump minor` (8.8.0 → 8.9.0). A2 is additive within the bot framework — no public-API removal — so this is minor, not major.
+
+- [ ] **Step 12.2:** Verify the bump:
+
+  ```bash
+  grep -n '8\.9\.0' culture/__init__.py pyproject.toml CHANGELOG.md
+  ```
+
+- [ ] **Step 12.3:** Edit the new `[8.9.0]` section of `CHANGELOG.md` to describe what changed. Suggested entries:
+
+  ```markdown
+  ### Changed
+  - Rewrote culture/bots/* against the public bot extension API in agentirc-cli 9.5.0 (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTPUB`, 5-field envelope from `agentirc.protocol`). Bots no longer hold an in-process IRCd reference. Webhook listener (`webhook_port`) ownership moved from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`. Public bot behavior unchanged.
+  - Bumped `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.5,<10`.
+
+  ### Notes
+  - This is the second of three phases extracting `culture/agentirc/` into the standalone `agentirc-cli` PyPI package. Phase A1 (config dataclasses) shipped in 8.8.0 (#309); Phase A3 (delete bundled IRCd, subprocess shim, major bump) follows.
+  ```
+
+- [ ] **Step 12.4:** Final test pass + format check:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q
+  uv run black culture/bots/ culture/agentirc/ircd.py
+  uv run isort culture/bots/ culture/agentirc/ircd.py
+  ```
+
+- [ ] **Step 12.5:** Commit and push:
+
+  ```bash
+  git commit -m "$(cat <<'EOF'
+  feat(bots): rewrite against agentirc-cli 9.5 public extension API (Track A2)
+
+  Drops the in-process IRCd reference from culture/bots/*. Bots now subscribe
+  via EVENTSUB/EVENTPUB and connect with the agentirc.io/bot CAP. Webhook
+  listener ownership moves from IRCd to BotManager (agentirc 9.5 no longer
+  binds webhook_port). Unblocks Phase A3.
+
+  - Claude
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  git push -u origin feat/bots-public-extension-api
+  ```
+
+- [ ] **Step 12.6:** Open the PR via the `pr-review` skill (or `gh pr create`):
+
+  ```bash
+  gh pr create --title "Phase A2: rewrite bots against agentirc-cli 9.5 public extension API" --body "$(cat <<'EOF'
+  ## Summary
+
+  - Rewrite `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` against the public bot extension API in agentirc-cli 9.5.0 (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, 5-field envelope from `agentirc.protocol`).
+  - `Event`/`EventType` now sourced from `agentirc.protocol` directly (the `agentirc.skill` re-exports are transitional, gone in 10.0.0).
+  - Webhook listener (`webhook_port`) ownership moves from the IRCd to `BotManager` — agentirc 9.5 stops binding the port (per agentculture/agentirc#15 closing comment).
+  - Bumps dep floor `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.5,<10`.
+  - `8.8.0 → 8.9.0` (minor — additive, no public-API removal).
+
+  ## Why
+
+  Phase A2 of the agentirc extraction (spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`). Unblocks Phase A3 (delete bundled IRCd, subprocess shim, major bump) by removing culture/bots' last in-process dependency on `culture/agentirc/`.
+
+  ## Test plan
+
+  - [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` — full suite green
+  - [x] All 10 bot test files pass: `test_bots_integration.py`, `test_bot.py`, `test_http_listener.py`, `test_events_bot_trigger.py`, `test_events_bot_chain.py`, `test_bot_config_fires_event_toplevel.py`, `test_bot_config.py`, `test_bot_manager.py`, `test_welcome_bot.py`, `test_virtual_client.py`
+  - [x] Pre-commit hooks clean
+  - [x] `superpowers:code-reviewer` clean
+  - [x] `doc-test-alignment` clean
+
+  ## Out of scope (Phase A3 follow-up)
+
+  Deletion of `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py`, subprocess shim at `culture/cli/server.py:_run_server`, culture major bump. Plan: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.
+
+  - Claude
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+- [ ] **Step 12.7:** Wait for CI:
+
+  ```bash
+  gh pr checks
+  ```
+
+  If anything fails, fix inline, push, run `/sonarclaude` before declaring ready (per culture/CLAUDE.md). Use the `pr-review` skill for automated reviewer comments.
+
+---
+
+## Summary
+
+- Rewrites `culture/bots/*` against the public bot extension API in `agentirc-cli==9.5.0`. Drops the in-process IRCd reference. `EVENTSUB`/`EVENTPUB` replace `BotManager.on_event`/`server.emit_event`.
+- Webhook listener (`webhook_port`) ownership moves from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`.
+- `agentirc.skill.{Event, EventType}` import path → `agentirc.protocol.{Event, EventType}`.
+- Bumps dep floor to `agentirc-cli>=9.5,<10`. Minor bump 8.8.0 → 8.9.0.
+
+User-visible bot behavior is unchanged: webhook URLs, event filters, fires_event chains, system bots, telemetry counters all behave identically. The change is purely architectural — bots become CAP clients of the IRCd instead of in-process consumers.
+
+Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (Track A2 row).
+A3 follow-up: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.
+
+## Test plan
+
+- [ ] Existing bot test suite passes (`bash .claude/skills/run-tests/scripts/test.sh -p -q`).
+- [ ] `superpowers:code-reviewer` runs clean against the staged diff.
+- [ ] `doc-test-alignment` reports no missing `docs/` or `protocol/extensions/` coverage.
+- [ ] Post-merge: verify on the spark host that `culture-agent-spark-culture.service` continues to receive bot events (system welcome bot still greets joins, any user-configured event-triggered bots still fire).
+
+---
+
+## Post-merge (notes for A3 author)
+
+After this PR merges:
+
+- The bundled IRCd in `culture/agentirc/` is bot-free. Only `culture/cli/server.py:_run_server` still imports it.
+- A3 can now delete `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` and `culture/agentirc/skills/`, and replace `_run_server` with a subprocess shim into the installed `agentirc` binary.
+- `culture/agentirc/config.py` (the A1 re-export shim) stays — A3 keeps it through the 9.x line per the spec.
+- The federation envelope sniff (spec § "Federation interop during the migration window") is no longer relevant once A3 lands; ship it only if mixed-version peers are expected during the A2-to-A3 window.

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
@@ -61,7 +61,8 @@
 | `culture/agentirc/config.py` | Keep | A1 re-export shim over `agentirc.config`. Stays through 9.x; remove in 10.0.0. |
 | `culture/agentirc/__init__.py` | Modify | Trim to a single re-export of `agentirc.config` symbols. |
 | `culture/transport/__init__.py` | Create | Re-exports the public class names from `client.py` and `remote_client.py`. |
-| `culture/cli/server.py` | Rewrite | ~25 lines. Argparse `REMAINDER` passthrough into `agentirc.cli.dispatch` or `subprocess.run`. |
+| `culture/cli/server.py` | Rewrite | ~30 lines. Partial passthrough — culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) dispatch to `culture/cli/server_local.py`; everything else forwards to `agentirc.cli.dispatch` (or `subprocess.run` for `start`). |
+| `culture/cli/server_local.py` | Create | Houses the moved handler bodies for `default`/`rename`/`archive`/`unarchive` (extracted from today's `culture/cli/server.py`). Helpers (`read_default_server`, rename/archive utilities) stay in `culture/cli/shared/`. |
 | `culture/bots/`, `culture/clients/*/daemon.py` | Modify (imports only) | `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`. |
 | `protocol/extensions/` | Delete (whole dir) | Lives in agentirc now. |
 | `tests/test_*` for IRCd internals | Delete | They live in agentirc's repo now. |
@@ -176,48 +177,84 @@
 
 **Files:** `culture/cli/server.py`.
 
-- [ ] **Step 4.1:** Read the current `culture/cli/server.py` and identify the exact entrypoint culture's CLI dispatcher calls (likely `_run_server(args)` or similar). Note the function signature and return-type contract.
+- [ ] **Step 4.1:** Read the current `culture/cli/server.py` and enumerate **every** subcommand it owns. Today's `culture server` parser carries (per `culture/cli/server.py:1` docstring + the subparser block):
 
-- [ ] **Step 4.2:** Replace with the shim. Preferred shape (in-process, per Task 1.3 decision):
+  | Verb | Owner after A3 |
+  |---|---|
+  | `start`, `stop`, `status` | agentirc (lifecycle) |
+  | `link`, `logs`, `version`, `serve` | agentirc (lifecycle / introspection) |
+  | `default` | **culture** (writes the local default-server pointer; reads `read_default_server()` from `culture/cli/shared/server.py`) |
+  | `rename` | **culture** (renames the server in the local config and updates agent nicks; touches culture's own state) |
+  | `archive` | **culture** (archives the local server config; culture-side state) |
+  | `unarchive` | **culture** (unarchives the local server config; culture-side state) |
+
+  Run `grep -n 'add_parser\|server_sub' culture/cli/server.py` to confirm the live list before continuing — do not rely on this table if it disagrees with the file.
+
+- [ ] **Step 4.2:** Decide the routing rule. The shim is a **partial** passthrough — culture-owned verbs (`default`, `rename`, `archive`, `unarchive`) stay in culture; everything else forwards to agentirc. Implement as a dispatch dict, not as a hard-coded "if argv[0] in {…}" + drop-through, so the verb list is reviewable in one place:
 
   ```python
-  """culture server <verb> — passthrough into the installed agentirc CLI."""
+  """culture server <verb> — partial passthrough; culture-owned verbs stay local."""
   from agentirc.cli import dispatch as _agentirc_dispatch
 
+  from culture.cli.server_local import (
+      cmd_default,
+      cmd_rename,
+      cmd_archive,
+      cmd_unarchive,
+  )
+
+  _CULTURE_OWNED = {
+      "default": cmd_default,
+      "rename": cmd_rename,
+      "archive": cmd_archive,
+      "unarchive": cmd_unarchive,
+  }
+
   def server(argv: list[str]) -> int:
-      """culture server <verb> <args> → agentirc <verb> <args>."""
+      """culture server <verb> <args> → culture-local handler if culture-owned, else agentirc."""
+      if argv and argv[0] in _CULTURE_OWNED:
+          return _CULTURE_OWNED[argv[0]](argv[1:])
       return _agentirc_dispatch(argv)
   ```
 
-  If Task 1.3 chose subprocess for `start`, special-case it:
+  If Task 1.3 chose subprocess for `start`, special-case it inside the agentirc branch:
 
   ```python
-  import os
   import subprocess
-  from agentirc.cli import dispatch as _agentirc_dispatch
 
   def server(argv: list[str]) -> int:
+      if argv and argv[0] in _CULTURE_OWNED:
+          return _CULTURE_OWNED[argv[0]](argv[1:])
       if argv and argv[0] == "start":
-          # long-running; isolate in subprocess so a culture upgrade can replace it cleanly
           return subprocess.run(["agentirc", *argv]).returncode
       return _agentirc_dispatch(argv)
   ```
 
-  Properties to preserve:
-  - **Pure forwarding.** Culture does not parse, validate, or rename any flag. New verbs added in agentirc are reachable via `culture server <new-verb>` automatically.
-  - **Single source of truth.** Help text, error messages, exit codes — all from agentirc.
+  Move the existing handler bodies for `default`/`rename`/`archive`/`unarchive` from `culture/cli/server.py` into a new `culture/cli/server_local.py` so the shim file stays small and the culture-owned logic has its own home. Keep the helpers (`read_default_server`, the rename/archive utilities) where they live today (`culture/cli/shared/`).
 
-- [ ] **Step 4.3:** Wire the shim into culture's CLI dispatcher. The dispatcher (in `culture/cli/__init__.py` or `culture/cli/main.py`) probably calls `_run_server(args)` today; switch it to call `server(argv)`.
+- [ ] **Step 4.3:** Properties to preserve:
+  - **Pure forwarding for non-culture verbs.** Culture does not parse, validate, or rename any flag agentirc owns. New verbs added in agentirc are reachable via `culture server <new-verb>` automatically.
+  - **Single source of truth for help / error / exit codes** of agentirc-owned verbs — all from agentirc.
+  - **Culture-owned verbs stay culture-owned.** `default`/`rename`/`archive`/`unarchive` keep their current signatures, flags, output, and exit codes. They must continue to operate on culture's state — agentirc has no notion of them.
 
-- [ ] **Step 4.4:** Manual smoke:
+- [ ] **Step 4.4:** Wire the shim into culture's CLI dispatcher. The dispatcher (in `culture/cli/__init__.py` or `culture/cli/main.py`) probably calls `_run_server(args)` today; switch it to call `server(argv)`.
+
+- [ ] **Step 4.5:** Manual smoke — covers both branches of the dispatch:
 
   ```bash
+  # agentirc branch:
   uv run python -m culture server --help
   uv run python -m culture server status
   uv run python -m culture server version
+
+  # culture-owned branch:
+  uv run python -m culture server default --help
+  uv run python -m culture server rename --help
+  uv run python -m culture server archive --help
+  uv run python -m culture server unarchive --help
   ```
 
-  Each should produce the same output as `agentirc --help`, `agentirc status`, `agentirc version`. Differences are bugs in the shim, not features.
+  Agentirc verbs should match `agentirc <verb> --help` exactly. Culture-owned verbs should print culture's own help text, identical to today's `culture server <verb> --help` before the shim landed.
 
 ---
 
@@ -225,10 +262,10 @@
 
 **Files:** `tests/test_server_shim.py`.
 
-- [ ] **Step 5.1:** Create the test:
+- [ ] **Step 5.1:** Create the test. Note: the shim is a **partial** passthrough (per Task 4.2), so the parity test only covers agentirc-owned verbs. Culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) get their own regression tests that assert their pre-A3 behavior is unchanged.
 
   ```python
-  """Asserts culture server <verb> is byte-identical to agentirc <verb>."""
+  """Asserts culture server <verb> is byte-identical to agentirc <verb> for agentirc-owned verbs."""
   import subprocess
   import sys
 
@@ -237,33 +274,54 @@
   CULTURE = [sys.executable, "-m", "culture", "server"]
   AGENTIRC = ["agentirc"]
 
+  # Agentirc-owned verbs only; culture-owned verbs (default/rename/archive/unarchive)
+  # are tested separately because they have no agentirc counterpart.
+  AGENTIRC_VERBS = ["status", "version", "logs", "start", "stop", "restart", "link", "serve"]
+
+
   def _run(cmd: list[str]) -> tuple[int, str, str]:
       proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
       return proc.returncode, proc.stdout, proc.stderr
 
-  def test_help_matches() -> None:
-      culture_rc, culture_out, culture_err = _run([*CULTURE, "--help"])
-      agentirc_rc, agentirc_out, agentirc_err = _run([*AGENTIRC, "--help"])
-      assert culture_rc == agentirc_rc
-      # The argv[0] in usage lines will differ ("culture server" vs "agentirc"); strip it.
-      def _strip_argv0(text: str) -> str:
-          return "\n".join(
-              line.replace("culture server", "agentirc")
-              for line in text.splitlines()
-          )
-      assert _strip_argv0(culture_out) == agentirc_out
 
-  @pytest.mark.parametrize("verb", ["status", "version", "logs"])
-  def test_verb_help_matches(verb: str) -> None:
+  def _strip_argv0(text: str) -> str:
+      """The argv[0] in usage lines will differ ("culture server" vs "agentirc"); normalize it."""
+      return "\n".join(
+          line.replace("culture server", "agentirc")
+          for line in text.splitlines()
+      )
+
+
+  def test_top_level_help_lists_all_agentirc_verbs() -> None:
+      """`culture server --help` must list every verb agentirc lists, plus the culture-owned ones."""
+      _, culture_out, _ = _run([*CULTURE, "--help"])
+      _, agentirc_out, _ = _run([*AGENTIRC, "--help"])
+      for verb in AGENTIRC_VERBS:
+          assert verb in culture_out, f"agentirc-owned verb {verb!r} missing from culture's help"
+          assert verb in agentirc_out
+      for verb in ("default", "rename", "archive", "unarchive"):
+          assert verb in culture_out, f"culture-owned verb {verb!r} missing from culture's help"
+
+
+  @pytest.mark.parametrize("verb", AGENTIRC_VERBS)
+  def test_agentirc_verb_help_matches(verb: str) -> None:
+      """Help text for agentirc-owned verbs must be byte-identical between culture and agentirc."""
       culture_rc, culture_out, _ = _run([*CULTURE, verb, "--help"])
       agentirc_rc, agentirc_out, _ = _run([*AGENTIRC, verb, "--help"])
       assert culture_rc == agentirc_rc
-      def _strip_argv0(text: str) -> str:
-          return "\n".join(line.replace("culture server", "agentirc") for line in text.splitlines())
       assert _strip_argv0(culture_out) == agentirc_out
+
+
+  @pytest.mark.parametrize("verb", ["default", "rename", "archive", "unarchive"])
+  def test_culture_owned_verb_still_dispatches_locally(verb: str) -> None:
+      """Culture-owned verbs must NOT be forwarded to agentirc. `--help` must succeed without an agentirc binary on PATH."""
+      rc, out, err = _run([*CULTURE, verb, "--help"])
+      assert rc == 0, f"{verb} --help failed: {err}"
+      # Sanity: this is culture's argparse output, not agentirc's. argparse usage line includes the parser path.
+      assert verb in out
   ```
 
-  Pattern lifted from PR #309's `tests/test_agentirc_config_shim.py::test_shim_is_identity` — same identity-invariant style.
+  Pattern for the agentirc-side comparison lifted from PR #309's `tests/test_agentirc_config_shim.py::test_shim_is_identity` — same identity-invariant style. The culture-owned verb tests are new and are A3's regression guardrail against accidentally over-shimming.
 
 - [ ] **Step 5.2:** Run it:
 
@@ -356,12 +414,12 @@
 
   All new code should import from `agentirc.config` directly.
   """
-  from culture.agentirc.config import ServerConfig, LinkConfig, PeerSpec, TelemetryConfig
+  from culture.agentirc.config import LinkConfig, ServerConfig, TelemetryConfig
 
-  __all__ = ["ServerConfig", "LinkConfig", "PeerSpec", "TelemetryConfig"]
+  __all__ = ["LinkConfig", "ServerConfig", "TelemetryConfig"]
   ```
 
-  Match the actual exports of `culture/agentirc/config.py` after A1; don't speculate.
+  This matches the actual A1 shim shipped in culture#309 (`culture/agentirc/config.py` re-exports exactly `LinkConfig`, `ServerConfig`, `TelemetryConfig` from `agentirc.config` — no `PeerSpec`; `agentirc.config` does not export a `PeerSpec` class as of 9.5, peer entries are represented as `LinkConfig` instances). Verify against the file before committing — don't speculate.
 
 - [ ] **Step 7.3:** `git rm` `protocol/extensions/`:
 
@@ -417,7 +475,7 @@
 
   ```markdown
   ### Changed (breaking)
-  - The bundled IRCd in `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` and `culture/agentirc/skills/` is gone; `culture server <verb>` now passes through to the installed `agentirc-cli` binary. User-visible behavior is unchanged.
+  - The bundled IRCd in `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` and `culture/agentirc/skills/` is gone. `culture server <verb>` is now a partial passthrough into the installed `agentirc-cli` binary for lifecycle verbs (`start`/`stop`/`restart`/`status`/`serve`/`link`/`logs`/`version`); culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) continue to dispatch to culture's own handlers. User-visible behavior is unchanged for every existing verb.
   - `python -m culture.agentirc` is removed (no known callers). Use `agentirc` (CLI) or `python -m agentirc`.
   - `protocol/extensions/` moved to agentirc's repo.
   - `culture/agentirc/{client,remote_client}.py` moved to `culture/transport/`. Code that imported them under the old path needs to update imports — `culture/bots/*` and `culture/clients/*/daemon.py` are already updated.
@@ -469,7 +527,7 @@
 
   - Delete `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` and `culture/agentirc/skills/` — the bundled IRCd is gone. Final phase of the agentirc extraction.
   - `git mv culture/agentirc/{client,remote_client}.py → culture/transport/` (preserves blame). Update importers across `culture/bots/*` and `culture/clients/*/daemon.py`.
-  - Replace `culture/cli/server.py:_run_server` with a thin passthrough into `agentirc.cli.dispatch`. New verbs added in agentirc reach `culture server <verb>` automatically.
+  - Replace `culture/cli/server.py:_run_server` with a partial-passthrough shim: lifecycle verbs (`start`/`stop`/`restart`/`status`/`serve`/`link`/`logs`/`version`) forward into `agentirc.cli.dispatch`, while culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) keep dispatching to culture's own handlers (now in `culture/cli/server_local.py`). New agentirc verbs reach `culture server <verb>` automatically; culture's own verbs are not affected.
   - Delete `protocol/extensions/` (lives in agentirc's repo now).
   - Keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; removed in 10.0.0.
   - `8.9.x → 9.0.0` (major — structural change, even though user-visible CLI is unchanged).
@@ -520,14 +578,14 @@
 - Keeps `culture/agentirc/config.py` as the A1 re-export shim through 9.x.
 - Major version bump 8.9.x → 9.0.0.
 
-User-visible behavior unchanged: every `culture server <verb> <args>` invocation continues to work, with flags / output / exit codes coming from `agentirc-cli`. On-disk footprint (config path, sockets, systemd units, logs) unchanged.
+User-visible behavior unchanged: every `culture server <verb> <args>` invocation continues to work. Lifecycle verbs (`start`/`stop`/`restart`/`status`/`serve`/`link`/`logs`/`version`) get their flags / output / exit codes from `agentirc-cli` via the shim; culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) keep their existing culture-side implementations. On-disk footprint (config path, sockets, systemd units, logs) unchanged.
 
 Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`.
 
 ## Test plan
 
 - [ ] Existing test suite passes (`bash .claude/skills/run-tests/scripts/test.sh -p -q`).
-- [ ] New `tests/test_server_shim.py` asserts every verb in `agentirc --help` is reachable via `culture server <verb> --help`.
+- [ ] New `tests/test_server_shim.py` asserts every agentirc-owned verb is reachable with byte-identical help via `culture server <verb> --help`, and that culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) continue to dispatch locally rather than being shimmed to agentirc.
 - [ ] New `tests/test_agentirc_smoke.py` boots `agentirc serve` as a subprocess and TCP-connects to it.
 - [ ] Post-merge: verify on the spark host that `culture-agent-spark-culture.service` restarts cleanly with the new release; `culture server status` and `agentirc status` produce identical output (Track C verification).
 

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
@@ -1,0 +1,544 @@
+# AgentIRC Extraction — Track A3 (Final Cutover) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **This plan supersedes** `docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md`. The original drafted A1+A2+A3 as a single PR; phasing forced a split. A1 shipped in culture#309 (8.8.0); A2 ships in `feat/bots-public-extension-api` (8.9.0, see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`); A3 is this plan.
+
+**Goal:** Delete the bundled IRCd in `culture/agentirc/` and shim `culture server <verb>` to the installed `agentirc` binary. After A3, the only Python files remaining under `culture/agentirc/` are `config.py` (the A1 re-export shim) and `__init__.py`. Major version bump 8.x → 9.0.0.
+
+**Architecture:** Single PR off `main`, after A2 has merged. `git rm` the IRCd source files (`ircd.py`, `server_link.py`, `channel.py`, `events.py`, the four stores, `rooms_util.py`, `skill.py`, `skills/`). `git mv` `client.py` and `remote_client.py` to `culture/transport/` (preserves blame; they were never IRCd code). Replace `culture/cli/server.py:_run_server` with a thin passthrough into `agentirc.cli.dispatch` (in-process) or `subprocess.run(["agentirc", *argv])` (subprocess) — Task 4 chooses. Delete `protocol/extensions/` (lives in agentirc's repo). Bump major.
+
+**Tech Stack:** Python 3.x, uv, argparse, pytest + pytest-asyncio + pytest-xdist, pre-commit (black + isort + flake8 + pylint + bandit + markdownlint).
+
+**Companion spec:** `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (sections "Boundary", "Architecture", "CLI surface", "Import contract").
+
+---
+
+## Preconditions (do not start until all are true)
+
+- A2 has merged and a culture release has been cut. `culture/bots/*` no longer imports anything from `culture.agentirc.{ircd, server_link, channel, events, room_store, thread_store, history_store, rooms_util, skill}`. Verify:
+
+  ```bash
+  grep -rn 'from culture\.agentirc\.\(ircd\|server_link\|channel\|events\|room_store\|thread_store\|history_store\|rooms_util\|skill\)' culture/bots/ tests/
+  ```
+
+  Expected: no matches under `culture/bots/`. Test files may still hit IRCd internals — Task 7 cleans those up.
+
+- `agentirc-cli>=9.5,<10` exposes the full CLI surface culture is shimming to:
+
+  ```bash
+  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" agentirc --help
+  ```
+
+  Expected: subcommands `serve start stop restart status link logs version` (or a superset). If anything's missing, **stop** — the shim parity test (Task 5) will fail.
+
+- `agentirc.cli.dispatch(argv) -> int` is callable in-process (verifies the shim path works without forking a subprocess):
+
+  ```bash
+  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "
+  from agentirc.cli import dispatch
+  rc = dispatch(['version'])
+  print('exit code:', rc)
+  "
+  ```
+
+  Expected: agentirc prints its version and `exit code: 0`. If `dispatch` is not exposed (only `main()`), Task 4 must use the subprocess path.
+
+- Working tree on `main` is clean. `git status` shows no staged/unstaged changes inside `culture/agentirc/`, `culture/cli/server.py`, `culture/cli/shared/mesh.py`, `culture/transport/`, `protocol/extensions/`, or related tests.
+
+---
+
+## File Structure (what changes in this PR)
+
+| Path | Action | Notes |
+|---|---|---|
+| `pyproject.toml` | Modify | Drop `culture/agentirc/` from package data / wheel includes if explicitly listed. No dep change (A2 already pinned `>=9.5,<10`). |
+| `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` | Delete | The IRCd core. |
+| `culture/agentirc/skills/` | Delete (whole dir) | Server-side skill plugins. |
+| `culture/agentirc/__main__.py` | Delete | `python -m culture.agentirc` retired (no known callers). |
+| `culture/agentirc/client.py` | `git mv` → `culture/transport/client.py` | Preserves blame. |
+| `culture/agentirc/remote_client.py` | `git mv` → `culture/transport/remote_client.py` | Preserves blame. |
+| `culture/agentirc/config.py` | Keep | A1 re-export shim over `agentirc.config`. Stays through 9.x; remove in 10.0.0. |
+| `culture/agentirc/__init__.py` | Modify | Trim to a single re-export of `agentirc.config` symbols. |
+| `culture/transport/__init__.py` | Create | Re-exports the public class names from `client.py` and `remote_client.py`. |
+| `culture/cli/server.py` | Rewrite | ~25 lines. Argparse `REMAINDER` passthrough into `agentirc.cli.dispatch` or `subprocess.run`. |
+| `culture/bots/`, `culture/clients/*/daemon.py` | Modify (imports only) | `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`. |
+| `protocol/extensions/` | Delete (whole dir) | Lives in agentirc now. |
+| `tests/test_*` for IRCd internals | Delete | They live in agentirc's repo now. |
+| `tests/test_server_shim.py` | Create | Asserts every verb in `agentirc --help` is reachable via `culture server <verb> --help`. |
+| `tests/test_agentirc_smoke.py` | Create | Boots `agentirc serve` as a subprocess, connects a culture transport client, exchanges one message. |
+| `culture/__init__.py`, `pyproject.toml`, `CHANGELOG.md` | Modify | `/version-bump major` (8.9.x → 9.0.0). |
+
+---
+
+## Task 1 — Verify preconditions
+
+**Files:** none (verification only).
+
+- [ ] **Step 1.1:** Confirm A2 already cleaned up bot-side imports (run the grep from "Preconditions"). If any matches remain in `culture/bots/`, **stop** — A2 wasn't fully done.
+
+- [ ] **Step 1.2:** Confirm the agentirc CLI surface (run the `agentirc --help` snippet from "Preconditions"). Save the output — Task 5's shim parity test reads from this.
+
+- [ ] **Step 1.3:** Decide between in-process `dispatch` and subprocess `run`:
+
+  - **In-process** (`from agentirc.cli import dispatch; return dispatch(argv)`) — same Python interpreter, same env, faster, easier to debug, but couples culture's process to agentirc internals.
+  - **Subprocess** (`subprocess.run(["agentirc", *argv])`) — fully decoupled, works even if agentirc fails to import, but adds ~50ms fork overhead per invocation and may complicate signal handling for `culture server start` (which is long-running).
+
+  Recommendation: **in-process** for everything except `start` (which is long-running and benefits from process isolation). Verify `dispatch` is exposed (run the snippet from "Preconditions"). **Record the decision in this task before continuing.**
+
+---
+
+## Task 2 — Branch and audit remaining culture-side imports of `culture.agentirc.*`
+
+**Files:** none in this task (audit only).
+
+- [ ] **Step 2.1:** Branch out.
+
+  ```bash
+  git checkout main && git pull
+  git checkout -b feat/agentirc-extraction-cutover
+  ```
+
+- [ ] **Step 2.2:** Audit:
+
+  ```bash
+  grep -rn 'culture\.agentirc' culture/ tests/
+  ```
+
+  Tabulate. Expected categories:
+  1. `from culture.agentirc.config import …` — keep (config.py stays as the A1 shim).
+  2. `from culture.agentirc.client import Client` — Task 3 retargets to `culture.transport.client`.
+  3. `from culture.agentirc.remote_client import RemoteClient` — Task 3 retargets to `culture.transport.remote_client`.
+  4. `from culture.agentirc.{ircd,server_link,channel,events,…} import …` — Task 7 deletes / rewrites.
+  5. `python -m culture.agentirc` invocations in scripts/CI — replace with `agentirc` (binary) or `python -m agentirc`.
+
+  Anything outside these five categories is a surprise; investigate before deleting.
+
+---
+
+## Task 3 — Move `client.py` + `remote_client.py` to `culture/transport/`
+
+**Files:** `culture/agentirc/client.py`, `culture/agentirc/remote_client.py`, `culture/transport/__init__.py`.
+
+- [ ] **Step 3.1:** Create the destination directory:
+
+  ```bash
+  mkdir -p culture/transport
+  ```
+
+- [ ] **Step 3.2:** `git mv` (preserves blame):
+
+  ```bash
+  git mv culture/agentirc/client.py culture/transport/client.py
+  git mv culture/agentirc/remote_client.py culture/transport/remote_client.py
+  ```
+
+- [ ] **Step 3.3:** Create `culture/transport/__init__.py` re-exporting the public class names:
+
+  ```python
+  """Culture's IRC transport — TCP client + remote-server-link client."""
+
+  from culture.transport.client import Client
+  from culture.transport.remote_client import RemoteClient
+
+  __all__ = ["Client", "RemoteClient"]
+  ```
+
+  Names to re-export are whatever the moved files publicly defined; `grep -E '^class |^def ' culture/transport/{client,remote_client}.py` to enumerate. Don't speculate — match what was already there.
+
+- [ ] **Step 3.4:** Inside `culture/transport/client.py`, replace any IRC-verb / numeric / extension-tag string literals with `agentirc.protocol.*` constants. Survey first:
+
+  ```bash
+  grep -nE '"(JOIN|PART|PRIVMSG|NOTICE|NAMES|WHO|MODE|CAP|EVENT|EVENTSUB|EVENTPUB|EVENTUNSUB|EVENTERR|SEVENT|SMSG|THREAD|ROOM|HISTORY|DEFAULT|RENAME|ARCHIVE|UNARCHIVE|[0-9]{3})"' culture/transport/client.py
+  ```
+
+  Replace each match with the named constant from `agentirc.protocol`. This is the same retargeting A1 did for `culture/cli/shared/mesh.py` against `agentirc.config` — the pattern is mechanical. If `agentirc.protocol` doesn't expose a constant for a verb culture uses, file an issue against agentirc and keep the string literal for now (mark with a `# TODO(A3)` comment).
+
+- [ ] **Step 3.5:** Update every importer in culture:
+
+  ```bash
+  grep -rln 'from culture\.agentirc\.client import\|from culture\.agentirc\.remote_client import' culture/ tests/ | xargs sed -i 's|from culture\.agentirc\.client import|from culture.transport.client import|g; s|from culture\.agentirc\.remote_client import|from culture.transport.remote_client import|g'
+  ```
+
+  Spot-check the diff before staging.
+
+- [ ] **Step 3.6:** Run a focused test pass:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_*client*.py
+  ```
+
+  Expected: green. Transport behavior is unchanged; only the import path moved.
+
+---
+
+## Task 4 — Replace `culture/cli/server.py:_run_server` with a passthrough shim
+
+**Files:** `culture/cli/server.py`.
+
+- [ ] **Step 4.1:** Read the current `culture/cli/server.py` and identify the exact entrypoint culture's CLI dispatcher calls (likely `_run_server(args)` or similar). Note the function signature and return-type contract.
+
+- [ ] **Step 4.2:** Replace with the shim. Preferred shape (in-process, per Task 1.3 decision):
+
+  ```python
+  """culture server <verb> — passthrough into the installed agentirc CLI."""
+  from agentirc.cli import dispatch as _agentirc_dispatch
+
+  def server(argv: list[str]) -> int:
+      """culture server <verb> <args> → agentirc <verb> <args>."""
+      return _agentirc_dispatch(argv)
+  ```
+
+  If Task 1.3 chose subprocess for `start`, special-case it:
+
+  ```python
+  import os
+  import subprocess
+  from agentirc.cli import dispatch as _agentirc_dispatch
+
+  def server(argv: list[str]) -> int:
+      if argv and argv[0] == "start":
+          # long-running; isolate in subprocess so a culture upgrade can replace it cleanly
+          return subprocess.run(["agentirc", *argv]).returncode
+      return _agentirc_dispatch(argv)
+  ```
+
+  Properties to preserve:
+  - **Pure forwarding.** Culture does not parse, validate, or rename any flag. New verbs added in agentirc are reachable via `culture server <new-verb>` automatically.
+  - **Single source of truth.** Help text, error messages, exit codes — all from agentirc.
+
+- [ ] **Step 4.3:** Wire the shim into culture's CLI dispatcher. The dispatcher (in `culture/cli/__init__.py` or `culture/cli/main.py`) probably calls `_run_server(args)` today; switch it to call `server(argv)`.
+
+- [ ] **Step 4.4:** Manual smoke:
+
+  ```bash
+  uv run python -m culture server --help
+  uv run python -m culture server status
+  uv run python -m culture server version
+  ```
+
+  Each should produce the same output as `agentirc --help`, `agentirc status`, `agentirc version`. Differences are bugs in the shim, not features.
+
+---
+
+## Task 5 — Add the shim parity test
+
+**Files:** `tests/test_server_shim.py`.
+
+- [ ] **Step 5.1:** Create the test:
+
+  ```python
+  """Asserts culture server <verb> is byte-identical to agentirc <verb>."""
+  import subprocess
+  import sys
+
+  import pytest
+
+  CULTURE = [sys.executable, "-m", "culture", "server"]
+  AGENTIRC = ["agentirc"]
+
+  def _run(cmd: list[str]) -> tuple[int, str, str]:
+      proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+      return proc.returncode, proc.stdout, proc.stderr
+
+  def test_help_matches() -> None:
+      culture_rc, culture_out, culture_err = _run([*CULTURE, "--help"])
+      agentirc_rc, agentirc_out, agentirc_err = _run([*AGENTIRC, "--help"])
+      assert culture_rc == agentirc_rc
+      # The argv[0] in usage lines will differ ("culture server" vs "agentirc"); strip it.
+      def _strip_argv0(text: str) -> str:
+          return "\n".join(
+              line.replace("culture server", "agentirc")
+              for line in text.splitlines()
+          )
+      assert _strip_argv0(culture_out) == agentirc_out
+
+  @pytest.mark.parametrize("verb", ["status", "version", "logs"])
+  def test_verb_help_matches(verb: str) -> None:
+      culture_rc, culture_out, _ = _run([*CULTURE, verb, "--help"])
+      agentirc_rc, agentirc_out, _ = _run([*AGENTIRC, verb, "--help"])
+      assert culture_rc == agentirc_rc
+      def _strip_argv0(text: str) -> str:
+          return "\n".join(line.replace("culture server", "agentirc") for line in text.splitlines())
+      assert _strip_argv0(culture_out) == agentirc_out
+  ```
+
+  Pattern lifted from PR #309's `tests/test_agentirc_config_shim.py::test_shim_is_identity` — same identity-invariant style.
+
+- [ ] **Step 5.2:** Run it:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_server_shim.py
+  ```
+
+---
+
+## Task 6 — Add the cross-repo smoke test
+
+**Files:** `tests/test_agentirc_smoke.py`.
+
+- [ ] **Step 6.1:** Create a test that boots a real `agentirc serve` subprocess on a random port, connects a `culture.transport.Client`, and exchanges a `PRIVMSG`:
+
+  ```python
+  """End-to-end smoke: culture transport client talks to a real agentirc subprocess."""
+  import asyncio
+  import socket
+  import subprocess
+  import sys
+  from pathlib import Path
+
+  import pytest
+
+  from culture.transport import Client
+
+
+  def _free_port() -> int:
+      with socket.socket() as s:
+          s.bind(("127.0.0.1", 0))
+          return s.getsockname()[1]
+
+
+  @pytest.mark.asyncio
+  async def test_agentirc_subprocess_smoke(tmp_path: Path) -> None:
+      port = _free_port()
+      cfg = tmp_path / "server.yaml"
+      cfg.write_text(f"name: smoke\nirc_port: {port}\nwebhook_port: 0\n")
+      proc = subprocess.Popen(
+          ["agentirc", "serve", "--config", str(cfg)],
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+      )
+      try:
+          await asyncio.sleep(1.0)  # give the daemon a beat to bind
+          client = Client(host="127.0.0.1", port=port, nick="smoke")
+          await client.connect()
+          await client.privmsg("smoke", "hello")
+          await client.disconnect()
+      finally:
+          proc.terminate()
+          proc.wait(timeout=5)
+  ```
+
+  This is the *only* cross-repo integration test in culture — it imports nothing from agentirc internals; it just confirms the wire works.
+
+- [ ] **Step 6.2:** Run it:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_agentirc_smoke.py
+  ```
+
+---
+
+## Task 7 — Delete the bundled IRCd
+
+**Files:** `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py`, `culture/agentirc/skills/`, `culture/agentirc/__main__.py`, `culture/agentirc/__init__.py`, `protocol/extensions/`, IRCd-internal tests under `tests/`.
+
+- [ ] **Step 7.1:** `git rm` the IRCd source:
+
+  ```bash
+  git rm culture/agentirc/ircd.py
+  git rm culture/agentirc/server_link.py
+  git rm culture/agentirc/channel.py
+  git rm culture/agentirc/events.py
+  git rm culture/agentirc/room_store.py
+  git rm culture/agentirc/thread_store.py
+  git rm culture/agentirc/history_store.py
+  git rm culture/agentirc/rooms_util.py
+  git rm culture/agentirc/skill.py
+  git rm -r culture/agentirc/skills/
+  git rm culture/agentirc/__main__.py
+  ```
+
+- [ ] **Step 7.2:** Trim `culture/agentirc/__init__.py` to just the A1 re-export shim:
+
+  ```python
+  """A1-introduced re-export shim — kept through the 9.x line, removed in 10.0.0.
+
+  All new code should import from `agentirc.config` directly.
+  """
+  from culture.agentirc.config import ServerConfig, LinkConfig, PeerSpec, TelemetryConfig
+
+  __all__ = ["ServerConfig", "LinkConfig", "PeerSpec", "TelemetryConfig"]
+  ```
+
+  Match the actual exports of `culture/agentirc/config.py` after A1; don't speculate.
+
+- [ ] **Step 7.3:** `git rm` `protocol/extensions/`:
+
+  ```bash
+  git rm -r protocol/extensions/
+  ```
+
+  These were already moved to agentirc's repo as part of Track B (see spec). The culture-side directory is dead weight.
+
+- [ ] **Step 7.4:** Delete IRCd-internal tests. Survey:
+
+  ```bash
+  grep -rln 'from culture\.agentirc\.\(ircd\|server_link\|channel\|events\|room_store\|thread_store\|history_store\|rooms_util\|skill\)' tests/
+  ```
+
+  For each match, `git rm` the test file. They live in agentirc's repo now (per Track B's test-suite migration). Examples likely to appear: `tests/test_ircd_*.py`, `tests/test_server_link_*.py`, `tests/test_channel_*.py`, `tests/test_room_store_*.py`, etc.
+
+  **Caveat:** preserve any test that survives because it covers culture's *use* of these modules, not the modules themselves. Such tests are rare after A2; if you find one, list it for review before deleting.
+
+- [ ] **Step 7.5:** Run the full suite:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q
+  ```
+
+  Expected: green. The remaining tests cover transport, bots (now CAP clients), CLI, telemetry, and the new shim/smoke tests.
+
+---
+
+## Task 8 — Doc-test alignment + pre-push reviewer + version bump
+
+**Files:** `culture/__init__.py`, `pyproject.toml`, `CHANGELOG.md`, plus any docs surfaced by the audit.
+
+- [ ] **Step 8.1:** Run `doc-test-alignment`:
+
+  ```bash
+  Agent(subagent_type="doc-test-alignment", prompt="Audit the staged diff on feat/agentirc-extraction-cutover for new public surface and report missing docs/ or protocol/extensions/ coverage. Note that protocol/extensions/ was deleted in this PR — references to it in docs/ should be removed or pointed at agentirc's repo.")
+  ```
+
+  Address findings: update `docs/` references, point at agentirc's docs where appropriate, remove dead links.
+
+- [ ] **Step 8.2:** Stage, then run `superpowers:code-reviewer`:
+
+  ```bash
+  git add -A
+  ```
+
+  Then invoke `superpowers:code-reviewer` per culture/CLAUDE.md's "Pre-push review for library/protocol code" rule. A3 is structural — deleting code, moving call sites, swapping a process boundary. The reviewer catches anything that breaks an exception-handling chain or leaves dangling imports.
+
+- [ ] **Step 8.3:** `/version-bump major` (8.9.x → 9.0.0). A3 deletes in-tree code and changes the launch model from in-process to (potentially) subprocess; that's structural, even though user-visible CLI is unchanged.
+
+- [ ] **Step 8.4:** Edit the new `[9.0.0]` section of `CHANGELOG.md`:
+
+  ```markdown
+  ### Changed (breaking)
+  - The bundled IRCd in `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` and `culture/agentirc/skills/` is gone; `culture server <verb>` now passes through to the installed `agentirc-cli` binary. User-visible behavior is unchanged.
+  - `python -m culture.agentirc` is removed (no known callers). Use `agentirc` (CLI) or `python -m agentirc`.
+  - `protocol/extensions/` moved to agentirc's repo.
+  - `culture/agentirc/{client,remote_client}.py` moved to `culture/transport/`. Code that imported them under the old path needs to update imports — `culture/bots/*` and `culture/clients/*/daemon.py` are already updated.
+
+  ### Kept (transitional)
+  - `culture/agentirc/config.py` remains as a re-export shim over `agentirc.config` through the 9.x line; remove in 10.0.0.
+
+  ### Notes
+  - Final phase of the agentirc extraction. A1 (config dataclasses, 8.8.0, #309) and A2 (bot framework rewrite, 8.9.0) preceded this. Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`.
+  ```
+
+- [ ] **Step 8.5:** Final test pass + format check:
+
+  ```bash
+  bash .claude/skills/run-tests/scripts/test.sh -p -q
+  uv run black culture/ tests/
+  uv run isort culture/ tests/
+  ```
+
+- [ ] **Step 8.6:** Commit and push:
+
+  ```bash
+  git commit -m "$(cat <<'EOF'
+  feat!: delete bundled IRCd; shim culture server to agentirc-cli (Track A3)
+
+  Final phase of the agentirc extraction. Deletes culture/agentirc/{ircd,
+  server_link,channel,events,...} and protocol/extensions/. Moves
+  client.py + remote_client.py to culture/transport/. Replaces
+  culture/cli/server.py:_run_server with a passthrough into
+  agentirc.cli.dispatch. culture/agentirc/config.py stays as the A1
+  re-export shim through 9.x.
+
+  BREAKING CHANGE: python -m culture.agentirc is gone. User-visible
+  culture server <verb> behavior is unchanged.
+
+  - Claude
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  git push -u origin feat/agentirc-extraction-cutover
+  ```
+
+- [ ] **Step 8.7:** Open the PR:
+
+  ```bash
+  gh pr create --title "Phase A3: delete bundled IRCd; shim culture server to agentirc-cli" --body "$(cat <<'EOF'
+  ## Summary
+
+  - Delete `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` and `culture/agentirc/skills/` — the bundled IRCd is gone. Final phase of the agentirc extraction.
+  - `git mv culture/agentirc/{client,remote_client}.py → culture/transport/` (preserves blame). Update importers across `culture/bots/*` and `culture/clients/*/daemon.py`.
+  - Replace `culture/cli/server.py:_run_server` with a thin passthrough into `agentirc.cli.dispatch`. New verbs added in agentirc reach `culture server <verb>` automatically.
+  - Delete `protocol/extensions/` (lives in agentirc's repo now).
+  - Keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; removed in 10.0.0.
+  - `8.9.x → 9.0.0` (major — structural change, even though user-visible CLI is unchanged).
+
+  ## Why
+
+  Final phase of the agentirc extraction (spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`). A1 (config dataclasses, #309) and A2 (bot framework rewrite, see Track A2 plan) preceded this; A3 completes the cutover.
+
+  ## Test plan
+
+  - [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` — full suite green
+  - [x] New `tests/test_server_shim.py` asserts every verb in `agentirc --help` is reachable via `culture server <verb> --help` with byte-identical output
+  - [x] New `tests/test_agentirc_smoke.py` boots `agentirc serve` as a subprocess and TCP-connects via `culture.transport.Client`
+  - [x] Pre-commit hooks clean
+  - [x] `superpowers:code-reviewer` clean
+  - [x] `doc-test-alignment` clean
+
+  ## Migration notes for users
+
+  - `python -m culture.agentirc` is gone. Run `agentirc` (CLI) or `python -m agentirc` instead.
+  - Code that imports from `culture.agentirc.{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}` is broken. There is no replacement in culture; depend on `agentirc-cli` and import from `agentirc.*`.
+  - `culture.agentirc.{client,remote_client}` imports — update to `culture.transport.{client,remote_client}`.
+  - `culture.agentirc.config` imports — still work; remove in 10.0.0.
+
+  - Claude
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+- [ ] **Step 8.8:** Wait for CI:
+
+  ```bash
+  gh pr checks
+  ```
+
+  If anything fails, fix inline, push, run `/sonarclaude` before declaring ready (per culture/CLAUDE.md). Use the `pr-review` skill for automated reviewer comments.
+
+---
+
+## Summary
+
+- Deletes `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` + `skills/` (~3,600 LOC). Final structural change of the agentirc extraction.
+- Moves `client.py` + `remote_client.py` to `culture/transport/` (`git mv` preserves blame).
+- Replaces `culture/cli/server.py:_run_server` with a passthrough into `agentirc.cli.dispatch`.
+- Deletes `protocol/extensions/` (lives in agentirc's repo).
+- Keeps `culture/agentirc/config.py` as the A1 re-export shim through 9.x.
+- Major version bump 8.9.x → 9.0.0.
+
+User-visible behavior unchanged: every `culture server <verb> <args>` invocation continues to work, with flags / output / exit codes coming from `agentirc-cli`. On-disk footprint (config path, sockets, systemd units, logs) unchanged.
+
+Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`.
+
+## Test plan
+
+- [ ] Existing test suite passes (`bash .claude/skills/run-tests/scripts/test.sh -p -q`).
+- [ ] New `tests/test_server_shim.py` asserts every verb in `agentirc --help` is reachable via `culture server <verb> --help`.
+- [ ] New `tests/test_agentirc_smoke.py` boots `agentirc serve` as a subprocess and TCP-connects to it.
+- [ ] Post-merge: verify on the spark host that `culture-agent-spark-culture.service` restarts cleanly with the new release; `culture server status` and `agentirc status` produce identical output (Track C verification).
+
+---
+
+## Post-merge (Track C — out of scope for this plan, but on the to-do list)
+
+After this PR merges and a culture release is published:
+
+- `pip install -U culture` on the spark host.
+- Confirm `culture-agent-spark-culture.service` restarts cleanly.
+- Confirm `culture server status` and `agentirc status` produce byte-identical output.
+- Confirm an existing peer link still establishes (`culture server link` → other peer responds).
+- Optionally: schedule a follow-up agent in 6 months to drop `culture/agentirc/config.py` (and the surrounding shim machinery) when culture cuts a 10.0.0 release.

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -21,7 +21,7 @@ a documented out-of-process bot extension API (`agentirc.io/bot` CAP,
 | **B** (agentirc bootstrap) | `agentirc-cli==9.4.1` published, public API stable, on-disk layout preserved | ✅ done (see culture#308) |
 | **A1** (culture-side public-API migration) | Pin `agentirc-cli>=9.4,<10`; `culture/agentirc/config.py` becomes a re-export shim over `agentirc.config`; canonical call sites (telemetry, mesh CLI, conftest) retarget; minor bump 8.7.1 → 8.8.0 | ✅ done 2026-05-01 (culture#309) |
 | **A2** (rewrite bots against public extension API) | Bump dep floor to `agentirc-cli>=9.5,<10`; rewrite `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` against `agentirc.io/bot` CAP + `EVENTSUB`/`EVENTPUB` + 5-field envelope; culture takes ownership of the `webhook_port` HTTP listener (agentirc 9.5 stops binding it); minor bump 8.8.0 → 8.9.0 | 🟢 ready — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md` |
-| **A3** (final cutover) | Delete `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` + `culture/agentirc/skills/`; move `client.py`/`remote_client.py` → `culture/transport/`; replace `culture/cli/server.py:_run_server` with `subprocess.run(["agentirc", *argv])` (or `agentirc.cli.dispatch`); keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; major bump 8.x → 9.0 | 🟢 ready after A2 — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md` |
+| **A3** (final cutover) | Delete the bundled IRCd: `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` + `culture/agentirc/skills/`; `git mv` `culture/agentirc/{client,remote_client}.py` → `culture/transport/`; replace `culture/cli/server.py:_run_server` with `subprocess.run(["agentirc", *argv])` (or `agentirc.cli.dispatch`) while preserving culture-owned verbs `default`/`rename`/`archive`/`unarchive` in culture's own dispatcher; keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; major bump 8.x → 9.0 | 🟢 ready after A2 — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md` |
 
 The Boundary / Plan sections below describe the A3 end state. They
 remain the target; the phased approach is purely about how culture
@@ -34,7 +34,7 @@ federation wire (`SEVENT` payloads and the IRCv3 `event-data` tag on
 `#system` PRIVMSGs):
 
 ```json
-{"type": "user.join", "channel": "#room", "nick": "alice", "data": {"text": "hi"}, "timestamp": 1714568400.0}
+{"type": "user.join", "channel": "#room", "nick": "alice", "data": {"text": "hi"}, "timestamp": 1777680000.0}
 ```
 
 9.5 receivers sniff for the envelope and tolerate the legacy data-only
@@ -125,14 +125,15 @@ This is the first of several planned splits — `culture-agent` and `culture-bot
 | `culture/transport/client.py` | from `culture/agentirc/client.py` | Culture's bots and backend daemons are the only consumers. |
 | `culture/transport/remote_client.py` | from `culture/agentirc/remote_client.py` | Same. |
 | `culture/cli/server.py` | rewritten as 1-function passthrough | See "CLI surface" below. |
-| `culture/cli/shared/mesh.py` | imports `LinkConfig`, `PeerSpec` from `agentirc.config` | Mesh manifest read/write stays culture-side. |
+| `culture/cli/shared/mesh.py` | imports `LinkConfig` from `agentirc.config` | Mesh manifest read/write stays culture-side. |
 | `culture/bots/`, `culture/clients/*/daemon.py` | imports updated to `culture.transport` | Transport ownership unchanged from the consumer's POV. |
 | `packages/agent-harness/` | unchanged | Agent backend citation reference is culture's concern. |
 
 ### What is deleted from culture
 
-- `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` and `culture/agentirc/skills/`.
+- `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` and `culture/agentirc/skills/`.
 - `culture/agentirc/__main__.py` (no replacement; `python -m culture.agentirc` is gone).
+- `culture/agentirc/{client,remote_client}.py` are **moved**, not deleted — `git mv` to `culture/transport/{client,remote_client}.py`. They're transport code, not IRCd code, and they stay in culture (see "What stays in culture" above).
 - `culture/agentirc/config.py` is **kept** as an A1-introduced re-export shim over `agentirc.config` through the 9.x line, then removed in 10.0.0. (Decision deferred to A3 in `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.)
 - `culture/bots/http_listener.py` is **not** deleted — culture takes ownership of the webhook listener in A2 because agentirc 9.5 stops binding `webhook_port`. The listener moves from being driven by `culture/agentirc/ircd.py` (today) to being driven by `culture/bots/bot_manager.py`.
 
@@ -151,7 +152,7 @@ agentirc/
 │   ├── __main__.py         # python -m agentirc
 │   ├── cli.py              # main(), dispatch(argv)
 │   ├── protocol.py         # verb names, numerics, extension tags
-│   ├── config.py           # ServerConfig, LinkConfig, PeerSpec (public)
+│   ├── config.py           # ServerConfig, LinkConfig, TelemetryConfig (public)
 │   ├── ircd.py
 │   ├── server_link.py
 │   ├── channel.py
@@ -245,7 +246,7 @@ The public surface of agentirc — what culture (and any third-party consumer) i
 
 | Module | Members | Stability |
 |---|---|---|
-| `agentirc.config` | `ServerConfig`, `LinkConfig`, `PeerSpec`, `TelemetryConfig`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
+| `agentirc.config` | `ServerConfig`, `LinkConfig`, `TelemetryConfig`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
 | `agentirc.cli` | `main()`, `dispatch(argv) -> int` | Public, semver-tracked. |
 | `agentirc.protocol` | Verb name constants (incl. `EVENTSUB`, `EVENTUNSUB`, `EVENT`, `EVENTERR`, `EVENTPUB`), numeric reply codes, extension tag names, the canonical 5-field `Event` envelope (`type`/`channel`/`nick`/`data`/`timestamp`), `EVENT_TYPE_RE` | Public, semver-tracked. Wire format byte-locked under semver (see agentirc `tests/test_wire_format_envelope.py::test_envelope_byte_lock`). |
 | `agentirc.skill` | Re-exports `Event`, `EventType` from `agentirc.protocol` | **Transitional** — present through the 9.5.x line, removed in 10.0.0. New code should import from `agentirc.protocol` directly. |
@@ -257,7 +258,7 @@ Everything else — `agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`,
 | Culture module | Imports |
 |---|---|
 | `culture/cli/server.py` | `agentirc.cli.dispatch` |
-| `culture/cli/shared/mesh.py` | `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec` |
+| `culture/cli/shared/mesh.py` | `agentirc.config.LinkConfig` |
 | `culture/config.py`, `culture/telemetry/{metrics,tracing,audit}.py`, `tests/conftest.py` | `agentirc.config.{ServerConfig, LinkConfig, TelemetryConfig}` (since A1, culture#309) |
 | `culture/transport/client.py` | `agentirc.protocol.*` (verb / numeric / tag constants) |
 | `culture/bots/{virtual_client,bot,bot_manager}.py` | `agentirc.protocol.{Event, EventType, EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB}` (after A2) |
@@ -344,7 +345,7 @@ This block is the deliverable. It is **handed to the agent working in `../agenti
 
 - `pip install agentirc-cli==9.0.0` from PyPI produces a working `agentirc` binary.
 - `agentirc serve --config ~/.culture/server.yaml` starts an IRCd indistinguishable from today's `culture server start`.
-- `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec`, `agentirc.cli.dispatch`, and `agentirc.protocol.*` are importable.
+- `agentirc.config.LinkConfig`, `agentirc.config.ServerConfig`, `agentirc.config.TelemetryConfig`, `agentirc.cli.dispatch`, and `agentirc.protocol.*` are importable.
 - All tests in `../agentirc/tests/` pass under `pytest -n auto`.
 - `git grep -E '^(from|import) culture' agentirc/ tests/` returns nothing.
 
@@ -400,7 +401,7 @@ Tests under culture's `tests/` are sorted into three buckets at copy time:
 | Protocol constants drift between agentirc (server) and culture/transport (client). | `agentirc.protocol` is the single source. Both sides import from there; tests on either side fail fast on missing constants. |
 | Existing deployment breaks because something on disk is unexpectedly named. | Goals/Non-Goals: nothing on disk is renamed. The verification step on a real deployment catches anything we missed. |
 | `culture server --help` output diverges from `agentirc --help` over time. | The shim parity test asserts byte-equality of the help text. CI fails if drift appears. |
-| First PyPI release of agentirc is broken; culture cutover PR can't merge. | Culture pins `agentirc-cli>=9.5,<10.0`. Patches go out as `9.0.1`, `9.0.2`. Culture's PR can wait or pin to a specific known-good `==9.0.X`. |
+| An agentirc-cli release introduces a regression that breaks culture. | Culture pins `agentirc-cli>=9.5,<10.0`. Patches go out as `9.5.1`, `9.5.2`, etc. Culture can pin to a specific known-good `==9.5.X` if a patch in the floor range turns out to be broken. |
 | Future changes touch both repos at once and become hard to coordinate. | All-backends rule already requires multi-backend coordination; the same discipline extends to multi-repo coordination. Significant cross-repo work pairs an agentirc PR with a culture PR that bumps the floor pin. |
 
 ## Open questions

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -1,30 +1,61 @@
 # AgentIRC Extraction Design
 
-**Status:** In progress — Phase A1 landed in culture 8.8.0 (2026-05-01); Phase A3 blocked on agentculture/agentirc#15
+**Status:** In progress — A1 landed in culture 8.8.0 (2026-05-01); A2/A3 unblocked by agentirc-cli 9.5.0 (2026-05-02, agentculture/agentirc#15 closed)
 **Date:** 2026-04-30
 **Owner:** Ori Nachum
 
-## Implementation status (added 2026-05-01)
+## Implementation status (updated 2026-05-02)
 
 Track A on the culture side is split into phases because the literal
 "delete `culture/agentirc/{ircd, ...}.py` and shim `culture server start`"
 described below cannot land in one PR — culture's bots
 (`culture/bots/*`) hold an in-process `IRCd` reference and call
 `server.emit_event`/`server.channels`/`server.get_or_create_channel`
-directly. agentirc's published public API (see
-`docs/api-stability.md` in agentirc) exposes no out-of-process bot
-hook, and `Event`/`EventType` are explicitly internal.
+directly. With `agentirc-cli==9.5.0` (2026-05-02), agentirc now exposes
+a documented out-of-process bot extension API (`agentirc.io/bot` CAP,
+`EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, public
+5-field envelope in `agentirc.protocol`), so A2 is no longer blocked.
 
 | Phase | Scope | Status |
 |---|---|---|
 | **B** (agentirc bootstrap) | `agentirc-cli==9.4.1` published, public API stable, on-disk layout preserved | ✅ done (see culture#308) |
-| **A1** (culture-side public-API migration) | Pin `agentirc-cli>=9.4,<10`; `culture/agentirc/config.py` becomes a re-export shim over `agentirc.config`; canonical call sites (telemetry, mesh CLI, conftest) retarget; minor bump 8.7.1 → 8.8.0 | ✅ done 2026-05-01 |
-| **A2** (decide bot-runtime story) | agentirc to add a documented out-of-process bot extension API (event-stream verb, public Event/EventType, silent-bot connection convention); culture/bots/* rewritten against it | ⏸ blocked on agentculture/agentirc#15 |
-| **A3** (final cutover) | Delete `culture/agentirc/{ircd,server_link,channel,config,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` + `culture/agentirc/skills/`; drop `culture/agentirc/` from wheel packages; replace `culture/cli/server.py:_run_server` with `subprocess.run(["agentirc", *argv])` (or `agentirc.cli.dispatch`); keep culture-only verbs `default`/`rename`/`archive`/`unarchive`; major bump | ⏸ depends on A2 |
+| **A1** (culture-side public-API migration) | Pin `agentirc-cli>=9.4,<10`; `culture/agentirc/config.py` becomes a re-export shim over `agentirc.config`; canonical call sites (telemetry, mesh CLI, conftest) retarget; minor bump 8.7.1 → 8.8.0 | ✅ done 2026-05-01 (culture#309) |
+| **A2** (rewrite bots against public extension API) | Bump dep floor to `agentirc-cli>=9.5,<10`; rewrite `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` against `agentirc.io/bot` CAP + `EVENTSUB`/`EVENTPUB` + 5-field envelope; culture takes ownership of the `webhook_port` HTTP listener (agentirc 9.5 stops binding it); minor bump 8.8.0 → 8.9.0 | 🟢 ready — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md` |
+| **A3** (final cutover) | Delete `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` + `culture/agentirc/skills/`; move `client.py`/`remote_client.py` → `culture/transport/`; replace `culture/cli/server.py:_run_server` with `subprocess.run(["agentirc", *argv])` (or `agentirc.cli.dispatch`); keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; major bump 8.x → 9.0 | 🟢 ready after A2 — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md` |
 
 The Boundary / Plan sections below describe the A3 end state. They
 remain the target; the phased approach is purely about how culture
 gets there without breaking bots in flight.
+
+## Federation interop during the migration window
+
+`agentirc-cli==9.5.0` ships a canonical 5-field envelope on the
+federation wire (`SEVENT` payloads and the IRCv3 `event-data` tag on
+`#system` PRIVMSGs):
+
+```json
+{"type": "user.join", "channel": "#room", "nick": "alice", "data": {"text": "hi"}, "timestamp": 1714568400.0}
+```
+
+9.5 receivers sniff for the envelope and tolerate the legacy data-only
+shape, so **≤9.4 → 9.5 federation works**. The reverse direction
+(**9.5 → ≤9.4**) breaks because pre-9.5 daemons have no sniff and
+fail to find expected fields. Culture's bundled IRCd is ≤9.4 until A3
+deletes it, so any operator running a `culture server` instance
+peered with an upgraded `agentirc serve` peer will see one-way drops.
+
+Mitigation (optional): mirror agentirc 9.5's ~10-LOC envelope sniff
+into `culture/agentirc/server_link.py:_handle_sevent`. After the
+existing `_decode_sevent_payload` call, if the decoded dict has the
+canonical 5 keys with `data` as a top-level dict, treat the value of
+`data` as the legacy data-only payload that the rest of `_handle_sevent`
+already expects; otherwise fall through unchanged. Zero behavior
+change for ≤9.4 → ≤9.4 traffic, fixes the 9.5 → ≤9.4 break. Reference:
+[agentirc#15 comment 4363115522](https://github.com/agentculture/agentirc/issues/15#issuecomment-4363115522).
+
+Ship as a small standalone patch PR (8.8.x patch bump) if mixed-version
+peers are expected during the A2/A3 window. Independent of the A2/A3
+plans below; not required when A3 lands.
 
 ## Summary
 
@@ -52,7 +83,7 @@ This is the first of several planned splits — `culture-agent` and `culture-bot
 ## Goals
 
 - agentirc lives in `../agentirc` as an independently versioned package on PyPI (distribution name `agentirc-cli`, import name `agentirc`), with its own CLI binary `agentirc`.
-- Culture consumes it as a normal dependency (`agentirc-cli>=9.0,<10.0`).
+- Culture consumes it as a normal dependency (`agentirc-cli>=9.5,<10.0`).
 - `culture server <verb> <args>` continues to work for every existing verb, with identical flags, output, and exit codes — implemented as a 1:1 passthrough into `agentirc.cli.dispatch`.
 - On-disk footprint stays culture-named: `~/.culture/server.yaml`, current socket paths, `culture-agent-*.service` systemd units, current log paths. Existing deployments need zero migration.
 - The IRCd's protocol surface (`protocol/extensions/`) lives in agentirc, where it belongs.
@@ -100,8 +131,10 @@ This is the first of several planned splits — `culture-agent` and `culture-bot
 
 ### What is deleted from culture
 
-- `culture/agentirc/` — the entire directory.
+- `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` and `culture/agentirc/skills/`.
 - `culture/agentirc/__main__.py` (no replacement; `python -m culture.agentirc` is gone).
+- `culture/agentirc/config.py` is **kept** as an A1-introduced re-export shim over `agentirc.config` through the 9.x line, then removed in 10.0.0. (Decision deferred to A3 in `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.)
+- `culture/bots/http_listener.py` is **not** deleted — culture takes ownership of the webhook listener in A2 because agentirc 9.5 stops binding `webhook_port`. The listener moves from being driven by `culture/agentirc/ircd.py` (today) to being driven by `culture/bots/bot_manager.py`.
 
 ## Architecture
 
@@ -146,7 +179,7 @@ agentirc/
 
 ```
 culture/
-├── pyproject.toml          # adds: agentirc-cli>=9.0,<10.0
+├── pyproject.toml          # adds: agentirc-cli>=9.5,<10.0
 ├── uv.lock                 # regenerated
 ├── culture/
 │   ├── agentirc/           # DELETED
@@ -212,11 +245,12 @@ The public surface of agentirc — what culture (and any third-party consumer) i
 
 | Module | Members | Stability |
 |---|---|---|
-| `agentirc.config` | `ServerConfig`, `LinkConfig`, `PeerSpec`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
+| `agentirc.config` | `ServerConfig`, `LinkConfig`, `PeerSpec`, `TelemetryConfig`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
 | `agentirc.cli` | `main()`, `dispatch(argv) -> int` | Public, semver-tracked. |
-| `agentirc.protocol` | Verb name constants, numeric reply codes, extension tag names | Public, semver-tracked. |
+| `agentirc.protocol` | Verb name constants (incl. `EVENTSUB`, `EVENTUNSUB`, `EVENT`, `EVENTERR`, `EVENTPUB`), numeric reply codes, extension tag names, the canonical 5-field `Event` envelope (`type`/`channel`/`nick`/`data`/`timestamp`), `EVENT_TYPE_RE` | Public, semver-tracked. Wire format byte-locked under semver (see agentirc `tests/test_wire_format_envelope.py::test_envelope_byte_lock`). |
+| `agentirc.skill` | Re-exports `Event`, `EventType` from `agentirc.protocol` | **Transitional** — present through the 9.5.x line, removed in 10.0.0. New code should import from `agentirc.protocol` directly. |
 
-Everything else — `agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`, the stores, the skills — is internal. Agentirc may refactor freely without breaking culture. Documented in `agentirc/docs/api-stability.md`.
+Everything else — `agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`, the stores, the in-tree skills, anything under `agentirc._internal.*` — is internal. Agentirc may refactor freely without breaking culture. Documented in `agentirc/docs/api-stability.md`.
 
 ### Where culture imports from agentirc
 
@@ -224,8 +258,10 @@ Everything else — `agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`,
 |---|---|
 | `culture/cli/server.py` | `agentirc.cli.dispatch` |
 | `culture/cli/shared/mesh.py` | `agentirc.config.LinkConfig`, `agentirc.config.PeerSpec` |
+| `culture/config.py`, `culture/telemetry/{metrics,tracing,audit}.py`, `tests/conftest.py` | `agentirc.config.{ServerConfig, LinkConfig, TelemetryConfig}` (since A1, culture#309) |
 | `culture/transport/client.py` | `agentirc.protocol.*` (verb / numeric / tag constants) |
-| `culture/bots/*`, `culture/clients/*/daemon.py` | nothing — they import `culture.transport` |
+| `culture/bots/{virtual_client,bot,bot_manager}.py` | `agentirc.protocol.{Event, EventType, EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB}` (after A2) |
+| `culture/clients/*/daemon.py` | `culture.transport` only (no agentirc internals) |
 
 ## Configuration & on-disk footprint
 
@@ -246,7 +282,7 @@ The migration runs in **two tracks** owned by two different agents. The culture-
 
 A single PR off `main`, following culture's standard workflow.
 
-1. `pyproject.toml`: add `agentirc-cli>=9.0,<10.0`. Regenerate `uv.lock`.
+1. `pyproject.toml`: add `agentirc-cli>=9.5,<10.0`. Regenerate `uv.lock`.
 2. Delete `culture/agentirc/` entirely.
 3. Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.
 4. Replace `culture/cli/server.py` with the passthrough shim (see "CLI surface" above).
@@ -323,14 +359,14 @@ After Track A merges and culture is released:
 
 ### Distribution
 
-- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=9.0,<10.0`.
+- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=9.5,<10.0`.
 - TestPyPI carries both `agentirc-cli` and a squatted `agentirc`; only `agentirc-cli` is the canonical name. Anything publishing or installing should use `agentirc-cli`.
 - agentirc adopts culture's version workflow (`/version-bump`, CHANGELOG, version-check CI).
 - All-backends rule still applies: changes that cross the agentirc / culture-transport boundary must be reflected across all four backends in culture (`claude`, `codex`, `copilot`, `acp`).
 
 ### Rollback
 
-If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=9.0,<10.0` means culture cannot accidentally pick up an incompatible 10.0.0 release.
+If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=9.5,<10.0` means culture cannot accidentally pick up an incompatible 10.0.0 release.
 
 ## Testing strategy
 
@@ -364,7 +400,7 @@ Tests under culture's `tests/` are sorted into three buckets at copy time:
 | Protocol constants drift between agentirc (server) and culture/transport (client). | `agentirc.protocol` is the single source. Both sides import from there; tests on either side fail fast on missing constants. |
 | Existing deployment breaks because something on disk is unexpectedly named. | Goals/Non-Goals: nothing on disk is renamed. The verification step on a real deployment catches anything we missed. |
 | `culture server --help` output diverges from `agentirc --help` over time. | The shim parity test asserts byte-equality of the help text. CI fails if drift appears. |
-| First PyPI release of agentirc is broken; culture cutover PR can't merge. | Culture pins `agentirc-cli>=9.0,<10.0`. Patches go out as `9.0.1`, `9.0.2`. Culture's PR can wait or pin to a specific known-good `==9.0.X`. |
+| First PyPI release of agentirc is broken; culture cutover PR can't merge. | Culture pins `agentirc-cli>=9.5,<10.0`. Patches go out as `9.0.1`, `9.0.2`. Culture's PR can wait or pin to a specific known-good `==9.0.X`. |
 | Future changes touch both repos at once and become hard to coordinate. | All-backends rule already requires multi-backend coordination; the same discipline extends to multi-repo coordination. Significant cross-repo work pairs an agentirc PR with a culture PR that bumps the floor pin. |
 
 ## Open questions


### PR DESCRIPTION
## Summary

agentirc-cli 9.5.0 (2026-05-02) ships the public bot extension API the spec was waiting on. Phase A2 is now unblocked, and A3 (the original Track A end state) follows. This is a docs-only PR that continues the spec/plan work after #309 (Phase A1) merged.

- **Spec update** (`docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`):
  - Status: `A1 landed in 8.8.0; A2/A3 unblocked by agentirc-cli 9.5.0 (agentculture/agentirc#15 closed)`.
  - Phasing table — A2 row gets concrete scope (rewrite `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` against `agentirc.io/bot` CAP + `EVENTSUB`/`EVENTPUB`); A3 row gets concrete deletion scope and the new \"keep `culture/agentirc/config.py` as A1 shim through 9.x\" rule.
  - New section: \"Federation interop during the migration window\" — documents the 9.5 → ≤9.4 envelope-shape break ([agentirc#15 comment 4363115522](https://github.com/agentculture/agentirc/issues/15#issuecomment-4363115522)) and the optional ~10-LOC sniff into the bundled IRCd's `_handle_sevent`.
  - Public surface table grows: `agentirc.protocol` lists the new EVENT* verb constants, the canonical 5-field envelope, and `EVENT_TYPE_RE`. `agentirc.skill` flagged as transitional (gone in 10.0).
  - Body dep floor `agentirc-cli>=9.0,<10.0` → `agentirc-cli>=9.5,<10.0` (the 9.5 verbs are required for A2).

- **A2 plan** (`docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`, new):
  - 12 tasks, `- [ ]` checkbox style (matches the existing track-a plan format).
  - Task 4 carries an explicit decision point — TCP CAP-bot client vs in-process Python bot API — to be resolved at execution time after verifying which agentirc 9.5 supports.
  - Bundled-IRCd CAP backport noted as a separate small precondition PR if the in-tree IRCd doesn't yet advertise `agentirc.io/bot`.
  - Webhook listener (`webhook_port`) ownership transition documented: from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`.
  - Minor bump 8.8.0 → 8.9.0 (additive, no public-API removal).

- **A3 plan** (`docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`, new):
  - 8 tasks, scoped to deletion + subprocess shim + major bump.
  - Decision point at Task 1.3 — in-process `agentirc.cli.dispatch` vs `subprocess.run([\"agentirc\", *argv])` (recommendation: in-process for everything except long-running `start`).
  - `culture/agentirc/config.py` kept as the A1 re-export shim through 9.x; removed in 10.0.0.
  - Major bump 8.9.x → 9.0.0.

- **Original track-a plan** (`docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md`):
  - Marked superseded with a banner pointing at the A2 + A3 plans. Kept for historical context.

## Why

Continuation of the agentirc extraction spec/plan after #309 (A1) merged and agentculture/agentirc#15 closed. With 9.5.0 published, the path from A2 → A3 is concrete enough to write detailed plans for. Operators see no behavior change from this PR — it's purely documentation.

## Test plan

- [x] markdownlint clean (`docs/superpowers/**` is in the project ignore list per `.markdownlint-cli2.yaml`, but pre-commit ran the same hook — Passed)
- [x] Pre-commit hooks all green (trailing whitespace, end-of-file, large files, private key, markdownlint)
- [x] `git diff origin/main` shows only the 4 doc files changed — no code or config drift

## Out of scope

- Executing A2 (the bot framework rewrite) — separate PR per the new A2 plan.
- Executing A3 (deletion + subprocess shim + major bump) — separate PR per the new A3 plan, after A2 lands.
- The optional federation envelope sniff — separate small patch PR (8.8.x patch bump) if mixed-version peers expected.

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)