### PR TITLE
fix(cicd): vendor pr-* trio + version-bump from steward, add --push flag (10.3.2) (#318)

### DIFF
--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -66,7 +66,7 @@ commit and push to the same branch.
 3. Bump the version (required before PR):
 
    ```bash
-   echo '{"fixed":["..."]}' | python3 ~/.claude/skills/version-bump/scripts/bump.py patch
+   echo '{"fixed":["..."]}' | python3 .claude/skills/version-bump/scripts/bump.py patch
    ```
 
 4. Stage and commit:
@@ -81,7 +81,8 @@ commit and push to the same branch.
    )"
    ```
 
-5. Push:
+5. Push — pass `--push` to `create-pr-and-wait.sh` in Step 3 instead of
+   pushing manually. If you want to push without opening a PR yet, use:
 
    ```bash
    git push -u origin <branch-name>
@@ -89,13 +90,14 @@ commit and push to the same branch.
 
 ## Step 3 — Create PR (and wait for reviewers in one shot)
 
-**Recommended:** use `create-pr-and-wait.sh`. It runs `gh pr create`, sleeps 3
-minutes, then dumps all reviewer feedback in one invocation — no separate
-step 4. Automated reviewers (qodo, copilot, sonarcloud) need that 3-minute
-window to post; checking sooner returns zero comments and forces you to poll.
+**Recommended:** use `create-pr-and-wait.sh --push`. It pushes the current
+branch, runs `gh pr create`, sleeps 3 minutes, then dumps all reviewer
+feedback in one invocation — no separate step 4 and no separate `git push`.
+Automated reviewers (qodo, copilot, sonarcloud) need that 3-minute window
+to post; checking sooner returns zero comments and forces you to poll.
 
 ```bash
-bash .claude/skills/cicd/scripts/create-pr-and-wait.sh \
+bash .claude/skills/cicd/scripts/create-pr-and-wait.sh --push \
     --title "Short title" \
     --body-file /tmp/pr-body.md
 ```
@@ -103,7 +105,7 @@ bash .claude/skills/cicd/scripts/create-pr-and-wait.sh \
 Or pipe the body via heredoc on stdin:
 
 ```bash
-bash .claude/skills/cicd/scripts/create-pr-and-wait.sh \
+bash .claude/skills/cicd/scripts/create-pr-and-wait.sh --push \
     --title "Short title" <<'EOF'
 ## Summary
 - Bullet points describing changes
@@ -117,16 +119,19 @@ EOF
 
 The script prints the new PR URL on stdout, then sleeps 180s (override with
 `--wait SECS`), then runs `pr-comments.sh` so feedback lands in your output
-when control returns. Pass any extra `gh pr create` flags through positionally
-(e.g. `--base main --reviewer @user`).
+when control returns. The body always travels via `--body-file` to a tempfile,
+so large self-contained briefs don't hit the OS argv length limit (the
+failure mode that motivated issue #318). Pass any extra `gh pr create` flags
+through positionally (e.g. `--base main --reviewer @user`). Drop `--push` if
+you've already pushed the branch yourself.
 
 **If you must do it by hand** (e.g. PR was opened earlier and you only need
 to fetch feedback now):
 
 ```bash
-gh pr create --title "Short title" --body "$(cat /tmp/pr-body.md)"
+gh pr create --title "Short title" --body-file /tmp/pr-body.md
 sleep 180   # qodo/copilot/sonarcloud need ~3 min to post
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+bash .claude/skills/cicd/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
 Do **not** check for comments before the 3-minute mark. Empty comment lists
@@ -150,10 +155,10 @@ need a different duration. If the second window is also empty, fall back
 to polling:
 
 ```bash
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+bash .claude/skills/cicd/scripts/pr-comments.sh <PR_NUMBER>
 # if still empty:
 sleep 60
-bash ~/.claude/skills/pr-review/scripts/pr-comments.sh <PR_NUMBER>
+bash .claude/skills/cicd/scripts/pr-comments.sh <PR_NUMBER>
 ```
 
 Three consecutive polls returning zero comments means reviewers are done /
@@ -187,7 +192,7 @@ Guidelines:
 Use batch mode to reply to all comments at once:
 
 ```bash
-bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR_NUMBER> <<'EOF'
+bash .claude/skills/cicd/scripts/pr-batch.sh --resolve <PR_NUMBER> <<'EOF'
 {"comment_id": 123, "body": "Fixed -- changed X to Y.\n\n- Claude"}
 {"comment_id": 456, "body": "Intentional -- this follows the pattern in Z because...\n\n- Claude"}
 EOF
@@ -196,7 +201,7 @@ EOF
 Or reply to a single comment:
 
 ```bash
-bash ~/.claude/skills/pr-review/scripts/pr-reply.sh --resolve <PR_NUMBER> <COMMENT_ID> "Fixed -- updated.\n\n- Claude"
+bash .claude/skills/cicd/scripts/pr-reply.sh --resolve <PR_NUMBER> <COMMENT_ID> "Fixed -- updated.\n\n- Claude"
 ```
 
 **Important:**
@@ -228,13 +233,15 @@ CULTURE_NICK="<agent-nick>" culture channel message "#general" "PR #<N> — all 
 
 | Script | Location | Purpose |
 |--------|----------|---------|
-| `create-pr-and-wait.sh` | `.claude/skills/cicd/scripts/` (project) | `gh pr create` + `sleep 180` + `pr-comments.sh` in one invocation |
+| `create-pr-and-wait.sh` | `.claude/skills/cicd/scripts/` (project) | Optional `git push` (`--push`) + `gh pr create --body-file` + `sleep 180` + `pr-comments.sh` in one invocation |
 | `wait-and-check.sh <PR>` | `.claude/skills/cicd/scripts/` (project) | `sleep 180` + `pr-comments.sh` for an existing PR (a second deliberate window after `create-pr-and-wait.sh` or after a follow-up push) |
-| `pr-comments.sh <PR>` | `~/.claude/skills/pr-review/scripts/` (global) | Fetch all review comments |
-| `pr-reply.sh [--resolve] <PR> <ID> "body"` | `~/.claude/skills/pr-review/scripts/` (global) | Reply to one comment |
-| `pr-batch.sh [--resolve] <PR> < jsonl` | `~/.claude/skills/pr-review/scripts/` (global) | Batch reply from JSONL stdin |
+| `pr-comments.sh <PR>` | `.claude/skills/cicd/scripts/` (project) | Fetch all review comments |
+| `pr-reply.sh [--resolve] <PR> <ID> "body"` | `.claude/skills/cicd/scripts/` (project) | Reply to one comment |
+| `pr-batch.sh [--resolve] <PR> < jsonl` | `.claude/skills/cicd/scripts/` (project) | Batch reply from JSONL stdin |
 
-All scripts auto-detect `owner/repo` from the current git remote.
+All scripts auto-detect `owner/repo` from the current git remote. The trio
+(`pr-comments.sh`, `pr-reply.sh`, `pr-batch.sh`) is vendored from steward
+(the AgentCulture alignment hub) — re-cite from there if you need updates.
 
 ## Quick reference — full flow
 
@@ -242,13 +249,12 @@ All scripts auto-detect `owner/repo` from the current git remote.
 git checkout -b fix/my-fix
 # ... make changes ...
 uv run pytest tests/ -x -q
-echo '{"fixed":["desc"]}' | python3 ~/.claude/skills/version-bump/scripts/bump.py patch
+echo '{"fixed":["desc"]}' | python3 .claude/skills/version-bump/scripts/bump.py patch
 git add <files> && git commit -m "message"
-git push -u origin fix/my-fix
-bash .claude/skills/cicd/scripts/create-pr-and-wait.sh \
+bash .claude/skills/cicd/scripts/create-pr-and-wait.sh --push \
     --title "..." --body-file /tmp/pr-body.md
-# (waits 3 min, then dumps reviewer comments)
+# (pushes the branch, then waits 3 min, then dumps reviewer comments)
 # ... fix issues, commit, push ...
-bash ~/.claude/skills/pr-review/scripts/pr-batch.sh --resolve <PR> <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
+bash .claude/skills/cicd/scripts/pr-batch.sh --resolve <PR> <<< '{"comment_id":N,"body":"Fixed\n\n- Claude"}'
 # Wait for manual merge — never merge yourself
 ```

--- a/.claude/skills/cicd/scripts/create-pr-and-wait.sh
+++ b/.claude/skills/cicd/scripts/create-pr-and-wait.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Create a PR, wait for automated reviewers (qodo, copilot, sonarcloud) to
 # post comments, then dump the feedback. Wraps the manual `gh pr create →
-# sleep 300 → pr-comments.sh` sequence into one invocation.
+# sleep 180 → pr-comments.sh` sequence into one invocation.
 #
 # culture-divergence: this script adds an opt-in `--push` flag (issue #318)
 # that runs `git push -u origin HEAD` before `gh pr create` so callers don't
@@ -44,8 +44,11 @@ set -euo pipefail
 #   *  Whatever `git push`, `gh pr create`, or the comment-fetch step returns.
 
 usage() {
+    # Exit code: 0 when invoked via --help (informational), 2 when the
+    # caller passed bad/missing args (real usage error).
+    local rc="${1:-2}"
     echo "Usage: create-pr-and-wait.sh [--push] --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
-    exit 2
+    exit "$rc"
 }
 
 require_value() {
@@ -67,7 +70,7 @@ while [[ $# -gt 0 ]]; do
         --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
         --wait)       require_value "$@"; WAIT_SECS="$2"; shift 2 ;;
         --push)       PUSH=true; shift ;;
-        -h|--help)    usage ;;
+        -h|--help)    usage 0 ;;
         *) PASSTHROUGH+=("$1"); shift ;;
     esac
 done

--- a/.claude/skills/cicd/scripts/create-pr-and-wait.sh
+++ b/.claude/skills/cicd/scripts/create-pr-and-wait.sh
@@ -5,9 +5,14 @@ set -euo pipefail
 # post comments, then dump the feedback. Wraps the manual `gh pr create →
 # sleep 300 → pr-comments.sh` sequence into one invocation.
 #
+# culture-divergence: this script adds an opt-in `--push` flag (issue #318)
+# that runs `git push -u origin HEAD` before `gh pr create` so callers don't
+# have to remember the separate push step. Steward's upstream copy does not
+# carry this flag; if you re-cite from steward, re-apply the --push patch.
+#
 # Usage:
-#   create-pr-and-wait.sh --title "Title" --body-file PATH [--wait SECS] [extra gh pr create flags...]
-#   create-pr-and-wait.sh --title "Title" [--wait SECS] [extra gh pr create flags...] < body-on-stdin
+#   create-pr-and-wait.sh [--push] --title "Title" --body-file PATH [--wait SECS] [extra gh pr create flags...]
+#   create-pr-and-wait.sh [--push] --title "Title" [--wait SECS] [extra gh pr create flags...] < body-on-stdin
 #
 # Flags:
 #   --title TITLE     PR title (required)
@@ -16,26 +21,30 @@ set -euo pipefail
 #                     comments. Default: 180 (3 min). qodo/copilot/sonarcloud
 #                     usually post within this window. Use `wait-and-check.sh`
 #                     to extend by another 3 min if reviewers haven't finished.
+#   --push            Run `git push -u origin <current-branch>` before
+#                     `gh pr create`. Off by default (back-compat). Recommended
+#                     so the whole push+create+wait flow is one invocation.
 #   Any other flags pass through to `gh pr create` (e.g. --base, --reviewer).
 #
 # Behavior:
-#   1. `gh pr create` with the given title/body (and any passthrough flags).
-#   2. `sleep $WAIT_SECS` to give reviewers time to post.
-#   3. Run `pr-comments.sh <PR_NUMBER>` to dump inline + issue + review
-#      comments. Looks for the script in this directory first, then in the
-#      user's global ~/.claude/skills/pr-review/scripts/ (still under the
-#      old skill name — steward 0.7's rename is in-repo only), then falls
-#      back to an inline `gh api` dump.
+#   1. (Optional, --push) `git push -u origin <current-branch>` — refuses
+#      to run on a detached HEAD.
+#   2. Stage the body to a tempfile and `gh pr create --body-file …` so
+#      large self-contained briefs don't hit the OS argv length limit.
+#   3. `sleep $WAIT_SECS` to give reviewers time to post.
+#   4. Run the sibling `pr-comments.sh <PR_NUMBER>` (vendored next to this
+#      script) to dump inline + issue + review comments.
 #
 # Exit codes:
 #   0  PR created and feedback fetched (no judgment about whether feedback
 #      is clean — caller decides what to do with it).
-#   2  Bad usage (missing --title).
+#   2  Bad usage (missing --title, or no body source on a TTY, or --push on
+#      a detached HEAD).
 #   3  Could not parse PR number from `gh pr create` output.
-#   *  Whatever `gh pr create` or the comment-fetch step returns.
+#   *  Whatever `git push`, `gh pr create`, or the comment-fetch step returns.
 
 usage() {
-    echo "Usage: create-pr-and-wait.sh --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
+    echo "Usage: create-pr-and-wait.sh [--push] --title TITLE [--body-file PATH | < stdin] [--wait SECS] [gh pr create flags...]" >&2
     exit 2
 }
 
@@ -49,6 +58,7 @@ require_value() {
 WAIT_SECS=180
 TITLE=""
 BODY_FILE=""
+PUSH=false
 PASSTHROUGH=()
 
 while [[ $# -gt 0 ]]; do
@@ -56,6 +66,7 @@ while [[ $# -gt 0 ]]; do
         --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
         --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
         --wait)       require_value "$@"; WAIT_SECS="$2"; shift 2 ;;
+        --push)       PUSH=true; shift ;;
         -h|--help)    usage ;;
         *) PASSTHROUGH+=("$1"); shift ;;
     esac
@@ -65,14 +76,37 @@ if [[ -z "$TITLE" ]]; then
     usage
 fi
 
+# Step 0 (optional): push the current branch. Refuse on detached HEAD —
+# `git push -u origin HEAD` on a detached HEAD does not set up a tracking
+# branch and produces a confusing remote name.
+if [[ "$PUSH" == true ]]; then
+    BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+    if [[ -z "$BRANCH" ]]; then
+        echo "--push requires a non-detached HEAD." >&2
+        exit 2
+    fi
+    echo "Pushing $BRANCH to origin..."
+    git push -u origin "$BRANCH"
+fi
+
+# Stage the body to a tempfile and pass `--body-file` to gh. Large
+# self-contained briefs can otherwise hit the OS argv length limit
+# (~128 KB) when passed via `--body "$BODY"`.
+TMP_BODY=$(mktemp -t cicd-create-pr-body.XXXXXX)
+trap 'rm -f "$TMP_BODY"' EXIT
+
 if [[ -n "$BODY_FILE" ]]; then
-    BODY=$(cat "$BODY_FILE")
+    cat "$BODY_FILE" > "$TMP_BODY"
+elif [[ ! -t 0 ]]; then
+    cat > "$TMP_BODY"
 else
-    BODY=$(cat)
+    echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+    echo "Pass --body-file PATH or pipe the body in." >&2
+    exit 2
 fi
 
 # Step 1: create the PR
-PR_URL=$(gh pr create --title "$TITLE" --body "$BODY" "${PASSTHROUGH[@]}")
+PR_URL=$(gh pr create --title "$TITLE" --body-file "$TMP_BODY" "${PASSTHROUGH[@]}")
 echo "Created: $PR_URL"
 
 PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' || true)
@@ -85,29 +119,8 @@ fi
 echo "Waiting ${WAIT_SECS}s for automated reviewers (qodo, copilot, sonarcloud)..."
 sleep "$WAIT_SECS"
 
-# Step 3: dump feedback
+# Step 3: dump feedback. The cicd skill always vendors pr-comments.sh
+# next to this script — no per-user $HOME fallback (would violate the
+# skills-portability rule).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_COMMENTS="$SCRIPT_DIR/pr-comments.sh"
-# Global trio still lives under `pr-review/` (see header).
-GLOBAL_COMMENTS="$HOME/.claude/skills/pr-review/scripts/pr-comments.sh"
-
-if [[ -x "$PROJECT_COMMENTS" ]]; then
-    bash "$PROJECT_COMMENTS" "$PR_NUM"
-elif [[ -x "$GLOBAL_COMMENTS" ]]; then
-    bash "$GLOBAL_COMMENTS" "$PR_NUM"
-else
-    # Fallback: inline gh api dump.
-    echo "Note: pr-comments.sh not found at $PROJECT_COMMENTS or $GLOBAL_COMMENTS — using inline gh api fallback." >&2
-    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-    echo "════════════════ INLINE REVIEW COMMENTS ════════════════"
-    gh api "repos/$REPO/pulls/$PR_NUM/comments" --paginate \
-        --jq '.[] | "── ID: \(.id) ── \(.user.login) on \(.path):\(.original_line // .line // "?") ──\n\(.body)\n"'
-    echo ""
-    echo "════════════════ ISSUE COMMENTS ════════════════"
-    gh api "repos/$REPO/issues/$PR_NUM/comments" --paginate \
-        --jq '.[] | "── ID: \(.id) ── \(.user.login) ──\n\(.body)\n"'
-    echo ""
-    echo "════════════════ TOP-LEVEL REVIEWS ════════════════"
-    gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
-        --jq '.[] | select((.body // "") != "") | "── ID: \(.id) ── \(.user.login) ── State: \(.state) ──\n\(.body)\n"'
-fi
+bash "$SCRIPT_DIR/pr-comments.sh" "$PR_NUM"

--- a/.claude/skills/cicd/scripts/pr-batch.sh
+++ b/.claude/skills/cicd/scripts/pr-batch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Batch reply to PR review comments from JSONL on stdin.
+# Each line: {"comment_id": 123, "body": "reply text"}
+# Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl
+
+REPO=""
+RESOLVE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-batch.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER < input.jsonl}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVE_FLAG=""
+if [[ "$RESOLVE" == true ]]; then
+    RESOLVE_FLAG="--resolve"
+fi
+
+SUCCESS=0
+FAIL=0
+
+while IFS= read -r line; do
+    # Skip empty lines
+    [[ -z "$line" ]] && continue
+
+    COMMENT_ID=$(echo "$line" | jq -r '.comment_id')
+    BODY=$(echo "$line" | jq -r '.body')
+
+    if [[ "$COMMENT_ID" == "null" || "$BODY" == "null" ]]; then
+        echo "SKIP: invalid line: $line"
+        ((FAIL++)) || true
+        continue
+    fi
+
+    echo "--- Comment $COMMENT_ID ---"
+    if bash "$SCRIPT_DIR/pr-reply.sh" --repo "$REPO" $RESOLVE_FLAG "$PR_NUMBER" "$COMMENT_ID" "$BODY"; then
+        ((SUCCESS++)) || true
+    else
+        echo "FAILED: comment $COMMENT_ID"
+        ((FAIL++)) || true
+    fi
+done
+
+echo ""
+echo "Done: $SUCCESS succeeded, $FAIL failed"

--- a/.claude/skills/cicd/scripts/pr-comments.sh
+++ b/.claude/skills/cicd/scripts/pr-comments.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch and display all PR feedback in one pass:
+#   1. Inline review comments (with thread resolve status)
+#   2. Issue comments (qodo summaries, sonarcloud, etc.)
+#   3. Top-level reviews with a non-empty body (copilot overview, etc.)
+#
+# Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER
+
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-comments.sh [--repo OWNER/REPO] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# ── Section 1: inline review comments ─────────────────────────────────────
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            nodes { databaseId }
+          }
+        }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+# Build a map from every comment ID in every thread → its thread metadata,
+# so replies in a thread also show resolved status (not just the first comment).
+THREAD_MAP=$(echo "$THREADS_JSON" | jq -r '
+  [.[] as $t | $t.comments.nodes[] | {
+    comment_id: .databaseId,
+    thread_id: $t.id,
+    resolved: $t.isResolved
+  }]
+')
+
+INLINE=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate)
+INLINE_COUNT=$(echo "$INLINE" | jq 'length')
+
+echo "════════════════ INLINE REVIEW COMMENTS ($INLINE_COUNT) ════════════════"
+echo "$INLINE" | jq -r --argjson threads "$THREAD_MAP" '
+  .[] | . as $c |
+  ($threads | map(select(.comment_id == $c.id)) | first // {resolved: "unknown", thread_id: "?"}) as $t |
+  "──────────────────────────────────────────────────",
+  "ID: \($c.id)  |  Thread: \(if $t.resolved == true then "RESOLVED" elif $t.resolved == false then "UNRESOLVED" else "?" end)  |  Reply-to: \($c.in_reply_to_id // "none")",
+  "File: \($c.path):\($c.original_line // $c.line // "?")",
+  "Thread ID: \($t.thread_id)",
+  "Author: \($c.user.login)",
+  "",
+  ($c.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 2: issue comments (general PR comments) ───────────────────────
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate)
+ISSUE_COUNT=$(echo "$ISSUE" | jq 'length')
+
+echo ""
+echo "════════════════ ISSUE COMMENTS ($ISSUE_COUNT) ════════════════"
+echo "$ISSUE" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "ID: \(.id)  |  Author: \(.user.login)  |  Created: \(.created_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'
+
+# ── Section 3: top-level reviews with a body ──────────────────────────────
+REVIEWS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate)
+REVIEWS_WITH_BODY=$(echo "$REVIEWS" | jq '[.[] | select((.body // "") != "")]')
+REVIEW_COUNT=$(echo "$REVIEWS_WITH_BODY" | jq 'length')
+
+echo ""
+echo "════════════════ TOP-LEVEL REVIEWS ($REVIEW_COUNT) ════════════════"
+echo "$REVIEWS_WITH_BODY" | jq -r '
+  .[] |
+  "──────────────────────────────────────────────────",
+  "Review ID: \(.id)  |  Author: \(.user.login)  |  State: \(.state)  |  Submitted: \(.submitted_at)",
+  "",
+  (.body | split("\n") | if length > 10 then .[:10] + ["... (truncated)"] else . end | join("\n")),
+  ""
+'

--- a/.claude/skills/cicd/scripts/pr-reply.sh
+++ b/.claude/skills/cicd/scripts/pr-reply.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+PRINT_BODY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        --print-body) PRINT_BODY=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] [--print-body] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ "$PRINT_BODY" != true && -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Sign with the agent's nick. Resolved per invocation so siblings that
+# vendor this skill pick up their own culture.yaml suffix automatically.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NICK="$("$SCRIPT_DIR/_resolve-nick.sh")"
+SIG="- ${NICK} (Claude)"
+if ! printf '%s' "$BODY" | grep -qFx -- "$SIG"; then
+    BODY="${BODY}
+
+${SIG}"
+fi
+
+if [[ "$PRINT_BODY" == true ]]; then
+    printf '%s\n' "$BODY"
+    exit 0
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/cicd/scripts/pr-reply.sh
+++ b/.claude/skills/cicd/scripts/pr-reply.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 # Reply to a PR review comment, optionally resolve its thread.
 # Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+#
+# culture-divergence: steward's upstream copy resolves the agent's nick
+# from culture.yaml via _resolve-nick.sh and signs as "- <nick> (Claude)".
+# Culture signs replies as plain "- Claude" per cicd/SKILL.md Step 8 and
+# the user's global CLAUDE.md convention. If you re-cite from steward,
+# re-apply this divergence (drop _resolve-nick.sh; hard-code SIG="- Claude").
 
 REPO=""
 RESOLVE=false
@@ -25,11 +31,8 @@ if [[ "$PRINT_BODY" != true && -z "$REPO" ]]; then
     REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 fi
 
-# Sign with the agent's nick. Resolved per invocation so siblings that
-# vendor this skill pick up their own culture.yaml suffix automatically.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NICK="$("$SCRIPT_DIR/_resolve-nick.sh")"
-SIG="- ${NICK} (Claude)"
+# Sign with culture's standard signature (hard-coded; see header comment).
+SIG="- Claude"
 if ! printf '%s' "$BODY" | grep -qFx -- "$SIG"; then
     BODY="${BODY}
 

--- a/.claude/skills/cicd/scripts/wait-and-check.sh
+++ b/.claude/skills/cicd/scripts/wait-and-check.sh
@@ -52,36 +52,12 @@ echo "Waiting ${WAIT_SECS}s before re-checking PR #${PR_NUM}..."
 sleep "$WAIT_SECS"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_COMMENTS="$SCRIPT_DIR/pr-comments.sh"
-# NOTE: the user's global skills dir still holds the trio
-# (pr-comments.sh / pr-reply.sh / pr-batch.sh) under the old `pr-review` name —
-# steward 0.7's rename is in-repo only. If the global ever moves to `cicd/`,
-# update this constant to match.
-GLOBAL_COMMENTS="$HOME/.claude/skills/pr-review/scripts/pr-comments.sh"
 
 REPO_ARG=()
 if [[ -n "$REPO" ]]; then
     REPO_ARG=(--repo "$REPO")
 fi
 
-if [[ -x "$PROJECT_COMMENTS" ]]; then
-    bash "$PROJECT_COMMENTS" "${REPO_ARG[@]}" "$PR_NUM"
-elif [[ -x "$GLOBAL_COMMENTS" ]]; then
-    bash "$GLOBAL_COMMENTS" "${REPO_ARG[@]}" "$PR_NUM"
-else
-    echo "Note: pr-comments.sh not found at $PROJECT_COMMENTS or $GLOBAL_COMMENTS — using inline gh api fallback." >&2
-    if [[ -z "$REPO" ]]; then
-        REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-    fi
-    echo "════════════════ INLINE REVIEW COMMENTS ════════════════"
-    gh api "repos/$REPO/pulls/$PR_NUM/comments" --paginate \
-        --jq '.[] | "── ID: \(.id) ── \(.user.login) on \(.path):\(.original_line // .line // "?") ──\n\(.body)\n"'
-    echo ""
-    echo "════════════════ ISSUE COMMENTS ════════════════"
-    gh api "repos/$REPO/issues/$PR_NUM/comments" --paginate \
-        --jq '.[] | "── ID: \(.id) ── \(.user.login) ──\n\(.body)\n"'
-    echo ""
-    echo "════════════════ TOP-LEVEL REVIEWS ════════════════"
-    gh api "repos/$REPO/pulls/$PR_NUM/reviews" --paginate \
-        --jq '.[] | select((.body // "") != "") | "── ID: \(.id) ── \(.user.login) ── State: \(.state) ──\n\(.body)\n"'
-fi
+# pr-comments.sh is vendored next to this script — no per-user $HOME
+# fallback (would violate the skills-portability rule).
+bash "$SCRIPT_DIR/pr-comments.sh" "${REPO_ARG[@]}" "$PR_NUM"

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: version-bump
+description: >
+  Bump the semver version in pyproject.toml (major, minor, or patch) and
+  prepend a Keep-a-Changelog entry to CHANGELOG.md. Use when preparing a
+  release, before creating a PR (the version-check CI job blocks merge if
+  you don't), or when the user says "bump version", "release", or
+  "increment version".
+---
+
+# Version Bump
+
+Bump the semver version in `pyproject.toml` and prepend a new entry to
+`CHANGELOG.md`. Mirrors the AgentCulture workflow used by `culture`,
+`afi-cli`, `cfafi`, and other org repos; vendored here so the repo is
+self-contained.
+
+## Usage
+
+Run from the repo root.
+
+```bash
+# With changelog content (pipe JSON via stdin):
+echo '{"added":["New X"],"changed":["Refactored Y"],"fixed":["Bug in Z"]}' \
+  | python3 .claude/skills/version-bump/scripts/bump.py minor
+
+# Without changelog content (inserts empty ### Added/Changed/Fixed stubs):
+python3 .claude/skills/version-bump/scripts/bump.py patch
+
+# Check current version without bumping:
+python3 .claude/skills/version-bump/scripts/bump.py show
+```
+
+## Bump Types
+
+| Type    | Example        | When to use                                                       |
+|---------|----------------|-------------------------------------------------------------------|
+| `major` | 0.1.0 → 1.0.0  | Breaking changes, namespace restructures, CLI surface breaks      |
+| `minor` | 0.1.0 → 0.2.0  | New features, new commands, new modules                           |
+| `patch` | 0.1.0 → 0.1.1  | Bug fixes, doc updates, dependency bumps, CI-only changes         |
+| `show`  | prints `0.1.0` | Read-only — no files changed                                      |
+
+## Changelog JSON Format
+
+Pass via stdin. All fields are optional — only non-empty sections are rendered.
+
+```json
+{
+  "added":   ["List of new features"],
+  "changed": ["List of changes to existing functionality"],
+  "fixed":   ["List of bug fixes"]
+}
+```
+
+## What it touches
+
+- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
+  `culture/__init__.py` reads it via `importlib.metadata`, so there's no
+  separate `__version__` literal to keep in sync).
+- `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
+
+The script does the rest. Pick a bump type from the diff (patch for fixes,
+minor for new features, major for breaking changes), summarize the diff into
+`added` / `changed` / `fixed` lists, pipe as JSON, and commit the resulting
+`pyproject.toml` + `CHANGELOG.md` alongside the code change so the
+`version-check` CI job sees a consistent bump.

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -130,7 +130,7 @@ def update_changelog(project_root: Path, new: str, entries: dict) -> None:
 
     marker = "## ["
     idx = text.find(marker)
-    if idx > 0:
+    if idx >= 0:
         changelog.write_text(text[:idx] + new_entry + text[idx:])
         print(f"Updated CHANGELOG.md with [{new}]")
     else:

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Bump the version in pyproject.toml and CHANGELOG.md.
+
+If the package's ``__init__.py`` contains a literal ``__version__ = "..."``
+assignment, the script also rewrites that value. In repos that read
+``__version__`` from package metadata (the steward-cli convention), the
+``__init__.py`` step is a no-op.
+
+Usage:
+    bump.py major    # 0.1.0 -> 1.0.0
+    bump.py minor    # 0.1.0 -> 0.2.0
+    bump.py patch    # 0.1.0 -> 0.1.1
+    bump.py show     # print current version
+
+Changelog entries are passed via stdin as a JSON object:
+    {
+      "added": ["New CLI command", "Observer module"],
+      "changed": ["Restructured namespace"],
+      "fixed": ["WHO reply index bug"]
+    }
+
+If no stdin is provided, an empty stub is inserted.
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def find_pyproject() -> Path:
+    """Walk up from cwd to find pyproject.toml."""
+    current = Path.cwd()
+    while current != current.parent:
+        candidate = current / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+    print("ERROR: pyproject.toml not found", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_version(path: Path) -> str:
+    """Extract version string from pyproject.toml."""
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: version field not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """Bump the specified part of a semver version."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"ERROR: version '{version}' is not semver (x.y.z)", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        print(f"ERROR: unknown bump type '{part}' (use major, minor, or patch)", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_version(path: Path, old: str, new: str) -> None:
+    """Replace old version with new in pyproject.toml."""
+    text = path.read_text()
+    updated = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    path.write_text(updated)
+
+
+def read_changelog_entries() -> dict:
+    """Read changelog entries from stdin as JSON."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print(
+            "WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr
+        )
+        return {}
+
+
+def format_changelog_section(new: str, entries: dict) -> str:
+    """Format a changelog section from entries dict.
+
+    Output uses single blank lines between elements (markdownlint MD012
+    compliant). Trailing blank line before the next existing entry is
+    included.
+    """
+    today = date.today().isoformat()
+    chunks = [f"## [{new}] - {today}\n"]
+
+    for section in ("added", "changed", "fixed"):
+        items = entries.get(section, [])
+        if items:
+            chunks.append(f"\n### {section.capitalize()}\n\n")
+            chunks.extend(f"- {item}\n" for item in items)
+
+    # If no entries at all, emit empty section stubs.
+    if not any(entries.get(s) for s in ("added", "changed", "fixed")):
+        chunks.append("\n### Added\n\n### Changed\n\n### Fixed\n")
+
+    chunks.append("\n")  # blank line before the next existing entry
+    return "".join(chunks)
+
+
+def update_changelog(project_root: Path, new: str, entries: dict) -> None:
+    """Insert a new changelog entry into CHANGELOG.md."""
+    changelog = project_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print("No CHANGELOG.md found — skipping")
+        return
+
+    text = changelog.read_text()
+    new_entry = format_changelog_section(new, entries)
+
+    marker = "## ["
+    idx = text.find(marker)
+    if idx > 0:
+        changelog.write_text(text[:idx] + new_entry + text[idx:])
+        print(f"Updated CHANGELOG.md with [{new}]")
+    else:
+        print("WARNING: could not find insertion point in CHANGELOG.md", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    part = sys.argv[1].lower()
+    path = find_pyproject()
+    current = read_version(path)
+
+    if part == "show":
+        print(current)
+        sys.exit(0)
+
+    # Read changelog entries before bumping
+    entries = read_changelog_entries()
+
+    new = bump(current, part)
+    write_version(path, current, new)
+
+    # Also update __init__.py if it has __version__
+    init_candidates = [
+        path.parent / path.parent.name / "__init__.py",
+    ]
+    for init in init_candidates:
+        if init.exists():
+            init_text = init.read_text()
+            if f'__version__ = "{current}"' in init_text:
+                init.write_text(
+                    init_text.replace(
+                        f'__version__ = "{current}"',
+                        f'__version__ = "{new}"',
+                    )
+                )
+                print(f"Updated {init.relative_to(path.parent)}")
+
+    # Update changelog
+    update_changelog(path.parent, new, entries)
+
+    print(f"{current} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.2] - 2026-05-06
+
+### Added
+
+- version-bump skill: vendored from steward into .claude/skills/version-bump/ so script-form bump.py invocations resolve in-repo
+- cicd skill: add opt-in --push flag to create-pr-and-wait.sh that runs git push -u origin HEAD before gh pr create, eliminating the separate push step
+
+### Fixed
+
+- cicd skill: vendor pr-comments.sh, pr-reply.sh, pr-batch.sh from steward into .claude/skills/cicd/scripts/ (issue #318)
+- cicd skill: replace create-pr-and-wait.sh with steward version that uses --body-file + tempfile, fixing argv-truncation on large PR bodies
+- cicd skill: drop broken ~/.claude/skills/pr-review/ fallback branches in create-pr-and-wait.sh and wait-and-check.sh
+- cicd skill: update SKILL.md to reference project-local script paths everywhere
+
 ## [10.3.1] - 2026-05-06
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.1"
+version = "10.3.2"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.1"
+version = "10.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Closes #318. Fixes three breakages in the project-scoped `cicd` skill that
make routine PR work fail with `No such file or directory`:

1. **`version-bump`** vendored into `.claude/skills/version-bump/` (was
   referenced as `~/.claude/skills/version-bump/scripts/bump.py`, which no
   longer exists since the global skill was removed).
2. **`pr-comments.sh` / `pr-reply.sh` / `pr-batch.sh`** vendored into
   `.claude/skills/cicd/scripts/` (was referenced as
   `~/.claude/skills/pr-review/scripts/...`, also gone).
3. **PR push UX** — replaced `create-pr-and-wait.sh` with the steward
   version (uses `--body-file` + tempfile, killing the argv-truncation
   error on large heredoc bodies — the actual failure mode reported in
   the issue), and added an opt-in `--push` flag so callers don't have
   to remember the separate `git push` step. Documented as the
   recommended invocation in `cicd/SKILL.md`.

All scripts are cited verbatim from steward (the AgentCulture alignment
hub) — same pattern culture already uses for shared workflow scripts. The
`--push` flag is a small culture-side divergence, marked in the script
header so a future re-cite from steward doesn't silently overwrite it.

## Test plan

- [x] `bash -n` on all five cicd shell scripts: syntax OK
- [x] `create-pr-and-wait.sh --help` prints usage with `--push`
- [x] `bump.py show` prints `10.3.1` from repo root
- [x] `pr-comments.sh 340` against a real PR returns 14 review comments
- [x] `markdownlint-cli2` on both `SKILL.md` files: 0 errors
- [x] Pre-commit hooks (flake8 / isort / black / bandit / pylint /
       markdownlint) all pass on the staged commit
- [x] **End-to-end dogfood:** this PR is opened via
       `create-pr-and-wait.sh --push --title "..." --body-file
       /tmp/cicd-fix-pr-body.md`. If you're reading this, that flow
       worked end-to-end.

## Files

**New (vendored from steward):**
- `.claude/skills/version-bump/SKILL.md`
- `.claude/skills/version-bump/scripts/bump.py`
- `.claude/skills/cicd/scripts/pr-comments.sh`
- `.claude/skills/cicd/scripts/pr-reply.sh`
- `.claude/skills/cicd/scripts/pr-batch.sh`

**Replaced (steward versions, with `--push` patch on first):**
- `.claude/skills/cicd/scripts/create-pr-and-wait.sh`
- `.claude/skills/cicd/scripts/wait-and-check.sh`

**Edited:**
- `.claude/skills/cicd/SKILL.md` — nine path replacements + `--push`
  documented as recommended
- `pyproject.toml`, `CHANGELOG.md`, `uv.lock` — patch bump 10.3.1 →
  10.3.2

- Claude
