### PR TITLE
fix(cli): clearer messages and hints for `culture mesh update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.0.1] - 2026-05-05
+
+### Changed
+
+- **`culture mesh update` now streams uv/pip output** instead of capturing it. A long-running upgrade (e.g. fresh major-version install pulling in `claude-agent-sdk` ~73 MiB plus the OpenTelemetry stack) is no longer indistinguishable from a hang — uv's progress bars and download messages show through to the terminal in real time.
+- **Default upgrade timeout raised from 120s to 600s.** The old ceiling spuriously fired mid-download on slow links during major-version bumps even though the upgrade was making progress.
+
+### Added
+
+- **`culture mesh update --upgrade-timeout SECONDS`** flag to override the default 600s ceiling for sites with very slow or very fast networks.
+- **Expanded timeout hint.** When the upgrade does time out, the CLI now suggests three recovery paths instead of one: run `uv tool upgrade culture` (or `pip install --upgrade culture`) directly, rerun with a larger `--upgrade-timeout`, or `--skip-upgrade` to restart services without upgrading.
+
 ## [10.0.0] - 2026-05-05
 
 ### Changed (breaking)

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -408,13 +408,13 @@ def _run_upgrade(tool_name: str, cmd: list[str], timeout_seconds: int) -> None:
     """
     print(f"Upgrading via {tool_name}...")
     try:
-        result = subprocess.run(cmd, timeout=timeout_seconds)
+        result = subprocess.run(cmd, timeout=timeout_seconds, stdin=subprocess.DEVNULL)
     except subprocess.TimeoutExpired:
         print(_upgrade_timeout_hint(tool_name, timeout_seconds), file=sys.stderr)
         sys.exit(1)
     if result.returncode != 0:
         print(
-            f"{tool_name} upgrade failed (exit {result.returncode})",
+            f"{tool_name} upgrade failed (exit {result.returncode}): {' '.join(cmd)}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -88,9 +88,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         type=int,
         default=_UPGRADE_TIMEOUT_SECONDS,
         metavar="SECONDS",
-        help=(
-            f"Max seconds to wait for the package upgrade " f"(default: {_UPGRADE_TIMEOUT_SECONDS})"
-        ),
+        help=f"Max seconds to wait for the package upgrade (default: {_UPGRADE_TIMEOUT_SECONDS})",
     )
 
     # -- console (deprecated) --------------------------------------------------

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -83,6 +83,15 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         default=os.path.expanduser("~/.culture/mesh.yaml"),
         help="Path to mesh.yaml",
     )
+    update_parser.add_argument(
+        "--upgrade-timeout",
+        type=int,
+        default=_UPGRADE_TIMEOUT_SECONDS,
+        metavar="SECONDS",
+        help=(
+            f"Max seconds to wait for the package upgrade " f"(default: {_UPGRADE_TIMEOUT_SECONDS})"
+        ),
+    )
 
     # -- console (deprecated) --------------------------------------------------
     console_parser = mesh_sub.add_parser(
@@ -374,28 +383,42 @@ def _find_upgrade_tool() -> tuple[str, list[str]] | None:
     return None
 
 
-_UPGRADE_TIMEOUT_SECONDS = 120
+_UPGRADE_TIMEOUT_SECONDS = 600
 _FALLBACK_START_TIMEOUT_SECONDS = 30
 
 
-def _run_upgrade(tool_name: str, cmd: list[str]) -> None:
-    """Run the upgrade subprocess and exit on failure or timeout."""
+def _upgrade_timeout_hint(tool_name: str, timeout_seconds: int) -> str:
+    """Build the multi-line hint shown after an upgrade timeout."""
+    direct_cmd = "uv tool upgrade culture" if tool_name == "uv" else "pip install --upgrade culture"
+    return (
+        f"{tool_name} upgrade timed out after {timeout_seconds}s.\n"
+        "What to do:\n"
+        f"  - Run `{direct_cmd}` directly — large dependency downloads can\n"
+        "    exceed the default ceiling, and running it yourself shows progress.\n"
+        "  - Or rerun: `culture mesh update --upgrade-timeout 1800`\n"
+        "  - Or skip the upgrade and just restart services:\n"
+        "    `culture mesh update --skip-upgrade`"
+    )
+
+
+def _run_upgrade(tool_name: str, cmd: list[str], timeout_seconds: int) -> None:
+    """Run the upgrade subprocess and exit on failure or timeout.
+
+    Stdout/stderr inherit the parent terminal so uv/pip progress is visible
+    in real time — without that, a slow download is indistinguishable from
+    a hang (see culture mesh update timeout hint).
+    """
     print(f"Upgrading via {tool_name}...")
     try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=_UPGRADE_TIMEOUT_SECONDS
-        )
+        result = subprocess.run(cmd, timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
+        print(_upgrade_timeout_hint(tool_name, timeout_seconds), file=sys.stderr)
+        sys.exit(1)
+    if result.returncode != 0:
         print(
-            f"{tool_name} upgrade timed out after {_UPGRADE_TIMEOUT_SECONDS}s — "
-            "rerun with --skip-upgrade to proceed without upgrading",
+            f"{tool_name} upgrade failed (exit {result.returncode})",
             file=sys.stderr,
         )
-        sys.exit(1)
-    if tool_name == "uv":
-        print(result.stdout.strip() if result.stdout else "")
-    if result.returncode != 0:
-        print(f"{tool_name} upgrade failed: {result.stderr}", file=sys.stderr)
         sys.exit(1)
 
 
@@ -414,10 +437,19 @@ def _upgrade_culture_package(args: argparse.Namespace) -> bool:
         print("Neither uv nor pip found", file=sys.stderr)
         sys.exit(1)
 
-    _run_upgrade(*tool)
+    _run_upgrade(*tool, timeout_seconds=args.upgrade_timeout)
 
     culture_bin = shutil.which("culture") or "culture"
-    reexec_args = [culture_bin, "mesh", "update", "--skip-upgrade", "--config", args.config]
+    reexec_args = [
+        culture_bin,
+        "mesh",
+        "update",
+        "--skip-upgrade",
+        "--config",
+        args.config,
+        "--upgrade-timeout",
+        str(args.upgrade_timeout),
+    ]
     print("Re-executing with updated code...")
     if sys.platform == "win32":
         sys.exit(subprocess.run(reexec_args).returncode)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -386,20 +386,32 @@ Upgrade the `culture` package and restart all running servers.
 culture mesh update                          # upgrade package + restart everything
 culture mesh update --dry-run                # preview steps without executing
 culture mesh update --skip-upgrade           # restart only, skip package upgrade
+culture mesh update --upgrade-timeout 1800   # allow up to 30 min for the upgrade
 culture mesh update --config /path/mesh.yaml
 ```
+
+uv/pip output streams to your terminal in real time, so the package upgrade
+shows download progress as it happens — a long-running upgrade is no longer
+indistinguishable from a hang.
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--dry-run` | off | Print each step without executing it |
 | `--skip-upgrade` | off | Skip the package upgrade step; just restart services |
+| `--upgrade-timeout SECONDS` | `600` | Max wait for the package upgrade step |
 | `--config PATH` | `~/.culture/mesh.yaml` | Path to `mesh.yaml` |
 
 Subprocess steps are bounded so a hung service unit cannot freeze the CLI: the
-package upgrade times out after 120s and aborts the command, while each
-service-restart command times out after 30s and the fallback
-`culture server start` step times out after 30s. Restart and fallback
-timeouts are reported on stderr, and the next step proceeds where applicable.
+package upgrade times out after `--upgrade-timeout` seconds (default 600) and
+aborts the command, while each service-restart command times out after 30s and
+the fallback `culture server start` step times out after 30s. Restart and
+fallback timeouts are reported on stderr, and the next step proceeds where
+applicable.
+
+When the package upgrade times out, the hint suggests three recovery paths:
+running `uv tool upgrade culture` (or `pip install --upgrade culture`)
+directly, rerunning with a larger `--upgrade-timeout`, or `--skip-upgrade` to
+restart services on the currently installed version.
 
 ## Bots
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.0.0"
+version = "10.0.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_setup_update_cli.py
+++ b/tests/test_setup_update_cli.py
@@ -1,6 +1,7 @@
 # tests/test_setup_update_cli.py
 """Lightweight parser tests for setup and update subcommands."""
 
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -22,16 +23,26 @@ def test_setup_parser():
 
 
 def test_update_parser():
-    """update subcommand parses --dry-run, --skip-upgrade, --config."""
+    """update subcommand parses --dry-run, --skip-upgrade, --config, --upgrade-timeout."""
     p = _build_parser()
     args = p.parse_args(["mesh", "update", "--dry-run", "--skip-upgrade"])
     assert args.command == "mesh"
     assert args.mesh_command == "update"
     assert args.dry_run is True
     assert args.skip_upgrade is True
+    # default upgrade-timeout matches the constant in culture.cli.mesh
+    from culture.cli.mesh import _UPGRADE_TIMEOUT_SECONDS
+
+    assert args.upgrade_timeout == _UPGRADE_TIMEOUT_SECONDS
+    assert (
+        _UPGRADE_TIMEOUT_SECONDS >= 300
+    ), "default must be high enough to absorb a fresh major-version install"
 
     args = p.parse_args(["mesh", "update", "--config", "/tmp/mesh.yaml"])
     assert args.config == "/tmp/mesh.yaml"
+
+    args = p.parse_args(["mesh", "update", "--upgrade-timeout", "900"])
+    assert args.upgrade_timeout == 900
 
 
 def test_setup_in_dispatch():
@@ -120,6 +131,66 @@ def test_update_skips_server_without_config(
 
     mock_restart.assert_not_called()
     assert "no config found" in capsys.readouterr().err
+
+
+# ---- _run_upgrade tests ----
+
+
+def test_run_upgrade_streams_output():
+    """_run_upgrade must NOT capture output — uv/pip progress has to reach the terminal.
+
+    Capturing output is what made the bare 'culture mesh update' look like a
+    hang on slow links: the 73 MiB claude-agent-sdk download is silent for
+    ~2 minutes when stdout/stderr are swallowed. Guard against a regression.
+    """
+    from culture.cli.mesh import _run_upgrade
+
+    with patch(f"{_MESH_MOD}.subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        _run_upgrade("uv", ["uv", "tool", "upgrade", "culture"], timeout_seconds=600)
+
+    assert mock_run.call_count == 1
+    _args, kwargs = mock_run.call_args
+    assert (
+        "capture_output" not in kwargs
+    ), "subprocess.run must inherit stdout/stderr so progress is visible"
+    assert kwargs.get("timeout") == 600
+
+
+def test_run_upgrade_timeout_message_has_three_hints(capsys):
+    """On timeout, the hint must offer all three recovery paths.
+
+    Listing only --skip-upgrade leaves a user who genuinely wants the new
+    version with no path forward. The hint must also point at running uv/pip
+    directly and at extending the timeout.
+    """
+    from culture.cli.mesh import _run_upgrade
+
+    with patch(f"{_MESH_MOD}.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="uv", timeout=5)
+        with pytest.raises(SystemExit) as exc_info:
+            _run_upgrade("uv", ["uv", "tool", "upgrade", "culture"], timeout_seconds=5)
+
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "uv tool upgrade culture" in err  # direct-tool suggestion
+    assert "--upgrade-timeout" in err  # extend-timeout suggestion
+    assert "--skip-upgrade" in err  # skip suggestion
+    assert "timed out after 5s" in err
+
+
+def test_run_upgrade_timeout_message_uses_pip_when_pip_selected(capsys):
+    """The direct-tool hint should match whichever upgrader was picked."""
+    from culture.cli.mesh import _run_upgrade
+
+    with patch(f"{_MESH_MOD}.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="pip", timeout=5)
+        with pytest.raises(SystemExit):
+            _run_upgrade("pip", ["pip", "install", "--upgrade", "culture"], timeout_seconds=5)
+
+    err = capsys.readouterr().err
+    assert "pip install --upgrade culture" in err
+    assert "uv tool upgrade culture" not in err
 
 
 # ---- _resolve_mesh_for_server tests ----

--- a/tests/test_setup_update_cli.py
+++ b/tests/test_setup_update_cli.py
@@ -155,6 +155,9 @@ def test_run_upgrade_streams_output():
         "capture_output" not in kwargs
     ), "subprocess.run must inherit stdout/stderr so progress is visible"
     assert kwargs.get("timeout") == 600
+    # stdin=DEVNULL guards against the upgrader hanging on an interactive prompt
+    # (e.g., pip dependency-resolution confirmations) when run non-interactively.
+    assert kwargs.get("stdin") == subprocess.DEVNULL
 
 
 def test_run_upgrade_timeout_message_has_three_hints(capsys):

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.0.0"
+version = "10.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Stream uv/pip output instead of capturing it — `culture mesh update` no longer looks like a hang on slow links; uv's download progress shows through to the terminal in real time.
- Raise the default upgrade timeout from 120s to 600s and add `--upgrade-timeout SECONDS` to override it. The old 120s ceiling spuriously fired mid-download on fresh major-version installs (e.g. 8.1.0 → 9.0.0 pulling in `claude-agent-sdk` ~73 MiB plus the OpenTelemetry stack) even though the upgrade was still making progress.
- Replace the one-line timeout hint with three recovery paths: run `uv tool upgrade culture` (or `pip install --upgrade culture`) directly, rerun with a larger `--upgrade-timeout`, or `--skip-upgrade` to restart on the current version. The previous hint only mentioned `--skip-upgrade`, which left users who actually wanted the new version with no path forward.

## Why

Hit live during an `8.1.0 → 9.0.0` upgrade: ~3 minutes of silence followed by `uv upgrade timed out after 120s — rerun with --skip-upgrade`. Two problems in one — the silence (output captured) and the spurious timeout (ceiling too low for a fresh major-version install on a residential link). The hint then pointed only at the option that *avoids* the upgrade.

## What changed

| Area | Change |
|------|--------|
| `culture/cli/mesh.py` | `_run_upgrade` no longer passes `capture_output=True`; new `_upgrade_timeout_hint` helper; `--upgrade-timeout` plumbed through the re-exec |
| `tests/test_setup_update_cli.py` | Parser default + override, `_run_upgrade` doesn't capture, hint contains all three suggestions, hint adapts to uv vs pip |
| `docs/reference/cli/index.md` | New flag in table + paragraph on streaming + paragraph on the recovery hint |
| `CHANGELOG.md` + `pyproject.toml` + `uv.lock` | Patch bump to `9.0.1` |

## Test plan

- [x] `pytest tests/test_setup_update_cli.py -v` — 12/12 green (3 new tests: streams output, three-hints message, pip variant)
- [x] `pytest -n auto` — full suite 979/979 green
- [x] `markdownlint-cli2` clean on both modified docs
- [x] Pre-commit hooks (black/isort/flake8/pylint/bandit/markdownlint) all pass
- [x] `culture mesh update --help` shows the new flag with the 600s default
- [x] `_upgrade_timeout_hint('uv', 5)` and `_upgrade_timeout_hint('pip', 600)` render correctly
- [ ] Manual smoke on a real upgrade: `uv tool install 'culture==9.0.0'` then `culture mesh update` — verify progress streams and 600s is enough
- [ ] SonarCloud green via `/sonarclaude` before declaring ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)