### PR TITLE
Phase A2: embed agentirc.ircd.IRCd and rewrite VirtualClient as wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.10.0] - 2026-05-03
+
+### Changed
+
+- `culture server start` now embeds `agentirc.ircd.IRCd` in-process directly, via the public class promoted in agentirc 9.6.0 ([agentculture/agentirc#22](https://github.com/agentculture/agentirc/issues/22) / PR #23). The bundled IRCd in `culture/agentirc/` is now orphaned in the production path; it is reached only by the test suite and is slated for deletion in Phase A3.
+- Rewrote `culture/bots/virtual_client.py` as a thin subclass over the public `agentirc.virtual_client.VirtualClient` (also promoted in agentirc 9.6.0). The 231-LOC file collapsed to 31 LOC; user-visible bot behavior (channel JOINs, `@`-mention notices, `send_dm`, `broadcast_to_channel`) is unchanged. Culture-specific glue (BotConfig, template engine, `fires_event` chaining, owner DM) lives in `culture/bots/bot.py`, not in VirtualClient.
+- Webhook listener (`webhook_port`) ownership moved from the bundled `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`. agentirc 9.5+ stopped binding the port itself; consumers (culture) now own the listener. `BotManager` gains `start()` / `stop()` lifecycle methods that wrap bot loading and HttpListener bind/unbind.
+- `_run_server` in `culture/cli/server.py` wraps the post-`ircd.start()` body in a `try/finally` so `bot_manager.stop()` and `ircd.stop()` always run on shutdown — even if bot teardown raises.
+- Bumped dep floor `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.6,<10`.
+- `Event` / `EventType` imports retargeted from `culture.agentirc.skill` to `agentirc.protocol` in the three sites that survive Phase A3 (`culture/bots/virtual_client.py`, `culture/bots/bot.py`, `culture/telemetry/audit.py` — TYPE_CHECKING). The bundled `culture.agentirc.skill` re-exports stay intact for the test suite, which still drives the bundled IRCd via `tests/conftest.py` until A3.
+
+### Notes
+
+- Plan: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`. Spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md` ("Implementation status" table, A2 row).
+- One deviation from the canonical plan: Task 10 ("Test harness migration" — switching `tests/conftest.py` and bot tests from the bundled IRCd to `agentirc.ircd.IRCd`) is **deferred to Phase A3**. The full test suite (1157 tests) passes unchanged on the bundled IRCd, which is structurally compatible with the public class — migrating now would be diff churn without behavioral risk reduction. The smoke test exercises the production agentirc IRCd + culture BotManager path end-to-end.
+- A pre-existing bot-load race (`Bot.start()` "Nick already in use" when one bot's `user.join` event triggers another bot's lazy-start during `BotManager.load_bots`) was surfaced in A2's smoke test and tracked at [#317](https://github.com/agentculture/culture/issues/317) for a follow-up patch. The error log is misleading but bot behavior is unaffected; this race exists identically on the bundled IRCd path and was not introduced by A2.
+
 ## [8.9.0] - 2026-05-03
 
 ### Changed

--- a/culture/agentirc/CLAUDE.md
+++ b/culture/agentirc/CLAUDE.md
@@ -6,7 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 AgentIRC is a custom async Python IRCd (IRC server) built from scratch for AI agent collaboration. It is **not** a wrapper around existing IRC servers. ~4,300 lines of pure async Python (asyncio). Located at `culture/agentirc/` within the culture project.
 
-**Extraction in progress (Track A).** As of culture 8.8.0, the canonical config dataclasses (`ServerConfig`, `LinkConfig`, `TelemetryConfig`) live in the published `agentirc-cli` PyPI package, not here. `culture/agentirc/config.py` is a re-export shim — `from culture.agentirc.config import ServerConfig` resolves to the same class as `from agentirc.config import ServerConfig`. The shim and the rest of `culture/agentirc/{ircd,client,remote_client,channel,events,server_link,room_store,thread_store,history_store,skill,skills/}.py` will be deleted in Phase A3 once the bot-runtime story is settled (tracking: agentculture/culture#308, agentculture/agentirc#15). Until then, the IRCd here remains the in-process host for `culture/bots/*`.
+**Extraction in progress (Track A).** As of culture 8.8.0, the canonical config dataclasses (`ServerConfig`, `LinkConfig`, `TelemetryConfig`) live in the published `agentirc-cli` PyPI package, not here. `culture/agentirc/config.py` is a re-export shim — `from culture.agentirc.config import ServerConfig` resolves to the same class as `from agentirc.config import ServerConfig`. The shim and the rest of `culture/agentirc/{ircd,client,remote_client,channel,events,server_link,room_store,thread_store,history_store,skill,skills/}.py` will be deleted in Phase A3 once the bot-runtime story is settled (tracking: agentculture/culture#308, agentculture/agentirc#15).
+
+## Status (after A2, culture 8.10.0)
+
+After Phase A2 (`feat/bots-embedded-agentirc`), `culture/cli/server.py:_run_server` constructs `agentirc.ircd.IRCd(config)` directly — the bundled IRCd in this directory is no longer instantiated by anything in production code. `culture/bots/virtual_client.py` is now a thin subclass of `agentirc.virtual_client.VirtualClient` (promoted to public in agentirc 9.6.0 via [agentculture/agentirc#22](https://github.com/agentculture/agentirc/issues/22) / [PR #23](https://github.com/agentculture/agentirc/pull/23)). `culture/bots/bot_manager.py` is wired into agentirc IRCd's `bot_manager` slot after `start()` and now owns the webhook HTTP listener (agentirc 9.5+ stopped binding `webhook_port` itself).
+
+The files in this directory are dead in production. They remain instantiated only by the test suite (via `tests/conftest.py`'s `ircd` fixture) — A3 migrates the tests to `agentirc.ircd.IRCd` and deletes everything here except `config.py` (which stays as a re-export shim through the 9.x line).
 
 ## Running
 

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -8,16 +8,16 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from agentirc.protocol import Event, EventType
 from opentelemetry import trace as _otel_trace
 
-from culture.agentirc.skill import Event, EventType
 from culture.bots.config import BOTS_DIR, BotConfig
 from culture.bots.template_engine import render_fallback, render_template
 from culture.bots.virtual_client import VirtualClient
 from culture.constants import EVENT_TYPE_RE
 
 if TYPE_CHECKING:
-    from culture.agentirc.ircd import IRCd
+    from agentirc.ircd import IRCd
 
 logger = logging.getLogger(__name__)
 

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -21,7 +21,9 @@ from culture.bots.filter_dsl import FilterParseError, compile_filter, evaluate
 _FILTER_ERRORS = (FilterParseError, TypeError)
 
 if TYPE_CHECKING:
-    from culture.agentirc.ircd import IRCd
+    from agentirc.ircd import IRCd
+
+    from culture.bots.http_listener import HttpListener
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +34,52 @@ class BotManager:
     def __init__(self, server: IRCd):
         self.server = server
         self.bots: dict[str, Bot] = {}  # name -> Bot
+        self._http_listener: HttpListener | None = None
+
+    async def start(self) -> None:
+        """Load configured bots and start the webhook HTTP listener.
+
+        Owned by ``BotManager`` after Phase A2 — agentirc 9.5+ stopped
+        binding ``webhook_port`` itself; consumers (culture) host the
+        listener now. Called by ``culture/cli/server.py:_run_server``
+        after ``ircd.start()`` completes and culture has assigned itself
+        to ``ircd.bot_manager``.
+
+        Crash-safe: if any step after ``load_bots`` raises, already-loaded
+        bots are torn down before the exception propagates so the caller
+        doesn't see a half-started state.
+        """
+        from culture.bots.http_listener import HttpListener
+
+        try:
+            await self.load_bots()
+            self.load_system_bots()
+
+            webhook_port = self.server.config.webhook_port
+            self._http_listener = HttpListener(self, "127.0.0.1", webhook_port)
+            try:
+                await self._http_listener.start()
+            except OSError:
+                # Port unavailable (e.g. tests using port 0 that got an
+                # in-use ephemeral port). Non-fatal — bots still work,
+                # just without the HTTP endpoint.
+                logger.warning("Could not start webhook listener on port %d", webhook_port)
+                self._http_listener = None
+        except Exception:
+            # Tear down anything already loaded so we don't leak running
+            # bots or a half-bound listener up to the caller.
+            await self.stop()
+            raise
+
+    async def stop(self) -> None:
+        """Stop all bots and the webhook HTTP listener."""
+        if self._http_listener is not None:
+            try:
+                await self._http_listener.stop()
+            except Exception:
+                logger.exception("Failed to stop webhook listener")
+            self._http_listener = None
+        await self.stop_all()
 
     async def load_bots(self) -> None:
         """Scan ~/.culture/bots/ and load all bot definitions."""

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -59,11 +59,17 @@ class BotManager:
             self._http_listener = HttpListener(self, "127.0.0.1", webhook_port)
             try:
                 await self._http_listener.start()
-            except OSError:
+            except OSError as exc:
                 # Port unavailable (e.g. tests using port 0 that got an
                 # in-use ephemeral port). Non-fatal — bots still work,
-                # just without the HTTP endpoint.
-                logger.warning("Could not start webhook listener on port %d", webhook_port)
+                # just without the HTTP endpoint. Surface the underlying
+                # errno so operators can distinguish EADDRINUSE / EACCES /
+                # other bind failures without re-running with a debugger.
+                logger.warning(
+                    "Could not start webhook listener on port %d: %s",
+                    webhook_port,
+                    exc,
+                )
                 self._http_listener = None
         except Exception:
             # Tear down anything already loaded so we don't leak running

--- a/culture/bots/virtual_client.py
+++ b/culture/bots/virtual_client.py
@@ -1,231 +1,31 @@
-"""Virtual IRC client for bot presence in channels."""
+"""Culture's wrapper around agentirc's public VirtualClient.
+
+After Phase A2 (agentirc-cli >= 9.6.0), all virtual-presence behavior —
+JOIN/PART, channel broadcasts, DMs, @-mention notices, IRC-text
+sanitization — lives in :class:`agentirc.virtual_client.VirtualClient`.
+That class was promoted to public in agentirc 9.6.0 (agentculture/agentirc#22)
+and is semver-tracked from that release forward.
+
+This module re-exports it as ``culture.bots.virtual_client.VirtualClient``
+to keep culture's existing import sites stable. The subclass exists so
+culture-specific extensions can land here without forking the upstream
+class — none are needed today (the Bot wrapper in ``culture.bots.bot``
+already owns the culture-specific glue: BotConfig, template engine,
+``fires_event`` chaining, owner DM).
+"""
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING
-
-from culture.agentirc.skill import Event, EventType
-from culture.protocol.message import Message
-
-if TYPE_CHECKING:
-    from culture.agentirc.channel import Channel
-    from culture.agentirc.ircd import IRCd
-
-logger = logging.getLogger(__name__)
+from agentirc.virtual_client import VirtualClient as _AgentircVirtualClient
 
 
-def _sanitize_irc_text(text: str) -> str:
-    """Strip CR/LF characters to prevent IRC protocol injection."""
-    return text.replace("\r", "").replace("\n", " ")
+class VirtualClient(_AgentircVirtualClient):
+    """A culture bot's IRC presence.
 
-
-class VirtualClient:
-    """A bot's IRC presence — appears in channels but has no TCP connection.
-
-    Duck-types the same interface as Client/RemoteClient so it works
-    in channel.members, NAMES, WHO, and WHOIS transparently.
+    All behavior is inherited from
+    :class:`agentirc.virtual_client.VirtualClient`. Subclassed so culture
+    can extend without forking the upstream class.
     """
 
-    def __init__(self, nick: str, user: str, server: IRCd):
-        self.nick = nick
-        self.user = user
-        self.host = "bot"
-        self.realname = f"Bot {nick}"
-        self.server = server
-        self.server_name = server.config.name
-        self.channels: set[Channel] = set()
-        self.tags: list[str] = ["bot"]
 
-    @property
-    def prefix(self) -> str:
-        return f"{self.nick}!{self.user}@{self.host}"
-
-    async def send(self, message: Message) -> None:
-        """No-op — bots don't receive messages from others."""
-
-    async def join_channel(self, channel_name: str, *, emit_event: bool = True) -> None:
-        """Join a channel, notify members, and optionally emit events.
-
-        Args:
-            channel_name: The channel to join.
-            emit_event: If False, skip emitting a user.join event (e.g. for
-                silent dynamic joins by event-triggered bots to avoid
-                triggering other bots that filter on user.join).
-        """
-        channel = self.server.get_or_create_channel(channel_name)
-        if self in channel.members:
-            return
-
-        channel.members.add(self)
-        self.channels.add(channel)
-
-        # Ensure bot is never auto-promoted to operator
-        channel.operators.discard(self)
-
-        join_msg = Message(
-            prefix=self.prefix,
-            command="JOIN",
-            params=[channel_name],
-        )
-        for member in list(channel.members):
-            if member is not self:
-                await member.send(join_msg)
-
-        if emit_event:
-            await self.server.emit_event(
-                Event(type=EventType.JOIN, channel=channel_name, nick=self.nick)
-            )
-
-    async def part_channel(self, channel_name: str) -> None:
-        """Leave a channel, notify members, and emit events."""
-        channel = self.server.channels.get(channel_name)
-        if not channel or self not in channel.members:
-            return
-
-        part_msg = Message(
-            prefix=self.prefix,
-            command="PART",
-            params=[channel_name],
-        )
-        for member in list(channel.members):
-            if member is not self:
-                await member.send(part_msg)
-
-        await self.server.emit_event(
-            Event(
-                type=EventType.PART,
-                channel=channel_name,
-                nick=self.nick,
-                data={"reason": "bot stopped"},
-            )
-        )
-
-        channel.members.discard(self)
-        self.channels.discard(channel)
-        channel.operators.discard(self)
-
-        if not channel.members and not channel.persistent:
-            del self.server.channels[channel_name]
-
-    async def broadcast_to_channel(self, channel_name: str, text: str) -> None:
-        """Post a PRIVMSG to a channel without joining it first.
-
-        Unlike ``send_to_channel``, this method does not require the bot to be
-        a member of the channel — it delivers directly to current members.
-        Used by event-triggered bots with no pre-configured channels (e.g.
-        the welcome bot) so they can respond to events without persistently
-        occupying a channel.
-        """
-        text = _sanitize_irc_text(text)
-        channel = self.server.channels.get(channel_name)
-        if channel is None:
-            logger.warning("Bot %s: channel %s not found for broadcast", self.nick, channel_name)
-            return
-
-        relay = Message(
-            prefix=self.prefix,
-            command="PRIVMSG",
-            params=[channel_name, text],
-        )
-        members_snapshot = list(channel.members)
-        for member in members_snapshot:
-            if member is not self:
-                await member.send(relay)
-
-        await self.server.emit_event(
-            Event(type=EventType.MESSAGE, channel=channel_name, nick=self.nick, data={"text": text})
-        )
-        await self._notify_mentions(channel_name, text)
-
-    async def send_to_channel(self, channel_name: str, text: str) -> None:
-        """Post a PRIVMSG to a channel as this bot."""
-        text = _sanitize_irc_text(text)
-        channel = self.server.channels.get(channel_name)
-        if not channel or self not in channel.members:
-            logger.warning("Bot %s not in channel %s", self.nick, channel_name)
-            return
-
-        relay = Message(
-            prefix=self.prefix,
-            command="PRIVMSG",
-            params=[channel_name, text],
-        )
-        for member in list(channel.members):
-            if member is not self:
-                await member.send(relay)
-
-        await self.server.emit_event(
-            Event(
-                type=EventType.MESSAGE,
-                channel=channel_name,
-                nick=self.nick,
-                data={"text": text},
-            )
-        )
-
-        # Trigger @mention notifications for mentioned agents
-        await self._notify_mentions(channel_name, text)
-
-    async def send_dm(self, target_nick: str, text: str) -> None:
-        """Send a direct PRIVMSG to a specific user."""
-        text = _sanitize_irc_text(text)
-        from culture.agentirc.remote_client import RemoteClient
-
-        recipient = self.server.get_client(target_nick)
-        if not recipient:
-            logger.warning("Bot %s: DM target %s not found", self.nick, target_nick)
-            return
-
-        relay = Message(
-            prefix=self.prefix,
-            command="PRIVMSG",
-            params=[target_nick, text],
-        )
-        if isinstance(recipient, RemoteClient):
-            await recipient.link.send_raw(
-                f":{self.server.config.name} SMSG {target_nick} {self.nick} :{text}"
-            )
-        else:
-            await recipient.send(relay)
-
-    async def _notify_mentions(
-        self,
-        channel_name: str,
-        text: str,
-    ) -> None:
-        """Send NOTICE to any @mentioned users in the text."""
-        import re
-
-        from culture.agentirc.remote_client import RemoteClient
-
-        mentioned_nicks = re.findall(r"@(\S+)", text)
-        if not mentioned_nicks:
-            return
-        channel = self.server.channels.get(channel_name)
-        seen: set[str] = set()
-        for raw_nick in mentioned_nicks:
-            nick = raw_nick.rstrip(".,;:!?")
-            if nick in seen or nick == self.nick:
-                continue
-            seen.add(nick)
-            target_client = self.server.get_client(nick)
-            if not target_client:
-                continue
-            if channel and target_client not in channel.members:
-                continue
-            notice = Message(
-                prefix=self.server.config.name,
-                command="NOTICE",
-                params=[
-                    nick,
-                    f"{self.nick} mentioned you in {channel_name}: {text}",
-                ],
-            )
-            if isinstance(target_client, RemoteClient):
-                await target_client.link.send_raw(
-                    f":{self.server.config.name} SNOTICE {nick} {self.server.config.name} "
-                    f":{self.nick} mentioned you in {channel_name}: {text}"
-                )
-            else:
-                await target_client.send(notice)
+__all__ = ["VirtualClient"]

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -417,8 +417,10 @@ async def _run_server(
     data_dir: str = "",
 ) -> None:
     """Run the IRC server (called in the daemon child process)."""
-    from culture.agentirc.config import ServerConfig
-    from culture.agentirc.ircd import IRCd
+    from agentirc.config import ServerConfig
+    from agentirc.ircd import IRCd
+
+    from culture.bots.bot_manager import BotManager
 
     config = ServerConfig(
         name=name,
@@ -430,27 +432,42 @@ async def _run_server(
     )
     ircd = IRCd(config)
     await ircd.start()
-    logger.info("Server '%s' listening on %s:%d", name, host, port)
 
-    for lc in config.links:
-        try:
-            await ircd.connect_to_peer(lc.host, lc.port, lc.password, lc.trust)
-            logger.info("Linking to %s at %s:%d", lc.name, lc.host, lc.port)
-        except Exception as e:
-            logger.error("Failed to link to %s: %s — will retry", lc.name, e)
-            ircd.maybe_retry_link(lc.name)
+    try:
+        # agentirc 9.6 ships a stub `bot_manager` that no-ops. Replace it
+        # with culture's, then load bots and start the webhook listener —
+        # agentirc stopped binding `webhook_port` in 9.5, so consumers
+        # own that surface.
+        ircd.bot_manager = BotManager(ircd)
+        await ircd.bot_manager.start()
+        logger.info("Server '%s' listening on %s:%d", name, host, port)
 
-    stop_event = asyncio.Event()
-    loop = asyncio.get_event_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        try:
-            loop.add_signal_handler(sig, stop_event.set)
-        except (NotImplementedError, RuntimeError):
-            signal.signal(sig, lambda *_: stop_event.set())
+        for lc in config.links:
+            try:
+                await ircd.connect_to_peer(lc.host, lc.port, lc.password, lc.trust)
+                logger.info("Linking to %s at %s:%d", lc.name, lc.host, lc.port)
+            except Exception as e:
+                logger.error("Failed to link to %s: %s — will retry", lc.name, e)
+                ircd.maybe_retry_link(lc.name)
 
-    await stop_event.wait()
-    logger.info("Server '%s' shutting down", name)
-    await ircd.stop()
+        stop_event = asyncio.Event()
+        loop = asyncio.get_event_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, stop_event.set)
+            except (NotImplementedError, RuntimeError):
+                signal.signal(sig, lambda *_: stop_event.set())
+
+        await stop_event.wait()
+    finally:
+        logger.info("Server '%s' shutting down", name)
+        bm = getattr(ircd, "bot_manager", None)
+        if bm is not None:
+            try:
+                await bm.stop()
+            except Exception:
+                logger.exception("bot_manager.stop failed")
+        await ircd.stop()
 
 
 def _wait_for_graceful_stop(pid: int, timeout_ticks: int = 50) -> bool:

--- a/culture/cli/server.py
+++ b/culture/cli/server.py
@@ -467,7 +467,13 @@ async def _run_server(
                 await bm.stop()
             except Exception:
                 logger.exception("bot_manager.stop failed")
-        await ircd.stop()
+        try:
+            await ircd.stop()
+        except Exception:
+            # Best-effort shutdown: a teardown failure here would otherwise
+            # mask the original exception that broke us out of the body
+            # (or turn a clean shutdown into a crash). Log and move on.
+            logger.exception("ircd.stop failed")
 
 
 def _wait_for_graceful_stop(pid: int, timeout_ticks: int = 50) -> bool:

--- a/culture/telemetry/audit.py
+++ b/culture/telemetry/audit.py
@@ -29,7 +29,8 @@ from typing import TYPE_CHECKING, Any
 from agentirc.config import ServerConfig
 
 if TYPE_CHECKING:
-    from culture.agentirc.skill import Event
+    from agentirc.protocol import Event
+
     from culture.telemetry.metrics import MetricsRegistry
 
 logger = logging.getLogger(__name__)

--- a/docs/agentirc/architecture-overview.md
+++ b/docs/agentirc/architecture-overview.md
@@ -9,9 +9,18 @@ permalink: /agentirc/architecture-overview/
 
 # Architecture
 
-Technical internals of the AgentIRC runtime. AgentIRC (`culture/agentirc/`) is a
-custom async Python IRCd designed for AI agent collaboration — approximately 4,300
-lines of pure asyncio Python, not a wrapper around existing IRC servers.
+Technical internals of the AgentIRC runtime. AgentIRC is a custom async Python
+IRCd designed for AI agent collaboration — approximately 4,300 lines of pure
+asyncio Python, not a wrapper around existing IRC servers.
+
+> **Where the IRCd lives (as of culture 8.10.0).** The runtime IRCd is shipped
+> as the [`agentirc-cli`](https://pypi.org/project/agentirc-cli/) PyPI package
+> — `culture server start` embeds `agentirc.ircd.IRCd` in-process from there.
+> The fork still on disk at `culture/agentirc/` is dead in production after
+> Phase A2 of the agentirc extraction; the bot framework reaches it only via
+> the test suite and the bundled tree is slated for removal in Phase A3. The
+> architecture below describes the AgentIRC runtime regardless of which
+> Python package hosts it.
 
 These docs cover its layered architecture, federation protocol, agent harness, and
 system design. For a conceptual introduction, start with [Why AgentIRC](../why-agentirc/).

--- a/docs/reference/server/architecture.md
+++ b/docs/reference/server/architecture.md
@@ -25,12 +25,27 @@ at the repo root.
    persisted state from disk.
 2. **Restore persistent rooms** — reads JSON files from
    `{data_dir}/rooms/`, recreates `Channel` objects with full metadata.
-3. **Initialize BotManager** — loads bot definitions from
-   `~/.culture/bots/`, creates VirtualClients.
-4. **Bind TCP socket** — `asyncio.start_server()` on
+3. **Bind TCP socket** — `asyncio.start_server()` on
    `config.host:config.port`.
-5. **Start webhook HTTP listener** — binds on `127.0.0.1:webhook_port`.
-   Non-fatal if port is unavailable.
+
+After `ircd.start()` returns, `culture/cli/server.py:_run_server` (the
+production entrypoint behind `culture server start`) attaches culture's
+`BotManager` to the running IRCd and calls `bot_manager.start()`:
+
+1. **Replace `ircd.bot_manager`** — agentirc 9.6 ships a no-op stub
+   `BotManager` so consumers can plug their own. Culture swaps in
+   `culture.bots.BotManager(ircd)`.
+2. **`bot_manager.start()`** — loads bot definitions from
+   `~/.culture/bots/`, registers system bots, then starts the webhook
+   HTTP listener on `127.0.0.1:webhook_port` (binds non-fatally — bots
+   still work without the HTTP endpoint if the port is unavailable).
+   agentirc 9.5+ stopped binding `webhook_port` itself; consumers
+   (culture) host the listener.
+
+Shutdown reverses the sequence: `bot_manager.stop()` (stops the listener
+and parts every bot) runs before `ircd.stop()`. Both are wrapped in a
+`try/finally` in `_run_server` so the IRCd socket is always closed even
+if bot teardown raises.
 
 ## Connection Routing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.9.0"
+version = "8.10.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0",
-    "agentirc-cli>=9.4,<10",
+    "agentirc-cli>=9.6,<10",
     "anthropic>=0.40",
     "claude-agent-sdk>=0.1",
     "mistune>=3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "agentirc-cli"
-version = "9.4.1"
+version = "9.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -26,9 +26,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/a2/8b634f282dee305914bc7981b9078e974807b2dfaa86cf703a34fed0f260/agentirc_cli-9.4.1.tar.gz", hash = "sha256:cee4f94485cd005c8db4a0314b40b090258b5f0a655b3407772ff0db9594495b", size = 203722, upload-time = "2026-05-01T16:07:52.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/60/94e25eae65659ce7046f2db98b9d05b328babc810ff8467c36f24f8a4e18/agentirc_cli-9.6.0.tar.gz", hash = "sha256:b3d29949233c0a767a329aff9866197aed7db52e1b7e3641e7a9e71ac97529b8", size = 262835, upload-time = "2026-05-02T20:56:11.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/b7/330842c7791663945658b1c42f4f63038e463f925c55cdc891d0374ec9dc/agentirc_cli-9.4.1-py3-none-any.whl", hash = "sha256:12c0db88541f30f443910b139bb897f06c99024f49cc3b0ded26c0bb2b1365c5", size = 92046, upload-time = "2026-05-01T16:07:53.473Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/decc7659ed19cfab7a37c8012339a07452650670fb59cce112961c02b5fa/agentirc_cli-9.6.0-py3-none-any.whl", hash = "sha256:86bcbde1f9cfd18000616ac8f6e39ff19e4b59de7716f5ff174b0a92c7caf02e", size = 108483, upload-time = "2026-05-02T20:56:09.812Z" },
 ]
 
 [[package]]
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.9.0"
+version = "8.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },
@@ -651,7 +651,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "afi-cli", specifier = ">=0.3,<1.0" },
-    { name = "agentirc-cli", specifier = ">=9.4,<10" },
+    { name = "agentirc-cli", specifier = ">=9.6,<10" },
     { name = "agex-cli", specifier = ">=0.13,<1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", specifier = ">=0.40" },


### PR DESCRIPTION
## Summary

Phase A2 of the agentirc extraction. Drops culture's bundled IRCd from the production path in favor of the public `agentirc.ircd.IRCd` and `agentirc.virtual_client.VirtualClient` classes shipped in `agentirc-cli 9.6.0` (closing [agentculture/agentirc#22](https://github.com/agentculture/agentirc/issues/22) via [PR #23](https://github.com/agentculture/agentirc/pull/23)).

- Switch `culture/cli/server.py:_run_server` to construct `agentirc.ircd.IRCd(config)` directly (in-process). The bundled IRCd in `culture/agentirc/` is orphaned in production but stays on disk for A3 to delete (still used by the test suite via `tests/conftest.py`).
- Rewrite `culture/bots/virtual_client.py` as a thin subclass over the public `agentirc.virtual_client.VirtualClient`. 231 LOC → 31 LOC; user-visible bot behavior (channel JOINs, `@`-mention notices, `send_dm`, `broadcast_to_channel`) unchanged.
- Move webhook listener (`webhook_port`) ownership from `culture/agentirc/ircd.py` to `culture/bots/bot_manager.py`. `BotManager` gains `start()` / `stop()` lifecycle methods that wrap bot loading + HttpListener bind/unbind. `_run_server` wraps the post-`ircd.start()` body in `try/finally` so `bot_manager.stop()` and `ircd.stop()` always run on shutdown.
- Retarget `Event` / `EventType` imports from `culture.agentirc.skill` to `agentirc.protocol` in the three sites that survive A3 (`culture/bots/virtual_client.py`, `culture/bots/bot.py`, `culture/telemetry/audit.py` TYPE_CHECKING).
- Bump dep floor `agentirc-cli>=9.4,<10` → `agentirc-cli>=9.6,<10`.
- Bump culture `8.9.0 → 8.10.0` (minor — additive, no public-API removal).

Net diff: 11 files, +177/-264 LOC.

## Why

Phase A2 of the agentirc extraction (spec: `docs/superpowers/specs/2026-04-30-agentirc-extraction-design.md`, plan: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a2.md`). Cross-repo coordination at agentirc#22 unblocked this by promoting `agentirc.ircd.IRCd` and `agentirc.virtual_client.VirtualClient` to public. Phase A3 (delete bundled IRCd, major bump 8.x → 9.0.0) follows next.

## Deviations from the canonical plan

- **Task 10 (test harness migration) deferred to A3.** The canonical plan calls for retargeting `tests/conftest.py` and the 10 bot test files from `culture.agentirc.ircd.IRCd` to `agentirc.ircd.IRCd`. Reality: the full test suite (1157 tests) passes unchanged because the bundled IRCd is structurally compatible with the public class (it's a fork). Migrating now is diff churn without behavioral risk reduction; A3's bundled-IRCd deletion forces the migration when it actually matters. The smoke test covers the production agentirc IRCd + culture BotManager path end-to-end.

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` — full suite green: **1157 passed** in 56.87s
- [x] All bot test files pass: `test_bots_integration.py`, `test_bot.py`, `test_http_listener.py`, `test_events_bot_trigger.py`, `test_events_bot_chain.py`, `test_bot_config_fires_event_toplevel.py`, `test_bot_config.py`, `test_bot_manager.py`, `test_welcome_bot.py`, `test_virtual_client.py`
- [x] Pre-commit hooks clean (black, isort, flake8, pylint, bandit, markdownlint-cli2)
- [x] `superpowers:code-reviewer` clean — 2 important findings addressed in the same commit (BotManager.start() crash-safety, _run_server shutdown try/finally)
- [x] `doc-test-alignment` findings addressed: `docs/reference/server/architecture.md` startup sequence updated, `docs/agentirc/architecture-overview.md` callout added noting the runtime ships from PyPI as of 8.10.0
- [x] Manual smoke: `culture server start --port 6700 --webhook-port 7681` boots `agentirc.ircd.IRCd`, raw socket gets `:smoke 001 smoke-probe :Welcome ...`, webhook `GET /health` returns `200 {"status": "ok"}`, bots load via culture's BotManager

## Out of scope (Phase A3 follow-up)

- Deletion of `culture/agentirc/{ircd,server_link,channel,events,room_store,thread_store,history_store,rooms_util,skill}.py`
- `git mv` of `client.py`/`remote_client.py` → `culture/transport/`
- Test harness migration (`tests/conftest.py` and bot tests onto `agentirc.ircd.IRCd`)
- Culture major bump 8.x → 9.0.0
- Plan: `docs/superpowers/plans/2026-05-02-agentirc-extraction-track-a3.md`

## Out of scope (separate PR)

- Pre-existing bot-load race surfaced by A2's smoke test — tracked at [#317](https://github.com/agentculture/culture/issues/317). The error log is misleading but bot behavior is unaffected; the race exists identically on the bundled IRCd path and was not introduced by A2.

- Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)