### PR TITLE
fix(cli): remove stale (coming soon) markers from `culture explain` (10.2.2) (#330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.2.2] - 2026-05-06
+
+### Fixed
+
+- **`culture explain` no longer lists shipped namespaces as `(coming soon)`** (#330). Six namespaces (`agent`, `server`, `mesh`, `channel`, `bot`, `skills`) had no registered explain handler, so the dispatcher rendered them with the "(coming soon)" marker even though all six were fully shipped — confusing new agents reading `culture explain` during onboarding ("the CLI is mostly stubs"). Each shipped namespace now has a hand-curated explain handler in `culture/cli/introspect.py` that lists its main verbs and a one-paragraph summary. The unshipped `identity` and `secret` namespaces were dropped from `_NAMESPACES` until they actually exist on the CLI.
+
 ## [10.2.1] - 2026-05-06
 
 ### Fixed

--- a/culture/cli/introspect.py
+++ b/culture/cli/introspect.py
@@ -106,6 +106,7 @@ _NAMESPACES = (
     "server",
     "mesh",
     "channel",
+    "console",
     "bot",
     "skills",
     "devex",
@@ -220,6 +221,7 @@ def _channel_explain(_topic: str | None) -> tuple[str, int]:
         "- `who` — list members of a channel\n"
         "- `join` / `part` — join or leave a channel\n"
         "- `ask` — send a question and wait for a reply\n"
+        "- `topic` — get or set the channel topic\n"
         "- `compact` / `clear` — operate on the calling agent's context "
         "window (despite the `channel` namespace)\n",
         0,
@@ -245,13 +247,18 @@ def _bot_explain(_topic: str | None) -> tuple[str, int]:
 def _skills_explain(_topic: str | None) -> tuple[str, int]:
     return (
         "# culture skills\n\n"
-        "Install culture's bundled `irc` / `culture-irc` skill into agent "
-        "harness directories so agents can use IRC channels without "
-        "needing to find the SKILL.md by hand.\n\n"
+        "Install culture's bundled skills into the per-backend skills "
+        "directory so agents can use them without hunting for SKILL.md "
+        "by hand.\n\n"
         "## Verbs\n\n"
-        "- `install` — copy the bundled SKILL.md into one or more backends "
-        "(`claude`, `codex`, `copilot`, `acp`; the alias `opencode` maps "
-        "to `acp`)\n",
+        "- `install <target>` — copy the bundled skills into the target's "
+        "harness dir. Three skills are installed per target:\n"
+        "  - `irc` / `culture-irc` — agent-facing IRC channel guide\n"
+        "  - `culture` (admin) — administrator-facing culture operations\n"
+        "  - `communicate` (with `scripts/`) — cross-repo + mesh "
+        "communication helpers\n"
+        "- Targets: `claude`, `codex`, `copilot`, `acp` (with `opencode` "
+        "as an alias for `acp`), or `all` to install for every backend\n",
         0,
     )
 

--- a/culture/cli/introspect.py
+++ b/culture/cli/introspect.py
@@ -110,8 +110,6 @@ _NAMESPACES = (
     "skills",
     "devex",
     "afi",
-    "identity",
-    "secret",
 )
 
 
@@ -154,6 +152,120 @@ def _culture_learn(_topic: str | None) -> tuple[str, int]:
     return generate_learn_prompt(), 0
 
 
+def _agent_explain(_topic: str | None) -> tuple[str, int]:
+    return (
+        "# culture agent\n\n"
+        "Manage AI agents on the mesh. Each agent runs as a daemon "
+        "with its own IRC connection and Claude Agent SDK harness.\n\n"
+        "## Verbs\n\n"
+        "- `create` / `join` — scaffold a new agent or register an existing "
+        "agent directory (claude / codex / copilot / acp)\n"
+        "- `register` / `unregister` — add or remove from `~/.culture/server.yaml`\n"
+        "- `start` / `stop` / `restart` / `status` — agent daemon lifecycle\n"
+        "- `sleep` / `wake` — pause and resume without unregistering\n"
+        "- `message` / `read` — DM other agents (read is currently a stub; use "
+        "`culture channel read` for shared history)\n"
+        "- `learn` — print the onboarding prompt the agent reads on first run\n"
+        "- `rename` / `assign` / `archive` / `unarchive` / `delete` — admin\n",
+        0,
+    )
+
+
+def _server_explain(_topic: str | None) -> tuple[str, int]:
+    return (
+        "# culture server\n\n"
+        "Manage the IRC server (lifecycle + agentirc passthrough). Servers "
+        "host channels and federate to peers via `link`.\n\n"
+        "## Culture-owned verbs\n\n"
+        "- `start` / `stop` / `status` — daemon lifecycle (writes "
+        "`~/.culture/pids/server-<name>.pid`)\n"
+        "- `default` — set the default server name resolved by other "
+        "commands\n"
+        "- `rename` / `archive` / `unarchive` — admin on `~/.culture/server.yaml`\n\n"
+        "## Forwarded verbs\n\n"
+        "These pass straight through to the bundled `agentirc` CLI:\n\n"
+        "- `restart` / `link` / `logs` / `version` / `serve`\n",
+        0,
+    )
+
+
+def _mesh_explain(_topic: str | None) -> tuple[str, int]:
+    return (
+        "# culture mesh\n\n"
+        "Inspect and configure the federated mesh of culture servers. The "
+        "mesh is a graph of servers linked over IRC server-to-server "
+        "connections, with trust managed via `~/.culture/mesh.yaml`.\n\n"
+        "## Verbs\n\n"
+        "- `overview` — rich status: rooms, online agents, federation links, "
+        "recent activity\n"
+        "- `setup` — interactive mesh-link configuration (writes "
+        "`mesh.yaml` and stores the password in the OS keyring)\n"
+        "- `update` — refresh trust + peer config from `mesh.yaml`\n"
+        "- `console` — DEPRECATED, use `culture console` instead\n",
+        0,
+    )
+
+
+def _channel_explain(_topic: str | None) -> tuple[str, int]:
+    return (
+        "# culture channel\n\n"
+        "Read, write, and inspect channels on the mesh. Most verbs route "
+        "through a running agent daemon (set `CULTURE_NICK`) or fall back "
+        "to an ephemeral peek client when no daemon is reachable.\n\n"
+        "## Verbs\n\n"
+        "- `list` — channels with members on the local server\n"
+        "- `read` — recent channel history (e.g. `culture channel read "
+        "'#general' --limit 50`)\n"
+        "- `message` — send a message to a channel\n"
+        "- `who` — list members of a channel\n"
+        "- `join` / `part` — join or leave a channel\n"
+        "- `ask` — send a question and wait for a reply\n"
+        "- `compact` / `clear` — operate on the calling agent's context "
+        "window (despite the `channel` namespace)\n",
+        0,
+    )
+
+
+def _bot_explain(_topic: str | None) -> tuple[str, int]:
+    return (
+        "# culture bot\n\n"
+        "Manage event-driven bots on a culture server. Bots react to "
+        "channel events (joins, messages, mentions) by running templates "
+        "or shell hooks defined in `bot.yaml`.\n\n"
+        "## Verbs\n\n"
+        "- `create` — scaffold a new bot directory with a `bot.yaml`\n"
+        "- `start` / `stop` / `list` — lifecycle and inventory\n"
+        "- `inspect` — show the bot's config, recent events, and last "
+        "render output\n"
+        "- `archive` / `unarchive` — soft-remove without losing config\n",
+        0,
+    )
+
+
+def _skills_explain(_topic: str | None) -> tuple[str, int]:
+    return (
+        "# culture skills\n\n"
+        "Install culture's bundled `irc` / `culture-irc` skill into agent "
+        "harness directories so agents can use IRC channels without "
+        "needing to find the SKILL.md by hand.\n\n"
+        "## Verbs\n\n"
+        "- `install` — copy the bundled SKILL.md into one or more backends "
+        "(`claude`, `codex`, `copilot`, `acp`; the alias `opencode` maps "
+        "to `acp`)\n",
+        0,
+    )
+
+
+_NAMESPACE_EXPLAINERS: dict[str, Handler] = {
+    "agent": _agent_explain,
+    "server": _server_explain,
+    "mesh": _mesh_explain,
+    "channel": _channel_explain,
+    "bot": _bot_explain,
+    "skills": _skills_explain,
+}
+
+
 def _register_root() -> None:
     register_topic(
         "culture",
@@ -161,6 +273,8 @@ def _register_root() -> None:
         overview=_culture_overview,
         learn=_culture_learn,
     )
+    for ns, handler in _NAMESPACE_EXPLAINERS.items():
+        register_topic(ns, explain=handler)
 
 
 _register_root()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.2.1"
+version = "10.2.2"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_introspect.py
+++ b/tests/test_cli_introspect.py
@@ -53,7 +53,7 @@ def test_root_explain_mentions_culture_and_namespaces():
     stdout, code = introspect.explain(None)
     assert code == 0
     assert "culture" in stdout.lower()
-    # Expected namespaces named in the root handler (existing + upcoming)
+    # All eight namespaces are listed.
     for ns in (
         "devex",
         "server",
@@ -63,10 +63,22 @@ def test_root_explain_mentions_culture_and_namespaces():
         "channel",
         "skills",
         "afi",
-        "identity",
-        "secret",
     ):
         assert ns in stdout
+    # The six namespaces with explain handlers wired up directly in
+    # introspect.py must not render with the "(coming soon)" marker (#330).
+    # `devex` and `afi` self-register via their own modules' import-time
+    # _passthrough.register_topic() calls — those modules aren't imported
+    # in this unit test, so we don't assert on them here.
+    for ns in ("agent", "server", "mesh", "channel", "bot", "skills"):
+        assert (
+            f"`culture {ns}`  (coming soon)" not in stdout
+        ), f"shipped namespace {ns!r} still rendered as (coming soon)"
+    # `identity` and `secret` are not shipped namespaces and were dropped
+    # from the listing in #330. If/when they ship they should be added
+    # back together with their explain handlers.
+    assert "identity" not in stdout
+    assert "secret" not in stdout
 
 
 def test_root_overview_is_nonempty():
@@ -128,19 +140,22 @@ def test_culture_explain_unknown_topic_exits_1():
     assert "unknown-topic-xyz" in result.stderr
 
 
-def test_culture_explain_coming_soon_namespace_exits_0():
-    # `agent` is advertised in _NAMESPACES but has no registered handler;
-    # the dispatcher should surface a "coming soon" message and exit 0
-    # instead of treating it as an unknown topic.
-    result = subprocess.run(
-        [sys.executable, "-m", "culture", "explain", "agent"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, result.stderr
-    assert "coming soon" in result.stdout.lower()
-    assert "agent" in result.stdout
+def test_culture_explain_shipped_namespace_returns_real_content():
+    # Each shipped namespace (#330) registers an explain handler so
+    # `culture explain <ns>` returns a real description rather than the
+    # legacy "coming soon" stub.
+    for ns in ("agent", "server", "mesh", "channel", "bot", "skills"):
+        result = subprocess.run(
+            [sys.executable, "-m", "culture", "explain", ns],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert ns in result.stdout.lower()
+        assert (
+            "coming soon" not in result.stdout.lower()
+        ), f"culture explain {ns} still says 'coming soon'"
 
 
 def test_resolve_unit_coming_soon_for_namespace_without_handler():

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.2.1"
+version = "10.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Closes #330. Six shipped namespaces (`agent`, `server`, `mesh`, `channel`, `bot`, `skills`) had no registered explain handler, so `culture explain` rendered them with the "(coming soon)" marker even though all six were fully shipped. A new agent running `culture explain` as part of `culture agent learn` read this as "the CLI is mostly stubs" and gave up exploring real surface.
- Each of the six namespaces now has a hand-curated explain handler in `culture/cli/introspect.py` that lists the namespace's main verbs and a one-paragraph summary.
- The unshipped `identity` and `secret` entries were dropped from `_NAMESPACES` until they actually appear on the CLI.

## Before

```
$ culture explain
...
## Namespaces

- `culture agent`  (coming soon)
- `culture server`  (coming soon)
- `culture mesh`  (coming soon)
- `culture channel`  (coming soon)
- `culture bot`  (coming soon)
- `culture skills`  (coming soon)
- `culture devex`
- `culture afi`
- `culture identity`  (coming soon)
- `culture secret`  (coming soon)
```

## After

```
$ culture explain
...
## Namespaces

- `culture agent`
- `culture server`
- `culture mesh`
- `culture channel`
- `culture bot`
- `culture skills`
- `culture devex`
- `culture afi`
```

`culture explain agent` (and the other 5) now returns a real description of the namespace's verbs instead of "coming soon".

## Follow-up

Auto-generation of explain content from each namespace's argparse (option 2 in #330) is deferred. The afi project ships a `surface_coherence_explain` doctor check that asserts every argparse leaf resolves via `afi.explain` — a culture equivalent could borrow that pattern.

## Test plan

- [x] `pytest tests/test_cli_introspect.py -v` — 13 passed (incl. updated assertions and new `test_culture_explain_shipped_namespace_returns_real_content`)
- [x] `pytest -n auto` — 1068 passed
- [x] Manual smoke: `culture explain`, `culture explain agent`, `culture explain server`, `culture explain mesh`, `culture explain channel`, `culture explain bot`, `culture explain skills` — all show real content; `culture explain identity` correctly errors as unknown topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude