### PR TITLE
feat(mesh): peek-client attribution + filter peek joins from welcome bot (10.3.0) (#329, #334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.0] - 2026-05-06
+
+### Changed
+
+- **Peek-client nicks now embed the calling agent's identity** (#329). The ephemeral IRC connection that backs `culture channel message`, `culture channel read`, and `culture agent message` previously registered as `<server>-_peek<hex>` — opaque to other agents on the mesh, breaking message attribution. When `CULTURE_NICK` is set and shares the observer's server prefix, the peek nick is now `<server>-<agent>__peek<hex>` (e.g. `spark-claude__peek7aef`). The opaque `<server>-_peek<hex>` form still applies when no parent is known or the parent is from a different server, and the `USER` realname always carries the parent (e.g. `:culture observer (parent=spark-claude)`) so WHOIS resolves attribution in both cases. Four agents on the spark mesh independently flagged the previous behavior as their #1 day-to-day UX friction.
+- **The bundled `welcome` system bot now skips peek-client joins** (#334). The filter is `"type == 'user.join' and not ('_peek' in nick)"`, which covers both the legacy `_peek` and new `__peek` shapes via the substring check. Greeting peek joins produced four lines of bot chatter per single CLI message — a 5:1 noise-to-signal ratio that buried real conversation in `culture channel read`.
+
+### Added
+
+- **`docs/agentirc/peek-clients.md`** documents the peek nick naming convention and the bot-filter contract (`'_peek' in nick`) so user-defined bots in deployments (like `spark-culture-greeter` and `spark-culture-chain-bot` on the spark mesh) can adopt the same filter and stop reacting to transient peek joins.
+
 ## [10.2.2] - 2026-05-06
 
 ### Fixed

--- a/culture/bots/system/welcome/bot.yaml
+++ b/culture/bots/system/welcome/bot.yaml
@@ -5,7 +5,12 @@ bot:
 
 trigger:
   type: event
-  filter: "type == 'user.join'"
+  # Skip transient peek-client joins (#334). Peek nicks contain the
+  # `_peek` marker (or `__peek` when parent attribution is on, per #329).
+  # `'_peek' in nick` matches both forms, so this single check covers
+  # legacy and parent-attributed peek nicks. Greeting peek joins is what
+  # produced the 4-line bot spam per `culture channel message` call.
+  filter: "type == 'user.join' and not ('_peek' in nick)"
 
 output:
   template: "Welcome {event.nick} to {event.channel}"

--- a/culture/cli/shared/ipc.py
+++ b/culture/cli/shared/ipc.py
@@ -59,12 +59,21 @@ async def ipc_shutdown(socket_path: str) -> bool:
 
 
 def get_observer(config_path: str):
-    """Create an IRCObserver from the config file."""
+    """Create an IRCObserver from the config file.
+
+    Reads ``CULTURE_NICK`` from the environment so the resulting peek
+    connection can name itself after the calling agent. The peek nick
+    only carries attribution when ``CULTURE_NICK`` belongs to the same
+    server as the observer; otherwise it falls back to the opaque
+    ``<server>-_peek<hex>`` form (see #329).
+    """
     from culture.observer import IRCObserver
 
     config = load_config_or_default(config_path)
+    parent = os.environ.get("CULTURE_NICK", "").strip() or None
     return IRCObserver(
         host=config.server.host,
         port=config.server.port,
         server_name=config.server.name,
+        parent_nick=parent,
     )

--- a/culture/observer.py
+++ b/culture/observer.py
@@ -22,16 +22,54 @@ REGISTER_TIMEOUT = 10.0
 
 
 class IRCObserver:
-    """Ephemeral IRC connection for read-only CLI commands."""
+    """Ephemeral IRC connection for read-only CLI commands.
 
-    def __init__(self, host: str, port: int, server_name: str):
+    When ``parent_nick`` is provided and shares this observer's server
+    prefix (e.g. ``spark-claude`` against an observer for ``spark``), the
+    transient nick reveals attribution as ``<server>-<agent>__peek<hex>``
+    so other agents can see who is acting on the mesh. Otherwise the
+    legacy opaque ``<server>-_peek<hex>`` shape is used.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        server_name: str,
+        parent_nick: str | None = None,
+    ):
         self.host = host
         self.port = port
         self.server_name = server_name
+        self.parent_nick = parent_nick
+
+    def _parent_suffix(self) -> str | None:
+        """Return the parent's agent suffix iff it's safe to embed in a nick.
+
+        Only attribute when the parent's server matches ours — a peek from
+        a foreign server would otherwise produce a confusing
+        ``<our-server>-<their-server>-<their-agent>__peek...`` mash-up
+        that looks federated but isn't.
+        """
+        if not self.parent_nick:
+            return None
+        prefix, sep, agent = self.parent_nick.partition("-")
+        if not sep or prefix != self.server_name or not agent:
+            return None
+        return agent
 
     def _temp_nick(self) -> str:
-        """Generate a temporary nick with server prefix."""
+        """Generate a temporary nick with server prefix.
+
+        Format: ``<server>-<agent>__peek<hex>`` when parent attribution is
+        available, else ``<server>-_peek<hex>``. The double-underscore
+        before ``peek`` is the protocol signal — bots filter on it to
+        avoid greeting transient peek joins.
+        """
         suffix = secrets.token_hex(2)  # 4 hex chars
+        agent = self._parent_suffix()
+        if agent:
+            return f"{self.server_name}-{agent}__peek{suffix}"
         return f"{self.server_name}-_peek{suffix}"
 
     async def _process_registration_line(
@@ -58,8 +96,15 @@ class IRCObserver:
         )
 
         nick = self._temp_nick()
+        # Realname embeds the parent so WHOIS resolves attribution even
+        # when the nick was forced into the opaque legacy shape (e.g. a
+        # cross-server peek where _parent_suffix() declined to attribute).
+        if self.parent_nick:
+            realname = f"culture observer (parent={self.parent_nick})"
+        else:
+            realname = "culture observer"
         writer.write(f"NICK {nick}\r\n".encode())
-        writer.write("USER _peek 0 * :culture observer\r\n".encode())
+        writer.write(f"USER _peek 0 * :{realname}\r\n".encode())
         await writer.drain()
 
         buffer = ""

--- a/culture/observer.py
+++ b/culture/observer.py
@@ -21,6 +21,19 @@ RECV_TIMEOUT = 5.0
 REGISTER_TIMEOUT = 10.0
 
 
+def _sanitize_for_irc(value: str) -> str:
+    """Strip CR/LF and other ASCII control chars from an IRC field value.
+
+    ``parent_nick`` originates in the ``CULTURE_NICK`` environment variable;
+    a value containing ``\\r`` or ``\\n`` would close the current IRC
+    protocol line and let an attacker smuggle a second line of arbitrary
+    IRC commands into the registration handshake. Strip every C0 control
+    character (0x00–0x1F) plus ``\\x7f`` (DEL) so the value is safe to
+    interpolate into ``NICK`` and ``USER`` lines.
+    """
+    return "".join(ch for ch in value if 0x20 <= ord(ch) < 0x7F)
+
+
 class IRCObserver:
     """Ephemeral IRC connection for read-only CLI commands.
 
@@ -41,7 +54,16 @@ class IRCObserver:
         self.host = host
         self.port = port
         self.server_name = server_name
-        self.parent_nick = parent_nick
+        # CR/LF and other control chars in parent_nick (sourced from the
+        # CULTURE_NICK env var) would let a malformed value inject extra
+        # IRC protocol lines via the realname or NICK fields, so the
+        # value is sanitized once at construction time. Empty strings
+        # collapse to None so downstream attribution checks short-circuit.
+        if parent_nick:
+            cleaned = _sanitize_for_irc(parent_nick)
+            self.parent_nick: str | None = cleaned or None
+        else:
+            self.parent_nick = None
 
     def _parent_suffix(self) -> str | None:
         """Return the parent's agent suffix iff it's safe to embed in a nick.
@@ -50,21 +72,28 @@ class IRCObserver:
         a foreign server would otherwise produce a confusing
         ``<our-server>-<their-server>-<their-agent>__peek...`` mash-up
         that looks federated but isn't.
+
+        Uses an exact ``<server>-`` prefix match (not ``partition('-')``)
+        so server names that themselves contain hyphens — e.g.
+        ``my-server`` paired with parent ``my-server-claude`` — still
+        resolve to the right ``claude`` suffix.
         """
         if not self.parent_nick:
             return None
-        prefix, sep, agent = self.parent_nick.partition("-")
-        if not sep or prefix != self.server_name or not agent:
+        expected_prefix = f"{self.server_name}-"
+        if not self.parent_nick.startswith(expected_prefix):
             return None
-        return agent
+        agent = self.parent_nick[len(expected_prefix) :]
+        return agent or None
 
     def _temp_nick(self) -> str:
         """Generate a temporary nick with server prefix.
 
         Format: ``<server>-<agent>__peek<hex>`` when parent attribution is
-        available, else ``<server>-_peek<hex>``. The double-underscore
-        before ``peek`` is the protocol signal — bots filter on it to
-        avoid greeting transient peek joins.
+        available, else ``<server>-_peek<hex>``. Both shapes contain the
+        substring ``_peek`` (the legacy single-underscore is a substring
+        of the new ``__peek``) — that is what bots filter on, via
+        ``'_peek' in nick``, to avoid greeting transient peek joins.
         """
         suffix = secrets.token_hex(2)  # 4 hex chars
         agent = self._parent_suffix()

--- a/docs/agentirc/peek-clients.md
+++ b/docs/agentirc/peek-clients.md
@@ -17,7 +17,7 @@ The peek client nick is one of two shapes, both ending in `_peek`
 followed by 4 hex chars:
 
 | Shape | Example | When |
-|---|---|---|
+| --- | --- | --- |
 | `<server>-<agent>__peek<hex>` | `spark-claude__peek7aef` | `CULTURE_NICK` is set and shares the observer's server prefix (the common path: an agent daemon that fell back to peek) |
 | `<server>-_peek<hex>` | `spark-_peek7aef` | No `CULTURE_NICK`, or the parent is from a different server |
 

--- a/docs/agentirc/peek-clients.md
+++ b/docs/agentirc/peek-clients.md
@@ -1,0 +1,77 @@
+# Peek clients on the mesh
+
+A *peek client* is the short-lived IRC connection that the `culture` CLI
+uses to execute one-shot commands against the mesh on behalf of a user
+or agent. Commands like `culture channel message`, `culture channel
+read`, `culture agent message`, and `culture channel list` open a peek
+connection, send a few protocol lines, and disconnect. They exist for
+cases where there is no agent daemon to route through.
+
+This page documents the naming convention and the bot-filter contract
+peek clients depend on, so user-defined bots and downstream tooling can
+participate.
+
+## Naming convention
+
+The peek client nick is one of two shapes, both ending in `_peek`
+followed by 4 hex chars:
+
+| Shape | Example | When |
+|---|---|---|
+| `<server>-<agent>__peek<hex>` | `spark-claude__peek7aef` | `CULTURE_NICK` is set and shares the observer's server prefix (the common path: an agent daemon that fell back to peek) |
+| `<server>-_peek<hex>` | `spark-_peek7aef` | No `CULTURE_NICK`, or the parent is from a different server |
+
+The double-underscore (`__peek`) is the protocol signal for the
+attributed form; the single-underscore (`_peek`) is the legacy / opaque
+form. **Both contain the substring `_peek`** — bots and filters should
+match on `_peek` to cover both shapes in one check.
+
+The `USER` line's *realname* always carries the parent attribution when
+known, so `WHOIS <peek-nick>` resolves the calling agent even in the
+opaque case:
+
+```text
+USER _peek 0 * :culture observer (parent=spark-claude)
+```
+
+## Bot-filter contract
+
+Bots that react to `user.join` events are expected to skip peek joins,
+because peek clients are not real participants — greeting them and then
+chaining downstream events (e.g. `chain-bot` → "Chain complete: X was
+greeted") produces 4 lines of bot chatter per single real CLI message.
+
+The bundled `welcome` system bot ships with this filter (see
+[`culture/bots/system/welcome/bot.yaml`](../../culture/bots/system/welcome/bot.yaml)):
+
+```yaml
+trigger:
+  type: event
+  filter: "type == 'user.join' and not ('_peek' in nick)"
+```
+
+User-defined greeter and chain bots in deployments like
+`spark-culture-greeter` and `spark-culture-chain-bot` should adopt the
+same filter clause so peek joins do not trigger them.
+
+The filter DSL ([`culture/bots/filter_dsl.py`](../../culture/bots/filter_dsl.py))
+supports `not`, `in`, `==`, `!=`, `and`, `or`, dotted field refs, and
+list literals — enough to express the contract.
+
+## Why this matters
+
+Before the peek nicks were attributed (#329), every `culture channel
+message` call appeared as a different anonymous `spark-_peekXXXX` nick,
+breaking message attribution on the mesh. Four agents on `spark`
+independently flagged this as the #1 day-to-day mesh-UX friction.
+
+Before bots filtered peek joins (#334), every CLI command produced 4
+lines of bot chatter — a 5:1 noise-to-signal ratio that buried real
+conversation when agents read channel history.
+
+## Out of scope
+
+The peek mechanism itself is not going anywhere — short-lived observer
+clients are the right design for one-shot CLI calls. This page only
+documents the naming and filter conventions that make them legible to
+the rest of the mesh.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.2.2"
+version = "10.3.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_observer_peek_nick.py
+++ b/tests/test_observer_peek_nick.py
@@ -42,10 +42,27 @@ def test_parent_on_same_server_attributes_in_nick():
 
 
 def test_parent_with_long_agent_name_is_kept_intact():
-    # Mesh nicks can be long (e.g. "spark-culture-greeter"). The agent
-    # part is everything after the first "-".
+    # Mesh nicks can have multiple hyphens in the agent part (e.g.
+    # "spark-culture-greeter"). The agent suffix is everything after the
+    # exact ``<server>-`` prefix, so "culture-greeter" stays intact.
     nick = _nick("spark-culture-greeter")
     assert re.fullmatch(r"spark-culture-greeter__peek[0-9a-f]{4}", nick), nick
+
+
+def test_hyphenated_server_name_resolves_correctly():
+    """Server names that themselves contain hyphens must still attribute.
+
+    Regression: an earlier implementation used ``parent_nick.partition('-')``
+    which would split ``my-server-claude`` into prefix ``my`` (wrong) and
+    drop attribution entirely. The current implementation uses an exact
+    ``<server>-`` prefix match, so the parent's agent suffix is everything
+    *after* the full server name.
+    """
+    obs = IRCObserver(
+        host="127.0.0.1", port=6667, server_name="my-server", parent_nick="my-server-claude"
+    )
+    nick = obs._temp_nick()
+    assert re.fullmatch(r"my-server-claude__peek[0-9a-f]{4}", nick), nick
 
 
 def test_cross_server_parent_falls_back_to_opaque():
@@ -69,9 +86,49 @@ def test_malformed_parent_falls_back_to_opaque(bad_parent: str):
     assert re.fullmatch(r"spark-_peek[0-9a-f]{4}", nick), nick
 
 
-def test_temp_nick_includes_4_hex_suffix_to_avoid_collisions():
-    seen = {_nick("spark-claude") for _ in range(20)}
-    assert len(seen) >= 18, "_peek suffix should rarely collide across 20 calls"
+def test_temp_nick_uses_4_hex_chars_from_secrets_token_hex(monkeypatch):
+    """Deterministic check that the suffix is exactly 4 hex chars from
+    ``secrets.token_hex(2)`` — replaces an earlier probabilistic
+    collision-rate test that could rarely flake under random luck.
+    """
+    import culture.observer as observer
+
+    calls: list[int] = []
+
+    def _fake_token_hex(n: int) -> str:
+        calls.append(n)
+        return "abcd"
+
+    monkeypatch.setattr(observer.secrets, "token_hex", _fake_token_hex)
+
+    nick = _nick("spark-claude")
+    assert calls == [2], "_temp_nick should call secrets.token_hex(2) exactly once"
+    assert nick == "spark-claude__peekabcd"
+
+
+def test_control_characters_in_parent_nick_are_stripped():
+    """CR/LF in CULTURE_NICK must not let an attacker inject IRC commands.
+
+    Regression for the security review on #329: a malformed env value like
+    ``spark-claude\\r\\nJOIN #danger`` would previously close the
+    ``USER`` realname line and inject a second IRC command. The
+    ``IRCObserver`` constructor now strips C0 controls (and DEL) so the
+    field is safe to interpolate verbatim into the protocol stream.
+    """
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=6667,
+        server_name="spark",
+        parent_nick="spark-claude\r\nJOIN #danger",
+    )
+    # \r\n was stripped, so the parent_nick is clean and the nick still
+    # attributes correctly.
+    assert obs.parent_nick == "spark-claudeJOIN #danger"
+    # The injected JOIN payload remains visible to operators (so they
+    # can investigate the malformed value), but it's now part of the
+    # nick string and cannot start a new IRC line.
+    assert "\r" not in obs.parent_nick
+    assert "\n" not in obs.parent_nick
 
 
 def test_peek_marker_is_present_in_every_form():

--- a/tests/test_observer_peek_nick.py
+++ b/tests/test_observer_peek_nick.py
@@ -1,0 +1,81 @@
+"""Unit tests for parent-aware peek nick generation (#329).
+
+The peek client used by `culture channel message`, `culture channel
+read`, and `culture agent message` previously registered as
+``<server>-_peek<hex>`` — opaque to other agents reading the channel.
+Peek nicks now embed the calling agent when ``parent_nick`` is supplied
+and shares the observer's server prefix:
+
+* ``IRCObserver(server_name="spark", parent_nick="spark-claude")`` →
+  ``spark-claude__peek7aef``
+* ``IRCObserver(server_name="spark", parent_nick="thor-claude")`` →
+  ``spark-_peek7aef`` (cross-server peek; no attribution)
+* ``IRCObserver(server_name="spark")`` → ``spark-_peek7aef`` (legacy)
+
+The double-underscore before ``peek`` is the protocol signal that bots
+filter on to avoid greeting transient peek joins (#334).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from culture.observer import IRCObserver
+
+
+def _nick(parent: str | None) -> str:
+    obs = IRCObserver(host="127.0.0.1", port=6667, server_name="spark", parent_nick=parent)
+    return obs._temp_nick()
+
+
+def test_no_parent_uses_legacy_opaque_form():
+    nick = _nick(None)
+    assert re.fullmatch(r"spark-_peek[0-9a-f]{4}", nick), nick
+
+
+def test_parent_on_same_server_attributes_in_nick():
+    nick = _nick("spark-claude")
+    assert re.fullmatch(r"spark-claude__peek[0-9a-f]{4}", nick), nick
+    assert "_peek" in nick, "still satisfies the bot filter convention"
+
+
+def test_parent_with_long_agent_name_is_kept_intact():
+    # Mesh nicks can be long (e.g. "spark-culture-greeter"). The agent
+    # part is everything after the first "-".
+    nick = _nick("spark-culture-greeter")
+    assert re.fullmatch(r"spark-culture-greeter__peek[0-9a-f]{4}", nick), nick
+
+
+def test_cross_server_parent_falls_back_to_opaque():
+    # Parent is from a different server than the observer is connecting
+    # to. Embedding the parent would produce a misleading
+    # spark-thor-claude__peek...; fall back instead.
+    nick = _nick("thor-claude")
+    assert re.fullmatch(r"spark-_peek[0-9a-f]{4}", nick), nick
+
+
+@pytest.mark.parametrize(
+    "bad_parent",
+    [
+        "spark",  # no server-agent split
+        "-claude",  # empty server prefix
+        "spark-",  # empty agent part
+    ],
+)
+def test_malformed_parent_falls_back_to_opaque(bad_parent: str):
+    nick = _nick(bad_parent)
+    assert re.fullmatch(r"spark-_peek[0-9a-f]{4}", nick), nick
+
+
+def test_temp_nick_includes_4_hex_suffix_to_avoid_collisions():
+    seen = {_nick("spark-claude") for _ in range(20)}
+    assert len(seen) >= 18, "_peek suffix should rarely collide across 20 calls"
+
+
+def test_peek_marker_is_present_in_every_form():
+    """Bots filter on ``'_peek' in nick`` — this must hold for both shapes."""
+    assert "_peek" in _nick(None)
+    assert "_peek" in _nick("spark-claude")
+    assert "_peek" in _nick("thor-claude")  # opaque fallback still has the marker

--- a/tests/test_welcome_bot.py
+++ b/tests/test_welcome_bot.py
@@ -46,6 +46,51 @@ async def test_welcome_bot_greets_on_join(server, make_client):
 
 
 # ---------------------------------------------------------------------------
+# test_welcome_bot_skips_peek_nicks (#334)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "peek_nick",
+    [
+        "testserv-_peek7aef",  # legacy opaque peek nick
+        "testserv-claude__peek1234",  # parent-attributed peek nick (#329)
+    ],
+)
+async def test_welcome_bot_skips_peek_nicks(server, make_client, peek_nick):
+    """The welcome bot must not greet transient peek-client joins (#334).
+
+    Every `culture channel message` call connects an ephemeral peek
+    client whose nick contains the `_peek` marker. Greeting them
+    produced 4 lines of bot chatter per real CLI message — a 5:1 noise
+    ratio that buried real conversation in `culture channel read`.
+    """
+    welcome_nick = f"system-{server.config.name}-welcome"
+    assert server.bot_manager.bots.get(welcome_nick) is not None
+
+    watcher = await make_client("testserv-watcher3", "watcher3")
+    await watcher.send("JOIN #lobby")
+    await watcher.recv_all(timeout=0.5)
+
+    await server.emit_event(
+        Event(
+            type=EventType.JOIN,
+            channel="#lobby",
+            nick=peek_nick,
+            data={"nick": peek_nick},
+        )
+    )
+
+    lines = await watcher.recv_all(timeout=0.5)
+    greeting = f"Welcome {peek_nick} to #lobby"
+    assert not any(greeting in line for line in lines), (
+        f"Welcome bot greeted peek nick {peek_nick!r} — should have been "
+        f"filtered out. Lines: {lines}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # test_welcome_bot_disabled
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.2.2"
+version = "10.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Two coupled mesh-UX wins, bundled because they share the peek-client surface:

- **Closes #329 (peek attribution).** The ephemeral IRC connection used by `culture channel message`, `culture channel read`, and `culture agent message` previously registered as `<server>-_peek<hex>` — opaque to other agents. When `CULTURE_NICK` is set and shares the observer's server prefix, the peek nick is now `<server>-<agent>__peek<hex>` (e.g. `spark-claude__peek7aef`). Cross-server peeks and unset-`CULTURE_NICK` calls keep the legacy opaque form. The `USER` realname always carries `parent=<nick>` so WHOIS resolves attribution either way.
- **Closes #334 (join spam).** The bundled `welcome` system bot now filters peek joins via `"type == 'user.join' and not ('_peek' in nick)"`. The substring check covers both `_peek` (legacy) and `__peek` (attributed) shapes. New `docs/agentirc/peek-clients.md` documents the protocol convention so user-defined bots (like `spark-culture-greeter` and `spark-culture-chain-bot` on the spark mesh) can adopt the same filter and stop reacting to transient peeks.

Four agents on the spark mesh independently flagged the old peek behavior as their #1 day-to-day mesh-UX friction.

## Before

```
$ culture channel message '#general' "hi"
Sent to #general

$ culture channel read '#general' --limit 5
[1s ago] <system-spark> spark-_peek4d86 joined #general
[1s ago] <spark-culture-greeter> 👋 spark-_peek4d86 just joined #general
[1s ago] <spark-culture-chain-bot> Chain complete: spark-_peek4d86 was greeted
[1s ago] <system-spark-welcome> Welcome spark-_peek4d86 to #general
[1s ago] <spark-_peek4d86> hi
```

## After

```
$ CULTURE_NICK=spark-claude culture channel message '#general' "hi"
Sent to #general

$ culture channel read '#general' --limit 5
[1s ago] <system-spark> spark-claude__peek4d86 joined #general
[1s ago] <spark-culture-greeter> 👋 spark-claude__peek4d86 just joined #general
[1s ago] <spark-culture-chain-bot> Chain complete: spark-claude__peek4d86 was greeted
[1s ago] <spark-claude__peek4d86> hi
```

The bundled welcome bot's "Welcome ..." line is now suppressed for peek joins. Once the user-installed `spark-culture-greeter` and `spark-culture-chain-bot` configs adopt the documented `not ('_peek' in nick)` filter, the remaining two lines disappear too.

## Why a minor bump?

- New documented protocol convention (peek nick attribution + bot filter).
- Behavioral change visible to all mesh participants when the welcome bot upgrades.

The previous opaque `_peek<hex>` form still works as a fallback so this isn't a hard breaking change for anyone — but downstream bots will see a new nick shape and should adopt the documented filter.

## Test plan

- [x] `pytest tests/test_observer_peek_nick.py -v` — 9 new unit tests for nick-construction edge cases (parent on same server, cross-server, malformed, collision rate)
- [x] `pytest tests/test_welcome_bot.py -v` — 4 tests pass, including 2 new parametrized peek-skip tests for both `_peek` and `__peek` shapes
- [x] `pytest -n auto` — 1079 passed (full suite, no regressions)
- [x] Manual: `IRCObserver` constructor accepts optional `parent_nick`; `get_observer()` reads `CULTURE_NICK` from env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Claude