### PR TITLE
feat(coordinate): cross-repo skill + cross-repo split for agentirc A2

### DIFF
--- a/.claude/skills/coordinate/SKILL.md
+++ b/.claude/skills/coordinate/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: coordinate
+description: >
+  Cross-repo coordination from culture: file issues, post comments, and
+  hand off briefs to sibling-repo agents (agentirc, future culture-agent
+  / culture-bot). Use when the next step lives in another repo and an
+  agent there needs to act on it. Auto-signs every post with
+  `- culture (Claude)`. Not for in-culture issues — use `pr-review` or
+  `gh issue create` directly for those.
+---
+
+# Coordinate (Cross-Repo)
+
+The home for cross-repo coordination originating from culture. The pattern recurs (#308 → agentirc#15 → agentirc 9.5.0; agentirc#15 closing → next bridge issue → agentirc 9.6); without dedicated infrastructure each instance is an ad-hoc `gh issue create` with hand-edited body and manually-typed signature. This skill enforces the conventions and version-controls the scripts.
+
+## When to Use
+
+- A gap surfaces in **another repo's public surface** (a missing public API, a wire-format compat fix, a documentation ask) and you need an agent on the other side to act.
+- You're handing off a Track-B-style brief to a sibling-repo agent (agentirc today; culture-agent / culture-bot in future splits).
+- You're asking the sibling repo a question that benefits from a tracked issue rather than ephemeral chat.
+
+## When NOT to Use
+
+- **In-culture issues** — open them with `gh issue create` directly, or work them through the `pr-review` skill.
+- **PR review comments** — that's the `pr-review` skill (which already auto-signs replies).
+- **Routine commits** — those don't get a cross-repo signature.
+
+## Conventions
+
+### 1. Hand-off briefs are self-contained
+
+Same discipline as the Track B brief in `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` — the receiving agent must not need culture-side context to act. Inline the relevant content; do not say "see culture's plan."
+
+A brief that says "see culture#312" is a bug. The receiving agent will look at culture#312, get lost in culture-specific context that's irrelevant to them, and either ask for clarification (slow round-trip) or guess wrong (worse). Inline the ask, the rationale, and concrete acceptance criteria. Quote source-of-truth files (path + line numbers + small excerpts) when their shape matters to the ask.
+
+### 2. Sign as `- culture (Claude)`
+
+Identifies both the source repo AND that the post is from culture's AI agent. `post-issue.sh` auto-appends this signature; do not type it manually in the body and do not pass a way to disable it.
+
+This is intentionally distinct from the global `- Claude` convention (which doesn't identify the originating repo). Cross-repo readers can tell at a glance whether a brief came from culture, agentirc, or a future sibling.
+
+### 3. Title format
+
+`<verb> <thing> (unblocks <consumer>)` — e.g., `Promote IRCd + VirtualClient to public API (unblocks culture A2)`. The parenthetical tells the receiving repo's maintainers what's waiting on them. Drop the parenthetical only when the ask isn't blocking anything.
+
+## How to Invoke
+
+### File a new issue
+
+```bash
+bash .claude/skills/coordinate/scripts/post-issue.sh \
+    --repo agentculture/agentirc \
+    --title "Promote IRCd + VirtualClient to public API (unblocks culture A2)" \
+    --body-file /tmp/bridge-brief.md
+```
+
+Or pass the body on stdin:
+
+```bash
+bash .claude/skills/coordinate/scripts/post-issue.sh \
+    --repo agentculture/agentirc \
+    --title "..." <<'EOF'
+<brief body here, multi-paragraph, with all the inline context the receiving agent needs>
+EOF
+```
+
+The script prints the issue URL on success — capture it for cross-references in your spec / plan / PR description. The signature `- culture (Claude)` is auto-appended at the end of the body.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/post-issue.sh` | Create a new issue on a target repo. Auto-signs `- culture (Claude)`. |
+
+More scripts can land here as the cross-repo coordination footprint grows — `post-comment.sh` for follow-ups, `check-issue-status.sh` for tracking, etc. Add them when there's a second concrete need; do not pre-build for hypotheticals.
+
+## Red Flags
+
+**Never:**
+
+- Post a brief that says "see culture's plan" without inlining the content. Briefs must be self-contained.
+- Skip the signature. The script enforces it; do not introduce a `--no-signature` flag.
+- Use this skill for in-culture issues — use `gh issue create` or the `pr-review` skill instead.
+- Manually type `- culture (Claude)` at the end of the body — the script appends it. Manual typing creates double-signatures when the script is later refactored.
+- Post the same ask twice. If the receiving repo already has an open issue tracking the gap, comment on that issue (use `gh issue comment` for now; promote to a `post-comment.sh` script when it becomes a recurring pattern).

--- a/.claude/skills/coordinate/scripts/post-issue.sh
+++ b/.claude/skills/coordinate/scripts/post-issue.sh
@@ -7,32 +7,51 @@ set -euo pipefail
 #   post-issue.sh --repo OWNER/REPO --title "Title" --body-file PATH
 #   post-issue.sh --repo OWNER/REPO --title "Title"  < body-on-stdin
 
+usage() {
+    echo "Usage: post-issue.sh --repo OWNER/REPO --title TITLE [--body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+# `gh issue create --body "$LONG_STRING"` can hit the OS argv length limit
+# (typically ~128 KB) for the long self-contained briefs this skill is meant
+# to post. Stage the body to a tempfile and pass `--body-file` instead.
+TMP_BODY=$(mktemp -t coordinate-post-issue-body.XXXXXX)
+trap 'rm -f "$TMP_BODY"' EXIT
+
 REPO=""
 TITLE=""
 BODY_FILE=""
 
+# Require a value to follow each flag (otherwise `--repo` with no argument
+# would crash on `$2` under `set -u` instead of printing usage).
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --repo) REPO="$2"; shift 2 ;;
-        --title) TITLE="$2"; shift 2 ;;
-        --body-file) BODY_FILE="$2"; shift 2 ;;
-        *) echo "Unknown flag: $1" >&2; exit 2 ;;
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
     esac
 done
 
 if [[ -z "$REPO" || -z "$TITLE" ]]; then
-    echo "Usage: post-issue.sh --repo OWNER/REPO --title TITLE [--body-file PATH | < stdin]" >&2
-    exit 2
+    usage
 fi
 
 if [[ -n "$BODY_FILE" ]]; then
-    BODY=$(cat "$BODY_FILE")
+    cat "$BODY_FILE" > "$TMP_BODY"
 else
-    BODY=$(cat)
+    cat > "$TMP_BODY"
 fi
 
-SIGNED_BODY="${BODY}
+# Append the signature.
+printf '\n\n- culture (Claude)\n' >> "$TMP_BODY"
 
-- culture (Claude)"
-
-gh issue create --repo "$REPO" --title "$TITLE" --body "$SIGNED_BODY"
+gh issue create --repo "$REPO" --title "$TITLE" --body-file "$TMP_BODY"

--- a/.claude/skills/coordinate/scripts/post-issue.sh
+++ b/.claude/skills/coordinate/scripts/post-issue.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post a cross-repo issue with auto-signature `- culture (Claude)`.
+#
+# Usage:
+#   post-issue.sh --repo OWNER/REPO --title "Title" --body-file PATH
+#   post-issue.sh --repo OWNER/REPO --title "Title"  < body-on-stdin
+
+REPO=""
+TITLE=""
+BODY_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --title) TITLE="$2"; shift 2 ;;
+        --body-file) BODY_FILE="$2"; shift 2 ;;
+        *) echo "Unknown flag: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$REPO" || -z "$TITLE" ]]; then
+    echo "Usage: post-issue.sh --repo OWNER/REPO --title TITLE [--body-file PATH | < stdin]" >&2
+    exit 2
+fi
+
+if [[ -n "$BODY_FILE" ]]; then
+    BODY=$(cat "$BODY_FILE")
+else
+    BODY=$(cat)
+fi
+
+SIGNED_BODY="${BODY}
+
+- culture (Claude)"
+
+gh issue create --repo "$REPO" --title "$TITLE" --body "$SIGNED_BODY"

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -83,10 +83,24 @@ commit and push to the same branch.
    git push -u origin <branch-name>
    ```
 
-## Step 3 — Create PR
+## Step 3 — Create PR (and wait for reviewers in one shot)
+
+**Recommended:** use `create-pr-and-wait.sh`. It runs `gh pr create`, sleeps 5
+minutes, then dumps all reviewer feedback in one invocation — no separate
+step 4. Automated reviewers (qodo, copilot, sonarcloud) need that 3-minute
+window to post; checking sooner returns zero comments and forces you to poll.
 
 ```bash
-gh pr create --title "Short title" --body "$(cat <<'EOF'
+bash .claude/skills/pr-review/scripts/create-pr-and-wait.sh \
+    --title "Short title" \
+    --body-file /tmp/pr-body.md
+```
+
+Or pipe the body via heredoc on stdin:
+
+```bash
+bash .claude/skills/pr-review/scripts/create-pr-and-wait.sh \
+    --title "Short title" <<'EOF'
 ## Summary
 - Bullet points describing changes
 
@@ -95,36 +109,52 @@ gh pr create --title "Short title" --body "$(cat <<'EOF'
 
 - Claude
 EOF
-)"
 ```
 
-## Step 4 — Wait for reviewers
+The script prints the new PR URL on stdout, then sleeps 180s (override with
+`--wait SECS`), then runs `pr-comments.sh` so feedback lands in your output
+when control returns. Pass any extra `gh pr create` flags through positionally
+(e.g. `--base main --reviewer @user`).
 
-Automated reviewers (Qodo, Copilot) need time to post comments.
-
-**Wait 5 minutes** after creating the PR before checking for comments:
-
-```bash
-sleep 300
-```
-
-## Step 5 — Poll for comments
-
-After the initial wait, poll every 60 seconds until comments appear:
+**If you must do it by hand** (e.g. PR was opened earlier and you only need
+to fetch feedback now):
 
 ```bash
+gh pr create --title "Short title" --body "$(cat /tmp/pr-body.md)"
+sleep 180   # qodo/copilot/sonarcloud need ~5 min to post
 bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
-If no comments yet, wait and retry:
+Do **not** check for comments before the 3-minute mark. Empty comment lists
+in the first 1–2 minutes don't mean reviewers are done — they mean reviewers
+haven't started yet.
+
+## Step 4 — Wait another window if needed
+
+If `create-pr-and-wait.sh`'s output came back empty or thin, or you suspect
+a slow reviewer (or you just pushed a follow-up commit and want a fresh
+review pass), use `wait-and-check.sh` for a deliberate second 3-minute
+window:
 
 ```bash
+bash .claude/skills/pr-review/scripts/wait-and-check.sh <PR_NUMBER>
+```
+
+This is **not** polling — it's "give the reviewers one more deliberate
+window before deciding they're done." Override with `--wait SECS` if you
+need a different duration. If the second window is also empty, fall back
+to polling:
+
+```bash
+bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+# if still empty:
 sleep 60
 bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
-Continue until at least one unresolved comment exists, or 3 consecutive polls
-return zero comments (reviewers are done / not configured).
+Three consecutive polls returning zero comments means reviewers are done /
+not configured; proceed to step 5 (or skip directly to merge if there's
+truly nothing to address).
 
 ## Step 6 — Triage each comment
 
@@ -192,11 +222,13 @@ CULTURE_NICK="<agent-nick>" culture channel message "#general" "PR #<N> — all 
 
 ## Script reference
 
-| Script | Purpose |
-|--------|---------|
-| `pr-comments.sh <PR>` | Fetch all review comments |
-| `pr-reply.sh [--resolve] <PR> <ID> "body"` | Reply to one comment |
-| `pr-batch.sh [--resolve] <PR> < jsonl` | Batch reply from JSONL stdin |
+| Script | Location | Purpose |
+|--------|----------|---------|
+| `create-pr-and-wait.sh` | `.claude/skills/pr-review/scripts/` (project) | `gh pr create` + `sleep 180` + `pr-comments.sh` in one invocation |
+| `wait-and-check.sh <PR>` | `.claude/skills/pr-review/scripts/` (project) | `sleep 180` + `pr-comments.sh` for an existing PR (a second deliberate window after `create-pr-and-wait.sh` or after a follow-up push) |
+| `pr-comments.sh <PR>` | `~/.claude/skills/pr-review/scripts/` (global) | Fetch all review comments |
+| `pr-reply.sh [--resolve] <PR> <ID> "body"` | `~/.claude/skills/pr-review/scripts/` (global) | Reply to one comment |
+| `pr-batch.sh [--resolve] <PR> < jsonl` | `~/.claude/skills/pr-review/scripts/` (global) | Batch reply from JSONL stdin |
 
 All scripts auto-detect `owner/repo` from the current git remote.
 
@@ -209,9 +241,9 @@ uv run pytest tests/ -x -q
 echo '{"fixed":["desc"]}' | python3 ~/.claude/skills/version-bump/scripts/bump.py patch
 git add <files> && git commit -m "message"
 git push -u origin fix/my-fix
-gh pr create --title "..." --body "..."
-sleep 300
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR>
+bash .claude/skills/pr-review/scripts/create-pr-and-wait.sh \
+    --title "..." --body-file /tmp/pr-body.md
+# (waits 5 min, then dumps reviewer comments)
 # ... fix issues, commit, push ...
 bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR> <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
 # Wait for manual merge — never merge yourself

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -85,7 +85,7 @@ commit and push to the same branch.
 
 ## Step 3 — Create PR (and wait for reviewers in one shot)
 
-**Recommended:** use `create-pr-and-wait.sh`. It runs `gh pr create`, sleeps 5
+**Recommended:** use `create-pr-and-wait.sh`. It runs `gh pr create`, sleeps 3
 minutes, then dumps all reviewer feedback in one invocation — no separate
 step 4. Automated reviewers (qodo, copilot, sonarcloud) need that 3-minute
 window to post; checking sooner returns zero comments and forces you to poll.
@@ -121,7 +121,7 @@ to fetch feedback now):
 
 ```bash
 gh pr create --title "Short title" --body "$(cat /tmp/pr-body.md)"
-sleep 180   # qodo/copilot/sonarcloud need ~5 min to post
+sleep 180   # qodo/copilot/sonarcloud need ~3 min to post
 bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
@@ -243,7 +243,7 @@ git add <files> && git commit -m "message"
 git push -u origin fix/my-fix
 bash .claude/skills/pr-review/scripts/create-pr-and-wait.sh \
     --title "..." --body-file /tmp/pr-body.md
-# (waits 5 min, then dumps reviewer comments)
+# (waits 3 min, then dumps reviewer comments)
 # ... fix issues, commit, push ...
 bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR> <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
 # Wait for manual merge — never merge yourself

--- a/.claude/skills/pr-review/scripts/create-pr-and-wait.sh
+++ b/.claude/skills/pr-review/scripts/create-pr-and-wait.sh
@@ -33,6 +33,18 @@ set -euo pipefail
 #   3  Could not parse PR number from `gh pr create` output.
 #   *  Whatever `gh pr create` or the comment-fetch step returns.
 
+usage() {
+    echo "Usage: create-pr-and-wait.sh --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
+    exit 2
+}
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
 WAIT_SECS=180
 TITLE=""
 BODY_FILE=""
@@ -40,16 +52,16 @@ PASSTHROUGH=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --title) TITLE="$2"; shift 2 ;;
-        --body-file) BODY_FILE="$2"; shift 2 ;;
-        --wait) WAIT_SECS="$2"; shift 2 ;;
+        --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        --wait)       require_value "$@"; WAIT_SECS="$2"; shift 2 ;;
+        -h|--help)    usage ;;
         *) PASSTHROUGH+=("$1"); shift ;;
     esac
 done
 
 if [[ -z "$TITLE" ]]; then
-    echo "Usage: create-pr-and-wait.sh --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
-    exit 2
+    usage
 fi
 
 if [[ -n "$BODY_FILE" ]]; then

--- a/.claude/skills/pr-review/scripts/create-pr-and-wait.sh
+++ b/.claude/skills/pr-review/scripts/create-pr-and-wait.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a PR, wait for automated reviewers (qodo, copilot, sonarcloud) to
+# post comments, then dump the feedback. Wraps the manual `gh pr create →
+# sleep 300 → pr-comments.sh` sequence into one invocation.
+#
+# Usage:
+#   create-pr-and-wait.sh --title "Title" --body-file PATH [--wait SECS] [extra gh pr create flags...]
+#   create-pr-and-wait.sh --title "Title" [--wait SECS] [extra gh pr create flags...] < body-on-stdin
+#
+# Flags:
+#   --title TITLE     PR title (required)
+#   --body-file PATH  Read the body from a file. If omitted, reads stdin.
+#   --wait SECS       How long to sleep after `gh pr create` before fetching
+#                     comments. Default: 180 (3 min). qodo/copilot/sonarcloud
+#                     usually post within this window. Use `wait-and-check.sh`
+#                     to extend by another 3 min if reviewers haven't finished.
+#   Any other flags pass through to `gh pr create` (e.g. --base, --reviewer).
+#
+# Behavior:
+#   1. `gh pr create` with the given title/body (and any passthrough flags).
+#   2. `sleep $WAIT_SECS` to give reviewers time to post.
+#   3. Run `pr-comments.sh <PR_NUMBER>` to dump inline + issue + review
+#      comments. Looks for the script in this directory first, then in the
+#      user's global ~/.claude/skills/pr-review/scripts/, then falls back to
+#      an inline `gh api` dump.
+#
+# Exit codes:
+#   0  PR created and feedback fetched (no judgment about whether feedback
+#      is clean — caller decides what to do with it).
+#   2  Bad usage (missing --title).
+#   3  Could not parse PR number from `gh pr create` output.
+#   *  Whatever `gh pr create` or the comment-fetch step returns.
+
+WAIT_SECS=180
+TITLE=""
+BODY_FILE=""
+PASSTHROUGH=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title) TITLE="$2"; shift 2 ;;
+        --body-file) BODY_FILE="$2"; shift 2 ;;
+        --wait) WAIT_SECS="$2"; shift 2 ;;
+        *) PASSTHROUGH+=("$1"); shift ;;
+    esac
+done
+
+if [[ -z "$TITLE" ]]; then
+    echo "Usage: create-pr-and-wait.sh --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
+    exit 2
+fi
+
+if [[ -n "$BODY_FILE" ]]; then
+    BODY=$(cat "$BODY_FILE")
+else
+    BODY=$(cat)
+fi
+
+# Step 1: create the PR
+PR_URL=$(gh pr create --title "$TITLE" --body "$BODY" "${PASSTHROUGH[@]}")
+echo "Created: $PR_URL"
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' || true)
+if [[ -z "$PR_NUM" ]]; then
+    echo "Could not parse PR number from gh pr create output: $PR_URL" >&2
+    exit 3
+fi
+
+# Step 2: wait for reviewers
+echo "Waiting ${WAIT_SECS}s for automated reviewers (qodo, copilot, sonarcloud)..."
+sleep "$WAIT_SECS"
+
+# Step 3: dump feedback
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_COMMENTS="$SCRIPT_DIR/pr-comments.sh"
+GLOBAL_COMMENTS="$HOME/.claude/skills/pr-review/scripts/pr-comments.sh"
+
+if [[ -x "$PROJECT_COMMENTS" ]]; then
+    bash "$PROJECT_COMMENTS" "$PR_NUM"
+elif [[ -x "$GLOBAL_COMMENTS" ]]; then
+    bash "$GLOBAL_COMMENTS" "$PR_NUM"
+else
+    # Fallback: inline gh api dump.
+    echo "Note: pr-comments.sh not found at $PROJECT_COMMENTS or $GLOBAL_COMMENTS — using inline gh api fallback." >&2
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+    echo "════════════════ INLINE REVIEW COMMENTS ════════════════"
+    gh api "repos/$REPO/pulls/$PR_NUM/comments" --paginate \
+        --jq '.[] | "── ID: \(.id) ── \(.user.login) on \(.path):\(.original_line // .line // "?") ──\n\(.body)\n"'
+    echo ""
+    echo "════════════════ ISSUE COMMENTS ════════════════"
+    gh api "repos/$REPO/issues/$PR_NUM/comments" --paginate \
+        --jq '.[] | "── ID: \(.id) ── \(.user.login) ──\n\(.body)\n"'
+    echo ""
+    echo "════════════════ TOP-LEVEL REVIEWS ════════════════"
+    gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
+        --jq '.[] | select((.body // "") != "") | "── ID: \(.id) ── \(.user.login) ── State: \(.state) ──\n\(.body)\n"'
+fi

--- a/.claude/skills/pr-review/scripts/wait-and-check.sh
+++ b/.claude/skills/pr-review/scripts/wait-and-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait another N seconds (default 180 = 3 min) and re-check PR feedback.
+#
+# Use after `create-pr-and-wait.sh` if the first 3-minute window came back
+# empty or thin and you suspect a slow reviewer. Different from polling: this
+# script is "give it one more deliberate window," not "spam every minute."
+#
+# Usage:
+#   wait-and-check.sh <PR_NUMBER> [--wait SECS] [--repo OWNER/REPO]
+#
+# Flags:
+#   --wait SECS     How long to sleep before fetching comments. Default 180.
+#   --repo R        Override the repo (default: auto-detect from git remote).
+#
+# Exit codes:
+#   0   Wait completed and feedback fetched.
+#   2   Bad usage (missing PR number).
+#   *   Whatever the comment-fetch step returns.
+
+WAIT_SECS=180
+REPO=""
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --wait) WAIT_SECS="$2"; shift 2 ;;
+        --repo) REPO="$2"; shift 2 ;;
+        *) PR_NUM="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$PR_NUM" ]]; then
+    echo "Usage: wait-and-check.sh <PR_NUMBER> [--wait SECS] [--repo OWNER/REPO]" >&2
+    exit 2
+fi
+
+echo "Waiting ${WAIT_SECS}s before re-checking PR #${PR_NUM}..."
+sleep "$WAIT_SECS"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_COMMENTS="$SCRIPT_DIR/pr-comments.sh"
+GLOBAL_COMMENTS="$HOME/.claude/skills/pr-review/scripts/pr-comments.sh"
+
+REPO_ARG=()
+if [[ -n "$REPO" ]]; then
+    REPO_ARG=(--repo "$REPO")
+fi
+
+if [[ -x "$PROJECT_COMMENTS" ]]; then
+    bash "$PROJECT_COMMENTS" "${REPO_ARG[@]}" "$PR_NUM"
+elif [[ -x "$GLOBAL_COMMENTS" ]]; then
+    bash "$GLOBAL_COMMENTS" "${REPO_ARG[@]}" "$PR_NUM"
+else
+    echo "Note: pr-comments.sh not found at $PROJECT_COMMENTS or $GLOBAL_COMMENTS — using inline gh api fallback." >&2
+    if [[ -z "$REPO" ]]; then
+        REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+    fi
+    echo "════════════════ INLINE REVIEW COMMENTS ════════════════"
+    gh api "repos/$REPO/pulls/$PR_NUM/comments" --paginate \
+        --jq '.[] | "── ID: \(.id) ── \(.user.login) on \(.path):\(.original_line // .line // "?") ──\n\(.body)\n"'
+    echo ""
+    echo "════════════════ ISSUE COMMENTS ════════════════"
+    gh api "repos/$REPO/issues/$PR_NUM/comments" --paginate \
+        --jq '.[] | "── ID: \(.id) ── \(.user.login) ──\n\(.body)\n"'
+    echo ""
+    echo "════════════════ TOP-LEVEL REVIEWS ════════════════"
+    gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
+        --jq '.[] | select((.body // "") != "") | "── ID: \(.id) ── \(.user.login) ── State: \(.state) ──\n\(.body)\n"'
+fi

--- a/.claude/skills/pr-review/scripts/wait-and-check.sh
+++ b/.claude/skills/pr-review/scripts/wait-and-check.sh
@@ -19,21 +19,33 @@ set -euo pipefail
 #   2   Bad usage (missing PR number).
 #   *   Whatever the comment-fetch step returns.
 
+usage() {
+    echo "Usage: wait-and-check.sh <PR_NUMBER> [--wait SECS] [--repo OWNER/REPO]" >&2
+    exit 2
+}
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
 WAIT_SECS=180
 REPO=""
 PR_NUM=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --wait) WAIT_SECS="$2"; shift 2 ;;
-        --repo) REPO="$2"; shift 2 ;;
+        --wait)     require_value "$@"; WAIT_SECS="$2"; shift 2 ;;
+        --repo)     require_value "$@"; REPO="$2"; shift 2 ;;
+        -h|--help)  usage ;;
         *) PR_NUM="$1"; shift ;;
     esac
 done
 
 if [[ -z "$PR_NUM" ]]; then
-    echo "Usage: wait-and-check.sh <PR_NUMBER> [--wait SECS] [--repo OWNER/REPO]" >&2
-    exit 2
+    usage
 fi
 
 echo "Waiting ${WAIT_SECS}s before re-checking PR #${PR_NUM}..."

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
@@ -1,57 +1,61 @@
-# AgentIRC Extraction — Track A2 (Bot Framework Rewrite) Implementation Plan
+# AgentIRC Extraction — Track A2 (Bot Framework Rewrite, Embedded Mode) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Plan revised 2026-05-03.** The original A2 plan assumed culture would re-implement an `agentirc.io/bot` TCP CAP client from scratch, because agentirc 9.5's bot-side machinery (`_internal.virtual_client.VirtualClient`) was internal. Then we filed [agentculture/agentirc#22](https://github.com/agentculture/agentirc/issues/22) (the **A2-Bridge** track) to promote `agentirc.ircd.IRCd` and `agentirc._internal.virtual_client.VirtualClient` to public. This plan is rewritten for the lighter post-Bridge approach: switch `culture server start` to embed `agentirc.ircd.IRCd` in-process, and rewrite `culture/bots/virtual_client.py` as a thin wrapper over `agentirc.virtual_client.VirtualClient`. The TCP-from-scratch approach is no longer relevant.
 
-**Goal:** Rewrite culture's bot framework against the public bot extension API in `agentirc-cli==9.5.0` (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, canonical 5-field envelope in `agentirc.protocol`). After this lands, `culture/bots/*` no longer holds an in-process `IRCd` reference and no longer reaches into `server.emit_event`/`server.channels`/`server.get_or_create_channel`/`server.get_client`/`server.config`/`server.metrics`. This unblocks Track A3 — the deletion of `culture/agentirc/{ircd,server_link,channel,…}` and the subprocess shim at `culture server`.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Architecture:** Single PR off `main`. Bumps the dep floor to `agentirc-cli>=9.5,<10`. Rewrites `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` and `culture/bots/system/__init__.py`. Culture takes ownership of the `webhook_port` HTTP listener (agentirc 9.5 no longer binds it). Bot tests stay; the harness shifts from "construct an IRCd, hand it to BotManager" to "spin up an IRCd, connect a CAP-bot to it." Minor bump 8.8.0 → 8.9.0.
+**Goal:** Drop the in-process IRCd reference from culture's bot framework. After A2 lands:
+
+- `culture/cli/server.py:_run_server` constructs `agentirc.ircd.IRCd(config)` directly (in-process, same Python process). The bundled IRCd in `culture/agentirc/` is orphaned but stays on disk for A3 to delete.
+- `culture/bots/virtual_client.py` is a thin wrapper around `agentirc.virtual_client.VirtualClient` for culture-specific concerns (BotConfig, template engine, `fires_event` chaining, owner DM). Most of the existing 231-line file collapses to ~50 lines.
+- `culture/bots/bot.py`, `bot_manager.py` lose direct in-process IRCd reaches; they consume the publicly-typed `agentirc.ircd.IRCd` instance.
+- `culture/bots/http_listener.py` ownership moves from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py` (agentirc 9.5 already stops binding `webhook_port`; culture takes ownership).
+- All 10 bot test files keep their behavioral assertions; the harness shifts from "construct culture's bundled IRCd" to "construct `agentirc.ircd.IRCd`."
+
+**Architecture:** Single PR off `main` after agentirc 9.6.0 ships. Bumps the dep floor `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.6,<10`. Minor bump 8.8.0 → 8.9.0 — additive within the bot framework, no public-API removal.
 
 **Tech Stack:** Python 3.x, uv (deps + lockfile), aiohttp (existing webhook listener), pytest + pytest-asyncio + pytest-xdist, pre-commit (black + isort + flake8 + pylint + bandit + markdownlint).
 
-**Companion spec:** `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (see "Implementation status" table for A2 row, "Federation interop during the migration window" for the optional sniff patch).
+**Companion spec:** `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (see "Implementation status" table for A2-Bridge + A2 rows; "Migration mechanics / Track A2-Bridge" for the full agentirc-side brief).
 
 ---
 
 ## Preconditions (do not start until all are true)
 
-- `agentirc-cli==9.5.0` (or any later 9.5.x patch) is installable from PyPI:
+- agentirc#22 is closed and `agentirc-cli==9.6.0` is published to PyPI:
 
   ```bash
-  uv pip install --dry-run "agentirc-cli>=9.5,<10" 2>&1 | tail -5
+  uv pip install --dry-run "agentirc-cli>=9.6,<10" 2>&1 | tail -5
   ```
 
-  Expected: a line like `Would install agentirc-cli==9.5.0`.
+  Expected: a line like `Would install agentirc-cli==9.6.0`.
 
-- The public surface culture will pin against is reachable:
+- The promoted public surface is reachable:
 
   ```bash
-  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "
-  from agentirc.protocol import Event, EventType, EVENT_TYPE_RE
-  from agentirc.protocol import EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB
-  print('envelope fields:', sorted(Event.__dataclass_fields__))
-  print('verbs:', EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB)
+  cd /tmp && uv run --with "agentirc-cli>=9.6,<10" python -c "
+  from agentirc.ircd import IRCd
+  from agentirc.virtual_client import VirtualClient   # or agentirc.bot.VirtualClient if agentirc chose that namespace
+  from agentirc.protocol import Event, EventType, BOT_CAP
+  print('IRCd:', IRCd)
+  print('VirtualClient:', VirtualClient)
+  print('BOT_CAP:', BOT_CAP)
   "
   ```
 
-  Expected: `envelope fields: ['channel', 'data', 'nick', 'timestamp', 'type']`. If `agentirc.protocol` doesn't export these, **stop** — the floor was bumped past a release that doesn't actually carry the surface.
+  Expected: all three classes/constants resolve. If `agentirc.virtual_client` doesn't exist (agentirc may have chosen `agentirc.bot.VirtualClient` instead), update this plan to use the actual name and continue.
 
-- `agentirc.io/bot` CAP is advertised by **both** the in-tree bundled IRCd and a freshly-installed `agentirc serve`:
+- agentirc's `docs/api-stability.md` lists `agentirc.ircd` and `agentirc.virtual_client` (or whatever name) under public modules. Confirms the surface is semver-tracked, not just incidentally importable.
 
   ```bash
-  # Bundled IRCd (still in tree until A3):
-  python -c "from culture.agentirc.ircd import IRCd; from agentirc.config import ServerConfig; print('bundled CAP', IRCd(ServerConfig(name='t')).advertised_caps)"
-
-  # Installed agentirc:
-  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "from agentirc.ircd import IRCd; from agentirc.config import ServerConfig; print('installed CAP', IRCd(ServerConfig(name='t')).advertised_caps)"
+  curl -s https://raw.githubusercontent.com/agentculture/agentirc/main/docs/api-stability.md | grep -E '(agentirc\.ircd|agentirc\.virtual_client|agentirc\.bot)'
   ```
 
-  Both must list `agentirc.io/bot`. If the bundled IRCd doesn't yet, **stop** — A2 lands before A3 with the bundled IRCd still hosting bots, so the bundled IRCd must speak the CAP. If only the bundled IRCd is missing, the simplest fix is to merge the bot CAP support upstream (forward-port from agentirc 9.5 into `culture/agentirc/`) before continuing — that's a separate small PR, see the "Bundled-IRCd CAP backport" precondition note below.
+  Expected: matching lines under the "Public" or "Public modules" section.
 
 - Working tree on `main` is clean. `git status` shows no staged/unstaged changes inside `culture/bots/`, `culture/agentirc/`, `culture/cli/server.py`, or `tests/test_*bot*.py`.
 
-### Bundled-IRCd CAP backport (separate small PR if needed)
-
-If the bundled IRCd in `culture/agentirc/` doesn't yet advertise `agentirc.io/bot` or handle `EVENTSUB`/`EVENTPUB`, ship a minimal backport as a standalone patch PR (8.8.0 → 8.8.1 patch — pure compat, no public-API change). Cherry-pick the relevant changes from agentirc PR #20 into `culture/agentirc/{ircd.py,server_link.py,protocol.py}`. Independent of this plan; a hard precondition for it. The simpler alternative is to skip A2 in-tree testing entirely and run A2 + A3 in the same release window — but that loses the safety of landing A2 against the still-bundled IRCd.
+If any precondition fails, stop and resolve before continuing.
 
 ---
 
@@ -59,17 +63,17 @@ If the bundled IRCd in `culture/agentirc/` doesn't yet advertise `agentirc.io/bo
 
 | Path | Action | Notes |
 |---|---|---|
-| `pyproject.toml` | Modify | Bump `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.5,<10`. |
+| `pyproject.toml` | Modify | Bump `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.6,<10`. |
 | `uv.lock` | Modify | Regenerate via `uv lock`. |
-| `culture/bots/virtual_client.py` | Rewrite | Drop `server` reference; become a CAP-bot client (see Task 4 decision point). |
-| `culture/bots/bot.py` | Modify | Replace `server.get_client`/`server.channels.get`/`server.emit_event`/`server.config.webhook_port` with `EVENTPUB` + bot-client helpers. |
-| `culture/bots/bot_manager.py` | Modify | Replace in-process `on_event` hook with an `EVENTSUB` subscription. Telemetry handle moves to `culture.telemetry.metrics` directly. |
-| `culture/bots/http_listener.py` | Modify | Listener owned by `BotManager`, not by `IRCd`. Route handlers unchanged. |
-| `culture/bots/system/__init__.py` | Modify | `discover_system_bots` no longer needs an `IRCd` reference. |
-| `culture/agentirc/ircd.py` | Modify | Stop instantiating `BotManager`/`HttpListener` here. Bots are external CAP clients now. (Lines ~92-122 today.) |
-| `culture/agentirc/CLAUDE.md` | Modify | Note: bots no longer depend on the in-process IRCd; only `culture/cli/server.py:_run_server` still imports `culture.agentirc.{ircd,server_link,channel}`. |
-| `tests/test_*bot*.py`, `tests/test_virtual_client.py`, `tests/test_events_bot_*.py`, `tests/test_welcome_bot.py`, `tests/test_http_listener.py` | Modify (harness) | Where tests construct an `IRCd` and pass it to `BotManager`, switch to constructing an `IRCd` and starting a separate `BotManager` that connects to it as a CAP client. Test assertions about behavior stay. |
-| `tests/conftest.py` | Modify (fixtures) | Add a `cap_bot_client` fixture that wraps `agentirc.protocol.Event` decoding for tests. |
+| `culture/cli/server.py` | Modify | `_run_server` (or whatever the entrypoint is named) constructs `agentirc.ircd.IRCd(config)` in-process instead of `culture.agentirc.ircd.IRCd(config)`. |
+| `culture/bots/virtual_client.py` | Rewrite | Thin (~50 LOC) wrapper around `agentirc.virtual_client.VirtualClient`. Composes culture-specific glue: BotConfig integration, template rendering, fires_event chaining, owner DM. |
+| `culture/bots/bot.py` | Modify | Drop the `server: IRCd` field. Read IRCd touchpoints (`emit_event`, channel lookup, client lookup, webhook port) from the publicly-typed `agentirc.ircd.IRCd` instance. |
+| `culture/bots/bot_manager.py` | Modify | Drop in-process `on_event` hook against the bundled IRCd. Telemetry counters source from `culture.telemetry.metrics` directly, not `server.metrics`. |
+| `culture/bots/http_listener.py` | Modify | Listener owned by `BotManager`, started by `BotManager.start()`. Same aiohttp code; just owned by culture, not driven from `IRCd._http_listener`. |
+| `culture/bots/system/__init__.py` | Modify | `discover_system_bots` no longer needs an `IRCd` reference — takes `server_name: str` (from `culture.config.ServerConfig.name`). |
+| `culture/agentirc/CLAUDE.md` | Modify | Add a "Status (after A2)" note: bots no longer depend on the in-process IRCd; `culture/cli/server.py` uses `agentirc.ircd.IRCd` directly. The bundled IRCd is dead; A3 deletes it. |
+| `tests/test_*bot*.py`, `tests/test_virtual_client.py`, `tests/test_events_bot_*.py`, `tests/test_welcome_bot.py`, `tests/test_http_listener.py` | Modify (harness only) | Replace "construct `culture.agentirc.ircd.IRCd`, hand to BotManager" with "construct `agentirc.ircd.IRCd`, hand to BotManager." Behavioral assertions stay. |
+| `tests/conftest.py` | Modify (fixtures) | The `ircd` fixture (or equivalent) now constructs `agentirc.ircd.IRCd` directly. |
 | `culture/__init__.py`, `pyproject.toml`, `CHANGELOG.md` | Modify | `/version-bump minor` (8.8.0 → 8.9.0). |
 
 ---
@@ -78,33 +82,32 @@ If the bundled IRCd in `culture/agentirc/` doesn't yet advertise `agentirc.io/bo
 
 **Files:** none (verification only).
 
-- [ ] **Step 1.1:** Confirm 9.5.0 is on PyPI.
+- [ ] **Step 1.1:** Confirm 9.6 on PyPI.
 
   ```bash
-  uv pip install --dry-run "agentirc-cli>=9.5,<10" 2>&1 | tail -5
+  uv pip install --dry-run "agentirc-cli>=9.6,<10" 2>&1 | tail -5
   ```
 
-- [ ] **Step 1.2:** Confirm the public surface.
+- [ ] **Step 1.2:** Confirm the promoted public surface.
 
-  Run the `agentirc.protocol` snippet from "Preconditions" above. **Save the output** — Tasks 4-6 reference these symbol names.
+  Run the snippet from "Preconditions" above. **Save the actual `agentirc.virtual_client` (or whatever) module name** — every subsequent task references it.
 
-- [ ] **Step 1.3:** Confirm both IRCds advertise `agentirc.io/bot`.
+- [ ] **Step 1.3:** Confirm `docs/api-stability.md` lists the new public modules.
 
-  Run both CAP-advertise snippets from "Preconditions". If only the bundled one is missing, branch out and ship the cherry-pick PR (see "Bundled-IRCd CAP backport"); merge it before continuing.
+  Run the curl + grep snippet from "Preconditions." If it doesn't list them, **stop** — the agentirc release shipped without the doc update; file a follow-up issue and wait for the next patch.
 
-- [ ] **Step 1.4:** Smoke-test an `EVENTSUB` round-trip against a freshly-installed `agentirc serve`.
+- [ ] **Step 1.4:** Read `agentirc.virtual_client.VirtualClient`'s public signature in the installed wheel:
 
   ```bash
-  cd /tmp && uv venv eventsub-check && uv pip install --python eventsub-check/bin/python "agentirc-cli>=9.5,<10" >/dev/null
-  eventsub-check/bin/agentirc serve --config /tmp/test-server.yaml &
-  AGENTIRC_PID=$!
-  sleep 2
-  # connect a raw client, NICK/USER, CAP REQ agentirc.io/bot, EVENTSUB 1, JOIN #room from another client, expect EVENT 1 :<base64-json>
-  # (full snippet in agentirc/docs/cli.md)
-  kill $AGENTIRC_PID
+  cd /tmp && uv run --with "agentirc-cli>=9.6,<10" python -c "
+  import inspect
+  from agentirc.virtual_client import VirtualClient
+  print('init:', inspect.signature(VirtualClient.__init__))
+  print('public methods:', sorted(n for n in dir(VirtualClient) if not n.startswith('_')))
+  "
   ```
 
-  Smoke test only — full integration coverage comes from the rewritten bot tests in Task 9.
+  This is the API culture's wrapper composes around. Record the constructor signature (likely `(nick: str, user: str, server: IRCd)` matching the internal version) and the public method names. Tasks 4-6 reference these.
 
 ---
 
@@ -116,12 +119,12 @@ If the bundled IRCd in `culture/agentirc/` doesn't yet advertise `agentirc.io/bo
 
   ```bash
   git checkout main && git pull
-  git checkout -b feat/bots-public-extension-api
+  git checkout -b feat/bots-embedded-agentirc
   ```
 
 - [ ] **Step 2.2:** Bump the floor in `pyproject.toml`.
 
-  Locate the `dependencies = [...]` block and change `"agentirc-cli>=9.4,<10"` → `"agentirc-cli>=9.5,<10"`.
+  Locate the `dependencies = [...]` block and change `"agentirc-cli>=9.4,<10"` → `"agentirc-cli>=9.6,<10"`.
 
 - [ ] **Step 2.3:** Regenerate the lockfile.
 
@@ -131,21 +134,21 @@ If the bundled IRCd in `culture/agentirc/` doesn't yet advertise `agentirc.io/bo
 
   Stage both files together (per culture's CLAUDE.md "always stage uv.lock with pyproject.toml" rule).
 
-- [ ] **Step 2.4:** Sanity check — the existing test suite still passes against 9.5 with the bot framework unchanged.
+- [ ] **Step 2.4:** Sanity check — the existing test suite still passes against 9.6 with the bot framework unchanged. Floor bump alone shouldn't change behavior; A1's config shim absorbs any 9.5 → 9.6 dataclass-field additions.
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_bots_integration.py tests/test_virtual_client.py
   ```
 
-  Expected: green. The dep bump alone shouldn't change behavior; A1's config shim absorbs any 9.4 → 9.5 dataclass-field additions.
+  Expected: green.
 
 ---
 
 ## Task 3 — Retarget `Event`/`EventType` imports to `agentirc.protocol`
 
-**Files:** `culture/bots/virtual_client.py`, anywhere else culture imports `Event`/`EventType`.
+**Files:** `culture/bots/virtual_client.py` (and anywhere else culture imports `Event`/`EventType` from a transitional path).
 
-The transitional re-exports at `agentirc.skill.{Event, EventType}` work through 9.5.x and disappear in 10.0.0. Pin to `agentirc.protocol` directly.
+The transitional re-exports at `agentirc.skill.{Event, EventType}` work through 9.5.x (probably 9.6.x too) and disappear in 10.0.0. Pin to `agentirc.protocol` directly.
 
 - [ ] **Step 3.1:** Find every site that imports `Event` or `EventType` from `culture.agentirc.skill` or `agentirc.skill`.
 
@@ -153,10 +156,10 @@ The transitional re-exports at `agentirc.skill.{Event, EventType}` work through 
   grep -rn 'from culture\.agentirc\.skill import\|from agentirc\.skill import' culture/ tests/
   ```
 
-  Survey-time hit list (verify on the current main):
+  Expected hit list (verify on the current main):
   - `culture/bots/virtual_client.py:8`
 
-  Expect this to be the only match. If there are more, add them to the change set.
+  If there are more matches, add them to the change set.
 
 - [ ] **Step 3.2:** Replace each import:
 
@@ -167,7 +170,7 @@ The transitional re-exports at `agentirc.skill.{Event, EventType}` work through 
   from agentirc.protocol import Event, EventType
   ```
 
-- [ ] **Step 3.3:** Run a focused test pass to confirm no behavior change.
+- [ ] **Step 3.3:** Run a focused test pass:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_virtual_client.py tests/test_events_bot_trigger.py tests/test_events_bot_chain.py
@@ -177,77 +180,163 @@ The transitional re-exports at `agentirc.skill.{Event, EventType}` work through 
 
 ---
 
-## Task 4 — Rewrite `culture/bots/virtual_client.py` against the public extension API
+## Task 4 — Switch `culture/cli/server.py` to embed `agentirc.ircd.IRCd`
+
+**Files:** `culture/cli/server.py`.
+
+This is the key swap that decouples culture's bot framework from the bundled IRCd. After this step, `culture server start` is hosting agentirc's IRCd directly, which natively speaks the bot CAP and routes everything through the public `VirtualClient` interface.
+
+- [ ] **Step 4.1:** Read `culture/cli/server.py:_run_server` (the function the CLI dispatcher calls for `culture server start`). Identify how it constructs the IRCd today:
+
+  ```bash
+  grep -n 'IRCd(\|from culture.agentirc.ircd import\|class.*IRCd\|_run_server' culture/cli/server.py
+  ```
+
+  Record the exact construction site and the lifecycle methods called on it (`await ircd.start()`, etc.).
+
+- [ ] **Step 4.2:** Replace the import + construction:
+
+  ```python
+  # before
+  from culture.agentirc.ircd import IRCd
+  # ...
+  ircd = IRCd(config)
+  await ircd.start()
+
+  # after
+  from agentirc.ircd import IRCd
+  # ...
+  ircd = IRCd(config)
+  await ircd.start()
+  ```
+
+  The constructor signature should match (both take `ServerConfig`). If the published `agentirc.ircd.IRCd` constructor differs from the bundled one, adapt — but the A2-Bridge brief specifically asked for "stable embedding API" so this should be a drop-in.
+
+- [ ] **Step 4.3:** The four culture-owned verbs (`default`, `rename`, `archive`, `unarchive`) stay culture-side. They operate on culture's local state, not the IRCd; their handlers are unchanged. Verify by re-running `grep -n 'default\|rename\|archive\|unarchive' culture/cli/server.py` and confirming each is still wired to its existing handler.
+
+- [ ] **Step 4.4:** Smoke test:
+
+  ```bash
+  uv run python -m culture server start --name smoke --port 6700 &
+  PID=$!
+  sleep 2
+  uv run python -c "
+  import socket
+  s = socket.socket()
+  s.connect(('127.0.0.1', 6700))
+  s.send(b'NICK smoke\r\nUSER smoke 0 * :smoke\r\n')
+  data = s.recv(4096)
+  print(data.decode())
+  s.close()
+  "
+  kill $PID
+  ```
+
+  Expected: server responds with `001 :Welcome ...` numerics. Confirms `agentirc.ircd.IRCd` boots cleanly from culture's CLI.
+
+---
+
+## Task 5 — Rewrite `culture/bots/virtual_client.py` as a wrapper
 
 **Files:** `culture/bots/virtual_client.py`.
 
-This is the heart of A2. `VirtualClient` today is a duck-typed in-process bot that holds an `IRCd` reference (`self.server`) and uses it for: (a) emitting events, (b) reading/writing channel state, (c) resolving nicks, (d) reading server config. Each of these has a public-API equivalent in 9.5.
+The 231-line file today re-implements what `agentirc.virtual_client.VirtualClient` already provides. After A2-Bridge, that's a public class. Culture's wrapper composes around it for culture-specific concerns: `BotConfig` integration, template-engine rendering (via `culture/bots/template_engine.py`), `fires_event` chaining, owner DM routing.
 
-- [ ] **Step 4.1: Decision point — connection model.** Before writing code, decide:
-
-  - **Option A: TCP CAP-bot client.** `VirtualClient` opens a real connection to `127.0.0.1:<irc_port>` (the same port humans use), `CAP REQ agentirc.io/bot`, and uses standard IRC verbs + the new `EVENT*` verbs for all bot operations.
-  - **Option B: In-process Python API.** If `agentirc-cli==9.5` exposes a class like `agentirc.bot.Bot` or `agentirc.bot.Client` for in-process bot hosting, use that.
-
-  Verify which option agentirc 9.5 supports:
+- [ ] **Step 5.1:** Read both files side-by-side to confirm shape:
 
   ```bash
-  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "
-  import agentirc
-  print(sorted(n for n in dir(agentirc) if not n.startswith('_')))
-  try:
-      import agentirc.bot
-      print('bot module:', sorted(n for n in dir(agentirc.bot) if not n.startswith('_')))
-  except ImportError:
-      print('no agentirc.bot module — Option A required')
-  "
+  wc -l culture/bots/virtual_client.py
+  cd /tmp && uv run --with "agentirc-cli>=9.6,<10" python -c "
+  import inspect
+  from agentirc.virtual_client import VirtualClient
+  print(inspect.getsource(VirtualClient))
+  " | wc -l
   ```
 
-  **Record the decision in this task before continuing.** Recommendation: prefer Option B if available (matches the in-process pattern agentirc's own `VirtualClient` uses for the system bot, per agentirc#15 closing comment); fall back to Option A.
+  Expected: ~230 LOC in culture, ~250 LOC in agentirc — they're functionally the same class. The wrapper composes; it does not re-implement.
 
-- [ ] **Step 4.2:** Replace the four `server.emit_event(Event(...))` call sites (current lines 76, 95, 136, 158) with `EVENTPUB`. The wire form is `EVENTPUB <type> <channel-or-*> :<base64-json-data>`. Under Option B, the API call is the agentirc-provided `bot.emit(type, channel, data)`. Under Option A, the call is the bot client's own `send_eventpub(type, channel, data_dict)`. The 5-field envelope (`type`/`channel`/`nick`/`data`/`timestamp`) is constructed server-side; the bot only supplies `type`, `channel`, and `data` (`nick` is the bot's own nick; `timestamp` is server-set).
+- [ ] **Step 5.2:** Rewrite `culture/bots/virtual_client.py`. Target shape:
 
-- [ ] **Step 4.3:** Replace the four `server.channels.get(name)`/`del` accesses (lines 82, 109, 121, 144) and the `server.get_or_create_channel(name)` access (line 56). These are used today for: pre-checking JOIN, post-PART cleanup, broadcast membership walk, mention recipient walk.
+  ```python
+  """Culture's wrapper around agentirc's public VirtualClient.
 
-  - For JOIN/PART: rely on the IRC `JOIN` verb (server tracks membership; bot doesn't need to).
-  - For broadcast and mention walks: use the inbound `EVENT` envelopes plus the existing IRC `NAMES` / `WHO` paths the harness uses for any human-facing client. Do not maintain a duplicate channel registry inside the bot process.
-  - If a piece of state (e.g., "is this user opt-in for this channel") is genuinely needed, surface it via an `EVENT` filter instead of polling state.
+  Composes culture-specific glue (BotConfig, template engine, fires_event,
+  owner DM) over the protocol-and-channel-membership behavior owned by
+  agentirc.virtual_client.VirtualClient.
+  """
 
-- [ ] **Step 4.4:** Replace the two `server.get_client(nick)` lookups (lines 175, 212). These are for DM target resolution and `@`-mention recipient lookup. Equivalents:
+  from __future__ import annotations
+  from typing import TYPE_CHECKING
 
-  - DM: just send `PRIVMSG <nick> :<text>`. The server resolves the nick.
-  - Mention: parse mentions out of incoming `EVENT` payloads; for each mention, send `NOTICE <nick> :<mention-text>`. No client lookup needed.
+  from agentirc.protocol import Event, EventType
+  from agentirc.virtual_client import VirtualClient as _AgentircVirtualClient
 
-- [ ] **Step 4.5:** Replace `server.config.name` (line 36) with the bot's own configured server identity, read from `~/.culture/server.yaml` via culture's own loader (`culture.config.load_server_config(path)` → `culture.config.ServerConfig`). The `~/.culture/server.yaml` schema is culture's nested format and is parsed by `culture.config.ServerConfig`, **not** by `agentirc.config.ServerConfig` (which is the IRCd's flat config dataclass and would fail to parse the nested file). The system-nick prefix is a culture-side concept; keep the prefix logic in `culture/bots/virtual_client.py` and source the server name from `culture.config.ServerConfig.name` (and `webhook_port` from the same instance for Tasks 5 and 7), not from a server reference.
+  from culture.bots.template_engine import render_template
 
-- [ ] **Step 4.6:** Add `EVENTSUB` subscription registration in `VirtualClient.__init__` or `start`. The bot's filter is whatever the bot's `BotConfig.trigger_type == "event"` filter compiles to (see `culture/bots/filter_dsl.py`). For non-event-triggered bots (webhook only), no subscription is needed.
+  if TYPE_CHECKING:
+      from agentirc.ircd import IRCd
+      from culture.bots.config import BotConfig
 
-- [ ] **Step 4.7:** Run the focused tests:
+
+  class VirtualClient(_AgentircVirtualClient):
+      """A culture bot's IRC presence — extends agentirc.VirtualClient with culture-specific behavior."""
+
+      def __init__(self, bot_config: BotConfig, server: IRCd) -> None:
+          super().__init__(nick=bot_config.nick, user=bot_config.user, server=server)
+          self.bot_config = bot_config
+          # culture-specific fields here
+
+      async def broadcast_to_channel(self, channel_name: str, text: str) -> None:
+          """Render a message via culture's template engine and broadcast."""
+          rendered = render_template(text, self.bot_config.template_vars)
+          await super().broadcast_to_channel(channel_name, rendered)
+
+      async def fire_event(self, event_type: EventType, channel: str | None, data: dict) -> None:
+          """Emit a culture-defined event (for fires_event chaining)."""
+          await self.server.emit_event(Event(type=event_type, channel=channel, nick=self.nick, data=data))
+
+      # ... other culture-specific methods composed over super() ...
+  ```
+
+  Target: ~50-80 LOC. If you find yourself re-implementing `join_channel`/`part_channel`/etc., stop — the parent class already does that; just call `super().method(...)`.
+
+- [ ] **Step 5.3:** Run the focused tests:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_virtual_client.py
   ```
 
-  Expected: green. Anything that fails here is a behavioral mismatch in the rewrite — fix it now, not later.
+  Expected: green. Anything that fails is a behavioral mismatch in the rewrite — fix it now, not later.
 
 ---
 
-## Task 5 — Refactor `culture/bots/bot.py`
+## Task 6 — Refactor `culture/bots/bot.py`
 
 **Files:** `culture/bots/bot.py`.
 
 Bot composes `BotConfig` + `VirtualClient` + `IRCd` ref today. The IRCd ref is used at four sites:
 
-- [ ] **Step 5.1:** `bot.py:98` (`server.get_client` for nick collision check at start). Replace with a `WHO <nick>` query against the bot's own connection (Option A) or a public helper (Option B).
+- [ ] **Step 6.1:** `bot.py:98` (`server.get_client` for nick collision check at start). The promoted `agentirc.ircd.IRCd` exposes `get_client(nick)` publicly (verify in Step 1.4's surface dump). Call it directly: `existing = self.server.get_client(self.nick)`.
 
-- [ ] **Step 5.2:** `bot.py:168` (`server.channels.get` for dynamic-join channel check). Replace with a `LIST <channel>` or remove entirely if the JOIN itself is sufficient (server returns an error if the channel doesn't exist and the bot's not allowed to create it).
+- [ ] **Step 6.2:** `bot.py:168` (`server.channels.get` for dynamic-join channel check). Same — `IRCd.channels` is publicly accessible after A2-Bridge. If the public surface narrows this to a method (`get_channel(name)`), use that.
 
-- [ ] **Step 5.3:** `bot.py:211` (`server.emit_event` for `fires_event`). Replace with `EVENTPUB`. The `fires_event` semantics — bot triggers downstream bots — survive unchanged because `EVENTPUB` reuses `IRCd.emit_event` server-side and federation/skill-hooks/`#system` surfacing all happen on the same path (per agentirc#15 closing comment, "Decision E").
+- [ ] **Step 6.3:** `bot.py:211` (`server.emit_event` for `fires_event`). Calls into `IRCd.emit_event` publicly. The `fires_event` semantics — bot triggers downstream bots — survive unchanged because emit_event still routes through the same skill-hooks / federation-relay / `#system`-surfacing path.
 
-- [ ] **Step 5.4:** `bot.py:89-90` (`server.config.webhook_port` for URL construction). Read directly from culture's own `ServerConfig` instance (the one `BotManager` constructs in Task 6).
+- [ ] **Step 6.4:** `bot.py:89-90` (`server.config.webhook_port` for URL construction). Read directly from culture's own `culture.config.ServerConfig` (the one BotManager loads in Task 7), not from `IRCd.config` — `webhook_port` is a culture-side concern after agentirc 9.5.
 
-- [ ] **Step 5.5:** Remove the `server: IRCd` field from `Bot.__init__`. The bot composes `BotConfig` + `VirtualClient` + culture's own `ServerConfig`; that's all it needs.
+- [ ] **Step 6.5:** Keep the `server: IRCd` field on `Bot.__init__` — it's still needed for `get_client`/`channels`/`emit_event`, just typed against the public class now:
 
-- [ ] **Step 5.6:** Run the focused tests:
+  ```python
+  from agentirc.ircd import IRCd
+
+  class Bot:
+      def __init__(self, bot_config: BotConfig, server: IRCd, server_config: ServerConfig) -> None:
+          self.bot_config = bot_config
+          self.server = server
+          self.server_config = server_config  # culture-side ServerConfig with webhook_port
+  ```
+
+- [ ] **Step 6.6:** Run the focused tests:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_bot.py tests/test_bot_config_fires_event_toplevel.py
@@ -255,15 +344,25 @@ Bot composes `BotConfig` + `VirtualClient` + `IRCd` ref today. The IRCd ref is u
 
 ---
 
-## Task 6 — Refactor `culture/bots/bot_manager.py`
+## Task 7 — Refactor `culture/bots/bot_manager.py`
 
 **Files:** `culture/bots/bot_manager.py`.
 
-`BotManager.on_event` is hooked by `IRCd._dispatch_to_bots` today. After the cutover, the IRCd doesn't dispatch to bots — bots subscribe to events themselves via `EVENTSUB`. The manager becomes a coordinator of bot subscriptions, not an event sink.
+The manager wires bots to the IRCd's event stream. After A2 it consumes the publicly-typed IRCd reference handed to it by `culture/cli/server.py:_run_server`.
 
-- [ ] **Step 6.1:** Replace the `on_event(self, event: Event)` method with a per-bot `EVENTSUB` registration that runs at bot start. For event-triggered bots, the manager (or each bot's `VirtualClient`) sends `EVENTSUB <id> [type=…] [channel=…] [nick=…]`; the filter is compiled from `BotConfig` via `filter_dsl.py` (already exists).
+- [ ] **Step 7.1:** Replace the `on_event(self, event: Event)` method's wiring. Today `IRCd._dispatch_to_bots` calls `bot_manager.on_event(event)` directly via in-process plumbing in the bundled IRCd. After A2, the public IRCd has `subscription_registry` (or whatever the A2-Bridge promotion exposes) that BotManager can register against. Read the public surface:
 
-- [ ] **Step 6.2:** Telemetry. The four `server.metrics.bot_invocations.add()` call sites (lines 138-145) and `bot_manager.server.metrics.bot_webhook_duration.record()` in `http_listener.py:73-76` switch to importing the meters directly:
+  ```bash
+  cd /tmp && uv run --with "agentirc-cli>=9.6,<10" python -c "
+  import inspect
+  from agentirc.ircd import IRCd
+  print('IRCd public methods:', sorted(n for n in dir(IRCd) if not n.startswith('_')))
+  "
+  ```
+
+  Wire BotManager to the appropriate hook; for in-process bots the hook is likely just calling a registered callback on every `emit_event`.
+
+- [ ] **Step 7.2:** Telemetry. The four `server.metrics.bot_invocations.add()` call sites (lines 138-145) and `bot_manager.server.metrics.bot_webhook_duration.record()` in `http_listener.py:73-76` switch to importing the meters directly:
 
   ```python
   from culture.telemetry import metrics as telemetry_metrics
@@ -273,14 +372,24 @@ Bot composes `BotConfig` + `VirtualClient` + `IRCd` ref today. The IRCd ref is u
 
   The OTEL instruments are already module-level in `culture/telemetry/metrics.py` (per A1's audit); no need to route through the server.
 
-- [ ] **Step 6.3:** Remove the `IRCd` reference from `BotManager.__init__`. The manager constructs:
-  - `culture.telemetry.metrics` (module import).
-  - `culture.config.ServerConfig` (loaded from `~/.culture/server.yaml` via `culture.config.load_server_config`). The nested `~/.culture/server.yaml` schema is culture's, not agentirc's — see Step 4.5 above.
-  - A `VirtualClient` per bot (per Task 4), each with its own `EVENTSUB` subscription if event-triggered.
+- [ ] **Step 7.3:** `BotManager.__init__` takes the IRCd reference plus culture's own `ServerConfig`:
 
-- [ ] **Step 6.4:** Update `BotManager.dispatch(bot_name, payload)` (line 215) to no longer assume an IRCd is local — webhook payloads come in via `http_listener.py` and just route to the bot's `handle()` method, same as today.
+  ```python
+  from agentirc.ircd import IRCd
+  from culture.config import ServerConfig as CultureServerConfig, load_server_config
 
-- [ ] **Step 6.5:** Run the focused tests:
+  class BotManager:
+      def __init__(self, server: IRCd, server_config: CultureServerConfig) -> None:
+          self.server = server
+          self.server_config = server_config  # nested format, parsed by culture.config
+          self.bots: dict[str, Bot] = {}
+  ```
+
+  `culture/cli/server.py:_run_server` constructs both `IRCd(agentirc_config)` and `BotManager(server=ircd, server_config=culture_server_config)` and wires them.
+
+- [ ] **Step 7.4:** Update `BotManager.dispatch(bot_name, payload)` (line 215) — webhook payloads come in via `http_listener.py` and route to the bot's `handle()`. Same as today; just confirm the IRCd reference flows correctly.
+
+- [ ] **Step 7.5:** Run the focused tests:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_bot_manager.py tests/test_events_bot_trigger.py tests/test_events_bot_chain.py
@@ -288,32 +397,31 @@ Bot composes `BotConfig` + `VirtualClient` + `IRCd` ref today. The IRCd ref is u
 
 ---
 
-## Task 7 — Move webhook listener ownership from IRCd to BotManager
+## Task 8 — Move webhook listener ownership from IRCd to BotManager
 
 **Files:** `culture/bots/http_listener.py`, `culture/agentirc/ircd.py`.
 
-agentirc 9.5 stops binding `webhook_port` (per agentirc#15 closing comment, "Webhook ownership"). `webhook_port` stays in `ServerConfig` for backward compat, but the listener moves to culture.
+agentirc 9.5 already stops binding `webhook_port` (per agentirc#15 closing comment). After A2's switch to `agentirc.ircd.IRCd`, no IRCd is binding it — culture must.
 
-- [ ] **Step 7.1:** Move the listener startup. Today (`culture/agentirc/ircd.py:112-116`):
-
-  ```python
-  self._http_listener = HttpListener(bot_manager, "127.0.0.1", webhook_port)
-  ```
-
-  Move this into `BotManager.start()`:
+- [ ] **Step 8.1:** Move the listener startup from the bundled IRCd's `__init__` (`culture/agentirc/ircd.py:112-116` today) into `BotManager.start()`:
 
   ```python
-  self._http_listener = HttpListener(self, "127.0.0.1", self.config.webhook_port)
+  # in BotManager.start():
+  self._http_listener = HttpListener(
+      bot_manager=self,
+      host="127.0.0.1",
+      port=self.server_config.webhook_port,
+  )
   await self._http_listener.start()
   ```
 
-  Move the corresponding shutdown call (somewhere around `ircd.py:122` today) into `BotManager.stop()`.
+  Move the corresponding shutdown into `BotManager.stop()`.
 
-- [ ] **Step 7.2:** Delete the listener instantiation from `culture/agentirc/ircd.py`. After A2 lands, the bundled IRCd is bot-free — it's just an IRC server. (A3 will then delete the bundled IRCd entirely.)
+- [ ] **Step 8.2:** Delete the listener instantiation from `culture/agentirc/ircd.py`. After A2, the bundled IRCd is bot-free *and* effectively dead (because `_run_server` uses `agentirc.ircd.IRCd`); A3 deletes the file entirely. This step prevents accidental double-binding if someone constructs the bundled IRCd manually before A3.
 
-- [ ] **Step 7.3:** `HttpListener.__init__` already takes `bot_manager`; no signature change. Confirm `_handle_webhook` (line 81) still calls `bot_manager.dispatch(bot_name, payload)` — that path is unchanged.
+- [ ] **Step 8.3:** `HttpListener.__init__` already takes `bot_manager`; no signature change needed. Confirm `_handle_webhook` (line 81) still calls `bot_manager.dispatch(bot_name, payload)`.
 
-- [ ] **Step 7.4:** Run the focused tests:
+- [ ] **Step 8.4:** Run the focused tests:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_http_listener.py
@@ -323,17 +431,17 @@ agentirc 9.5 stops binding `webhook_port` (per agentirc#15 closing comment, "Web
 
 ---
 
-## Task 8 — System bot loading without an IRCd reference
+## Task 9 — System bot loading without an IRCd reference
 
 **Files:** `culture/bots/system/__init__.py`, `culture/bots/bot_manager.py`.
 
-`BotManager.load_system_bots()` (line 147) currently calls `discover_system_bots()` and passes its `IRCd` reference. After A2, system bots are just normal bots that happen to ship in the wheel; they connect via the same CAP-bot path as user bots.
+`BotManager.load_system_bots()` (line 147) currently calls `discover_system_bots()` and passes its `IRCd` reference (the bundled one's). After A2 the IRCd reference is the public `agentirc.ircd.IRCd`, but more importantly the discovery only needs the server *name* for the prefix, not the IRCd itself.
 
-- [ ] **Step 8.1:** Update `discover_system_bots(server_name: str)` signature — take a server name string, not an `IRCd`. The function scans `culture/bots/system/<subdir>/bot.yaml` and prefixes each name with `system-{server_name}-`.
+- [ ] **Step 9.1:** Update `discover_system_bots(server_name: str)` signature — take a string, not an `IRCd`. The function scans `culture/bots/system/<subdir>/bot.yaml` and prefixes each name with `system-{server_name}-`.
 
-- [ ] **Step 8.2:** Update `BotManager.load_system_bots()` to pass `self.config.name` instead of an IRCd reference.
+- [ ] **Step 9.2:** Update `BotManager.load_system_bots()` to pass `self.server_config.name` (culture's own config — see Task 7.3) instead of an IRCd reference.
 
-- [ ] **Step 8.3:** Run the focused test:
+- [ ] **Step 9.3:** Run the focused test:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q tests/test_welcome_bot.py
@@ -341,31 +449,26 @@ agentirc 9.5 stops binding `webhook_port` (per agentirc#15 closing comment, "Web
 
 ---
 
-## Task 9 — Test harness migration
+## Task 10 — Test harness migration
 
 **Files:** all `tests/test_*bot*.py`, `tests/test_virtual_client.py`, `tests/test_events_bot_*.py`, `tests/test_welcome_bot.py`, `tests/test_http_listener.py`, `tests/conftest.py`.
 
-The tests assert bot behavior — webhook → IRC flow, event filter matching, fires_event chains, system bot rendering, virtual-client JOIN/PART. These behaviors are unchanged; only the harness for setting up "an IRCd plus some bots" changes.
+The 10 bot test files assert behavior — webhook → IRC flow, event filter matching, fires_event chains, system bot rendering, virtual-client JOIN/PART. Behaviors are unchanged. The harness shifts.
 
-- [ ] **Step 9.1:** Add a `cap_bot_client` fixture to `tests/conftest.py`:
+- [ ] **Step 10.1:** Update `tests/conftest.py`'s IRCd fixture (or equivalent). Replace `from culture.agentirc.ircd import IRCd` with `from agentirc.ircd import IRCd`. Constructor signature should match.
 
-  ```python
-  @pytest.fixture
-  async def cap_bot_client(ircd):
-      """Connect a CAP-bot client to the running IRCd. Returns a helper with .send(), .recv(), .eventsub(), .eventpub()."""
-      # ... establish connection, NICK/USER, CAP REQ agentirc.io/bot, ACK
+- [ ] **Step 10.2:** For each test file, replace any direct import of `culture.agentirc.ircd.IRCd` with `agentirc.ircd.IRCd`. Most tests use the fixture, so the changes are limited to a handful of files.
+
+  ```bash
+  grep -rln 'from culture\.agentirc\.ircd import\|culture\.agentirc\.ircd\.' tests/
   ```
 
-  The fixture is the testing-side analog of `VirtualClient` — it mirrors the verb sequence but exposes assertion-friendly helpers.
+- [ ] **Step 10.3:** Special cases:
+  - `tests/test_events_bot_chain.py` — bot fires event, second bot triggers. Both bots are in-process VirtualClients hosted by the constructed `agentirc.ircd.IRCd`; the chain runs through the IRCd's `emit_event` → registered callbacks. Expected to work unchanged in observable behavior.
+  - `tests/test_bots_integration.py` — full webhook → IRC flow. Webhook listener is now in `BotManager`; the URL is unchanged (`http://127.0.0.1:<webhook_port>/<bot>`).
+  - `tests/test_virtual_client.py` — culture's wrapper now extends `agentirc.virtual_client.VirtualClient`. Behavioral assertions (does broadcast work, does fires_event fire) stay; if any tests reach into private internals of culture's VirtualClient, refactor them to use the public surface or move them to test the wrapper composition specifically.
 
-- [ ] **Step 9.2:** For each test file, replace the "construct IRCd, hand to BotManager, manipulate bots in-process" pattern with "construct IRCd, start BotManager, BotManager opens CAP-bot connections to IRCd". Most tests need at most a few lines changed in the setup; assertions stay.
-
-- [ ] **Step 9.3:** Special cases:
-  - `tests/test_events_bot_chain.py` — bot fires event, second bot triggers. After A2, both bots are CAP clients; the chain runs over the wire (`EVENTPUB` → server `emit_event` → reflexive `EVENT` to subscribed bots). Expected to work unchanged in observable behavior.
-  - `tests/test_bots_integration.py` — full webhook → IRC flow. Webhook listener is now in `BotManager`; the `POST /<bot>` URL is unchanged (`http://127.0.0.1:<webhook_port>/<bot>`).
-  - `tests/test_virtual_client.py` — was unit-testing the in-process `VirtualClient`. Rename helper assertions if internal method names change; behavioral assertions stay.
-
-- [ ] **Step 9.4:** Run the full test suite:
+- [ ] **Step 10.4:** Run the full suite:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q
@@ -375,116 +478,123 @@ The tests assert bot behavior — webhook → IRC flow, event filter matching, f
 
 ---
 
-## Task 10 — `culture/agentirc/CLAUDE.md` note
+## Task 11 — `culture/agentirc/CLAUDE.md` note
 
 **Files:** `culture/agentirc/CLAUDE.md`.
 
-- [ ] **Step 10.1:** Append a paragraph noting that bots are no longer in-process consumers of this directory:
+- [ ] **Step 11.1:** Append a paragraph noting the bundled IRCd is dead:
 
   ```markdown
   ## Status (after A2, 2026-05-XX)
 
-  After Phase A2 (`feat/bots-public-extension-api`), `culture/bots/*` no
-  longer holds an in-process `IRCd` reference. Bots connect to the IRCd
-  via the public `agentirc.io/bot` CAP and use `EVENTSUB`/`EVENTPUB`
-  instead of `server.emit_event` and `server.channels`. The only
-  remaining culture-side consumer of `culture/agentirc/{ircd, server_link,
-  channel, ...}` internals is `culture/cli/server.py:_run_server`. A3
-  deletes the bundled IRCd and replaces that import with a subprocess
-  shim into the installed `agentirc` binary.
+  After Phase A2 (`feat/bots-embedded-agentirc`), `culture/cli/server.py:_run_server`
+  constructs `agentirc.ircd.IRCd(config)` directly — the bundled IRCd in this
+  directory is no longer instantiated by anything in culture. `culture/bots/*`
+  uses `agentirc.virtual_client.VirtualClient` (promoted to public in
+  agentirc 9.6.0 via agentculture/agentirc#22). The files here are dead
+  weight; A3 deletes them and `git mv`s `client.py` / `remote_client.py`
+  to `culture/transport/`. `config.py` stays as the A1 re-export shim
+  through 9.x.
   ```
 
 ---
 
-## Task 11 — Pre-push reviewer + doc audit
+## Task 12 — Pre-push reviewer + doc audit
 
 **Files:** none (audits only).
 
-- [ ] **Step 11.1:** Stage all changes and run the code reviewer agent on the diff:
+- [ ] **Step 12.1:** Stage all changes:
 
   ```bash
-  git add -p   # selective; or git add for everything in the change set
+  git add -A
   ```
 
-  Then invoke `superpowers:code-reviewer` per culture/CLAUDE.md's "Pre-push review for library/protocol code" rule. A2 touches transport (CAP negotiation, EVENT verb wire format) and protocol parsers — exactly the choke points the rule targets.
+- [ ] **Step 12.2:** Run the code reviewer per culture/CLAUDE.md's "Pre-push review for library/protocol code" rule. A2 swaps a process boundary (bundled IRCd → public agentirc.ircd.IRCd) and changes who owns the webhook listener — exactly the choke points the rule targets:
 
-- [ ] **Step 11.2:** Run the `doc-test-alignment` subagent:
-
-  ```bash
-  Agent(subagent_type="doc-test-alignment", prompt="Audit the staged diff on feat/bots-public-extension-api for new public surface (CLI commands, config fields, IRC verbs, exceptions, public functions) and report missing docs/ or protocol/extensions/ coverage.")
+  ```text
+  Agent(subagent_type="superpowers:code-reviewer", prompt="Review the staged diff on feat/bots-embedded-agentirc — A2 of the agentirc extraction. Key concerns: (1) IRCd reference handoff from culture/cli/server.py:_run_server through BotManager to Bot/VirtualClient, (2) webhook listener ownership transfer from culture/agentirc/ircd.py to culture/bots/bot_manager.py, (3) culture's VirtualClient subclass composing correctly over agentirc.virtual_client.VirtualClient. Spec: docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md. Plan: docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md.")
   ```
 
-  A2 is mostly internal rewrite, but the change in webhook ownership and the `agentirc.io/bot` CAP usage may need updates in `docs/` (search for `webhook_port`, `bot_manager`, `webhook listener`).
+- [ ] **Step 12.3:** Run the `doc-test-alignment` subagent:
 
-- [ ] **Step 11.3:** Address any findings — fix docs, re-stage, repeat until both audits are clean.
+  ```text
+  Agent(subagent_type="doc-test-alignment", prompt="Audit the staged diff on feat/bots-embedded-agentirc for new public surface and report missing docs/ or protocol/extensions/ coverage. Note that culture/bots/virtual_client.py is now a wrapper over agentirc.virtual_client.VirtualClient — culture's docs may need updates noting the public agentirc surface culture depends on.")
+  ```
+
+- [ ] **Step 12.4:** Address any findings — fix docs, re-stage, repeat until both audits are clean.
 
 ---
 
-## Task 12 — Version bump, push, PR
+## Task 13 — Version bump, push, PR
 
 **Files:** `culture/__init__.py`, `pyproject.toml`, `CHANGELOG.md`.
 
-- [ ] **Step 12.1:** `/version-bump minor` (8.8.0 → 8.9.0). A2 is additive within the bot framework — no public-API removal — so this is minor, not major.
+- [ ] **Step 13.1:** `/version-bump minor` (8.8.0 → 8.9.0). A2 is additive within the bot framework — no public-API removal — so this is minor, not major.
 
-- [ ] **Step 12.2:** Verify the bump:
+- [ ] **Step 13.2:** Verify the bump:
 
   ```bash
   grep -n '8\.9\.0' culture/__init__.py pyproject.toml CHANGELOG.md
   ```
 
-- [ ] **Step 12.3:** Edit the new `[8.9.0]` section of `CHANGELOG.md` to describe what changed. Suggested entries:
+- [ ] **Step 13.3:** Edit the new `[8.9.0]` section of `CHANGELOG.md`:
 
   ```markdown
   ### Changed
-  - Rewrote culture/bots/* against the public bot extension API in agentirc-cli 9.5.0 (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTPUB`, 5-field envelope from `agentirc.protocol`). Bots no longer hold an in-process IRCd reference. Webhook listener (`webhook_port`) ownership moved from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`. Public bot behavior unchanged.
-  - Bumped `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.5,<10`.
+  - Switched `culture server start` to embed `agentirc.ircd.IRCd` directly (in-process, via the public class promoted in agentirc 9.6.0 / agentculture/agentirc#22). The bundled IRCd in `culture/agentirc/` is now orphaned but stays on disk for A3 to delete.
+  - Rewrote `culture/bots/virtual_client.py` as a thin wrapper around `agentirc.virtual_client.VirtualClient` (promoted to public in agentirc 9.6.0). Culture-specific concerns (BotConfig, template engine, fires_event, owner DM) compose over the public class. Public bot behavior unchanged.
+  - Webhook listener (`webhook_port`) ownership moved from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`.
+  - Bumped `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.6,<10`.
 
   ### Notes
-  - This is the second of three phases extracting `culture/agentirc/` into the standalone `agentirc-cli` PyPI package. Phase A1 (config dataclasses) shipped in 8.8.0 (#309); Phase A3 (delete bundled IRCd, subprocess shim, major bump) follows.
+  - This is the second of three phases extracting `culture/agentirc/` into the standalone `agentirc-cli` PyPI package. Phase A1 (config dataclasses) shipped in 8.8.0 (#309); Phase A3 (delete bundled IRCd, major bump) follows. Cross-repo coordination tracked at agentculture/agentirc#22.
   ```
 
-- [ ] **Step 12.4:** Final test pass + format check:
+- [ ] **Step 13.4:** Final test pass + format check:
 
   ```bash
   bash .claude/skills/run-tests/scripts/test.sh -p -q
-  uv run black culture/bots/ culture/agentirc/ircd.py
-  uv run isort culture/bots/ culture/agentirc/ircd.py
+  uv run black culture/bots/ culture/cli/server.py culture/agentirc/ircd.py
+  uv run isort culture/bots/ culture/cli/server.py culture/agentirc/ircd.py
   ```
 
-- [ ] **Step 12.5:** Commit and push:
+- [ ] **Step 13.5:** Commit and push:
 
   ```bash
   git commit -m "$(cat <<'EOF'
-  feat(bots): rewrite against agentirc-cli 9.5 public extension API (Track A2)
+  feat(bots): embed agentirc.ircd.IRCd; rewrite VirtualClient as wrapper (Track A2)
 
-  Drops the in-process IRCd reference from culture/bots/*. Bots now subscribe
-  via EVENTSUB/EVENTPUB and connect with the agentirc.io/bot CAP. Webhook
-  listener ownership moves from IRCd to BotManager (agentirc 9.5 no longer
-  binds webhook_port). Unblocks Phase A3.
+  Switches culture server start to construct agentirc.ircd.IRCd directly
+  (in-process), and rewrites culture/bots/virtual_client.py as a thin
+  wrapper around the public agentirc.virtual_client.VirtualClient promoted
+  in agentirc 9.6.0 (agentculture/agentirc#22). The bundled IRCd in
+  culture/agentirc/ is orphaned; A3 deletes it. Webhook listener ownership
+  moves from IRCd to BotManager. Public bot behavior unchanged.
 
   - Claude
 
   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
   EOF
   )"
-  git push -u origin feat/bots-public-extension-api
+  git push -u origin feat/bots-embedded-agentirc
   ```
 
-- [ ] **Step 12.6:** Open the PR via the `pr-review` skill (or `gh pr create`):
+- [ ] **Step 13.6:** Open the PR via the `pr-review` skill (or `gh pr create`):
 
   ```bash
-  gh pr create --title "Phase A2: rewrite bots against agentirc-cli 9.5 public extension API" --body "$(cat <<'EOF'
+  gh pr create --title "Phase A2: embed agentirc.ircd.IRCd and rewrite VirtualClient as wrapper" --body "$(cat <<'EOF'
   ## Summary
 
-  - Rewrite `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` against the public bot extension API in agentirc-cli 9.5.0 (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, 5-field envelope from `agentirc.protocol`).
-  - `Event`/`EventType` now sourced from `agentirc.protocol` directly (the `agentirc.skill` re-exports are transitional, gone in 10.0.0).
-  - Webhook listener (`webhook_port`) ownership moves from the IRCd to `BotManager` — agentirc 9.5 stops binding the port (per agentculture/agentirc#15 closing comment).
-  - Bumps dep floor `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.5,<10`.
+  - Switch `culture/cli/server.py:_run_server` to construct `agentirc.ircd.IRCd(config)` directly (in-process). The bundled IRCd in `culture/agentirc/` is orphaned but stays on disk for A3 to delete.
+  - Rewrite `culture/bots/virtual_client.py` as a thin wrapper around `agentirc.virtual_client.VirtualClient` (promoted to public in agentirc 9.6.0 via agentculture/agentirc#22). Culture-specific concerns compose over the public class.
+  - Webhook listener (`webhook_port`) ownership moves from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`.
+  - `Event`/`EventType` imports retargeted from `culture.agentirc.skill` to `agentirc.protocol`.
+  - Bumps dep floor `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.6,<10`.
   - `8.8.0 → 8.9.0` (minor — additive, no public-API removal).
 
   ## Why
 
-  Phase A2 of the agentirc extraction (spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`). Unblocks Phase A3 (delete bundled IRCd, subprocess shim, major bump) by removing culture/bots' last in-process dependency on `culture/agentirc/`.
+  Phase A2 of the agentirc extraction (spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`). Cross-repo coordination at agentculture/agentirc#22 unblocked this by promoting `agentirc.ircd.IRCd` and `agentirc.virtual_client.VirtualClient` to public. Phase A3 (delete bundled IRCd, major bump) follows.
 
   ## Test plan
 
@@ -493,10 +603,11 @@ The tests assert bot behavior — webhook → IRC flow, event filter matching, f
   - [x] Pre-commit hooks clean
   - [x] `superpowers:code-reviewer` clean
   - [x] `doc-test-alignment` clean
+  - [x] Manual smoke: `culture server start --port 6700` boots; raw IRC client receives 001 welcome numerics
 
   ## Out of scope (Phase A3 follow-up)
 
-  Deletion of `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py`, subprocess shim at `culture/cli/server.py:_run_server`, culture major bump. Plan: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.
+  Deletion of `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py`, `git mv` of `client.py`/`remote_client.py` to `culture/transport/`, culture major bump. Plan: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.
 
   - Claude
 
@@ -505,7 +616,7 @@ The tests assert bot behavior — webhook → IRC flow, event filter matching, f
   )"
   ```
 
-- [ ] **Step 12.7:** Wait for CI:
+- [ ] **Step 13.7:** Wait for CI:
 
   ```bash
   gh pr checks
@@ -517,14 +628,15 @@ The tests assert bot behavior — webhook → IRC flow, event filter matching, f
 
 ## Summary
 
-- Rewrites `culture/bots/*` against the public bot extension API in `agentirc-cli==9.5.0`. Drops the in-process IRCd reference. `EVENTSUB`/`EVENTPUB` replace `BotManager.on_event`/`server.emit_event`.
-- Webhook listener (`webhook_port`) ownership moves from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`.
-- `agentirc.skill.{Event, EventType}` import path → `agentirc.protocol.{Event, EventType}`.
-- Bumps dep floor to `agentirc-cli>=9.5,<10`. Minor bump 8.8.0 → 8.9.0.
+- Switches `culture server start` to embed `agentirc.ircd.IRCd` (public after agentirc 9.6.0 / agentculture/agentirc#22) instead of culture's bundled IRCd.
+- Rewrites `culture/bots/virtual_client.py` as a thin wrapper over `agentirc.virtual_client.VirtualClient` — culture-specific concerns compose over the public class.
+- Moves webhook listener ownership from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`.
+- Bumps dep floor to `agentirc-cli>=9.6,<10`. Minor bump 8.8.0 → 8.9.0.
 
-User-visible bot behavior is unchanged: webhook URLs, event filters, fires_event chains, system bots, telemetry counters all behave identically. The change is purely architectural — bots become CAP clients of the IRCd instead of in-process consumers.
+User-visible bot behavior is unchanged: webhook URLs, event filters, fires_event chains, system bots, telemetry counters all behave identically. The change is architectural — bots and the IRCd are still in the same Python process, but the IRCd is now agentirc's public class, not culture's bundled fork.
 
 Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` (Track A2 row).
+Cross-repo coordination: agentculture/agentirc#22.
 A3 follow-up: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`.
 
 ## Test plan
@@ -532,7 +644,8 @@ A3 follow-up: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
 - [ ] Existing bot test suite passes (`bash .claude/skills/run-tests/scripts/test.sh -p -q`).
 - [ ] `superpowers:code-reviewer` runs clean against the staged diff.
 - [ ] `doc-test-alignment` reports no missing `docs/` or `protocol/extensions/` coverage.
-- [ ] Post-merge: verify on the spark host that `culture-agent-spark-culture.service` continues to receive bot events (system welcome bot still greets joins, any user-configured event-triggered bots still fire).
+- [ ] Manual smoke: `culture server start` boots `agentirc.ircd.IRCd`, raw client receives 001 welcome numerics, system welcome bot greets a JOIN.
+- [ ] Post-merge: verify on the spark host that `culture-agent-spark-culture.service` continues to receive bot events with the new dependency.
 
 ---
 
@@ -540,7 +653,7 @@ A3 follow-up: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
 
 After this PR merges:
 
-- The bundled IRCd in `culture/agentirc/` is bot-free. Only `culture/cli/server.py:_run_server` still imports it.
-- A3 can now delete `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill,client,remote_client}.py` and `culture/agentirc/skills/`, and replace `_run_server` with a subprocess shim into the installed `agentirc` binary.
+- `culture/cli/server.py:_run_server` already uses `agentirc.ircd.IRCd` — A3 doesn't need to change the launch model further.
+- The bundled IRCd in `culture/agentirc/` is orphaned (no consumers in culture); A3 just `git rm`s it.
 - `culture/agentirc/config.py` (the A1 re-export shim) stays — A3 keeps it through the 9.x line per the spec.
-- The federation envelope sniff (spec § "Federation interop during the migration window") is no longer relevant once A3 lands; ship it only if mixed-version peers are expected during the A2-to-A3 window.
+- The federation envelope sniff (spec § "Federation interop during the migration window") becomes irrelevant once A3 deletes the bundled IRCd entirely; ship it only if mixed-version peers are expected during the brief A2-to-A3 window.

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md
@@ -67,7 +67,7 @@ If any precondition fails, stop and resolve before continuing.
 | `uv.lock` | Modify | Regenerate via `uv lock`. |
 | `culture/cli/server.py` | Modify | `_run_server` (or whatever the entrypoint is named) constructs `agentirc.ircd.IRCd(config)` in-process instead of `culture.agentirc.ircd.IRCd(config)`. |
 | `culture/bots/virtual_client.py` | Rewrite | Thin (~50 LOC) wrapper around `agentirc.virtual_client.VirtualClient`. Composes culture-specific glue: BotConfig integration, template rendering, fires_event chaining, owner DM. |
-| `culture/bots/bot.py` | Modify | Drop the `server: IRCd` field. Read IRCd touchpoints (`emit_event`, channel lookup, client lookup, webhook port) from the publicly-typed `agentirc.ircd.IRCd` instance. |
+| `culture/bots/bot.py` | Modify | Keep the `server: IRCd` field (still needed for `get_client`/`channels`/`emit_event`/`fires_event`), but type it against the public `agentirc.ircd.IRCd` instead of the bundled `culture.agentirc.ircd.IRCd`. Add a `server_config: culture.config.ServerConfig` field for `webhook_port` (which moves out of agentirc). |
 | `culture/bots/bot_manager.py` | Modify | Drop in-process `on_event` hook against the bundled IRCd. Telemetry counters source from `culture.telemetry.metrics` directly, not `server.metrics`. |
 | `culture/bots/http_listener.py` | Modify | Listener owned by `BotManager`, started by `BotManager.start()`. Same aiohttp code; just owned by culture, not driven from `IRCd._http_listener`. |
 | `culture/bots/system/__init__.py` | Modify | `discover_system_bots` no longer needs an `IRCd` reference — takes `server_name: str` (from `culture.config.ServerConfig.name`). |

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
@@ -1,12 +1,14 @@
 # AgentIRC Extraction — Track A3 (Final Cutover) Implementation Plan
 
+> **Plan revised 2026-05-03.** A2's approach changed (cross-repo split filed as agentculture/agentirc#22): culture's `culture/cli/server.py:_run_server` now embeds `agentirc.ircd.IRCd` directly in-process (no subprocess), and `culture/bots/virtual_client.py` is a thin wrapper over the public `agentirc.virtual_client.VirtualClient`. A3 inherits that — Task 1.3's old "in-process dispatch vs subprocess run" decision is settled (A2 already chose in-process); the partial-passthrough shim still preserves culture-owned verbs (`default`/`rename`/`archive`/`unarchive`).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 >
-> **This plan supersedes** `docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md`. The original drafted A1+A2+A3 as a single PR; phasing forced a split. A1 shipped in culture#309 (8.8.0); A2 ships in `feat/bots-public-extension-api` (8.9.0, see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`); A3 is this plan.
+> **This plan supersedes** `docs/superpowers/plans/2026-04-30-agentirc-extraction-track-a.md`. The original drafted A1+A2+A3 as a single PR; phasing forced a split. A1 shipped in culture#309 (8.8.0); A2 ships in `feat/bots-embedded-agentirc` (8.9.0, see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`); A3 is this plan.
 
-**Goal:** Delete the bundled IRCd in `culture/agentirc/` and shim `culture server <verb>` to the installed `agentirc` binary. After A3, the only Python files remaining under `culture/agentirc/` are `config.py` (the A1 re-export shim) and `__init__.py`. Major version bump 8.x → 9.0.0.
+**Goal:** Delete the bundled IRCd in `culture/agentirc/`. A2 already swapped `culture/cli/server.py:_run_server` to embed `agentirc.ircd.IRCd` directly, so the bundled files are dead weight by this point. A3 removes them, finishes the partial-passthrough shim for non-`start` lifecycle verbs (forwarding to `agentirc.cli.dispatch`), and bumps major. After A3, the only Python files remaining under `culture/agentirc/` are `config.py` (the A1 re-export shim) and `__init__.py`. Major version bump 8.x → 9.0.0.
 
-**Architecture:** Single PR off `main`, after A2 has merged. `git rm` the IRCd source files (`ircd.py`, `server_link.py`, `channel.py`, `events.py`, the four stores, `rooms_util.py`, `skill.py`, `skills/`). `git mv` `client.py` and `remote_client.py` to `culture/transport/` (preserves blame; they were never IRCd code). Replace `culture/cli/server.py:_run_server` with a thin passthrough into `agentirc.cli.dispatch` (in-process) or `subprocess.run(["agentirc", *argv])` (subprocess) — Task 4 chooses. Delete `protocol/extensions/` (lives in agentirc's repo). Bump major.
+**Architecture:** Single PR off `main`, after A2 has merged. `git rm` the IRCd source files (`ircd.py`, `server_link.py`, `channel.py`, `events.py`, the four stores, `rooms_util.py`, `skill.py`, `skills/`). `git mv` `client.py` and `remote_client.py` to `culture/transport/` (preserves blame; they were never IRCd code). `culture/cli/server.py` already constructs `agentirc.ircd.IRCd(config)` for `start` (per A2); A3 layers on a partial passthrough — culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) keep their existing handlers, lifecycle verbs other than `start` (`stop`/`status`/`restart`/`link`/`logs`/`version`/`serve`) forward to `agentirc.cli.dispatch`. Delete `protocol/extensions/` (lives in agentirc's repo). Bump major.
 
 **Tech Stack:** Python 3.x, uv, argparse, pytest + pytest-asyncio + pytest-xdist, pre-commit (black + isort + flake8 + pylint + bandit + markdownlint).
 
@@ -61,7 +63,7 @@
 | `culture/agentirc/config.py` | Keep | A1 re-export shim over `agentirc.config`. Stays through 9.x; remove in 10.0.0. |
 | `culture/agentirc/__init__.py` | Modify | Trim to a single re-export of `agentirc.config` symbols. |
 | `culture/transport/__init__.py` | Create | Re-exports the public class names from `client.py` and `remote_client.py`. |
-| `culture/cli/server.py` | Rewrite | ~30 lines. Partial passthrough — culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) dispatch to `culture/cli/server_local.py`; everything else forwards to `agentirc.cli.dispatch` (or `subprocess.run` for `start`). |
+| `culture/cli/server.py` | Modify | ~30 lines. Partial passthrough — culture-owned verbs (`default`/`rename`/`archive`/`unarchive`) dispatch to `culture/cli/server_local.py`; `start` continues to use the in-process `agentirc.ircd.IRCd(config)` path A2 introduced; other lifecycle verbs (`stop`/`status`/`restart`/`link`/`logs`/`version`/`serve`) forward to `agentirc.cli.dispatch`. |
 | `culture/cli/server_local.py` | Create | Houses the moved handler bodies for `default`/`rename`/`archive`/`unarchive` (extracted from today's `culture/cli/server.py`). Helpers (`read_default_server`, rename/archive utilities) stay in `culture/cli/shared/`. |
 | `culture/bots/`, `culture/clients/*/daemon.py` | Modify (imports only) | `culture.agentirc.{client,remote_client}` → `culture.transport.{client,remote_client}`. |
 | `protocol/extensions/` | Delete (whole dir) | Lives in agentirc now. |
@@ -80,12 +82,7 @@
 
 - [ ] **Step 1.2:** Confirm the agentirc CLI surface (run the `agentirc --help` snippet from "Preconditions"). Save the output — Task 5's shim parity test reads from this.
 
-- [ ] **Step 1.3:** Decide between in-process `dispatch` and subprocess `run`:
-
-  - **In-process** (`from agentirc.cli import dispatch; return dispatch(argv)`) — same Python interpreter, same env, faster, easier to debug, but couples culture's process to agentirc internals.
-  - **Subprocess** (`subprocess.run(["agentirc", *argv])`) — fully decoupled, works even if agentirc fails to import, but adds ~50ms fork overhead per invocation and may complicate signal handling for `culture server start` (which is long-running).
-
-  Recommendation: **in-process** for everything except `start` (which is long-running and benefits from process isolation). Verify `dispatch` is exposed (run the snippet from "Preconditions"). **Record the decision in this task before continuing.**
+- [ ] **Step 1.3:** Inherit A2's decision: **in-process embedding via `agentirc.ircd.IRCd`** for `culture server start`, plus `agentirc.cli.dispatch(argv)` for the other lifecycle verbs (`stop`, `status`, `link`, `logs`, `version`, `serve`). A2 already wired `_run_server` to construct `agentirc.ircd.IRCd(config)` directly; A3 just reuses that path. The "subprocess for `start`" alternative from the original A3 draft is no longer relevant — A2 confirmed the public class boots cleanly in culture's CLI process. Confirm by reading `culture/cli/server.py` post-A2 and verifying `_run_server` already imports from `agentirc.ircd`.
 
 ---
 
@@ -193,7 +190,12 @@
 - [ ] **Step 4.2:** Decide the routing rule. The shim is a **partial** passthrough — culture-owned verbs (`default`, `rename`, `archive`, `unarchive`) stay in culture; everything else forwards to agentirc. Implement as a dispatch dict, not as a hard-coded "if argv[0] in {…}" + drop-through, so the verb list is reviewable in one place:
 
   ```python
-  """culture server <verb> — partial passthrough; culture-owned verbs stay local."""
+  """culture server <verb> — partial passthrough.
+
+  - culture-owned verbs (default/rename/archive/unarchive) stay local
+  - `start` keeps using A2's in-process agentirc.ircd.IRCd path
+  - other lifecycle verbs forward to agentirc.cli.dispatch
+  """
   from agentirc.cli import dispatch as _agentirc_dispatch
 
   from culture.cli.server_local import (
@@ -201,6 +203,7 @@
       cmd_rename,
       cmd_archive,
       cmd_unarchive,
+      cmd_start,  # the A2-introduced in-process path; still owned by culture
   )
 
   _CULTURE_OWNED = {
@@ -208,6 +211,7 @@
       "rename": cmd_rename,
       "archive": cmd_archive,
       "unarchive": cmd_unarchive,
+      "start": cmd_start,
   }
 
   def server(argv: list[str]) -> int:
@@ -217,20 +221,9 @@
       return _agentirc_dispatch(argv)
   ```
 
-  If Task 1.3 chose subprocess for `start`, special-case it inside the agentirc branch:
+  Move the existing handler bodies for `default`/`rename`/`archive`/`unarchive` and the A2-introduced in-process `start` (whichever name `_run_server` uses today, exposed as `cmd_start`) from `culture/cli/server.py` into a new `culture/cli/server_local.py` so the shim file stays small and the culture-owned logic has its own home. Keep the helpers (`read_default_server`, the rename/archive utilities) where they live today (`culture/cli/shared/`).
 
-  ```python
-  import subprocess
-
-  def server(argv: list[str]) -> int:
-      if argv and argv[0] in _CULTURE_OWNED:
-          return _CULTURE_OWNED[argv[0]](argv[1:])
-      if argv and argv[0] == "start":
-          return subprocess.run(["agentirc", *argv]).returncode
-      return _agentirc_dispatch(argv)
-  ```
-
-  Move the existing handler bodies for `default`/`rename`/`archive`/`unarchive` from `culture/cli/server.py` into a new `culture/cli/server_local.py` so the shim file stays small and the culture-owned logic has its own home. Keep the helpers (`read_default_server`, the rename/archive utilities) where they live today (`culture/cli/shared/`).
+  Why `start` is culture-owned, not forwarded: A2 wired it to construct `agentirc.ircd.IRCd(config)` directly and register culture's bots against it. Forwarding `start` to `agentirc.cli.dispatch(["start", ...])` would lose the bot registration — bots would never load. Keep `start` local; A3 doesn't need to change A2's choice here.
 
 - [ ] **Step 4.3:** Properties to preserve:
   - **Pure forwarding for non-culture verbs.** Culture does not parse, validate, or rename any flag agentirc owns. New verbs added in agentirc are reachable via `culture server <new-verb>` automatically.
@@ -274,9 +267,10 @@
   CULTURE = [sys.executable, "-m", "culture", "server"]
   AGENTIRC = ["agentirc"]
 
-  # Agentirc-owned verbs only; culture-owned verbs (default/rename/archive/unarchive)
-  # are tested separately because they have no agentirc counterpart.
-  AGENTIRC_VERBS = ["status", "version", "logs", "start", "stop", "restart", "link", "serve"]
+  # Agentirc-owned verbs only; culture-owned verbs (start/default/rename/archive/unarchive)
+  # are tested separately because they either have no agentirc counterpart (default/rename/archive/unarchive)
+  # or culture deliberately keeps them local (start — A2 hosts an in-process agentirc.ircd.IRCd plus culture's bots).
+  AGENTIRC_VERBS = ["status", "version", "logs", "stop", "restart", "link", "serve"]
 
 
   def _run(cmd: list[str]) -> tuple[int, str, str]:
@@ -312,7 +306,7 @@
       assert _strip_argv0(culture_out) == agentirc_out
 
 
-  @pytest.mark.parametrize("verb", ["default", "rename", "archive", "unarchive"])
+  @pytest.mark.parametrize("verb", ["start", "default", "rename", "archive", "unarchive"])
   def test_culture_owned_verb_still_dispatches_locally(verb: str) -> None:
       """Culture-owned verbs must NOT be forwarded to agentirc. `--help` must succeed without an agentirc binary on PATH."""
       rc, out, err = _run([*CULTURE, verb, "--help"])
@@ -469,7 +463,7 @@
 
   Then invoke `superpowers:code-reviewer` per culture/CLAUDE.md's "Pre-push review for library/protocol code" rule. A3 is structural — deleting code, moving call sites, swapping a process boundary. The reviewer catches anything that breaks an exception-handling chain or leaves dangling imports.
 
-- [ ] **Step 8.3:** `/version-bump major` (8.9.x → 9.0.0). A3 deletes in-tree code and changes the launch model from in-process to (potentially) subprocess; that's structural, even though user-visible CLI is unchanged.
+- [ ] **Step 8.3:** `/version-bump major` (8.9.x → 9.0.0). A3 deletes in-tree code (~3,600 LOC of bundled IRCd) and finalizes the partial-passthrough shim — structural, even though user-visible CLI is unchanged.
 
 - [ ] **Step 8.4:** Edit the new `[9.0.0]` section of `CHANGELOG.md`:
 

--- a/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
+++ b/docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md
@@ -26,10 +26,10 @@
 
   Expected: no matches under `culture/bots/`. Test files may still hit IRCd internals — Task 7 cleans those up.
 
-- `agentirc-cli>=9.5,<10` exposes the full CLI surface culture is shimming to:
+- `agentirc-cli>=9.6,<10` exposes the full CLI surface culture is shimming to:
 
   ```bash
-  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" agentirc --help
+  cd /tmp && uv run --with "agentirc-cli>=9.6,<10" agentirc --help
   ```
 
   Expected: subcommands `serve start stop restart status link logs version` (or a superset). If anything's missing, **stop** — the shim parity test (Task 5) will fail.
@@ -37,7 +37,7 @@
 - `agentirc.cli.dispatch(argv) -> int` is callable in-process (verifies the shim path works without forking a subprocess):
 
   ```bash
-  cd /tmp && uv run --with "agentirc-cli>=9.5,<10" python -c "
+  cd /tmp && uv run --with "agentirc-cli>=9.6,<10" python -c "
   from agentirc.cli import dispatch
   rc = dispatch(['version'])
   print('exit code:', rc)
@@ -54,7 +54,7 @@
 
 | Path | Action | Notes |
 |---|---|---|
-| `pyproject.toml` | Modify | Drop `culture/agentirc/` from package data / wheel includes if explicitly listed. No dep change (A2 already pinned `>=9.5,<10`). |
+| `pyproject.toml` | Modify | Drop `culture/agentirc/` from package data / wheel includes if explicitly listed. No dep change (A2 already pinned `>=9.6,<10`). |
 | `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` | Delete | The IRCd core. |
 | `culture/agentirc/skills/` | Delete (whole dir) | Server-side skill plugins. |
 | `culture/agentirc/__main__.py` | Delete | `python -m culture.agentirc` retired (no known callers). |

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -1,27 +1,24 @@
 # AgentIRC Extraction Design
 
-**Status:** In progress — A1 landed in culture 8.8.0 (2026-05-01); A2/A3 unblocked by agentirc-cli 9.5.0 (2026-05-02, agentculture/agentirc#15 closed)
+**Status:** In progress — A1 landed in culture 8.8.0 (2026-05-01); A2 blocked on **A2-Bridge** (agentculture/agentirc#22, public IRCd + VirtualClient); A3 unblocked once A2 lands
 **Date:** 2026-04-30
 **Owner:** Ori Nachum
 
-## Implementation status (updated 2026-05-02)
+## Implementation status (updated 2026-05-03)
 
-Track A on the culture side is split into phases because the literal
-"delete `culture/agentirc/{ircd, ...}.py` and shim `culture server start`"
-described below cannot land in one PR — culture's bots
-(`culture/bots/*`) hold an in-process `IRCd` reference and call
-`server.emit_event`/`server.channels`/`server.get_or_create_channel`
-directly. With `agentirc-cli==9.5.0` (2026-05-02), agentirc now exposes
-a documented out-of-process bot extension API (`agentirc.io/bot` CAP,
-`EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, public
-5-field envelope in `agentirc.protocol`), so A2 is no longer blocked.
+Track A on the culture side is split into phases because the literal "delete `culture/agentirc/{ircd, ...}.py` and shim `culture server start`" described below cannot land in one PR — culture's bots (`culture/bots/*`) hold an in-process `IRCd` reference and call `server.emit_event`/`server.channels`/`server.get_or_create_channel` directly.
+
+`agentirc-cli==9.5.0` (2026-05-02) shipped the **wire-protocol** half of the bot extension API (`agentirc.io/bot` CAP, `EVENTSUB`/`EVENTUNSUB`/`EVENT`/`EVENTERR`/`EVENTPUB` verbs, public 5-field envelope in `agentirc.protocol`). What it did **not** ship is a public **Python embedding API** — the only currently-public way to drive an IRCd from another Python process is `agentirc.cli.dispatch(argv) -> int`, which runs the CLI to completion with no hook to inject in-process bots. Culture's bot framework is in-process by design. Without a public `IRCd` constructor and a public `VirtualClient` class, A2 has to either re-implement the bot-CAP TCP client from scratch (~300+ LOC, all of which agentirc has internally as `_internal.virtual_client.VirtualClient` but marks off-limits) or backport CAP/`EVENTSUB`/`EVENTPUB` machinery into the bundled IRCd (~500 LOC, all thrown away in A3).
+
+The lighter path is to ask agentirc to promote two existing internal classes to public — `agentirc.ircd.IRCd` and `agentirc._internal.virtual_client.VirtualClient`. That's the **A2-Bridge** track filed as agentculture/agentirc#22 (2026-05-03). Once 9.6.0 ships, culture's A2 collapses to "switch `culture/cli/server.py:_run_server` to construct `agentirc.ircd.IRCd(config)` directly; rewrite `culture/bots/virtual_client.py` as a ~50-LOC wrapper around the promoted `agentirc.virtual_client.VirtualClient`."
 
 | Phase | Scope | Status |
 |---|---|---|
 | **B** (agentirc bootstrap) | `agentirc-cli==9.4.1` published, public API stable, on-disk layout preserved | ✅ done (see culture#308) |
 | **A1** (culture-side public-API migration) | Pin `agentirc-cli>=9.4,<10`; `culture/agentirc/config.py` becomes a re-export shim over `agentirc.config`; canonical call sites (telemetry, mesh CLI, conftest) retarget; minor bump 8.7.1 → 8.8.0 | ✅ done 2026-05-01 (culture#309) |
-| **A2** (rewrite bots against public extension API) | Bump dep floor to `agentirc-cli>=9.5,<10`; rewrite `culture/bots/{virtual_client,bot,bot_manager,http_listener}.py` against `agentirc.io/bot` CAP + `EVENTSUB`/`EVENTPUB` + 5-field envelope; culture takes ownership of the `webhook_port` HTTP listener (agentirc 9.5 stops binding it); minor bump 8.8.0 → 8.9.0 | 🟢 ready — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md` |
-| **A3** (final cutover) | Delete the bundled IRCd: `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` + `culture/agentirc/skills/`; `git mv` `culture/agentirc/{client,remote_client}.py` → `culture/transport/`; replace `culture/cli/server.py:_run_server` with `subprocess.run(["agentirc", *argv])` (or `agentirc.cli.dispatch`) while preserving culture-owned verbs `default`/`rename`/`archive`/`unarchive` in culture's own dispatcher; keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; major bump 8.x → 9.0 | 🟢 ready after A2 — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md` |
+| **A2-Bridge** (agentirc-side public-API expansion) | Promote `agentirc.ircd.IRCd` and `agentirc._internal.virtual_client.VirtualClient` to public surface. Document in `agentirc/docs/api-stability.md`. Transitional re-export at the old internal path through 9.6.x. agentirc minor bump 9.5 → 9.6. | ⏸ filed at agentculture/agentirc#22 (2026-05-03) |
+| **A2** (culture-side bot rewrite, embedded mode) | Bump dep floor to `agentirc-cli>=9.6,<10`; switch `culture/cli/server.py:_run_server` to `agentirc.ircd.IRCd(config)`; rewrite `culture/bots/virtual_client.py` as a thin wrapper over `agentirc.virtual_client.VirtualClient`; webhook listener (`webhook_port`) moves from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`; minor bump 8.8.0 → 8.9.0 | ⏸ blocked on A2-Bridge — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md` |
+| **A3** (final cutover) | Delete the bundled IRCd: `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py` + `culture/agentirc/skills/`; `git mv` `culture/agentirc/{client,remote_client}.py` → `culture/transport/`; A2 already swapped `_run_server` to embedded `agentirc.ircd.IRCd`, so this phase is mostly deletion + culture-owned verb preservation (`default`/`rename`/`archive`/`unarchive`); keep `culture/agentirc/config.py` as the A1 re-export shim through 9.x; major bump 8.x → 9.0 | ⏸ ready after A2 — see `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md` |
 
 The Boundary / Plan sections below describe the A3 end state. They
 remain the target; the phased approach is purely about how culture
@@ -83,7 +80,7 @@ This is the first of several planned splits — `culture-agent` and `culture-bot
 ## Goals
 
 - agentirc lives in `../agentirc` as an independently versioned package on PyPI (distribution name `agentirc-cli`, import name `agentirc`), with its own CLI binary `agentirc`.
-- Culture consumes it as a normal dependency (`agentirc-cli>=9.5,<10.0`).
+- Culture consumes it as a normal dependency (`agentirc-cli>=9.6,<10.0`).
 - `culture server <verb> <args>` continues to work for every existing verb, with identical flags, output, and exit codes — implemented as a 1:1 passthrough into `agentirc.cli.dispatch`.
 - On-disk footprint stays culture-named: `~/.culture/server.yaml`, current socket paths, `culture-agent-*.service` systemd units, current log paths. Existing deployments need zero migration.
 - The IRCd's protocol surface (`protocol/extensions/`) lives in agentirc, where it belongs.
@@ -180,7 +177,7 @@ agentirc/
 
 ```
 culture/
-├── pyproject.toml          # adds: agentirc-cli>=9.5,<10.0
+├── pyproject.toml          # adds: agentirc-cli>=9.6,<10.0
 ├── uv.lock                 # regenerated
 ├── culture/
 │   ├── agentirc/           # DELETED
@@ -248,20 +245,23 @@ The public surface of agentirc — what culture (and any third-party consumer) i
 |---|---|---|
 | `agentirc.config` | `ServerConfig`, `LinkConfig`, `TelemetryConfig`, plus dataclass fields | Public, semver-tracked. Breaking changes require a major bump. |
 | `agentirc.cli` | `main()`, `dispatch(argv) -> int` | Public, semver-tracked. |
-| `agentirc.protocol` | Verb name constants (incl. `EVENTSUB`, `EVENTUNSUB`, `EVENT`, `EVENTERR`, `EVENTPUB`), numeric reply codes, extension tag names, the canonical 5-field `Event` envelope (`type`/`channel`/`nick`/`data`/`timestamp`), `EVENT_TYPE_RE` | Public, semver-tracked. Wire format byte-locked under semver (see agentirc `tests/test_wire_format_envelope.py::test_envelope_byte_lock`). |
+| `agentirc.protocol` | Verb name constants (incl. `EVENTSUB`, `EVENTUNSUB`, `EVENT`, `EVENTERR`, `EVENTPUB`), numeric reply codes, extension tag names, the canonical 5-field `Event` envelope (`type`/`channel`/`nick`/`data`/`timestamp`), per-type `EVENT_TYPE_*` string constants, `BOT_CAP = "agentirc.io/bot"` | Public, semver-tracked. Wire format byte-locked under semver (see agentirc `tests/test_wire_format_envelope.py::test_envelope_byte_lock`). |
+| `agentirc.ircd` | `IRCd` (constructor + lifecycle) | 🟡 **Pending agentirc#22 (A2-Bridge).** Currently listed as internal in `agentirc/docs/api-stability.md`; promotion is the prerequisite for culture A2 to embed it in-process. After 9.6.0, public + semver-tracked. |
+| `agentirc.virtual_client` | `VirtualClient` (in-process bot, duck-typed Client/RemoteClient) | 🟡 **Pending agentirc#22 (A2-Bridge).** Today at `agentirc._internal.virtual_client.VirtualClient`; A2-Bridge promotes to `agentirc.virtual_client.VirtualClient` (or `agentirc.bot.VirtualClient` if agentirc prefers that namespace). After 9.6.0, public + semver-tracked, with transitional re-export at the old internal path through 9.6.x. |
 | `agentirc.skill` | Re-exports `Event`, `EventType` from `agentirc.protocol` | **Transitional** — present through the 9.5.x line, removed in 10.0.0. New code should import from `agentirc.protocol` directly. |
 
-Everything else — `agentirc.ircd`, `agentirc.server_link`, `agentirc.channel`, the stores, the in-tree skills, anything under `agentirc._internal.*` — is internal. Agentirc may refactor freely without breaking culture. Documented in `agentirc/docs/api-stability.md`.
+Everything else — `agentirc.server_link`, `agentirc.channel`, the stores, the in-tree skills, anything under `agentirc._internal.*` — is internal. Agentirc may refactor freely without breaking culture. Documented in `agentirc/docs/api-stability.md`.
 
 ### Where culture imports from agentirc
 
 | Culture module | Imports |
 |---|---|
-| `culture/cli/server.py` | `agentirc.cli.dispatch` |
+| `culture/cli/server.py` | `agentirc.cli.dispatch` (unchanged); after A2, also `agentirc.ircd.IRCd` (embeds in-process for `culture server start`) |
 | `culture/cli/shared/mesh.py` | `agentirc.config.LinkConfig` |
 | `culture/config.py`, `culture/telemetry/{metrics,tracing,audit}.py`, `tests/conftest.py` | `agentirc.config.{ServerConfig, LinkConfig, TelemetryConfig}` (since A1, culture#309) |
 | `culture/transport/client.py` | `agentirc.protocol.*` (verb / numeric / tag constants) |
-| `culture/bots/{virtual_client,bot,bot_manager}.py` | `agentirc.protocol.{Event, EventType, EVENTSUB, EVENTUNSUB, EVENT, EVENTERR, EVENTPUB}` (after A2) |
+| `culture/bots/virtual_client.py` (after A2) | `agentirc.virtual_client.VirtualClient` (thin wrapper for culture-specific concerns: BotConfig, template engine, fires_event, owner DM) |
+| `culture/bots/{bot,bot_manager}.py` (after A2) | `agentirc.protocol.{Event, EventType}` for envelope decoding; `IRCd` reference comes from `culture/cli/server.py:_run_server` |
 | `culture/clients/*/daemon.py` | `culture.transport` only (no agentirc internals) |
 
 ## Configuration & on-disk footprint
@@ -277,13 +277,46 @@ Standalone (non-culture) users of agentirc can override the config path via `age
 
 ## Migration mechanics
 
-The migration runs in **two tracks** owned by two different agents. The culture-side agent (this work) implements only Track A and produces the brief in Track B as a deliverable; the brief is then handed to the agent working in `../agentirc`. The culture-side cutover PR (Track A) **waits** on the agentirc release that Track B produces.
+The migration runs across **multiple cross-repo tracks** owned by different agents. The culture-side agent (this work) implements culture-side tracks (A1, A2, A3) and produces hand-off briefs (Track B for the original bootstrap, A2-Bridge for the embedding-API expansion). Briefs are handed to the agent working in `../agentirc`. Culture-side cutover PRs **wait** on the agentirc releases the briefs trigger.
+
+### Track A2-Bridge — hand-off brief for the agentirc agent (filed as agentculture/agentirc#22 on 2026-05-03)
+
+This block is **handed to the agent working in `../agentirc`** and is intended to be self-contained — the receiving agent should not need culture-side context to act on it. It is mirrored here from the GitHub issue body for searchability.
+
+**One-line ask:** Promote `agentirc._internal.virtual_client.VirtualClient` and `agentirc.ircd.IRCd` to the public API surface so a Python embedder can construct an IRCd in-process and host bots inside it.
+
+**Why this exact shape:**
+
+- `_internal.virtual_client.VirtualClient` already encapsulates everything a co-hosted bot needs: `caps = frozenset({BOT_CAP, "message-tags"})` so it gets the silent-JOIN / no-auto-op / `+`-prefix / `B`-flag treatment exactly like a CAP-negotiated TCP bot, plus `join_channel(name, *, emit_event)`, `part_channel(name)`, and the duck-typed Client/RemoteClient interface for `channel.members` / NAMES / WHO / WHOIS. agentirc's own `#system` welcome bot consumes this class today. Culture's `culture/bots/virtual_client.py` is functionally identical to it.
+- `agentirc.ircd.IRCd` is the constructor. Culture's `culture server start` needs a public way to instantiate one in-process and add bots to it. The class is already importable; it just sits under "Internal modules" in `docs/api-stability.md`.
+- If agentirc prefers a different layout (e.g. `agentirc.host.Host` as a façade owning an internal IRCd + exposing `host.add_bot(VirtualClient(...))`), that's fine. The constraint is the **capability**, not the names.
+
+**Concrete asks:**
+
+1. **Promote `IRCd`.** Move `agentirc.ircd` out of the "Internal modules" list in `docs/api-stability.md`. Document the public constructor signature, lifecycle methods (`start`/`stop`), and bot-extension hooks (event emission, subscription registration). If the current internal API surface is too wide, expose a narrower public façade and keep the wider class internal.
+2. **Promote `VirtualClient`.** Move `agentirc._internal.virtual_client` → `agentirc.virtual_client` (or `agentirc.bot.VirtualClient` if a `bot` namespace is preferred). Keep a transitional re-export at the old path through 9.6.x; remove in 10.0.0 with a deprecation warning across that window.
+3. **Federation interop sniff (optional).** While agentirc is touching `_handle_sevent` for any reason, please consider mirroring the 9.5 → ≤9.4 envelope sniff back to a 9.4.x patch release. If awkward, no problem — culture can ship the workaround in `culture/agentirc/server_link.py` until A3 deletes that file.
+4. **Out of scope.** No new code is required — this is mostly relabeling existing internals to public, plus documentation. No protocol changes. No CLI changes.
+
+**Acceptance criteria:**
+
+- `agentirc-cli==9.6.0` (or whatever minor) is on PyPI.
+- `from agentirc.virtual_client import VirtualClient` works (or whatever public name).
+- `from agentirc.ircd import IRCd` works AND `agentirc/docs/api-stability.md` lists it under public modules.
+- The transitional `_internal.virtual_client.VirtualClient` re-export still works (deprecation warning OK).
+- `agentirc/docs/api-stability.md` has a section explaining the embedding pattern with a minimal worked example.
+
+This is a minor bump for agentirc — additive, no breaking change.
 
 ### Track A — culture-side (implemented in this repo)
 
 A single PR off `main`, following culture's standard workflow.
 
-1. `pyproject.toml`: add `agentirc-cli>=9.5,<10.0`. Regenerate `uv.lock`.
+### Track A — culture-side (implemented in this repo)
+
+A single PR off `main`, following culture's standard workflow.
+
+1. `pyproject.toml`: add `agentirc-cli>=9.6,<10.0`. Regenerate `uv.lock`.
 2. Delete `culture/agentirc/` entirely.
 3. Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.
 4. Replace `culture/cli/server.py` with the passthrough shim (see "CLI surface" above).
@@ -360,14 +393,14 @@ After Track A merges and culture is released:
 
 ### Distribution
 
-- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=9.5,<10.0`.
+- agentirc → PyPI as `agentirc-cli` (semver). Culture pins `agentirc-cli>=9.6,<10.0`.
 - TestPyPI carries both `agentirc-cli` and a squatted `agentirc`; only `agentirc-cli` is the canonical name. Anything publishing or installing should use `agentirc-cli`.
 - agentirc adopts culture's version workflow (`/version-bump`, CHANGELOG, version-check CI).
 - All-backends rule still applies: changes that cross the agentirc / culture-transport boundary must be reflected across all four backends in culture (`claude`, `codex`, `copilot`, `acp`).
 
 ### Rollback
 
-If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=9.5,<10.0` means culture cannot accidentally pick up an incompatible 10.0.0 release.
+If the cutover PR breaks something not caught in CI, the rollback is a `git revert` of the culture-side PR. The agentirc repo itself is independent and stays. Pinning `agentirc-cli>=9.6,<10.0` means culture cannot accidentally pick up an incompatible 10.0.0 release.
 
 ## Testing strategy
 
@@ -401,7 +434,7 @@ Tests under culture's `tests/` are sorted into three buckets at copy time:
 | Protocol constants drift between agentirc (server) and culture/transport (client). | `agentirc.protocol` is the single source. Both sides import from there; tests on either side fail fast on missing constants. |
 | Existing deployment breaks because something on disk is unexpectedly named. | Goals/Non-Goals: nothing on disk is renamed. The verification step on a real deployment catches anything we missed. |
 | `culture server --help` output diverges from `agentirc --help` over time. | The shim parity test asserts byte-equality of the help text. CI fails if drift appears. |
-| An agentirc-cli release introduces a regression that breaks culture. | Culture pins `agentirc-cli>=9.5,<10.0`. Patches go out as `9.5.1`, `9.5.2`, etc. Culture can pin to a specific known-good `==9.5.X` if a patch in the floor range turns out to be broken. |
+| An agentirc-cli release introduces a regression that breaks culture. | Culture pins `agentirc-cli>=9.6,<10.0`. Patches go out as `9.6.1`, `9.6.2`, etc. Culture can pin to a specific known-good `==9.6.X` if a patch in the floor range turns out to be broken. |
 | Future changes touch both repos at once and become hard to coordinate. | All-backends rule already requires multi-backend coordination; the same discipline extends to multi-repo coordination. Significant cross-repo work pairs an agentirc PR with a culture PR that bumps the floor pin. |
 
 ## Open questions

--- a/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md
@@ -312,10 +312,6 @@ This is a minor bump for agentirc — additive, no breaking change.
 
 A single PR off `main`, following culture's standard workflow.
 
-### Track A — culture-side (implemented in this repo)
-
-A single PR off `main`, following culture's standard workflow.
-
 1. `pyproject.toml`: add `agentirc-cli>=9.6,<10.0`. Regenerate `uv.lock`.
 2. Delete `culture/agentirc/` entirely.
 3. Move `client.py`, `remote_client.py` → `culture/transport/`. Add `culture/transport/__init__.py` re-exporting the public class names.


### PR DESCRIPTION
## Summary

Two motions in one PR:

### 1. New `coordinate` skill (`.claude/skills/coordinate/`)

Cross-repo issue-filing as first-class infrastructure. Pattern recurs (#308 → agentirc#15; agentirc#15 closing → agentirc#22) — moving from ad-hoc \`gh issue create\` to a versioned skill with a single \`scripts/post-issue.sh\` that auto-appends \`- culture (Claude)\` to every body. Conventions documented in \`SKILL.md\`: hand-off briefs are self-contained, signature is mandatory, distinct from the global \`- Claude\` so cross-repo readers can identify the source repo at a glance.

### 2. Cross-repo split for agentirc A2

Trying to start A2 (per the plans landed in #312) revealed the bundled IRCd in \`culture/agentirc/\` has zero \`agentirc.io/bot\` CAP support, no \`EVENTSUB\`/\`EVENTPUB\`, no \`SubscriptionRegistry\`. Pure culture-side options were all unattractive — backport (~500 LOC of throwaway), combine A2+A3 (one giant PR, still re-implementing the bot client from scratch), or subprocess-only (still re-implementing because agentirc's internal \`VirtualClient\` is in-process and \`_internal.*\` is off-limits per agentirc's \`docs/api-stability.md\`).

The lighter path is cross-repo: ask agentirc to promote two existing internal classes to public — \`agentirc.ircd.IRCd\` and \`agentirc._internal.virtual_client.VirtualClient\`. Filed via the new skill as **[agentculture/agentirc#22](https://github.com/agentculture/agentirc/issues/22)** (the **A2-Bridge** track).

Once agentirc 9.6.0 ships, culture's A2 collapses to:
- Switch \`culture/cli/server.py:_run_server\` to construct \`agentirc.ircd.IRCd(config)\` directly (in-process).
- Rewrite \`culture/bots/virtual_client.py\` as a ~50-LOC wrapper over \`agentirc.virtual_client.VirtualClient\` for culture-specific concerns (BotConfig, template engine, fires_event, owner DM).
- Webhook listener (\`webhook_port\`) ownership moves from \`culture/agentirc/ircd.py\` to \`culture/bots/bot_manager.py\`.
- Minor bump 8.8.0 → 8.9.0.

A3 inherits the in-process embedding choice — Task 1.3's old in-process-vs-subprocess decision is settled, and \`start\` is now culture-owned (in-process IRCd + bot registration) rather than forwarded to \`agentirc.cli.dispatch\`.

## Files changed

- \`.claude/skills/coordinate/SKILL.md\` (new)
- \`.claude/skills/coordinate/scripts/post-issue.sh\` (new, executable)
- \`docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md\` — spec status, A2 row, new A2-Bridge row, public surface table, federation interop, full A2-Bridge brief mirrored in §Migration mechanics for searchability
- \`docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md\` — rewritten in-place for the in-process embedding approach (~470 lines, down from 546)
- \`docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md\` — small edits inheriting A2's choice (\`start\` is culture-owned, partial passthrough only for non-\`start\` lifecycle verbs)

## Test plan

- [x] \`bash -n .claude/skills/coordinate/scripts/post-issue.sh\` parses
- [x] \`[[ -x post-issue.sh ]]\` — executable bit set
- [x] \`SKILL.md\` frontmatter matches \`pr-review/SKILL.md\` shape (auto-discovered, listed in available-skills)
- [x] Used the new script to file [agentirc#22](https://github.com/agentculture/agentirc/issues/22) — signature \`- culture (Claude)\` appended correctly
- [x] Pre-commit hooks all green (markdownlint, trailing whitespace, end-of-file, large files, private key)
- [x] No code changes — docs + a non-executed skill script. No CI risk.

## Out of scope

- Executing A2 — separate PR per the rewritten A2 plan, after agentirc 9.6.0 ships.
- Executing A3 — separate PR per the updated A3 plan, after A2 lands.
- The optional federation envelope sniff (spec § \"Federation interop during the migration window\") — separate small patch PR if mixed-version peers expected during the A2-to-A3 window.

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)