### PR TITLE
fix(cli): pass --help through `culture server <forwarded-verb>` to agentirc (10.2.1) (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.2.1] - 2026-05-06
+
+### Fixed
+
+- **`culture server <forwarded-verb> --help` now reaches agentirc** (#332). Previously `culture server restart --help` (and `link`, `logs`, `version`, `serve`) errored with `culture: error: unrecognized arguments: --help` because argparse's `REMAINDER` subparser leaked `--help` back to the root parser instead of capturing it. The fix bypasses argparse entirely for the forwarded surface: a new `_maybe_forward_to_agentirc()` helper in `culture/cli/__init__.py` short-circuits `culture server <forwarded-verb> ...` straight into `agentirc.cli.dispatch` before parser construction. All five forwarded verbs now show their proper agentirc help banner. The existing `test_forwarded_verb_is_reachable` regression test was strengthened to assert exit 0 + agentirc banner content (the prior assertion was too lenient and silently accepted the bug).
+
 ## [10.2.0] - 2026-05-05
 
 ### Changed

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -59,7 +59,29 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _maybe_forward_to_agentirc(argv: list[str]) -> int | None:
+    """Bypass argparse for ``culture server <forwarded-verb> ...`` calls.
+
+    Returns the exit code to propagate, or ``None`` if argparse should
+    handle the invocation. argparse's ``REMAINDER`` parser cannot capture
+    ``--help`` reliably (it leaks to the root parser as an unrecognized
+    argument), so the forwarded surface is short-circuited here before
+    argparse runs.
+    """
+    if len(argv) < 2 or argv[0] != "server":
+        return None
+    if argv[1] not in server._AGENTIRC_FORWARDED_VERBS:
+        return None
+    from agentirc.cli import dispatch as _agentirc_dispatch
+
+    return _agentirc_dispatch(argv[1:])
+
+
 def main() -> None:
+    forwarded = _maybe_forward_to_agentirc(sys.argv[1:])
+    if forwarded is not None:
+        sys.exit(forwarded)
+
     parser = _build_parser()
     args = parser.parse_args()
 

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -78,23 +78,27 @@ def _maybe_forward_to_agentirc(argv: list[str]) -> int | None:
 
 
 def main() -> None:
-    forwarded = _maybe_forward_to_agentirc(sys.argv[1:])
-    if forwarded is not None:
-        sys.exit(forwarded)
-
-    parser = _build_parser()
-    args = parser.parse_args()
-
-    if args.command is None:
-        parser.print_help()
-        sys.exit(1)
-
+    # Logging must be configured before any dispatch path runs — including
+    # the agentirc forwarder bypass below — so any logs emitted by
+    # agentirc.cli.dispatch land in culture's standard format rather than
+    # whatever default the importing process happens to have.
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
 
     try:
+        forwarded = _maybe_forward_to_agentirc(sys.argv[1:])
+        if forwarded is not None:
+            sys.exit(forwarded)
+
+        parser = _build_parser()
+        args = parser.parse_args()
+
+        if args.command is None:
+            parser.print_help()
+            sys.exit(1)
+
         for group in GROUPS:
             if args.command in _names_of(group):
                 group.dispatch(args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.2.0"
+version = "10.2.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_server_shim.py
+++ b/tests/test_server_shim.py
@@ -88,12 +88,12 @@ def test_forwarded_verb_help_passes_through(verb: str) -> None:
         "unknown server command" not in combined
     ), f"forwarded verb {verb!r} not reaching agentirc.cli.dispatch"
     assert rc == 0, f"culture server {verb} --help exited {rc}: stderr={err!r}"
-    assert "unrecognized arguments" not in err.lower(), (
-        f"culture server {verb} --help leaked --help to root parser: " f"{err!r}"
-    )
-    assert f"agentirc {verb}" in out, (
-        f"culture server {verb} --help output did not look like " f"agentirc help: {out!r}"
-    )
+    assert (
+        "unrecognized arguments" not in err.lower()
+    ), f"culture server {verb} --help leaked --help to root parser: {err!r}"
+    assert (
+        f"agentirc {verb}" in out
+    ), f"culture server {verb} --help output did not look like agentirc help: {out!r}"
 
 
 def test_culture_chat_is_removed() -> None:

--- a/tests/test_server_shim.py
+++ b/tests/test_server_shim.py
@@ -75,16 +75,25 @@ def test_forwarded_version_matches_agentirc() -> None:
 
 
 @pytest.mark.parametrize("verb", FORWARDED_VERBS)
-def test_forwarded_verb_is_reachable(verb: str) -> None:
-    """Each forwarded verb should be reachable; --help for those that
-    accept it should exit 0. agentirc-owned argparse may not accept
-    `--help` for every verb, so we only assert the verb is reachable
-    (no `Unknown server command` error)."""
-    _, out, err = _run([*CULTURE, verb, "--help"])
+def test_forwarded_verb_help_passes_through(verb: str) -> None:
+    """`culture server <forwarded-verb> --help` must dispatch to agentirc
+    and exit 0 with agentirc's help banner — not error out at culture's
+    root parser. Regression for #332: argparse's REMAINDER subparser was
+    leaking `--help` back to the root, producing
+    `culture: error: unrecognized arguments: --help`.
+    """
+    rc, out, err = _run([*CULTURE, verb, "--help"])
     combined = (out + "\n" + err).lower()
     assert (
         "unknown server command" not in combined
     ), f"forwarded verb {verb!r} not reaching agentirc.cli.dispatch"
+    assert rc == 0, f"culture server {verb} --help exited {rc}: stderr={err!r}"
+    assert "unrecognized arguments" not in err.lower(), (
+        f"culture server {verb} --help leaked --help to root parser: " f"{err!r}"
+    )
+    assert f"agentirc {verb}" in out, (
+        f"culture server {verb} --help output did not look like " f"agentirc help: {out!r}"
+    )
 
 
 def test_culture_chat_is_removed() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.2.0"
+version = "10.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Closes #332. `culture server restart --help` (and `link`, `logs`, `version`, `serve`) errored with `culture: error: unrecognized arguments: --help` because argparse's `REMAINDER` subparser leaked `--help` back to the root parser instead of capturing it.
- The fix bypasses argparse entirely for the forwarded surface: a new `_maybe_forward_to_agentirc()` helper in `culture/cli/__init__.py` short-circuits `culture server <forwarded-verb> ...` straight into `agentirc.cli.dispatch` before parser construction. All five forwarded verbs now show their proper agentirc help banner.
- The existing `test_forwarded_verb_is_reachable` regression test was too lenient (it only checked for the absence of `"Unknown server command"`) and silently accepted this bug. Strengthened to assert exit 0 plus an agentirc banner in stdout.

## Before

```
$ culture server restart --help
usage: culture [-h] [--version]
               {agent,server,mesh,channel,bot,skills,devex,afi,console,explain,overview,learn}
               ...
culture: error: unrecognized arguments: --help
```

## After

```
$ culture server restart --help
usage: agentirc restart [-h] [--name NAME] [--host HOST] [--port PORT]
                        [--link LINK] [--webhook-port WEBHOOK_PORT]
                        [--data-dir DATA_DIR] [--config CONFIG] [--foreground]
...
```

## Test plan

- [x] `pytest tests/test_server_shim.py -v` — 15 passed (including 5 strengthened forwarder tests)
- [x] `pytest tests/test_server_shim.py tests/test_cli_passthrough.py tests/test_register_cli.py tests/test_overview_cli.py tests/test_cli_introspect.py -n auto` — 54 passed
- [x] Manual smoke for all 5 forwarded verbs (`restart`, `link`, `logs`, `version`, `serve`) — exit 0, agentirc help banner shown
- [x] Regression check: `culture --help`, `culture server --help`, `culture server start --help`, `culture server status --help` — all exit 0 with culture's argparse help

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude