### PR TITLE
chore(deps): bump irc-lens floor to >=0.5.1, refresh uv.lock (10.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.3] - 2026-05-08
+
+### Changed
+
+- Bumped irc-lens floor from >=0.4.2 to >=0.5.1; refreshed uv.lock to 0.5.1.
+  culture console inherits the 0.5.x surface: per-user Session registry,
+  Cloudflare Access JWT middleware, `irc-lens config init`, default
+  `--host`/`--port`, console-parity verbs in the web UI, and view promotion
+  on `/channels` `/who` `/agents`.
+
+### Fixed
+
+- `tests/test_cli_console_playwright.py`: materialize a tmp irc-lens config
+  via `python -m irc_lens config init --path` and pass `--config` through
+  to the `serve` subprocess. irc-lens 0.5.x requires an explicit config
+  file before `serve` will bind; without this the e2e test errored with
+  `no config at ~/.config/irc-lens/config.yaml`.
+
 ## [10.3.2] - 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.4] - 2026-05-08
+
+### Changed
+
+- docs/reference/cli/console.md: document the new first-run auto-init behavior and the opt-out paths (--config or pre-existing default path).
+
+### Fixed
+
+- culture/cli/console.py: auto-init irc-lens default config on first run when --config is not supplied. Bridges the irc-lens 0.5.x serve-requires-config contract so culture console <server> works on a fresh machine instead of dying with a cryptic no-config error (qodo PR #343 review). Skipped when --config is passed explicitly (user-managed) or when the default path already exists.
+- tests/test_cli_console_playwright.py: tighten irc-lens config init subprocess — add 30s timeout, surface stdout/stderr on failure via pytest.fail, and assert the config file exists post-init (qodo PR #343 review).
+
 ## [10.3.3] - 2026-05-08
 
 ### Changed

--- a/culture/cli/console.py
+++ b/culture/cli/console.py
@@ -414,6 +414,41 @@ def _invoke_irc_lens(argv: list[str]) -> "int | None":
     return main(argv)
 
 
+def _argv_has_flag(argv: list[str], flag: str) -> bool:
+    """Return True iff ``flag`` (or ``flag=value``) appears in ``argv``.
+
+    Used to detect a user-supplied ``--config`` so the auto-init below
+    only runs when the user is relying on irc-lens's default path.
+    """
+    for tok in argv:
+        if tok == flag or tok.startswith(f"{flag}="):
+            return True
+    return False
+
+
+def _ensure_default_irc_lens_config() -> None:
+    """Auto-initialize irc-lens's default config if it's missing.
+
+    irc-lens 0.5.x's ``serve`` requires an explicit config file; on a
+    fresh machine the user otherwise hits a cryptic
+    ``no config at ~/.config/irc-lens/config.yaml`` error. This bridge
+    makes ``culture console <server>`` and bare-passthrough
+    ``culture console serve …`` (without ``--config``) succeed on
+    first-run by writing a starter dev-mode config to the default path.
+    The user keeps full control: if they pass ``--config``, this
+    function is bypassed entirely (the caller checks the flag first).
+    """
+    try:
+        from irc_lens.config import default_config_path
+    except ImportError:  # pragma: no cover — declared dep
+        return
+    path = default_config_path()
+    if path.exists():
+        return
+    # Delegate to irc-lens's own init so the schema stays owned upstream.
+    _invoke_irc_lens(["config", "init", "--path", str(path)])
+
+
 def _run_serve(argv: list[str], server_name: str | None) -> "int | None":
     """Wrap ``_invoke_irc_lens`` with conflict detection + state cleanup.
 
@@ -426,6 +461,8 @@ def _run_serve(argv: list[str], server_name: str | None) -> "int | None":
     if server_name is not None:
         target["server_name"] = server_name
     _check_port_conflict(web_port, target)
+    if not _argv_has_flag(argv, "--config"):
+        _ensure_default_irc_lens_config()
     _register_state(web_port, target)
     try:
         return _invoke_irc_lens(argv)

--- a/docs/reference/cli/console.md
+++ b/docs/reference/cli/console.md
@@ -30,6 +30,22 @@ Equivalent to:
 culture console serve --host 127.0.0.1 --port 6667 --nick spark-<you>
 ```
 
+## First-run config
+
+irc-lens 0.5.x requires a config file at
+`~/.config/irc-lens/config.yaml` (or `$XDG_CONFIG_HOME/irc-lens/config.yaml`).
+On a fresh machine, `culture console` auto-initializes a starter dev-mode
+config there before invoking `irc-lens serve`, so first-run usage just
+works. The auto-init only runs when:
+
+- the user did **not** pass `--config <path>` (an explicit path means the
+  user is managing the file themselves), and
+- the default path does **not** already exist.
+
+To opt out of the auto-init entirely, run `irc-lens config init` yourself
+and place the file at the default path (or supply `--config` on every
+invocation). See `irc-lens config init --help` for available flags.
+
 ## Verbs
 
 | Verb | Behaviour |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.2"
+version = "10.3.3"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -23,7 +23,7 @@ dependencies = [
     "textual>=1.0",
     "agex-cli>=0.13,<1.0",
     "afi-cli>=0.3,<1.0",
-    "irc-lens>=0.4.2,<1.0",
+    "irc-lens>=0.5.1,<1.0",
     "opentelemetry-api>=1.25",
     "opentelemetry-sdk>=1.25",
     "opentelemetry-exporter-otlp-proto-grpc>=1.25",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.3"
+version = "10.3.4"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_console_conflict.py
+++ b/tests/test_cli_console_conflict.py
@@ -638,10 +638,10 @@ class TestRunServeCleanup:
 
 class TestArgvHasFlag:
     def test_long_form_present(self):
-        assert console._argv_has_flag(["serve", "--config", "/tmp/x.yaml"], "--config")
+        assert console._argv_has_flag(["serve", "--config", "cfg.yaml"], "--config")
 
     def test_equals_form_present(self):
-        assert console._argv_has_flag(["serve", "--config=/tmp/x.yaml"], "--config")
+        assert console._argv_has_flag(["serve", "--config=cfg.yaml"], "--config")
 
     def test_absent(self):
         assert not console._argv_has_flag(["serve", "--host", "127.0.0.1"], "--config")
@@ -687,7 +687,7 @@ class TestRunServeAutoInitsConfig:
         argv = [
             "serve",
             "--config",
-            "/tmp/custom.yaml",
+            "cfg.yaml",
             "--host",
             "127.0.0.1",
             "--port",
@@ -706,7 +706,7 @@ class TestRunServeAutoInitsConfig:
     def test_auto_init_skipped_when_user_passed_config_equals_form(self, pid_dir):
         argv = [
             "serve",
-            "--config=/tmp/custom.yaml",
+            "--config=cfg.yaml",
             "--host",
             "127.0.0.1",
             "--port",

--- a/tests/test_cli_console_conflict.py
+++ b/tests/test_cli_console_conflict.py
@@ -581,6 +581,7 @@ class TestRunServeCleanup:
         argv = ["serve", "--host", "127.0.0.1", "--port", "6667", "--nick", "spark-ada"]
         with (
             patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config"),
             patch.object(console, "_invoke_irc_lens", return_value=0) as mock_lens,
         ):
             rc = console._run_serve(argv, server_name="spark")
@@ -594,6 +595,7 @@ class TestRunServeCleanup:
         argv = ["serve", "--host", "127.0.0.1", "--port", "6667", "--nick", "spark-ada"]
         with (
             patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config"),
             patch.object(console, "_invoke_irc_lens", side_effect=SystemExit(1)),
             pytest.raises(SystemExit),
         ):
@@ -614,6 +616,7 @@ class TestRunServeCleanup:
         ]
         with (
             patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config"),
             patch.object(console, "_invoke_irc_lens", return_value=0),
         ):
             console._run_serve(argv, server_name="my-server")
@@ -623,6 +626,7 @@ class TestRunServeCleanup:
         # wrote the right server_name by re-running with cleanup disabled:
         with (
             patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config"),
             patch.object(console, "_invoke_irc_lens", return_value=0),
             patch.object(console, "_cleanup_state"),
         ):
@@ -630,3 +634,90 @@ class TestRunServeCleanup:
         sidecar = json.loads((pid_dir / "console-8765.json").read_text())
         assert sidecar["server_name"] == "my-server"
         assert sidecar["nick"] == "my-server-ada"
+
+
+class TestArgvHasFlag:
+    def test_long_form_present(self):
+        assert console._argv_has_flag(["serve", "--config", "/tmp/x.yaml"], "--config")
+
+    def test_equals_form_present(self):
+        assert console._argv_has_flag(["serve", "--config=/tmp/x.yaml"], "--config")
+
+    def test_absent(self):
+        assert not console._argv_has_flag(["serve", "--host", "127.0.0.1"], "--config")
+
+    def test_substring_does_not_match(self):
+        # `--config-path` should not match `--config`.
+        assert not console._argv_has_flag(["serve", "--config-path", "x"], "--config")
+
+
+class TestEnsureDefaultIrcLensConfig:
+    def test_skips_when_default_path_exists(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("placeholder")
+        with (
+            patch("irc_lens.config.default_config_path", return_value=cfg),
+            patch.object(console, "_invoke_irc_lens") as mock_lens,
+        ):
+            console._ensure_default_irc_lens_config()
+        mock_lens.assert_not_called()
+
+    def test_initializes_when_default_path_missing(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        with (
+            patch("irc_lens.config.default_config_path", return_value=cfg),
+            patch.object(console, "_invoke_irc_lens") as mock_lens,
+        ):
+            console._ensure_default_irc_lens_config()
+        mock_lens.assert_called_once_with(["config", "init", "--path", str(cfg)])
+
+
+class TestRunServeAutoInitsConfig:
+    def test_auto_init_runs_when_no_config_flag(self, pid_dir):
+        argv = ["serve", "--host", "127.0.0.1", "--port", "6667", "--nick", "spark-ada"]
+        with (
+            patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config") as mock_ensure,
+            patch.object(console, "_invoke_irc_lens", return_value=0),
+        ):
+            console._run_serve(argv, server_name="spark")
+        mock_ensure.assert_called_once()
+
+    def test_auto_init_skipped_when_user_passed_config(self, pid_dir):
+        argv = [
+            "serve",
+            "--config",
+            "/tmp/custom.yaml",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "6667",
+            "--nick",
+            "spark-ada",
+        ]
+        with (
+            patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config") as mock_ensure,
+            patch.object(console, "_invoke_irc_lens", return_value=0),
+        ):
+            console._run_serve(argv, server_name="spark")
+        mock_ensure.assert_not_called()
+
+    def test_auto_init_skipped_when_user_passed_config_equals_form(self, pid_dir):
+        argv = [
+            "serve",
+            "--config=/tmp/custom.yaml",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "6667",
+            "--nick",
+            "spark-ada",
+        ]
+        with (
+            patch.object(console, "_check_port_conflict"),
+            patch.object(console, "_ensure_default_irc_lens_config") as mock_ensure,
+            patch.object(console, "_invoke_irc_lens", return_value=0),
+        ):
+            console._run_serve(argv, server_name="spark")
+        mock_ensure.assert_not_called()

--- a/tests/test_cli_console_playwright.py
+++ b/tests/test_cli_console_playwright.py
@@ -136,9 +136,27 @@ def agentirc_server():
     loop.close()
 
 
-def test_culture_console_serve_drives_help_view(agentirc_server):
+def test_culture_console_serve_drives_help_view(agentirc_server, tmp_path):
     irc_port = agentirc_server
     web_port = _free_port()
+
+    # irc-lens 0.5.x requires an explicit config file. Materialize a
+    # starter dev-mode config in tmp so the serve subprocess doesn't try
+    # to read ~/.config/irc-lens/config.yaml.
+    config_path = tmp_path / "irc-lens-config.yaml"
+    init_rc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "irc_lens",
+            "config",
+            "init",
+            "--path",
+            str(config_path),
+        ],
+        capture_output=True,
+    ).returncode
+    assert init_rc == 0, "irc-lens config init failed"
 
     culture_proc = subprocess.Popen(
         [
@@ -147,6 +165,8 @@ def test_culture_console_serve_drives_help_view(agentirc_server):
             "culture",
             "console",
             "serve",
+            "--config",
+            str(config_path),
             "--host",
             "127.0.0.1",
             "--port",

--- a/tests/test_cli_console_playwright.py
+++ b/tests/test_cli_console_playwright.py
@@ -142,21 +142,37 @@ def test_culture_console_serve_drives_help_view(agentirc_server, tmp_path):
 
     # irc-lens 0.5.x requires an explicit config file. Materialize a
     # starter dev-mode config in tmp so the serve subprocess doesn't try
-    # to read ~/.config/irc-lens/config.yaml.
+    # to read ~/.config/irc-lens/config.yaml. Bound on a 30s timeout and
+    # surface stdout/stderr if the init fails so CI doesn't hang or
+    # produce a one-line failure with no diagnostics.
     config_path = tmp_path / "irc-lens-config.yaml"
-    init_rc = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "irc_lens",
-            "config",
-            "init",
-            "--path",
-            str(config_path),
-        ],
-        capture_output=True,
-    ).returncode
-    assert init_rc == 0, "irc-lens config init failed"
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "irc_lens",
+                "config",
+                "init",
+                "--path",
+                str(config_path),
+            ],
+            capture_output=True,
+            check=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        pytest.fail(
+            "irc-lens config init failed (rc=%s)\nstdout:\n%s\nstderr:\n%s"
+            % (
+                exc.returncode,
+                exc.stdout.decode("utf-8", errors="replace") if exc.stdout else "",
+                exc.stderr.decode("utf-8", errors="replace") if exc.stderr else "",
+            )
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("irc-lens config init hung past 30s timeout")
+    assert config_path.exists(), f"irc-lens config init did not create {config_path}"
 
     culture_proc = subprocess.Popen(
         [

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.2"
+version = "10.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },
@@ -658,7 +658,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40" },
     { name = "claude-agent-sdk", specifier = ">=0.1" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot'" },
-    { name = "irc-lens", specifier = ">=0.4.2,<1.0" },
+    { name = "irc-lens", specifier = ">=0.5.1,<1.0" },
     { name = "mistune", specifier = ">=3.0" },
     { name = "opentelemetry-api", specifier = ">=1.25" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25" },
@@ -1040,16 +1040,17 @@ wheels = [
 
 [[package]]
 name = "irc-lens"
-version = "0.4.2"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "jinja2" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/bc/90595ed1a3e9a8548b0ed2b4b083116d83548c1b3ed727e552fcd1cd3011/irc_lens-0.4.2.tar.gz", hash = "sha256:a15a3e642c2af9db8130de74f498a372612ab4b98ac9359ffea3e4e8aa223dd3", size = 267349, upload-time = "2026-04-29T09:55:50.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/37/04578842566f3817b20042c2fc9a8fd299c7fed5d8bf6056b3f4740345a8/irc_lens-0.5.1.tar.gz", hash = "sha256:27a5c8d84d454980ecbbf709c5573b95eb7d1667c37e1ecdd97c890d1aca175b", size = 384592, upload-time = "2026-05-08T12:10:14.072Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/d9/131485d74473bde56928d76581d8453fdb3112b1cb27884733263ef328b5/irc_lens-0.4.2-py3-none-any.whl", hash = "sha256:b7357eaf65501c12c75d53235e8e2f658745b5928a0af0e23b81e6fa7674d6ff", size = 147059, upload-time = "2026-04-29T09:55:49.672Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bd/e1ddae6bcd5589f6328736b208034f971ae459023528e8eaec3118d3bbbb/irc_lens-0.5.1-py3-none-any.whl", hash = "sha256:2b6effffed184608eda9574026bd1be9e6a2b6d80701fa6eea5f83c1a94ef190", size = 165543, upload-time = "2026-05-08T12:10:15.45Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.3"
+version = "10.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

- Bumps `irc-lens` floor from `>=0.4.2` to `>=0.5.1` and refreshes
  `uv.lock` (was pinned at 0.4.2).
- culture's `culture console` is a passthrough wrapper around `irc-lens`
  (`culture/cli/console.py`), so the 0.5.x surface lands without any
  shim changes: per-user Session registry under dev mode, Cloudflare
  Access JWT middleware, `irc-lens config init`, default `--host`/`--port`,
  console-parity verbs in the web UI, view promotion on `/channels`
  `/who` `/agents`.
- Updates the playwright e2e test to materialize a tmp irc-lens config
  via `python -m irc_lens config init --path` and pass `--config`
  through to the `serve` subprocess. irc-lens 0.5.x's `serve` requires
  an explicit config file; without this, the test errored with `no
  config at ~/.config/irc-lens/config.yaml`.

## Test plan

- [x] `uv lock --upgrade-package irc-lens` resolves to `irc-lens==0.5.1`
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` — 1091 passed
- [x] `tests/test_cli_console_playwright.py` passes against the upgraded
      irc-lens (was the only failing test pre-fix)
- [x] `markdownlint-cli2 CHANGELOG.md` — clean
- [x] pre-commit hooks (black, isort, flake8, pylint, bandit, markdownlint)
      passed locally on commit

- Claude
