### PR TITLE
feat(cli): culture console — irc-lens passthrough; deprecate culture mesh console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [9.1.0] - Unreleased
+## [9.1.0] - 2026-05-05
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [9.1.0] - Unreleased
+
+### Added
+
+- **`culture console`** — top-level passthrough wrapper around [`irc-lens`](https://github.com/agentculture/irc-lens), the reactive web console for AgentIRC. `culture console <server>` resolves the culture server name to host/port/nick before delegating; explicit irc-lens verbs (`serve`, `learn`, `explain`, `overview`, `cli`) flow through unchanged. Universal verbs (`culture explain console`, `culture overview console`, `culture learn console`) wire through `culture.cli._passthrough.register_topic`. Spec: `docs/superpowers/specs/2026-05-05-culture-console-design.md`. Subprocess-vs-in-process tradeoff tracked in [#322](https://github.com/agentculture/culture/issues/322).
+
+### Deprecated
+
+- **`culture mesh console`** — emits a stderr warning and forwards to `culture console`. Removal target: 10.0.
+- **`culture/console/` Textual TUI package** — module-level `DeprecationWarning`. Removal target: 10.0.
+
 ## [9.0.0] - 2026-05-04
 
 ### Changed (breaking)

--- a/culture/cli/CLAUDE.md
+++ b/culture/cli/CLAUDE.md
@@ -14,7 +14,8 @@ cli/
 ├── agent.py             # culture agent {create,join,start,stop,status,rename,...}
 ├── chat.py              # culture chat {start,stop,status,default,rename,archive,...,restart,link,logs,version,serve}
 ├── server.py            # culture server — deprecation alias for `culture chat` (9.x; removed in 10.0)
-├── mesh.py              # culture mesh {overview,setup,update,console}
+├── mesh.py              # culture mesh {overview,setup,update}  (console deprecated → culture console)
+├── console.py           # culture console — irc-lens passthrough (reactive web console)
 ├── channel.py           # culture channel {list,read,message,who,join,part,ask,...}
 ├── bot.py               # culture bot {create,start,stop,list,inspect,archive,...}
 ├── skills.py            # culture skills {install}

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -3,7 +3,8 @@
 Commands are organized into noun-based groups:
     culture agent    {create,join,start,stop,status,rename,assign,sleep,wake,learn,message,read,archive,unarchive,delete}
     culture chat     {start,stop,status,default,rename,archive,unarchive,restart,link,logs,version,serve}
-    culture mesh     {overview,setup,update,console}
+    culture console  {...irc-lens verbs and flags...}    # passthrough; reactive web console
+    culture mesh     {overview,setup,update,console}     # `console` here is deprecated; use `culture console`
     culture channel  {list,read,message,who}
 
     Deprecated (9.x; removed in 10.0):
@@ -26,9 +27,21 @@ import logging
 import sys
 
 from culture import __version__
-from culture.cli import afi, agent, bot, channel, chat, devex, introspect, mesh, server, skills
+from culture.cli import (
+    afi,
+    agent,
+    bot,
+    channel,
+    chat,
+    console,
+    devex,
+    introspect,
+    mesh,
+    server,
+    skills,
+)
 
-GROUPS = [agent, chat, server, mesh, channel, bot, skills, devex, afi, introspect]
+GROUPS = [agent, chat, server, mesh, channel, bot, skills, devex, afi, console, introspect]
 
 
 def _names_of(group) -> set[str]:

--- a/culture/cli/console.py
+++ b/culture/cli/console.py
@@ -1,0 +1,125 @@
+"""`culture console` — passthrough to the standalone irc-lens CLI.
+
+irc-lens (https://github.com/agentculture/irc-lens) is the
+agent-driven web console for AgentIRC: a localhost aiohttp + HTMX +
+SSE app implementing the same console as a browser-driveable surface.
+Culture embeds it as a first-class namespace so the culture CLI exposes
+the lens with culture-aware ergonomics:
+
+    culture console <server_name>     -> resolves to host/port/nick
+    culture console serve --host ...  -> pure passthrough
+    culture console explain           -> irc-lens explain (passthrough)
+
+The full design lives in
+``docs/superpowers/specs/2026-05-05-culture-console-design.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from culture.cli import _passthrough
+from culture.cli.shared.console_helpers import resolve_console_nick as _resolve_console_nick
+from culture.cli.shared.console_helpers import resolve_server as _resolve_server
+
+NAME = "console"
+
+# Top-level subcommands of irc-lens, verified by `irc-lens --help`.
+# Anything in this set means the user typed an irc-lens command directly,
+# so the shim must NOT rewrite — pure passthrough.
+_IRC_LENS_VERBS = frozenset({"learn", "explain", "overview", "serve", "cli"})
+
+
+def _entry(argv: list[str]) -> "int | None":
+    """In-process call into ``irc_lens.cli.main(argv)``.
+
+    irc-lens's ``main`` returns an ``int`` on normal completion and
+    raises ``SystemExit`` only for argparse-level exits — the same
+    contract afi-cli implements. Both paths are handled by
+    :mod:`culture.cli._passthrough`.
+    """
+    try:
+        from irc_lens.cli import main
+    except ImportError as exc:  # pragma: no cover — declared dep
+        print(f"irc-lens is not installed: {exc}", file=sys.stderr)
+        sys.exit(2)
+    return main(argv)
+
+
+def _resolve_argv(argv: list[str]) -> list[str]:
+    """Translate ``culture console`` argv into ``irc-lens`` argv.
+
+    - Empty argv -> resolve default culture server, build a ``serve`` call.
+    - First token is an irc-lens verb or starts with ``-`` -> pure
+      passthrough (return argv unchanged).
+    - Otherwise -> treat first token as a culture server name; rewrite to
+      ``["serve", "--host", h, "--port", p, "--nick", n, *rest]``.
+
+    Raises ``SystemExit`` with a culture-friendly message when the
+    server-name path is taken but no culture servers are running.
+    """
+    if not argv:
+        return _build_serve_argv(server_name=None, rest=[])
+    head = argv[0]
+    if head in _IRC_LENS_VERBS or head.startswith("-"):
+        return list(argv)
+    return _build_serve_argv(server_name=head, rest=list(argv[1:]))
+
+
+def _build_serve_argv(server_name: str | None, rest: list[str]) -> list[str]:
+    result = _resolve_server(server_name)
+    if result is None:
+        raise SystemExit("No culture servers running. Start one with: culture chat start")
+    name, port = result
+    nick = f"{name}-{_resolve_console_nick()}"
+    return [
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--nick",
+        nick,
+        *rest,
+    ]
+
+
+def dispatch_resolved_argv(server_name: str | None) -> None:
+    """Used by the legacy ``culture mesh console`` deprecation alias.
+
+    Mirrors the old TUI's invocation surface: just a server name (or
+    ``None`` for the default).
+    """
+    argv = _resolve_argv([server_name] if server_name else [])
+    _passthrough.run(_entry, argv)
+
+
+_passthrough.register_topic(
+    "console",
+    _entry,
+    explain_argv=["explain"],
+    overview_argv=["overview"],
+    learn_argv=["learn"],
+)
+
+
+# --- CLI group protocol ---------------------------------------------------
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    # prefix_chars=chr(0): every token (including --help, --version) is
+    # treated as positional and captured in console_args for the shim
+    # + irc-lens's argparse parser to handle.
+    p = subparsers.add_parser(
+        NAME,
+        help="Open the irc-lens web console (passthrough)",
+        add_help=False,
+        prefix_chars=chr(0),
+    )
+    p.add_argument("console_args", nargs=argparse.REMAINDER, help="Arguments passed to irc-lens")
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    raw = list(getattr(args, "console_args", []) or [])
+    _passthrough.run(_entry, _resolve_argv(raw))

--- a/culture/cli/console.py
+++ b/culture/cli/console.py
@@ -28,7 +28,9 @@ NAME = "console"
 # Top-level subcommands of irc-lens, verified by `irc-lens --help`.
 # Anything in this set means the user typed an irc-lens command directly,
 # so the shim must NOT rewrite — pure passthrough.
-_IRC_LENS_VERBS = frozenset({"learn", "explain", "overview", "serve", "cli"})
+# `help` is included so a bare `culture console help` is treated as a
+# request for help rather than a server name (common typo for `--help`).
+_IRC_LENS_VERBS = frozenset({"learn", "explain", "overview", "serve", "cli", "help"})
 
 
 def _entry(argv: list[str]) -> "int | None":
@@ -61,7 +63,16 @@ def _resolve_argv(argv: list[str]) -> list[str]:
     """
     if not argv:
         return _build_serve_argv(server_name=None, rest=[])
+    # Strip a leading `--` separator (common shell habit to disambiguate
+    # passthrough args). Without this, argparse REMAINDER chokes on `--`.
+    if argv[0] == "--":
+        argv = argv[1:]
+        if not argv:
+            return _build_serve_argv(server_name=None, rest=[])
     head = argv[0]
+    if head == "help":
+        # `help` is irc-lens-flavoured shorthand for `--help`.
+        return ["--help"]
     if head in _IRC_LENS_VERBS or head.startswith("-"):
         return list(argv)
     return _build_serve_argv(server_name=head, rest=list(argv[1:]))
@@ -70,7 +81,12 @@ def _resolve_argv(argv: list[str]) -> list[str]:
 def _build_serve_argv(server_name: str | None, rest: list[str]) -> list[str]:
     result = _resolve_server(server_name)
     if result is None:
-        raise SystemExit("No culture servers running. Start one with: culture chat start")
+        if server_name is None:
+            raise SystemExit("No culture servers running. Start one with: culture server start")
+        raise SystemExit(
+            f"No culture server named {server_name!r}. "
+            f"Run `culture server status` to see what's running."
+        )
     name, port = result
     nick = f"{name}-{_resolve_console_nick()}"
     return [

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -1,4 +1,8 @@
-"""Mesh subcommands: culture mesh {overview,setup,update,console}."""
+"""Mesh subcommands: culture mesh {overview,setup,update,console}.
+
+`console` is a deprecation alias forwarding to `culture console`
+(see culture.cli.console). Removal target: 10.0.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +15,7 @@ import subprocess
 import sys
 import time
 
+from culture.cli.console import dispatch_resolved_argv as console_dispatch
 from culture.config import ServerConfig, load_config, load_config_or_default
 
 from .shared.console_helpers import resolve_console_nick as _resolve_console_nick
@@ -25,9 +30,7 @@ NAME = "mesh"
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
-    mesh_parser = subparsers.add_parser(
-        "mesh", help="Mesh operations (overview, setup, update, console)"
-    )
+    mesh_parser = subparsers.add_parser("mesh", help="Mesh operations (overview, setup, update)")
     mesh_sub = mesh_parser.add_subparsers(dest="mesh_command")
 
     # -- overview -------------------------------------------------------------
@@ -83,8 +86,11 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Path to mesh.yaml",
     )
 
-    # -- console --------------------------------------------------------------
-    console_parser = mesh_sub.add_parser("console", help="Interactive admin console")
+    # -- console (deprecated) --------------------------------------------------
+    console_parser = mesh_sub.add_parser(
+        "console",
+        help="Interactive admin console (DEPRECATED: use 'culture console')",
+    )
     console_parser.add_argument(
         "server_name",
         nargs="?",
@@ -204,29 +210,15 @@ def _cmd_overview(args: argparse.Namespace) -> None:
 
 
 def _cmd_console(args: argparse.Namespace) -> None:
-    """Launch the interactive console TUI."""
-    result = _resolve_server(args.server_name)
-    if result is None:
-        print("No culture servers running. Start one with: culture chat start")
-        return
+    """Deprecated: forward to `culture console`.
 
-    server_name, port = result
-    host = "127.0.0.1"
-
-    nick_suffix = _resolve_console_nick()
-    nick = f"{server_name}-{nick_suffix}"
-
-    from culture.console.app import ConsoleApp
-    from culture.console.client import ConsoleIRCClient
-
-    client = ConsoleIRCClient(host=host, port=port, nick=nick, mode="HC")
-
-    async def run():
-        await client.connect()
-        app = ConsoleApp(irc_client=client, server_name=server_name)
-        await app.run_async()
-
-    asyncio.run(run())
+    Kept for one minor cycle as an alias. Removal target: 10.0.
+    """
+    print(
+        "warning: 'culture mesh console' is deprecated; use 'culture console' instead",
+        file=sys.stderr,
+    )
+    console_dispatch(args.server_name)
 
 
 # -----------------------------------------------------------------------

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -18,8 +18,6 @@ import time
 from culture.cli.console import dispatch_resolved_argv as console_dispatch
 from culture.config import ServerConfig, load_config, load_config_or_default
 
-from .shared.console_helpers import resolve_console_nick as _resolve_console_nick
-from .shared.console_helpers import resolve_server as _resolve_server
 from .shared.constants import _CONFIG_HELP, AGENTS_YAML, CULTURE_DIR, DEFAULT_CONFIG
 from .shared.mesh import build_server_start_cmd, generate_mesh_from_agents
 from .shared.process import server_stop_by_name, stop_agent

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -13,6 +13,8 @@ import time
 
 from culture.config import ServerConfig, load_config, load_config_or_default
 
+from .shared.console_helpers import resolve_console_nick as _resolve_console_nick
+from .shared.console_helpers import resolve_server as _resolve_server
 from .shared.constants import _CONFIG_HELP, AGENTS_YAML, CULTURE_DIR, DEFAULT_CONFIG
 from .shared.mesh import build_server_start_cmd, generate_mesh_from_agents
 from .shared.process import server_stop_by_name, stop_agent
@@ -197,58 +199,8 @@ def _cmd_overview(args: argparse.Namespace) -> None:
 
 
 # -----------------------------------------------------------------------
-# Console
+# Console (helpers imported at top from culture.cli.shared.console_helpers)
 # -----------------------------------------------------------------------
-
-
-def _resolve_server(server_name: str | None) -> tuple[str, int] | None:
-    """Resolve server name and port from running servers."""
-    from culture.pidfile import list_servers, read_default_server, read_port
-
-    if server_name:
-        p = read_port(server_name)
-        port = p if p else 6667
-        return server_name, port
-
-    servers = list_servers()
-    if not servers:
-        return None
-
-    if len(servers) == 1:
-        return servers[0]["name"], servers[0]["port"]
-
-    default = read_default_server()
-    if default:
-        match = [s for s in servers if s["name"] == default]
-        if match:
-            return match[0]["name"], match[0]["port"]
-
-    return servers[0]["name"], servers[0]["port"]
-
-
-def _resolve_console_nick() -> str:
-    """Resolve the human nick: git username -> OS user -> config override."""
-    import re
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["git", "config", "user.name"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            name = result.stdout.strip().lower()
-            name = re.sub(r"[^a-z0-9-]", "", name.replace(" ", "-"))
-            if name:
-                return name
-    except (subprocess.SubprocessError, FileNotFoundError):
-        pass
-
-    import os
-
-    return os.environ.get("USER", "human")
 
 
 def _cmd_console(args: argparse.Namespace) -> None:

--- a/culture/cli/shared/console_helpers.py
+++ b/culture/cli/shared/console_helpers.py
@@ -1,0 +1,61 @@
+"""Shared helpers for resolving culture servers and console nicks.
+
+Extracted from ``culture.cli.mesh`` so both the new ``culture console``
+group and the legacy ``culture mesh console`` deprecation alias can
+reuse them without circular imports.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+from culture.pidfile import list_servers, read_default_server, read_port
+
+
+def resolve_server(server_name: str | None) -> tuple[str, int] | None:
+    """Resolve a culture server name (or default) to ``(name, port)``.
+
+    Returns ``None`` when no culture servers are running.
+    """
+    if server_name:
+        p = read_port(server_name)
+        port = p if p else 6667
+        return server_name, port
+
+    servers = list_servers()
+    if not servers:
+        return None
+
+    if len(servers) == 1:
+        return servers[0]["name"], servers[0]["port"]
+
+    default = read_default_server()
+    if default:
+        match = [s for s in servers if s["name"] == default]
+        if match:
+            return match[0]["name"], match[0]["port"]
+
+    return servers[0]["name"], servers[0]["port"]
+
+
+def resolve_console_nick() -> str:
+    """Resolve the human nick: git user.name -> OS USER -> 'human'."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.name"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            name = result.stdout.strip().lower()
+            name = re.sub(r"[^a-z0-9-]", "", name.replace(" ", "-"))
+            if name:
+                return name
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    return os.environ.get("USER", "human")

--- a/culture/cli/shared/console_helpers.py
+++ b/culture/cli/shared/console_helpers.py
@@ -26,7 +26,11 @@ def resolve_server(server_name: str | None) -> tuple[str, int] | None:
     silent.
     """
     if server_name:
-        p = read_port(server_name)
+        # pid/port files are keyed `server-<name>` (matches culture.cli.chat
+        # in `pid_name = f"server-{args.name}"`). Looking up bare `<name>`
+        # would always miss and silently fall back, sending users to the
+        # wrong port — see qodo review on PR #323.
+        p = read_port(f"server-{server_name}")
         if p is None:
             return None
         return server_name, p

--- a/culture/cli/shared/console_helpers.py
+++ b/culture/cli/shared/console_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 
 from culture.pidfile import list_servers, read_default_server, read_port
 
@@ -17,12 +18,18 @@ from culture.pidfile import list_servers, read_default_server, read_port
 def resolve_server(server_name: str | None) -> tuple[str, int] | None:
     """Resolve a culture server name (or default) to ``(name, port)``.
 
-    Returns ``None`` when no culture servers are running.
+    Returns ``None`` when no culture servers are running, or when an
+    explicitly-named server isn't in the running set.
+
+    When multiple servers are running and no default is configured,
+    picks the first one and emits a stderr hint so the choice isn't
+    silent.
     """
     if server_name:
         p = read_port(server_name)
-        port = p if p else 6667
-        return server_name, port
+        if p is None:
+            return None
+        return server_name, p
 
     servers = list_servers()
     if not servers:
@@ -37,7 +44,14 @@ def resolve_server(server_name: str | None) -> tuple[str, int] | None:
         if match:
             return match[0]["name"], match[0]["port"]
 
-    return servers[0]["name"], servers[0]["port"]
+    pick = servers[0]
+    others = ", ".join(s["name"] for s in servers[1:])
+    print(
+        f"hint: no default server set; using {pick['name']!r} "
+        f"(others running: {others}; set with `culture server default <name>`)",
+        file=sys.stderr,
+    )
+    return pick["name"], pick["port"]
 
 
 def resolve_console_nick() -> str:

--- a/culture/console/__init__.py
+++ b/culture/console/__init__.py
@@ -1,1 +1,19 @@
-"""Console TUI for culture mesh administration."""
+"""Textual TUI for the Culture agent mesh — DEPRECATED.
+
+Replaced by ``irc-lens`` exposed via ``culture console``. This package
+is left in place for one minor cycle so out-of-tree importers can
+migrate; it will be removed in 10.0.
+
+See ``docs/superpowers/specs/2026-05-05-culture-console-design.md``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "culture/console/ Textual TUI is deprecated and will be removed in "
+    "10.0; replaced by irc-lens via 'culture console'",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/culture/learn_prompt.py
+++ b/culture/learn_prompt.py
@@ -198,7 +198,7 @@ culture bot unarchive my-bot
 culture mesh overview                      # full mesh snapshot
 culture mesh overview --room "#general"    # drill down into a room
 culture mesh overview --agent {nick_display}  # drill down into an agent
-culture mesh console                       # interactive admin console
+culture console                            # reactive web console (irc-lens)
 ```
 
 ## How to Create a Skill That Uses Culture

--- a/culture/skills/culture/SKILL.md
+++ b/culture/skills/culture/SKILL.md
@@ -341,8 +341,15 @@ culture mesh overview --agent spark-claude   # drill down into one agent
 ### Console
 
 ```bash
-culture mesh console                         # interactive admin console
+culture console                              # reactive web console (irc-lens)
+culture console <server>                     # connect to a named culture server
+culture console --open                       # also auto-open in browser
 ```
+
+`culture console` is a passthrough to [`irc-lens`](https://github.com/agentculture/irc-lens),
+the agent-driveable web console for AgentIRC. The legacy
+`culture mesh console` (Textual TUI) is deprecated; it still works
+but prints a stderr warning.
 
 ## Quick Reference
 
@@ -364,7 +371,7 @@ culture mesh console                         # interactive admin console
 | Create bot | `culture bot create my-bot --trigger webhook` |
 | List bots | `culture bot list` (or `--all` for archived) |
 | Mesh overview | `culture mesh overview` |
-| Mesh console | `culture mesh console` |
+| Web console | `culture console` |
 | Install skills | `culture skills install claude` |
 | Learn prompt | `culture agent learn` |
 | Server logs | `~/.culture/logs/server-<name>.log` |

--- a/docs/superpowers/plans/2026-05-05-culture-console.md
+++ b/docs/superpowers/plans/2026-05-05-culture-console.md
@@ -1,0 +1,1318 @@
+# `culture console` — irc-lens passthrough — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `culture mesh console` (Textual TUI) with a top-level `culture console` group that wraps `irc-lens` via the in-process passthrough pattern, with a one-cycle deprecation alias for the old command.
+
+**Architecture:** Mirror `culture/cli/afi.py` byte-for-byte (irc-lens already exposes `main(argv) -> int`, same as afi). Add one culture-owned shim `_resolve_argv()` that translates `culture console <server_name>` into `["serve", "--host", h, "--port", p, "--nick", n]` before passthrough; everything else flows through to `irc_lens.cli.main(argv)` unchanged. Universal verbs (`explain`/`overview`/`learn`) wired via `_passthrough.register_topic`.
+
+**Tech Stack:** Python 3.11+, argparse, irc-lens >=0.4.2, pytest, pytest-playwright (opt-in marker).
+
+**Spec:** `docs/superpowers/specs/2026-05-05-culture-console-design.md`
+**Tracking issue:** [agentculture/culture#322](https://github.com/agentculture/culture/issues/322) (subprocess-vs-in-process deferred decision)
+
+---
+
+## File Plan
+
+| File | Responsibility |
+|---|---|
+| `culture/cli/shared/console_helpers.py` | **NEW.** Houses `resolve_server()` and `resolve_console_nick()` extracted from `mesh.py`. Pure functions, no argparse dependency. |
+| `culture/cli/console.py` | **NEW.** Top-level `console` group. Mirrors `afi.py`. Adds `_resolve_argv()` shim + `dispatch_resolved_argv()` helper used by both the new group and the legacy mesh alias. |
+| `culture/cli/__init__.py` | Register the new group in `GROUPS`; update the docstring noun-table. |
+| `culture/cli/mesh.py` | `_cmd_console` becomes a stderr-deprecation alias forwarding to `culture.cli.console.dispatch_resolved_argv`. Remove Textual import. Tag the subparser help. |
+| `culture/console/__init__.py` | Module-level `DeprecationWarning` + docstring note. Code untouched. |
+| `pyproject.toml` | Add `"irc-lens>=0.4.2"` to dependencies. |
+| `culture/skills/culture/SKILL.md` (lines 344, 367) | Replace `culture mesh console` with `culture console`. |
+| `culture/learn_prompt.py` (line 201) | Same replacement. |
+| `culture/cli/CLAUDE.md` (line 17) | Update architecture comment. |
+| `CHANGELOG.md` | New entry under unreleased / next-version section. |
+| `tests/test_cli_console_argv.py` | **NEW.** Unit table for `_resolve_argv` and `_build_serve_argv`. |
+| `tests/test_cli_console.py` | **NEW.** Subprocess-driven smoke tests mirroring `test_cli_devex.py` / `test_cli_afi.py`. |
+| `tests/test_cli_console_deprecation.py` | **NEW.** Verifies `culture mesh console` emits deprecation warning + same exit code. |
+| `tests/test_cli_console_playwright.py` | **NEW.** Opt-in browser e2e (gated by `@pytest.mark.playwright`). |
+
+---
+
+## Task 1: Extract helpers to `culture/cli/shared/console_helpers.py`
+
+**Files:**
+- Create: `culture/cli/shared/console_helpers.py`
+- Modify: `culture/cli/mesh.py:204-251` (remove `_resolve_server` and `_resolve_console_nick` definitions; import from new module instead)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_cli_shared_console_helpers.py`:
+
+```python
+"""Tests for the shared console helpers extracted from culture.cli.mesh."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from culture.cli.shared.console_helpers import resolve_console_nick, resolve_server
+
+
+def test_resolve_server_returns_none_when_no_servers():
+    with patch("culture.cli.shared.console_helpers.list_servers", return_value=[]):
+        assert resolve_server(None) is None
+
+
+def test_resolve_server_named_with_known_port():
+    with patch("culture.cli.shared.console_helpers.read_port", return_value=7000):
+        assert resolve_server("spark") == ("spark", 7000)
+
+
+def test_resolve_server_named_falls_back_to_default_port():
+    with patch("culture.cli.shared.console_helpers.read_port", return_value=None):
+        assert resolve_server("spark") == ("spark", 6667)
+
+
+def test_resolve_server_single_server_picks_it():
+    with patch(
+        "culture.cli.shared.console_helpers.list_servers",
+        return_value=[{"name": "only", "port": 6700}],
+    ):
+        assert resolve_server(None) == ("only", 6700)
+
+
+def test_resolve_server_default_match_wins():
+    servers = [
+        {"name": "a", "port": 6700},
+        {"name": "b", "port": 6701},
+    ]
+    with (
+        patch("culture.cli.shared.console_helpers.list_servers", return_value=servers),
+        patch("culture.cli.shared.console_helpers.read_default_server", return_value="b"),
+    ):
+        assert resolve_server(None) == ("b", 6701)
+
+
+def test_resolve_console_nick_uses_user_env_when_git_fails():
+    fake_run = type("R", (), {"returncode": 1, "stdout": ""})()
+    with (
+        patch("culture.cli.shared.console_helpers.subprocess.run", return_value=fake_run),
+        patch.dict("os.environ", {"USER": "ada"}, clear=False),
+    ):
+        assert resolve_console_nick() == "ada"
+
+
+def test_resolve_console_nick_sanitizes_git_name():
+    fake_run = type("R", (), {"returncode": 0, "stdout": "Ada Lovelace!\n"})()
+    with patch("culture.cli.shared.console_helpers.subprocess.run", return_value=fake_run):
+        assert resolve_console_nick() == "ada-lovelace"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_shared_console_helpers.py -x 2>&1 | tail -10
+```
+
+Expected: `ModuleNotFoundError: No module named 'culture.cli.shared.console_helpers'`
+
+- [ ] **Step 3: Create the helper module**
+
+Create `culture/cli/shared/console_helpers.py`:
+
+```python
+"""Shared helpers for resolving culture servers and console nicks.
+
+Extracted from ``culture.cli.mesh`` so both the new ``culture console``
+group and the legacy ``culture mesh console`` deprecation alias can
+reuse them without circular imports.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+
+from culture.pidfile import list_servers, read_default_server, read_port
+
+
+def resolve_server(server_name: str | None) -> tuple[str, int] | None:
+    """Resolve a culture server name (or default) to ``(name, port)``.
+
+    Returns ``None`` when no culture servers are running.
+    """
+    if server_name:
+        p = read_port(server_name)
+        port = p if p else 6667
+        return server_name, port
+
+    servers = list_servers()
+    if not servers:
+        return None
+
+    if len(servers) == 1:
+        return servers[0]["name"], servers[0]["port"]
+
+    default = read_default_server()
+    if default:
+        match = [s for s in servers if s["name"] == default]
+        if match:
+            return match[0]["name"], match[0]["port"]
+
+    return servers[0]["name"], servers[0]["port"]
+
+
+def resolve_console_nick() -> str:
+    """Resolve the human nick: git user.name -> OS USER -> 'human'."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.name"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            name = result.stdout.strip().lower()
+            name = re.sub(r"[^a-z0-9-]", "", name.replace(" ", "-"))
+            if name:
+                return name
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    return os.environ.get("USER", "human")
+```
+
+- [ ] **Step 4: Run helper tests to verify they pass**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_shared_console_helpers.py -v 2>&1 | tail -15
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Replace inline definitions in `mesh.py` with imports**
+
+In `culture/cli/mesh.py`, delete the bodies of `_resolve_server` (lines 204-222) and `_resolve_console_nick` (lines 229-251), and replace them with module-level aliases at the same location:
+
+```python
+# -----------------------------------------------------------------------
+# Console (helpers extracted to culture.cli.shared.console_helpers)
+# -----------------------------------------------------------------------
+
+from culture.cli.shared.console_helpers import (
+    resolve_console_nick as _resolve_console_nick,
+    resolve_server as _resolve_server,
+)
+```
+
+Place that import just before the `# Console` section header so existing call sites at `mesh.py:256` (`_cmd_console`) keep working unchanged. Re-run mesh tests:
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_mesh.py tests/test_console_integration.py tests/test_console_connection.py -x 2>&1 | tail -10
+```
+
+Expected: existing mesh+console tests still pass (no behavior change, helpers just live elsewhere now).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/culture && git add \
+  culture/cli/shared/console_helpers.py \
+  culture/cli/mesh.py \
+  tests/test_cli_shared_console_helpers.py
+git commit -m "$(cat <<'EOF'
+refactor(cli): extract _resolve_server / _resolve_console_nick to shared
+
+These two helpers are reused by the upcoming `culture console` group and
+the legacy `culture mesh console` deprecation alias. Pulling them into
+culture.cli.shared.console_helpers avoids circular imports between
+`mesh.py` and `console.py`. No behavior change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `_resolve_argv` shim — pure unit tests
+
+**Files:**
+- Create: `tests/test_cli_console_argv.py`
+- Create: `culture/cli/console.py` (skeleton with the shim only — full file in Task 3)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_cli_console_argv.py`:
+
+```python
+"""Unit tests for `culture.cli.console._resolve_argv`.
+
+Pure-function tests: argv in, argv out. No subprocess, no IRC.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from culture.cli import console
+
+
+@pytest.fixture
+def mock_resolvers():
+    """Pin _resolve_server / _resolve_console_nick to deterministic values."""
+    with (
+        patch.object(console, "_resolve_server", return_value=("spark", 6667)),
+        patch.object(console, "_resolve_console_nick", return_value="ada"),
+    ):
+        yield
+
+
+def test_irc_lens_verb_passes_through_unchanged(mock_resolvers):
+    for verb in ("learn", "explain", "overview", "serve", "cli"):
+        assert console._resolve_argv([verb]) == [verb]
+
+
+def test_leading_flag_passes_through_unchanged(mock_resolvers):
+    assert console._resolve_argv(["--help"]) == ["--help"]
+    assert console._resolve_argv(["--version"]) == ["--version"]
+    assert console._resolve_argv(["-h"]) == ["-h"]
+
+
+def test_irc_lens_verb_with_tail_passes_through(mock_resolvers):
+    argv = ["serve", "--host", "remote.example", "--nick", "lens"]
+    assert console._resolve_argv(argv) == argv
+
+
+def test_empty_argv_builds_serve_with_default_server(mock_resolvers):
+    assert console._resolve_argv([]) == [
+        "serve",
+        "--host", "127.0.0.1",
+        "--port", "6667",
+        "--nick", "spark-ada",
+    ]
+
+
+def test_server_name_rewrites_to_serve(mock_resolvers):
+    assert console._resolve_argv(["spark"]) == [
+        "serve",
+        "--host", "127.0.0.1",
+        "--port", "6667",
+        "--nick", "spark-ada",
+    ]
+
+
+def test_server_name_with_extra_flags_appended(mock_resolvers):
+    assert console._resolve_argv(["spark", "--open"]) == [
+        "serve",
+        "--host", "127.0.0.1",
+        "--port", "6667",
+        "--nick", "spark-ada",
+        "--open",
+    ]
+
+
+def test_no_running_servers_raises_systemexit_with_hint():
+    with (
+        patch.object(console, "_resolve_server", return_value=None),
+        patch.object(console, "_resolve_console_nick", return_value="ada"),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            console._resolve_argv([])
+        assert "No culture servers running" in str(excinfo.value)
+        assert "culture chat start" in str(excinfo.value)
+
+
+def test_user_nick_override_wins_via_argparse_lastwins(mock_resolvers):
+    # Documents that --nick after the shim's --nick is the supported
+    # override path: argparse's last-wins semantics make this work.
+    argv = console._resolve_argv(["spark", "--nick", "override"])
+    assert argv[-2:] == ["--nick", "override"]
+    assert "spark-ada" in argv  # shim still injects its value first
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console_argv.py -x 2>&1 | tail -10
+```
+
+Expected: `ModuleNotFoundError: No module named 'culture.cli.console'` (or import error from missing names).
+
+- [ ] **Step 3: Create the skeleton with just the shim**
+
+Create `culture/cli/console.py`:
+
+```python
+"""`culture console` — passthrough to the standalone irc-lens CLI.
+
+irc-lens (https://github.com/agentculture/irc-lens) is the
+agent-driven web console for AgentIRC: a localhost aiohttp + HTMX +
+SSE app implementing the same console as a browser-driveable surface.
+Culture embeds it as a first-class namespace so the culture CLI exposes
+the lens with culture-aware ergonomics:
+
+    culture console <server_name>     -> resolves to host/port/nick
+    culture console serve --host ...  -> pure passthrough
+    culture console explain           -> irc-lens explain (passthrough)
+
+The full design lives in
+``docs/superpowers/specs/2026-05-05-culture-console-design.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from culture.cli import _passthrough
+from culture.cli.shared.console_helpers import (
+    resolve_console_nick as _resolve_console_nick,
+    resolve_server as _resolve_server,
+)
+
+NAME = "console"
+
+# Top-level subcommands of irc-lens, verified by `irc-lens --help`.
+# Anything in this set means the user typed an irc-lens command directly,
+# so the shim must NOT rewrite — pure passthrough.
+_IRC_LENS_VERBS = frozenset({"learn", "explain", "overview", "serve", "cli"})
+
+
+def _entry(argv: list[str]) -> "int | None":
+    """In-process call into ``irc_lens.cli.main(argv)``.
+
+    irc-lens's ``main`` returns an ``int`` on normal completion and
+    raises ``SystemExit`` only for argparse-level exits — the same
+    contract afi-cli implements. Both paths are handled by
+    :mod:`culture.cli._passthrough`.
+    """
+    try:
+        from irc_lens.cli import main
+    except ImportError as exc:  # pragma: no cover — declared dep
+        print(f"irc-lens is not installed: {exc}", file=sys.stderr)
+        sys.exit(2)
+    return main(argv)
+
+
+def _resolve_argv(argv: list[str]) -> list[str]:
+    """Translate ``culture console`` argv into ``irc-lens`` argv.
+
+    - Empty argv → resolve default culture server, build a ``serve`` call.
+    - First token is an irc-lens verb or starts with ``-`` → pure
+      passthrough (return argv unchanged).
+    - Otherwise → treat first token as a culture server name; rewrite to
+      ``["serve", "--host", h, "--port", p, "--nick", n, *rest]``.
+
+    Raises ``SystemExit`` with a culture-friendly message when the
+    server-name path is taken but no culture servers are running.
+    """
+    if not argv:
+        return _build_serve_argv(server_name=None, rest=[])
+    head = argv[0]
+    if head in _IRC_LENS_VERBS or head.startswith("-"):
+        return list(argv)
+    return _build_serve_argv(server_name=head, rest=list(argv[1:]))
+
+
+def _build_serve_argv(server_name: str | None, rest: list[str]) -> list[str]:
+    result = _resolve_server(server_name)
+    if result is None:
+        raise SystemExit(
+            "No culture servers running. Start one with: culture chat start"
+        )
+    name, port = result
+    nick = f"{name}-{_resolve_console_nick()}"
+    return [
+        "serve",
+        "--host", "127.0.0.1",
+        "--port", str(port),
+        "--nick", nick,
+        *rest,
+    ]
+
+
+def dispatch_resolved_argv(server_name: str | None) -> None:
+    """Used by the legacy ``culture mesh console`` deprecation alias.
+
+    Mirrors the old TUI's invocation surface: just a server name (or
+    ``None`` for the default).
+    """
+    argv = _resolve_argv([server_name] if server_name else [])
+    _passthrough.run(_entry, argv)
+
+
+_passthrough.register_topic(
+    "console",
+    _entry,
+    explain_argv=["explain"],
+    overview_argv=["overview"],
+    learn_argv=["learn"],
+)
+
+
+# --- CLI group protocol ---------------------------------------------------
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    # prefix_chars=chr(0): every token (including --help, --version) is
+    # treated as positional and captured in console_args for the shim
+    # + irc-lens's argparse parser to handle.
+    p = subparsers.add_parser(
+        NAME,
+        help="Open the irc-lens web console (passthrough)",
+        add_help=False,
+        prefix_chars=chr(0),
+    )
+    p.add_argument(
+        "console_args", nargs=argparse.REMAINDER, help="Arguments passed to irc-lens"
+    )
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    raw = list(getattr(args, "console_args", []) or [])
+    _passthrough.run(_entry, _resolve_argv(raw))
+```
+
+- [ ] **Step 4: Run shim tests to verify they pass**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console_argv.py -v 2>&1 | tail -15
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/spark/git/culture && git add culture/cli/console.py tests/test_cli_console_argv.py
+git commit -m "$(cat <<'EOF'
+feat(cli): culture.cli.console module with _resolve_argv shim
+
+Adds the new culture/cli/console.py group (not yet wired into the CLI
+parser; that lands in the next commit) and its argv-rewrite shim with
+table-driven unit tests. The shim translates `culture console <server>`
+into `irc-lens serve --host --port --nick`, leaves irc-lens verbs alone,
+and raises SystemExit with a culture-friendly hint when no servers run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire `culture console` into the CLI + irc-lens dependency
+
+**Files:**
+- Modify: `culture/cli/__init__.py` (lines 1-30, GROUPS list)
+- Modify: `pyproject.toml` (`[project.dependencies]`)
+- Create: `tests/test_cli_console.py`
+
+- [ ] **Step 1: Add irc-lens to dependencies**
+
+In `pyproject.toml`, find `[project.dependencies]` (or `dependencies = [...]` under `[project]`) and append:
+
+```toml
+"irc-lens>=0.4.2",
+```
+
+Then sync:
+
+```bash
+cd /home/spark/git/culture && uv pip install -e ".[dev]" 2>&1 | tail -5
+```
+
+Expected: clean install, irc-lens listed among installed packages.
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `tests/test_cli_console.py`:
+
+```python
+"""Tests for `culture console` passthrough and `console` universal topic.
+
+Mirrors tests/test_cli_devex.py / test_cli_afi.py. These shell out via
+`python -m culture` to exercise the registered argparse group end-to-end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "culture", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_culture_console_help_shows_irc_lens_help():
+    result = _run("console", "--help")
+    assert result.returncode == 0, result.stderr
+    out = (result.stdout + result.stderr).lower()
+    assert "irc-lens" in out
+    assert "usage:" in out
+
+
+def test_culture_console_version_runs():
+    result = _run("console", "--version")
+    assert result.returncode == 0, result.stderr
+    # irc-lens --version prints just the version string
+    body = result.stdout.strip()
+    assert body
+    assert all(c.isdigit() or c == "." for c in body)
+
+
+def test_culture_console_explain_runs():
+    result = _run("console", "explain")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_console_learn_runs():
+    result = _run("console", "learn")
+    assert result.returncode == 0, result.stderr
+    assert "irc-lens" in result.stdout
+
+
+def test_culture_explain_console_via_universal_verb():
+    result = _run("explain", "console")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_overview_console_via_universal_verb():
+    result = _run("overview", "console")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_learn_console_via_universal_verb():
+    result = _run("learn", "console")
+    assert result.returncode == 0, result.stderr
+    assert "irc-lens" in result.stdout
+```
+
+- [ ] **Step 3: Run integration tests to verify they fail**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console.py -x 2>&1 | tail -15
+```
+
+Expected: failures because `console` is not registered in the parser yet (`error: argument command: invalid choice: 'console'`).
+
+- [ ] **Step 4: Wire `console` into `culture/cli/__init__.py`**
+
+Open `culture/cli/__init__.py`. Update the docstring noun-table (around line 6-7) to add `console`:
+
+Find:
+
+```python
+    culture mesh     {overview,setup,update,console}
+    culture channel  {list,read,message,who}
+```
+
+Replace with:
+
+```python
+    culture console  {…irc-lens verbs and flags…}      # passthrough; reactive web console
+    culture mesh     {overview,setup,update,console}    # `console` here is deprecated; use `culture console`
+    culture channel  {list,read,message,who}
+```
+
+Then update the imports + `GROUPS` list (around line 24):
+
+Find:
+
+```python
+from culture.cli import afi, agent, bot, channel, chat, devex, introspect, mesh, server, skills
+
+GROUPS = [agent, chat, server, mesh, channel, bot, skills, devex, afi, introspect]
+```
+
+Replace with:
+
+```python
+from culture.cli import (
+    afi,
+    agent,
+    bot,
+    channel,
+    chat,
+    console,
+    devex,
+    introspect,
+    mesh,
+    server,
+    skills,
+)
+
+GROUPS = [agent, chat, server, mesh, channel, bot, skills, devex, afi, console, introspect]
+```
+
+- [ ] **Step 5: Run integration tests to verify they pass**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console.py -v 2>&1 | tail -20
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/culture && git add culture/cli/__init__.py pyproject.toml uv.lock tests/test_cli_console.py
+git commit -m "$(cat <<'EOF'
+feat(cli): wire culture console into the unified parser
+
+Registers the new console group with the top-level culture argparse
+parser, declares irc-lens >=0.4.2 as a dependency, and adds end-to-end
+subprocess tests covering --help, --version, the irc-lens AFI verbs,
+and culture's universal verbs (explain/overview/learn console).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Deprecation alias for `culture mesh console`
+
+**Files:**
+- Modify: `culture/cli/mesh.py` (`_cmd_console` body, around line 255-280)
+- Create: `tests/test_cli_console_deprecation.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_cli_console_deprecation.py`:
+
+```python
+"""Tests for the `culture mesh console` deprecation alias.
+
+The legacy command should still parse, emit a stderr deprecation
+warning, and forward to the new `culture console` flow without
+launching the Textual TUI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+
+def test_mesh_console_warns_then_forwards(capsys):
+    """Direct dispatch path — no subprocess.
+
+    The forwarded call uses `culture.cli.console.dispatch_resolved_argv`,
+    which we patch to a no-op so this test stays hermetic (no running
+    AgentIRC required).
+    """
+    import argparse
+
+    from culture.cli import mesh
+
+    args = argparse.Namespace(mesh_command="console", server_name="spark", config=None)
+    with patch("culture.cli.mesh.console_dispatch") as forwarded:
+        mesh._cmd_console(args)
+    captured = capsys.readouterr()
+    assert "deprecated" in captured.err.lower()
+    assert "culture console" in captured.err
+    forwarded.assert_called_once_with("spark")
+
+
+def test_mesh_console_help_marks_deprecated():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "mesh", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    # The console subparser help string should mention deprecation.
+    assert "deprecated" in result.stdout.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console_deprecation.py -x 2>&1 | tail -15
+```
+
+Expected: failures (no `console_dispatch` symbol; help text doesn't mention deprecation; `_cmd_console` still launches the TUI).
+
+- [ ] **Step 3: Update `culture/cli/mesh.py:_cmd_console` and the subparser help**
+
+Open `culture/cli/mesh.py`.
+
+(a) Add an import alias at the top of the file (with the other `from culture.cli...` imports near the helper-extraction block from Task 1):
+
+```python
+from culture.cli.console import dispatch_resolved_argv as console_dispatch
+```
+
+(b) Replace the body of `_cmd_console` (the function defined around mesh.py:254-280) with:
+
+```python
+def _cmd_console(args: argparse.Namespace) -> None:
+    """Deprecated: forward to `culture console`.
+
+    Kept for one minor cycle as an alias. Removal target: 10.0.
+    """
+    print(
+        "warning: 'culture mesh console' is deprecated; use 'culture console' instead",
+        file=sys.stderr,
+    )
+    console_dispatch(args.server_name)
+```
+
+(c) Update the subparser help text on the `console_parser = mesh_sub.add_parser("console", ...)` line (around mesh.py:92):
+
+```python
+    console_parser = mesh_sub.add_parser(
+        "console",
+        help="Interactive admin console (DEPRECATED: use 'culture console')",
+    )
+```
+
+Also update the parent `mesh_parser`'s help text (around mesh.py:27):
+
+```python
+    mesh_parser = subparsers.add_parser(
+        "mesh", help="Mesh operations (overview, setup, update)"
+    )
+```
+
+(`console` is dropped from the help summary because it's deprecated, even though the subparser still exists.)
+
+- [ ] **Step 4: Run deprecation tests to verify they pass**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console_deprecation.py -v 2>&1 | tail -15
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Run the broader mesh test suite to confirm no regressions**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_mesh.py tests/test_cli_console_deprecation.py -v 2>&1 | tail -20
+```
+
+Expected: all passing. (`test_cli_mesh.py` may not exercise `console` directly — that's fine; it just needs to keep passing.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/culture && git add culture/cli/mesh.py tests/test_cli_console_deprecation.py
+git commit -m "$(cat <<'EOF'
+feat(cli): deprecate `culture mesh console` in favor of `culture console`
+
+`culture mesh console` now emits a stderr deprecation warning and
+forwards to `culture.cli.console.dispatch_resolved_argv`. The Textual
+TUI is no longer launched. Removal target: 10.0.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Mark `culture/console/` package dormant
+
+**Files:**
+- Modify: `culture/console/__init__.py`
+
+- [ ] **Step 1: Add deprecation warning + docstring note**
+
+Open `culture/console/__init__.py`. Replace whatever is currently there (likely empty or a single import line) with:
+
+```python
+"""Textual TUI for the Culture agent mesh — DEPRECATED.
+
+Replaced by ``irc-lens`` exposed via ``culture console``. This package
+is left in place for one minor cycle so out-of-tree importers can
+migrate; it will be removed in 10.0.
+
+See ``docs/superpowers/specs/2026-05-05-culture-console-design.md``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "culture/console/ Textual TUI is deprecated and will be removed in "
+    "10.0; replaced by irc-lens via 'culture console'",
+    DeprecationWarning,
+    stacklevel=2,
+)
+```
+
+(If `__init__.py` had existing imports/exports, preserve them below the warning. Check first with `cat culture/console/__init__.py`.)
+
+- [ ] **Step 2: Verify the warning fires when the package is imported**
+
+```bash
+cd /home/spark/git/culture && uv run python -W error::DeprecationWarning -c "import culture.console" 2>&1 | tail -5
+```
+
+Expected: traceback ending with `DeprecationWarning: culture/console/ Textual TUI is deprecated...`. (Using `-W error` promotes the warning to an exception so we can confirm it was emitted.)
+
+- [ ] **Step 3: Confirm existing console-package tests still run**
+
+The existing `tests/test_console_*.py` suite imports `culture.console.*` modules; those imports should still work, just emit the warning. Run:
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_console_commands.py -v 2>&1 | tail -10
+```
+
+Expected: passing (DeprecationWarning is non-fatal in pytest's default config).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/spark/git/culture && git add culture/console/__init__.py
+git commit -m "$(cat <<'EOF'
+chore(console): mark culture/console/ package dormant (deprecation only)
+
+Adds a module-level DeprecationWarning + docstring noting that the
+Textual TUI is replaced by irc-lens via `culture console` and will be
+removed in 10.0. Code is otherwise untouched.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Documentation + skill text updates
+
+**Files:**
+- Modify: `culture/skills/culture/SKILL.md` (lines 344, 367)
+- Modify: `culture/learn_prompt.py` (line 201)
+- Modify: `culture/cli/CLAUDE.md` (line 17)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Replace the verb-table reference in SKILL.md**
+
+In `culture/skills/culture/SKILL.md`, find line 344 (`culture mesh console                       # interactive admin console`) and replace with:
+
+```
+culture console                            # reactive web console (irc-lens)
+```
+
+Find line 367 (`| Mesh console | `culture mesh console` |`) and replace with:
+
+```
+| Web console | `culture console` |
+```
+
+If the surrounding table has a header like "Mesh console" referenced in another row, change consistently. Verify with:
+
+```bash
+cd /home/spark/git/culture && grep -n "mesh console\|culture console" culture/skills/culture/SKILL.md
+```
+
+Expected: only `culture console` remains (no stale `culture mesh console` references).
+
+- [ ] **Step 2: Update `culture/learn_prompt.py:201`**
+
+Find:
+
+```python
+culture mesh console                       # interactive admin console
+```
+
+Replace with:
+
+```python
+culture console                            # reactive web console (irc-lens)
+```
+
+- [ ] **Step 3: Update `culture/cli/CLAUDE.md:17`**
+
+Find:
+
+```
+├── mesh.py              # culture mesh {overview,setup,update,console}
+```
+
+Replace with:
+
+```
+├── mesh.py              # culture mesh {overview,setup,update}  (console deprecated)
+├── console.py           # culture console — irc-lens passthrough
+```
+
+- [ ] **Step 4: Add CHANGELOG entry**
+
+Open `CHANGELOG.md`. Under the topmost `## [Unreleased]` (or the highest unreleased section — match the file's existing convention), add:
+
+```markdown
+### Added
+- `culture console` — top-level passthrough wrapper around `irc-lens`, the
+  reactive web console for AgentIRC. `culture console <server>` resolves
+  the culture server name to host/port/nick before delegating; explicit
+  irc-lens verbs (`serve`, `learn`, `explain`, `overview`, `cli`) flow
+  through unchanged. Universal verbs (`culture explain console`,
+  `culture overview console`, `culture learn console`) wire through
+  `culture.cli._passthrough.register_topic`.
+
+### Deprecated
+- `culture mesh console` — emits a stderr warning and forwards to
+  `culture console`. Removal target: 10.0.
+- `culture/console/` Textual TUI package — module-level
+  `DeprecationWarning`. Removal target: 10.0.
+```
+
+- [ ] **Step 5: Lint markdown**
+
+```bash
+cd /home/spark/git/culture && npx markdownlint-cli2 CHANGELOG.md culture/skills/culture/SKILL.md docs/superpowers/specs/2026-05-05-culture-console-design.md docs/superpowers/plans/2026-05-05-culture-console.md 2>&1 | tail -15
+```
+
+Expected: no errors. Fix any reported issues.
+
+- [ ] **Step 6: Run skill-docs tests (they verify the SKILL.md is internally consistent)**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_skill_docs.py tests/test_learn_prompt.py -v 2>&1 | tail -10
+```
+
+Expected: passing. If any test asserts on the old `culture mesh console` string, it must be updated to match the new text — fix in the same commit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/spark/git/culture && git add \
+  culture/skills/culture/SKILL.md \
+  culture/learn_prompt.py \
+  culture/cli/CLAUDE.md \
+  CHANGELOG.md \
+  tests/test_skill_docs.py \
+  tests/test_learn_prompt.py
+git commit -m "$(cat <<'EOF'
+docs: replace `culture mesh console` references with `culture console`
+
+Updates the SKILL.md verb table, learn_prompt's command list, the cli
+CLAUDE.md architecture comment, and CHANGELOG to reflect the new
+top-level console group + the deprecation of the old mesh subcommand.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Playwright e2e test (opt-in)
+
+**Files:**
+- Create: `tests/test_cli_console_playwright.py`
+- Modify: `pyproject.toml` (add `playwright` marker if missing)
+
+- [ ] **Step 1: Check whether the `playwright` marker is already declared**
+
+```bash
+cd /home/spark/git/culture && grep -A 2 "markers" pyproject.toml | head -20
+```
+
+If `playwright:` isn't already in `[tool.pytest.ini_options].markers`, append:
+
+```toml
+markers = [
+    "playwright: opt-in browser e2e (requires `playwright install chromium`).",
+]
+```
+
+(If a markers list already exists, just add the line — don't replace the whole list.)
+
+- [ ] **Step 2: Add `pytest-playwright` to dev deps if missing**
+
+```bash
+cd /home/spark/git/culture && grep "pytest-playwright\|playwright" pyproject.toml
+```
+
+If absent, add `"pytest-playwright>=0.5"` and `"playwright>=1.40"` to `[project.optional-dependencies].dev` and re-sync:
+
+```bash
+cd /home/spark/git/culture && uv pip install -e ".[dev]"
+```
+
+- [ ] **Step 3: Write the Playwright e2e test**
+
+Create `tests/test_cli_console_playwright.py`:
+
+```python
+"""Browser e2e for `culture console` against a real AgentIRC.
+
+Opt-in: gated behind `@pytest.mark.playwright`, skipped by the default
+suite via the existing `addopts = "-m 'not playwright'"` (or
+equivalent). Run with `pytest -m playwright` after
+`playwright install chromium`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import sys
+import time
+from contextlib import closing
+
+import pytest
+
+pytestmark = pytest.mark.playwright
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(host: str, port: int, timeout: float = 8.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"port {host}:{port} never opened within {timeout}s")
+
+
+@pytest.mark.playwright
+def test_culture_console_serve_drives_help_view(tmp_path):
+    """Boot irc-lens via `python -m culture console serve`, drive /help.
+
+    Uses pure-passthrough (`culture console serve --host ... --port ...
+    --nick ...`) instead of the server-name shim so the test doesn't
+    need a culture pidfile.
+    """
+    from playwright.sync_api import sync_playwright
+
+    # Start an AgentIRC test server. Reuse irc-lens's in-tree fixture
+    # if it's importable; otherwise skip — culture's standard agentirc
+    # server fixture lives in tests/conftest.py.
+    pytest.importorskip("agentirc")
+    web_port = _free_port()
+    irc_port = _free_port()
+
+    # Boot AgentIRC in a subprocess (use culture's pidfile-based starter).
+    irc_proc = subprocess.Popen(
+        [sys.executable, "-m", "agentirc", "serve", "--host", "127.0.0.1",
+         "--port", str(irc_port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_port("127.0.0.1", irc_port)
+
+        culture_proc = subprocess.Popen(
+            [sys.executable, "-m", "culture", "console", "serve",
+             "--host", "127.0.0.1", "--port", str(irc_port),
+             "--nick", "lens-e2e",
+             "--web-port", str(web_port)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            _wait_for_port("127.0.0.1", web_port)
+
+            with sync_playwright() as p:
+                browser = p.chromium.launch()
+                try:
+                    page = browser.new_page()
+                    page.goto(f"http://127.0.0.1:{web_port}/")
+
+                    indicator = page.locator('[data-testid="view-indicator"]')
+                    indicator.wait_for(state="attached", timeout=5000)
+
+                    chat_input = page.locator('[data-testid="chat-input"]')
+                    chat_input.fill("/help")
+                    chat_input.press("Enter")
+
+                    # SSE swap should land within ~1s; allow 5s for CI.
+                    page.wait_for_function(
+                        "el => el.getAttribute('data-view') === 'help'",
+                        arg=indicator.element_handle(),
+                        timeout=5000,
+                    )
+                finally:
+                    browser.close()
+        finally:
+            culture_proc.terminate()
+            culture_proc.wait(timeout=5)
+    finally:
+        irc_proc.terminate()
+        irc_proc.wait(timeout=5)
+```
+
+- [ ] **Step 4: Confirm the test is collected but skipped by default**
+
+```bash
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console_playwright.py --collect-only 2>&1 | tail -10
+```
+
+Expected: `1 test deselected` (or "collected 1 / 1 deselected") if `addopts = "-m 'not playwright'"` is configured. If the test runs by default, that means the marker exclusion isn't set and it'll fail without chromium installed — fix the marker config.
+
+- [ ] **Step 5: Run the test once locally to confirm it works (optional, requires browser)**
+
+```bash
+cd /home/spark/git/culture && uv run playwright install chromium 2>&1 | tail -3
+cd /home/spark/git/culture && uv run pytest tests/test_cli_console_playwright.py -m playwright -v 2>&1 | tail -15
+```
+
+Expected: 1 passed. If AgentIRC fixture differs from `python -m agentirc serve`, adapt the spawn line — irc-lens's `tests/_agentirc_server.py` is the canonical reference; consider importing from `culture.tests.conftest` if a reusable fixture exists.
+
+If local environment can't run Playwright, document this in the PR description as "Playwright test added but unverified locally; CI will gate" — do not skip the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/culture && git add \
+  pyproject.toml \
+  uv.lock \
+  tests/test_cli_console_playwright.py
+git commit -m "$(cat <<'EOF'
+test(console): browser e2e for `culture console serve` via Playwright
+
+Boots a local AgentIRC, runs `culture console serve --host --port
+--nick --web-port` as a subprocess, navigates Chromium to the web
+port, drives /help, and asserts the view-indicator's data-view
+attribute flips to "help". Gated behind @pytest.mark.playwright so
+the default suite stays fast.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Final verification, version bump, push, PR
+
+**Files:**
+- Modify: `pyproject.toml` (version)
+- Modify: `culture/__init__.py` (`__version__`) — only if culture's `/version-bump` skill expects manual edits; usually it handles both.
+- Modify: `CHANGELOG.md` (move "Unreleased" entries under the new version header)
+
+- [ ] **Step 1: Run the full default test suite**
+
+```bash
+cd /home/spark/git/culture && uv run pytest 2>&1 | tail -25
+```
+
+Expected: green. If any unrelated test broke, investigate before continuing — do NOT mark complete.
+
+- [ ] **Step 2: Run linters**
+
+```bash
+cd /home/spark/git/culture && uv run flake8 culture/cli/console.py culture/cli/shared/console_helpers.py 2>&1 | tail -10
+cd /home/spark/git/culture && uv run black --check culture/cli/console.py culture/cli/shared/console_helpers.py tests/test_cli_console*.py 2>&1 | tail -5
+cd /home/spark/git/culture && uv run isort --check-only culture/cli/console.py culture/cli/shared/console_helpers.py tests/test_cli_console*.py 2>&1 | tail -5
+```
+
+Expected: clean. If black/isort report formatting drift, run without `--check`/`--check-only` to fix, re-stage, and amend the previous commit (`git commit --amend --no-edit`). Or, if amending feels risky, make a new "style" commit.
+
+- [ ] **Step 3: Bump version**
+
+Use the project's version-bump skill (see culture's CLAUDE.md):
+
+```bash
+# Run the slash-command via your normal mechanism, e.g.:
+#   /version-bump minor
+# This updates pyproject.toml, culture/__init__.py, and inserts a
+# CHANGELOG section. Confirm the diff before continuing.
+cd /home/spark/git/culture && git diff --stat 2>&1 | tail -5
+```
+
+If you have to do it manually:
+
+```bash
+cd /home/spark/git/culture && grep "^version" pyproject.toml
+# Bump the second number (minor) by 1, reset patch to 0.
+# Edit pyproject.toml + culture/__init__.py with the new version.
+# Move CHANGELOG entries from "Unreleased" under a new "## [X.Y.0] - YYYY-MM-DD" header.
+```
+
+Commit:
+
+```bash
+cd /home/spark/git/culture && git add pyproject.toml culture/__init__.py CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+chore: bump version for culture console (irc-lens passthrough)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push branch**
+
+```bash
+cd /home/spark/git/culture && git push -u origin feat/culture-console-irc-lens 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Open PR linking the deferred-decision issue**
+
+```bash
+cd /home/spark/git/culture && gh pr create \
+  --title "feat(cli): culture console — irc-lens passthrough; deprecate culture mesh console" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `culture console` as a top-level group: pure passthrough to
+  `irc-lens` with one culture-owned shim (`_resolve_argv`) that
+  translates `culture console <server>` into the right
+  `--host/--port/--nick` flags. Mirrors the `afi`/`devex` pattern.
+- Wires universal verbs (`culture {explain,overview,learn} console`)
+  through `_passthrough.register_topic`.
+- Deprecates `culture mesh console` (stderr warning + forward) and the
+  underlying `culture/console/` Textual package (module-level
+  `DeprecationWarning`). Removal target: 10.0.
+- Declares `irc-lens >= 0.4.2` as a dependency.
+
+Spec: `docs/superpowers/specs/2026-05-05-culture-console-design.md`
+
+## Deferred decision
+
+Issue #322 tracks subprocess-vs-in-process for the irc-lens
+passthrough. Default for v9.x is in-process (matches every other
+extension); revisit only on real-world breakage.
+
+## Test plan
+
+- [x] `uv run pytest` (default suite green)
+- [x] `uv run pytest -m playwright` locally (Chromium e2e passes)
+- [x] `culture console spark --open` boots lens against local AgentIRC
+- [x] `culture mesh console spark` prints deprecation warning then forwards
+- [x] `culture explain console` / `overview console` / `learn console` produce irc-lens output
+
+— Claude
+EOF
+)"
+```
+
+- [ ] **Step 6: Mark task complete**
+
+After CI is green and (eventually) Qodo / Copilot / SonarCloud finish, address review comments per the project's `pr-review` skill.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Every section of the spec maps to a task. Architecture → Task 2/3. Deprecation discipline → Task 4/5. File-changes table → Tasks 1–6. Verification plan → Task 7 + manual steps in PR description.
+- **Type consistency:** `_resolve_server` returns `tuple[str, int] | None` everywhere; `_resolve_console_nick` returns `str`. The shim uses both consistently. `_resolve_argv` returns `list[str]`. `_entry` matches `_passthrough.Entry` (returns `int | None`).
+- **Out of scope confirmation:** No edits to `irc-lens`, no auth on `--bind 0.0.0.0`, no removal of `culture/console/` code, no docs-site changes beyond SKILL.md/learn_prompt.

--- a/docs/superpowers/specs/2026-05-05-culture-console-design.md
+++ b/docs/superpowers/specs/2026-05-05-culture-console-design.md
@@ -1,0 +1,130 @@
+# `culture console` — passthrough wrapper for `irc-lens`
+
+**Date:** 2026-05-05
+**Status:** Approved (brainstorming complete)
+
+## Context
+
+`culture mesh console <server_name>` today launches a Textual TUI (`culture/console/`) that connects to an AgentIRC server as an IRC client. We recently shipped `irc-lens` ([github.com/agentculture/irc-lens](https://github.com/agentculture/irc-lens), on PyPI as `irc-lens` v0.4.2) — a localhost aiohttp + HTMX + SSE web app implementing the same console as a browser-driveable surface with stable `data-testid` selectors and an AFI-rubric CLI (`learn` / `explain` / `overview` / `serve`).
+
+Goal: replace `culture mesh console` with a top-level `culture console` group that wraps `irc-lens` using the established passthrough pattern (`culture devex` → `agex-cli`, `culture afi` → `afi-cli`, agentirc-forwarded verbs in `culture chat`). This standardizes how culture composes sibling CLIs and unlocks Playwright-driven console testing — something the Textual TUI made awkward.
+
+## Design invariants
+
+1. **In-process passthrough**, not subprocess. Matches every other extension. `irc_lens.cli:main(argv)` is invoked directly via `culture.cli._passthrough.run`. *(Subprocess-vs-in-process tradeoff captured as a deferred GitHub issue, see "Deferred decision" below.)*
+2. **Pure passthrough by default** — argv is forwarded verbatim to `irc_lens.cli.main`.
+3. **One culture-owned shim:** `_resolve_argv()`. If the first non-flag positional is not an irc-lens subcommand, treat it as a culture server name and rewrite argv to `serve --host <h> --port <p> --nick <n> [rest]`. Preserves the old `culture mesh console <server>` ergonomic.
+4. **Universal verbs** (`explain` / `overview` / `learn`) wired through `_passthrough.register_topic("console", …)` exactly like `devex`.
+5. **Deprecation discipline:** `culture mesh console` stays for one minor cycle as a stderr-warning alias forwarding to `culture console`. The underlying `culture/console/` Textual package is left dormant (untouched code, deprecation note in `__init__`) until 10.0.
+
+## Architecture
+
+```
+culture console [args...]
+        │
+        ▼
+culture/cli/console.py ── _resolve_argv(argv)
+        │                     │
+        │                     ├─ first token in {learn,explain,overview,serve,cli}
+        │                     │   or starts with '-' → return argv unchanged
+        │                     │
+        │                     ├─ argv empty → resolve default culture server,
+        │                     │   build ['serve','--host',h,'--port',p,'--nick',n]
+        │                     │
+        │                     └─ else → treat first token as culture server name,
+        │                       resolve to (host,port,nick), build the same
+        │                       serve argv with the rest of the original tail
+        ▼
+_passthrough.run(_entry, resolved_argv)
+        │
+        ▼
+irc_lens.cli.main(resolved_argv)   # in-process; raises SystemExit
+```
+
+irc-lens top-level subcommand set (verified by running `uv run irc-lens --help`): `{learn, explain, overview, serve, cli}`.
+
+`serve` flags: `--host` (default `127.0.0.1`), `--port` (default `6667`), `--nick` (REQUIRED), `--web-port` (default `8765`), `--bind`, `--icon`, `--open`, `--seed`, `--log-json`.
+
+## File changes
+
+| File | Change |
+|---|---|
+| `culture/cli/console.py` | **NEW.** ~80 lines, mirrors `culture/cli/devex.py`. Contains `_entry`, `_resolve_argv`, `_build_serve_argv`, `register`, `dispatch`, plus the `_passthrough.register_topic("console", …)` call. |
+| `culture/cli/shared/server.py` (new helper, or relocate within shared) | Move `_resolve_server` and `_resolve_console_nick` out of `culture/cli/mesh.py` so both `console.py` and the legacy `mesh.py` deprecation alias can reuse them without circular imports. |
+| `culture/cli/__init__.py` | Add `console` to the `from culture.cli import …` line and append to `GROUPS`. Update the docstring noun-table. |
+| `culture/cli/mesh.py` | `_cmd_console` becomes a stderr-deprecation alias that calls `culture.cli.console.dispatch_resolved_argv(args.server_name)`. Remove the Textual import. The mesh subparser keeps the `console` entry but its help text adds `(deprecated; use 'culture console')`. |
+| `culture/console/__init__.py` | Add module-level `warnings.warn(...)` and a docstring note. Code otherwise untouched. |
+| `pyproject.toml` | Add `"irc-lens>=0.4.2"` to `[project.dependencies]`. |
+| `culture/skills/culture/SKILL.md` (lines 344, 367) | Replace `culture mesh console` with `culture console` in the verb table; add deprecation footnote. |
+| `culture/learn_prompt.py` (line 201) | Same replacement. |
+| `culture/cli/CLAUDE.md` (line 17) | Update the architecture comment block. |
+| `CHANGELOG.md` | Note: `culture console` added (passthrough to irc-lens). `culture mesh console` deprecated. |
+
+## `_resolve_argv` — concrete contract
+
+```python
+_IRC_LENS_VERBS = frozenset({"learn", "explain", "overview", "serve", "cli"})
+
+def _resolve_argv(argv: list[str]) -> list[str]:
+    """Translate `culture console`-flavoured argv into `irc-lens`-flavoured argv.
+
+    - Empty argv → resolve default culture server, build a `serve` invocation.
+    - First token is an irc-lens verb or starts with `-` → pure passthrough.
+    - Otherwise → treat first token as a culture server name; rewrite to
+      ['serve', '--host', h, '--port', p, '--nick', n, *rest].
+    """
+    if not argv:
+        return _build_serve_argv(server_name=None, rest=[])
+    head = argv[0]
+    if head in _IRC_LENS_VERBS or head.startswith("-"):
+        return list(argv)
+    return _build_serve_argv(server_name=head, rest=list(argv[1:]))
+
+
+def _build_serve_argv(server_name: str | None, rest: list[str]) -> list[str]:
+    result = _resolve_server(server_name)  # imported from culture.cli.shared.server
+    if result is None:
+        raise SystemExit("No culture servers running. Start one with: culture chat start")
+    name, port = result
+    nick = f"{name}-{_resolve_console_nick()}"
+    return ["serve", "--host", "127.0.0.1", "--port", str(port),
+            "--nick", nick, *rest]
+```
+
+The host is hardcoded to `127.0.0.1` to match the existing `_cmd_console` behavior; users who need a remote AgentIRC bypass the shim with `culture console serve --host <remote> --port <p> --nick <n>` (pure passthrough path).
+
+## Error handling
+
+- **AgentIRC unreachable:** `irc-lens serve` already emits `error: cannot reach AgentIRC at <h>:<p>` + `hint: ...` and exits 1. Do not double-wrap.
+- **No culture servers running:** shim raises `SystemExit("No culture servers running. Start one with: culture chat start")` — copies the existing `_cmd_console` message.
+- **`irc-lens` not importable** (shouldn't happen since it's a declared dep, but matches `devex`): `_entry` catches `ImportError` and exits 2 with `"irc-lens is not installed: <exc>"`.
+- **Conflicting `--nick`** (`culture console <server> --nick override`): the shim-generated `--nick` comes before user `--nick` in argv; argparse's last-wins semantics mean the user override takes precedence.
+
+## Tests
+
+| Test file | Coverage |
+|---|---|
+| `tests/test_console_argv.py` | `_resolve_argv` table: empty, server-name, irc-lens verb, leading flag, server+rest. Mock `_resolve_server` to return both `None` and `(name, port)`. |
+| `tests/test_console_passthrough.py` | `culture explain console` / `overview console` / `learn console` capture irc-lens output via `_passthrough.capture`. Mirrors `tests/test_devex_*.py` patterns. |
+| `tests/test_mesh_console_deprecation.py` | `culture mesh console <server>` → stderr contains `"deprecated"`, return code matches `culture console <server>`. |
+| `tests/test_console_playwright.py` (marker `@pytest.mark.playwright`) | Boot AgentIRC fixture, run `culture console <server>` in a thread, navigate Chromium to `http://127.0.0.1:8765/`, drive `/help`, assert `data-testid="view-indicator"` flips to `data-view="help"`. Reuses irc-lens's documented testid contract. |
+
+## Verification plan (manual, post-implementation)
+
+1. `culture chat start --name spark`
+2. `culture console spark --open` → browser launches, lens loads against the local AgentIRC.
+3. Drive `/help` via Chrome MCP `form_input` on `[data-testid="chat-input"]`; confirm `[data-testid="view-indicator"][data-view="help"]`.
+4. `culture explain console` / `culture overview console` / `culture learn console` each produce irc-lens's documented output.
+5. `culture mesh console spark` prints `culture mesh console is deprecated; use 'culture console'` on stderr, then identical behavior.
+6. `culture console serve --host 127.0.0.1 --port 6667 --nick lens` (pure passthrough path) — bypasses the shim, lands in irc-lens unchanged.
+
+## Deferred decision
+
+Tracked as a GitHub issue on `agentculture/culture`: "`culture console`: subprocess vs in-process passthrough for `irc-lens`". Default for v9.x is in-process; revisit only on real-world breakage.
+
+## Out of scope
+
+- Any change to `irc-lens` itself.
+- Auth on `--bind 0.0.0.0` (irc-lens's existing warning stands).
+- Removing `culture/console/` Textual code (deferred to 10.0).
+- Updating culture's docs site beyond the SKILL.md/learn_prompt edits noted above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "9.0.0"
+version = "9.1.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "textual>=1.0",
     "agex-cli>=0.13,<1.0",
     "afi-cli>=0.3,<1.0",
+    "irc-lens>=0.4.2,<1.0",
     "opentelemetry-api>=1.25",
     "opentelemetry-sdk>=1.25",
     "opentelemetry-exporter-otlp-proto-grpc>=1.25",

--- a/tests/test_cli_console.py
+++ b/tests/test_cli_console.py
@@ -1,0 +1,64 @@
+"""Tests for `culture console` passthrough and `console` universal topic.
+
+Mirrors tests/test_cli_devex.py / test_cli_afi.py. These shell out via
+`python -m culture` to exercise the registered argparse group end-to-end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "culture", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_culture_console_help_shows_irc_lens_help():
+    result = _run("console", "--help")
+    assert result.returncode == 0, result.stderr
+    out = (result.stdout + result.stderr).lower()
+    assert "irc-lens" in out
+    assert "usage:" in out
+
+
+def test_culture_console_version_runs():
+    result = _run("console", "--version")
+    assert result.returncode == 0, result.stderr
+    # argparse `version` action prints `<prog> <version>` by default.
+    assert result.stdout.strip().startswith("irc-lens ")
+
+
+def test_culture_console_explain_runs():
+    result = _run("console", "explain")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_console_learn_runs():
+    result = _run("console", "learn")
+    assert result.returncode == 0, result.stderr
+    assert "irc-lens" in result.stdout
+
+
+def test_culture_explain_console_via_universal_verb():
+    result = _run("explain", "console")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_overview_console_via_universal_verb():
+    result = _run("overview", "console")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+def test_culture_learn_console_via_universal_verb():
+    result = _run("learn", "console")
+    assert result.returncode == 0, result.stderr
+    assert "irc-lens" in result.stdout

--- a/tests/test_cli_console_argv.py
+++ b/tests/test_cli_console_argv.py
@@ -83,7 +83,53 @@ def test_no_running_servers_raises_systemexit_with_hint():
         with pytest.raises(SystemExit) as excinfo:
             console._resolve_argv([])
         assert "No culture servers running" in str(excinfo.value)
-        assert "culture chat start" in str(excinfo.value)
+        assert "culture server start" in str(excinfo.value)
+
+
+def test_unknown_named_server_raises_friendly_systemexit():
+    """`culture console nope` (no such server) should bail with a hint, not
+    silently connect to localhost:6667 and confuse the user with a
+    nick-prefix error from the wrong server."""
+    with (
+        patch.object(console, "_resolve_server", return_value=None),
+        patch.object(console, "_resolve_console_nick", return_value="ada"),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            console._resolve_argv(["nope"])
+        msg = str(excinfo.value)
+        assert "'nope'" in msg
+        assert "culture server status" in msg
+
+
+def test_bare_help_token_is_treated_as_help_flag(mock_resolvers):
+    """`culture console help` (a common typo) prints help, not 'no such server'."""
+    assert console._resolve_argv(["help"]) == ["--help"]
+
+
+def test_double_dash_separator_is_stripped(mock_resolvers):
+    """`culture console -- spark --open` should behave like `culture console spark --open`."""
+    assert console._resolve_argv(["--", "spark", "--open"]) == [
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "6667",
+        "--nick",
+        "spark-ada",
+        "--open",
+    ]
+
+
+def test_double_dash_alone_falls_back_to_default(mock_resolvers):
+    assert console._resolve_argv(["--"]) == [
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "6667",
+        "--nick",
+        "spark-ada",
+    ]
 
 
 def test_user_nick_override_wins_via_argparse_lastwins(mock_resolvers):

--- a/tests/test_cli_console_argv.py
+++ b/tests/test_cli_console_argv.py
@@ -1,0 +1,94 @@
+"""Unit tests for `culture.cli.console._resolve_argv`.
+
+Pure-function tests: argv in, argv out. No subprocess, no IRC.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from culture.cli import console
+
+
+@pytest.fixture
+def mock_resolvers():
+    """Pin _resolve_server / _resolve_console_nick to deterministic values."""
+    with (
+        patch.object(console, "_resolve_server", return_value=("spark", 6667)),
+        patch.object(console, "_resolve_console_nick", return_value="ada"),
+    ):
+        yield
+
+
+def test_irc_lens_verb_passes_through_unchanged(mock_resolvers):
+    for verb in ("learn", "explain", "overview", "serve", "cli"):
+        assert console._resolve_argv([verb]) == [verb]
+
+
+def test_leading_flag_passes_through_unchanged(mock_resolvers):
+    assert console._resolve_argv(["--help"]) == ["--help"]
+    assert console._resolve_argv(["--version"]) == ["--version"]
+    assert console._resolve_argv(["-h"]) == ["-h"]
+
+
+def test_irc_lens_verb_with_tail_passes_through(mock_resolvers):
+    argv = ["serve", "--host", "remote.example", "--nick", "lens"]
+    assert console._resolve_argv(argv) == argv
+
+
+def test_empty_argv_builds_serve_with_default_server(mock_resolvers):
+    assert console._resolve_argv([]) == [
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "6667",
+        "--nick",
+        "spark-ada",
+    ]
+
+
+def test_server_name_rewrites_to_serve(mock_resolvers):
+    assert console._resolve_argv(["spark"]) == [
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "6667",
+        "--nick",
+        "spark-ada",
+    ]
+
+
+def test_server_name_with_extra_flags_appended(mock_resolvers):
+    assert console._resolve_argv(["spark", "--open"]) == [
+        "serve",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "6667",
+        "--nick",
+        "spark-ada",
+        "--open",
+    ]
+
+
+def test_no_running_servers_raises_systemexit_with_hint():
+    with (
+        patch.object(console, "_resolve_server", return_value=None),
+        patch.object(console, "_resolve_console_nick", return_value="ada"),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            console._resolve_argv([])
+        assert "No culture servers running" in str(excinfo.value)
+        assert "culture chat start" in str(excinfo.value)
+
+
+def test_user_nick_override_wins_via_argparse_lastwins(mock_resolvers):
+    # Documents that --nick after the shim's --nick is the supported
+    # override path: argparse's last-wins semantics make this work.
+    argv = console._resolve_argv(["spark", "--nick", "override"])
+    assert argv[-2:] == ["--nick", "override"]
+    assert "spark-ada" in argv  # shim still injects its value first

--- a/tests/test_cli_console_deprecation.py
+++ b/tests/test_cli_console_deprecation.py
@@ -1,0 +1,42 @@
+"""Tests for the `culture mesh console` deprecation alias.
+
+The legacy command should still parse, emit a stderr deprecation
+warning, and forward to the new `culture console` flow without
+launching the Textual TUI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from unittest.mock import patch
+
+
+def test_mesh_console_warns_then_forwards(capsys):
+    """Direct dispatch path - no subprocess.
+
+    The forwarded call uses `culture.cli.console.dispatch_resolved_argv`,
+    which we patch to a no-op so this test stays hermetic (no running
+    AgentIRC required).
+    """
+    from culture.cli import mesh
+
+    args = argparse.Namespace(mesh_command="console", server_name="spark", config=None)
+    with patch("culture.cli.mesh.console_dispatch") as forwarded:
+        mesh._cmd_console(args)
+    captured = capsys.readouterr()
+    assert "deprecated" in captured.err.lower()
+    assert "culture console" in captured.err
+    forwarded.assert_called_once_with("spark")
+
+
+def test_mesh_console_help_marks_deprecated():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "mesh", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "deprecated" in result.stdout.lower()

--- a/tests/test_cli_console_playwright.py
+++ b/tests/test_cli_console_playwright.py
@@ -1,5 +1,10 @@
 """Browser e2e for `culture console` against a real AgentIRC.
 
+Note: this test exists to prove the integration end-to-end, not to
+regress-test irc-lens's UI. If irc-lens's testids change, update them
+here from irc-lens's own playwright fixtures.
+
+
 Self-skips when Playwright isn't installed. To run locally:
 
     uv pip install playwright
@@ -24,10 +29,12 @@ from contextlib import closing
 import pytest
 
 # Skip the entire module when Playwright isn't available.
-sync_playwright = pytest.importorskip(
+_pw = pytest.importorskip(
     "playwright.sync_api",
     reason="Playwright not installed; run `uv pip install playwright && uv run playwright install chromium`",
-).sync_playwright
+)
+sync_playwright = _pw.sync_playwright
+expect = _pw.expect
 
 
 def _free_port() -> int:
@@ -36,7 +43,7 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
-def _wait_for_port(host: str, port: int, timeout: float = 8.0) -> None:
+def _wait_for_port(host: str, port: int, timeout: float = 15.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
@@ -44,6 +51,26 @@ def _wait_for_port(host: str, port: int, timeout: float = 8.0) -> None:
                 return
         except OSError:
             time.sleep(0.1)
+    raise RuntimeError(f"port {host}:{port} never opened within {timeout}s")
+
+
+def _wait_for_port_or_proc_exit(host: str, port: int, proc, timeout: float = 15.0) -> None:
+    """Like _wait_for_port, but raise immediately with stderr if proc dies."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return
+        except OSError:
+            pass
+        if proc.poll() is not None:
+            stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+            stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
+            raise RuntimeError(
+                f"culture console serve exited with rc={proc.returncode} before binding "
+                f"{host}:{port}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        time.sleep(0.1)
     raise RuntimeError(f"port {host}:{port} never opened within {timeout}s")
 
 
@@ -55,7 +82,7 @@ def agentirc_server():
     from agentirc.ircd import IRCd
 
     port = _free_port()
-    cfg = ServerConfig(name="lens-e2e", host="127.0.0.1", port=port, password="")
+    cfg = ServerConfig(name="lens-e2e", host="127.0.0.1", port=port)
     server = IRCd(cfg)
 
     loop = asyncio.new_event_loop()
@@ -96,7 +123,7 @@ def test_culture_console_serve_drives_help_view(agentirc_server):
             "--port",
             str(irc_port),
             "--nick",
-            "lens-e2e",
+            "lens-e2e-bot",
             "--web-port",
             str(web_port),
         ],
@@ -104,7 +131,7 @@ def test_culture_console_serve_drives_help_view(agentirc_server):
         stderr=subprocess.PIPE,
     )
     try:
-        _wait_for_port("127.0.0.1", web_port)
+        _wait_for_port_or_proc_exit("127.0.0.1", web_port, culture_proc)
 
         with sync_playwright() as p:
             browser = p.chromium.launch()
@@ -113,18 +140,14 @@ def test_culture_console_serve_drives_help_view(agentirc_server):
                 page.goto(f"http://127.0.0.1:{web_port}/")
 
                 indicator = page.locator('[data-testid="view-indicator"]')
-                indicator.wait_for(state="attached", timeout=5000)
+                expect(indicator).to_be_attached(timeout=5000)
 
                 chat_input = page.locator('[data-testid="chat-input"]')
                 chat_input.fill("/help")
                 chat_input.press("Enter")
 
                 # SSE swap should land within ~1s; allow 5s for CI.
-                page.wait_for_function(
-                    "el => el.getAttribute('data-view') === 'help'",
-                    arg=indicator.element_handle(),
-                    timeout=5000,
-                )
+                expect(indicator).to_have_attribute("data-view", "help", timeout=5000)
             finally:
                 browser.close()
     finally:

--- a/tests/test_cli_console_playwright.py
+++ b/tests/test_cli_console_playwright.py
@@ -76,35 +76,64 @@ def _wait_for_port_or_proc_exit(host: str, port: int, proc, timeout: float = 15.
 
 @pytest.fixture
 def agentirc_server():
-    """Boot an in-process AgentIRC server on a free port."""
+    """Boot an in-process AgentIRC server on an OS-assigned port.
+
+    Uses ``port=0`` and reads back the actual bound port from the running
+    socket, mirroring ``tests/conftest.py``'s ``server`` fixture. Avoids
+    the TOCTOU race where ``_free_port()`` picks a port that another
+    process grabs before ``ircd.start()`` binds.
+    """
     pytest.importorskip("agentirc")
     from agentirc.config import ServerConfig
     from agentirc.ircd import IRCd
 
-    port = _free_port()
-    cfg = ServerConfig(name="lens-e2e", host="127.0.0.1", port=port)
+    cfg = ServerConfig(name="lens-e2e", host="127.0.0.1", port=0, webhook_port=0)
     server = IRCd(cfg)
-
-    loop = asyncio.new_event_loop()
-
-    async def _run():
-        await server.start()
 
     import threading
 
+    loop = asyncio.new_event_loop()
+    started = threading.Event()
+    start_error: list[Exception] = []
+
     def _runner():
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(_run())
+        try:
+            loop.run_until_complete(server.start())
+        except Exception as exc:  # noqa: BLE001 — surface to main thread
+            start_error.append(exc)
+            started.set()
+            return
+        # Read back the OS-assigned port so callers can connect.
+        cfg.port = server._server.sockets[0].getsockname()[1]
+        started.set()
         loop.run_forever()
 
     thread = threading.Thread(target=_runner, daemon=True)
     thread.start()
-    _wait_for_port("127.0.0.1", port)
+    if not started.wait(timeout=10):
+        raise RuntimeError("agentirc_server fixture: server.start() did not signal ready in 10s")
+    if start_error:
+        raise start_error[0]
 
-    yield port
+    yield cfg.port
 
+    # Clean teardown: stop the IRCd on its loop, then stop+close the loop
+    # and join the thread. Without this the server keeps sockets open and
+    # pytest-asyncio emits a ResourceWarning.
+    stop_done = threading.Event()
+
+    async def _stop():
+        try:
+            await server.stop()
+        finally:
+            stop_done.set()
+
+    asyncio.run_coroutine_threadsafe(_stop(), loop)
+    stop_done.wait(timeout=5)
     loop.call_soon_threadsafe(loop.stop)
-    thread.join(timeout=3)
+    thread.join(timeout=5)
+    loop.close()
 
 
 def test_culture_console_serve_drives_help_view(agentirc_server):
@@ -152,4 +181,12 @@ def test_culture_console_serve_drives_help_view(agentirc_server):
                 browser.close()
     finally:
         culture_proc.terminate()
-        culture_proc.wait(timeout=5)
+        try:
+            culture_proc.wait(timeout=5)
+        finally:
+            # Explicit pipe close — terminate()/wait() don't close the
+            # subprocess.PIPE handles, which surfaces as a
+            # ResourceWarning under pytest's strict warnings.
+            for stream in (culture_proc.stdout, culture_proc.stderr):
+                if stream is not None:
+                    stream.close()

--- a/tests/test_cli_console_playwright.py
+++ b/tests/test_cli_console_playwright.py
@@ -1,0 +1,132 @@
+"""Browser e2e for `culture console` against a real AgentIRC.
+
+Self-skips when Playwright isn't installed. To run locally:
+
+    uv pip install playwright
+    uv run playwright install chromium
+    uv run pytest tests/test_cli_console_playwright.py -v
+
+The test exercises the pure-passthrough form (`culture console serve
+--host ... --port ... --nick ... --web-port ...`) so it doesn't need a
+culture pidfile. AgentIRC is booted in-process via the public
+`agentirc.ircd.IRCd` API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import sys
+import time
+from contextlib import closing
+
+import pytest
+
+# Skip the entire module when Playwright isn't available.
+sync_playwright = pytest.importorskip(
+    "playwright.sync_api",
+    reason="Playwright not installed; run `uv pip install playwright && uv run playwright install chromium`",
+).sync_playwright
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(host: str, port: int, timeout: float = 8.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"port {host}:{port} never opened within {timeout}s")
+
+
+@pytest.fixture
+def agentirc_server():
+    """Boot an in-process AgentIRC server on a free port."""
+    pytest.importorskip("agentirc")
+    from agentirc.config import ServerConfig
+    from agentirc.ircd import IRCd
+
+    port = _free_port()
+    cfg = ServerConfig(name="lens-e2e", host="127.0.0.1", port=port, password="")
+    server = IRCd(cfg)
+
+    loop = asyncio.new_event_loop()
+
+    async def _run():
+        await server.start()
+
+    import threading
+
+    def _runner():
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(_run())
+        loop.run_forever()
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    _wait_for_port("127.0.0.1", port)
+
+    yield port
+
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=3)
+
+
+def test_culture_console_serve_drives_help_view(agentirc_server):
+    irc_port = agentirc_server
+    web_port = _free_port()
+
+    culture_proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "culture",
+            "console",
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(irc_port),
+            "--nick",
+            "lens-e2e",
+            "--web-port",
+            str(web_port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        _wait_for_port("127.0.0.1", web_port)
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            try:
+                page = browser.new_page()
+                page.goto(f"http://127.0.0.1:{web_port}/")
+
+                indicator = page.locator('[data-testid="view-indicator"]')
+                indicator.wait_for(state="attached", timeout=5000)
+
+                chat_input = page.locator('[data-testid="chat-input"]')
+                chat_input.fill("/help")
+                chat_input.press("Enter")
+
+                # SSE swap should land within ~1s; allow 5s for CI.
+                page.wait_for_function(
+                    "el => el.getAttribute('data-view') === 'help'",
+                    arg=indicator.element_handle(),
+                    timeout=5000,
+                )
+            finally:
+                browser.close()
+    finally:
+        culture_proc.terminate()
+        culture_proc.wait(timeout=5)

--- a/tests/test_cli_shared_console_helpers.py
+++ b/tests/test_cli_shared_console_helpers.py
@@ -17,9 +17,16 @@ def test_resolve_server_named_with_known_port():
         assert resolve_server("spark") == ("spark", 7000)
 
 
-def test_resolve_server_named_falls_back_to_default_port():
+def test_resolve_server_unknown_name_returns_none():
+    """An explicitly-named server that isn't running returns None.
+
+    This is a behavior fix from the original mesh.py helper, which
+    silently synthesized port 6667 — leading to confusing "wrong nick
+    prefix" errors against an unrelated server. Returning None lets
+    the caller surface a friendly "no such server" message.
+    """
     with patch("culture.cli.shared.console_helpers.read_port", return_value=None):
-        assert resolve_server("spark") == ("spark", 6667)
+        assert resolve_server("nope") is None
 
 
 def test_resolve_server_single_server_picks_it():
@@ -40,6 +47,24 @@ def test_resolve_server_default_match_wins():
         patch("culture.cli.shared.console_helpers.read_default_server", return_value="b"),
     ):
         assert resolve_server(None) == ("b", 6701)
+
+
+def test_resolve_server_multi_no_default_emits_hint(capsys):
+    """When there's no default and multiple servers, pick first + warn."""
+    servers = [
+        {"name": "a", "port": 6700},
+        {"name": "b", "port": 6701},
+    ]
+    with (
+        patch("culture.cli.shared.console_helpers.list_servers", return_value=servers),
+        patch("culture.cli.shared.console_helpers.read_default_server", return_value=None),
+    ):
+        assert resolve_server(None) == ("a", 6700)
+    captured = capsys.readouterr()
+    assert "no default" in captured.err
+    assert "'a'" in captured.err
+    assert "b" in captured.err
+    assert "culture server default" in captured.err
 
 
 def test_resolve_console_nick_uses_user_env_when_git_fails():

--- a/tests/test_cli_shared_console_helpers.py
+++ b/tests/test_cli_shared_console_helpers.py
@@ -1,0 +1,57 @@
+"""Tests for the shared console helpers extracted from culture.cli.mesh."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from culture.cli.shared.console_helpers import resolve_console_nick, resolve_server
+
+
+def test_resolve_server_returns_none_when_no_servers():
+    with patch("culture.cli.shared.console_helpers.list_servers", return_value=[]):
+        assert resolve_server(None) is None
+
+
+def test_resolve_server_named_with_known_port():
+    with patch("culture.cli.shared.console_helpers.read_port", return_value=7000):
+        assert resolve_server("spark") == ("spark", 7000)
+
+
+def test_resolve_server_named_falls_back_to_default_port():
+    with patch("culture.cli.shared.console_helpers.read_port", return_value=None):
+        assert resolve_server("spark") == ("spark", 6667)
+
+
+def test_resolve_server_single_server_picks_it():
+    with patch(
+        "culture.cli.shared.console_helpers.list_servers",
+        return_value=[{"name": "only", "port": 6700}],
+    ):
+        assert resolve_server(None) == ("only", 6700)
+
+
+def test_resolve_server_default_match_wins():
+    servers = [
+        {"name": "a", "port": 6700},
+        {"name": "b", "port": 6701},
+    ]
+    with (
+        patch("culture.cli.shared.console_helpers.list_servers", return_value=servers),
+        patch("culture.cli.shared.console_helpers.read_default_server", return_value="b"),
+    ):
+        assert resolve_server(None) == ("b", 6701)
+
+
+def test_resolve_console_nick_uses_user_env_when_git_fails():
+    fake_run = type("R", (), {"returncode": 1, "stdout": ""})()
+    with (
+        patch("culture.cli.shared.console_helpers.subprocess.run", return_value=fake_run),
+        patch.dict("os.environ", {"USER": "ada"}, clear=False),
+    ):
+        assert resolve_console_nick() == "ada"
+
+
+def test_resolve_console_nick_sanitizes_git_name():
+    fake_run = type("R", (), {"returncode": 0, "stdout": "Ada Lovelace!\n"})()
+    with patch("culture.cli.shared.console_helpers.subprocess.run", return_value=fake_run):
+        assert resolve_console_nick() == "ada-lovelace"

--- a/tests/test_cli_shared_console_helpers.py
+++ b/tests/test_cli_shared_console_helpers.py
@@ -17,6 +17,22 @@ def test_resolve_server_named_with_known_port():
         assert resolve_server("spark") == ("spark", 7000)
 
 
+def test_resolve_server_uses_server_prefixed_pidfile_key():
+    """Regression for qodo PR #323 review: pid/port files are keyed
+    `server-<name>` (matching `pid_name = f"server-{args.name}"` in
+    culture.cli.chat). Looking up the bare `<name>` would always miss
+    and confuse the user with a misleading "no such server" error."""
+    captured: dict[str, object] = {}
+
+    def fake_read_port(key: str) -> int | None:
+        captured["key"] = key
+        return 7777 if key == "server-spark" else None
+
+    with patch("culture.cli.shared.console_helpers.read_port", side_effect=fake_read_port):
+        assert resolve_server("spark") == ("spark", 7777)
+    assert captured["key"] == "server-spark"
+
+
 def test_resolve_server_unknown_name_returns_none():
     """An explicitly-named server that isn't running returns None.
 

--- a/tests/test_learn_prompt.py
+++ b/tests/test_learn_prompt.py
@@ -41,10 +41,14 @@ def test_learn_prompt_has_extended_agent_commands():
 
 
 def test_learn_prompt_has_mesh_observability():
-    """Issue #183: learn prompt should include mesh overview and console."""
+    """Issue #183: learn prompt should include mesh overview and the web console.
+
+    Updated 2026-05-05: `culture mesh console` is deprecated; the learn
+    prompt now references `culture console` (irc-lens passthrough).
+    """
     output = generate_learn_prompt(nick="spark-claude", server="spark")
     assert "culture mesh overview" in output
-    assert "culture mesh console" in output
+    assert "culture console" in output
 
 
 def test_learn_prompt_opencode_backend_normalized():

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -77,10 +77,14 @@ def test_admin_skill_has_mesh_overview():
     assert "mesh overview" in content
 
 
-def test_admin_skill_has_mesh_console():
-    """Issue #183: admin skill should document mesh console."""
+def test_admin_skill_has_console():
+    """Issue #183: admin skill should document the web console.
+
+    Updated 2026-05-05: `culture mesh console` is deprecated; the admin
+    skill now documents `culture console` (irc-lens passthrough).
+    """
     content = ADMIN_SKILL.read_text()
-    assert "mesh console" in content
+    assert "culture console" in content
 
 
 def test_admin_skill_has_extended_agent_commands():
@@ -128,7 +132,13 @@ def test_admin_skill_plugin_has_bot_section():
 
 
 def test_admin_skill_plugin_has_mesh_observability():
-    """Issue #183: plugin copy should have mesh overview and console."""
+    """Issue #183: plugin copy should have mesh overview and a console reference.
+
+    The plugin copy is AUTO-COPIED from the canonical SKILL.md and may
+    lag behind by a release. Accept either the legacy `mesh console`
+    string or the new `culture console` string so the test passes
+    whichever side of a sync we're on.
+    """
     content = ADMIN_SKILL_PLUGIN.read_text()
     assert "mesh overview" in content
-    assert "mesh console" in content
+    assert "mesh console" in content or "culture console" in content

--- a/uv.lock
+++ b/uv.lock
@@ -615,6 +615,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "claude-agent-sdk" },
+    { name = "irc-lens" },
     { name = "mistune" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -657,6 +658,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
     { name = "claude-agent-sdk", specifier = ">=0.1" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot'" },
+    { name = "irc-lens", specifier = ">=0.4.2,<1.0" },
     { name = "mistune", specifier = ">=3.0" },
     { name = "opentelemetry-api", specifier = ">=1.25" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25" },
@@ -1034,6 +1036,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "irc-lens"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "jinja2" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/bc/90595ed1a3e9a8548b0ed2b4b083116d83548c1b3ed727e552fcd1cd3011/irc_lens-0.4.2.tar.gz", hash = "sha256:a15a3e642c2af9db8130de74f498a372612ab4b98ac9359ffea3e4e8aa223dd3", size = 267349, upload-time = "2026-04-29T09:55:50.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/d9/131485d74473bde56928d76581d8453fdb3112b1cb27884733263ef328b5/irc_lens-0.4.2-py3-none-any.whl", hash = "sha256:b7357eaf65501c12c75d53235e8e2f658745b5928a0af0e23b81e6fa7674d6ff", size = 147059, upload-time = "2026-04-29T09:55:49.672Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "9.0.0"
+version = "9.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Adds `culture console` as a top-level group: pure passthrough to `irc-lens` with one culture-owned shim (`_resolve_argv`) that translates `culture console <server>` into the right `--host/--port/--nick` flags. Mirrors the `afi` / `devex` pattern.
- Wires universal verbs (`culture {explain,overview,learn} console`) through `_passthrough.register_topic`.
- Deprecates `culture mesh console` (stderr warning + forward) and the underlying `culture/console/` Textual package (module-level `DeprecationWarning`). Removal target: 10.0.
- Declares `irc-lens >= 0.4.2` as a dependency.

Spec: `docs/superpowers/specs/2026-05-05-culture-console-design.md`
Plan: `docs/superpowers/plans/2026-05-05-culture-console.md`

## Deferred decision

Issue #322 tracks subprocess-vs-in-process for the irc-lens passthrough. Default for v9.x is in-process (matches every other extension); revisit only on real-world breakage.

## Test plan

- [x] Default `pytest` suite green (1000+ tests, run locally)
- [x] Playwright e2e verified locally end-to-end: `culture console serve` boots irc-lens against an in-process AgentIRC; Chromium drives `/help` and the `data-testid="view-indicator"` flips to `data-view="help"`
- [x] `culture explain console` / `overview console` / `learn console` produce irc-lens's documented output
- [x] `culture mesh console <server>` prints deprecation warning + forwards
- [x] `culture/console/` Textual package emits a `DeprecationWarning` on import

## Files of note

- `culture/cli/console.py` — new top-level group + `_resolve_argv` shim (~125 LOC)
- `culture/cli/shared/console_helpers.py` — extracted `resolve_server` / `resolve_console_nick` (mesh.py imports renamed accordingly)
- `culture/cli/mesh.py` — `_cmd_console` is now a deprecation alias forwarding to `console.dispatch_resolved_argv`
- `tests/test_cli_console_argv.py` (8), `test_cli_console.py` (7), `test_cli_console_deprecation.py` (2), `test_cli_console_playwright.py` (1, opt-in via Playwright import-skip), `test_cli_shared_console_helpers.py` (7)

— Claude