### PR TITLE
fix(mesh): stop emitting legacy --config in agent systemd units (10.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   to `~/.culture/server.yaml` via argparse. New regression test in
   `tests/test_setup_update_cli.py` asserts the absence of `--config`
   and any `.culture/agents.yaml` token in the generated agent argv.
-  Recovery runbook for stale 10.3.x units at
+  Recovery runbook for stale pre-10.3.5 units at
   `docs/reference/cli/agent-systemd.md`.
 
 ## [10.3.4] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.5] - 2026-05-08
+
+### Fixed
+
+- `culture/cli/mesh.py`: stop generating systemd units that pin
+  `--config <workdir>/.culture/agents.yaml`. Three call sites
+  (`_install_mesh_services`, `_cmd_update`'s service rewrite,
+  `_cmd_update`'s service-fallback restart helper) emitted `ExecStart`
+  pointing at a path culture migrated away from when per-directory
+  `culture.yaml` became the format. On real deployments the daemon
+  exited 1 immediately and systemd respawned every 5s — restart
+  counters reached 38000+. Now generated units are
+  `culture agent start <nick> --foreground`, with `--config` defaulting
+  to `~/.culture/server.yaml` via argparse. New regression test in
+  `tests/test_setup_update_cli.py` asserts the absence of `--config`
+  and any `.culture/agents.yaml` token in the generated agent argv.
+  Recovery runbook for stale 10.3.x units at
+  `docs/reference/cli/agent-systemd.md`.
+
 ## [10.3.4] - 2026-05-08
 
 ### Changed

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -307,16 +307,17 @@ def _install_mesh_services(mesh, server_name: str, culture_bin: str, config_path
 
     for agent in mesh.agents:
         full_nick = f"{server_name}-{agent.nick}"
-        workdir = os.path.expanduser(agent.workdir)
-        agent_config_path = os.path.join(workdir, CULTURE_DIR, AGENTS_YAML)
+        # No --config: defer to `culture agent start`'s argparse default
+        # (DEFAULT_CONFIG = ~/.culture/server.yaml — the manifest the rest
+        # of the CLI treats as source of truth). Pinning a per-workdir
+        # legacy path here crashlooped real deployments when culture
+        # migrated to per-directory culture.yaml.
         agent_cmd = [
             culture_bin,
             "agent",
             "start",
             full_nick,
             "--foreground",
-            "--config",
-            agent_config_path,
         ]
         agent_svc = f"culture-agent-{full_nick}"
         path = install_service(agent_svc, agent_cmd, f"culture agent {full_nick}")
@@ -547,16 +548,14 @@ def _restart_mesh_services(
 
     for agent in mesh.agents:
         full_nick = f"{server_name}-{agent.nick}"
-        workdir = os.path.expanduser(agent.workdir)
-        agent_config_path = os.path.join(workdir, CULTURE_DIR, AGENTS_YAML)
+        # See _install_mesh_services for the rationale behind omitting
+        # --config; this restart path mirrors that contract.
         agent_cmd = [
             culture_bin,
             "agent",
             "start",
             full_nick,
             "--foreground",
-            "--config",
-            agent_config_path,
         ]
         install_service(f"culture-agent-{full_nick}", agent_cmd, f"culture agent {full_nick}")
 
@@ -591,15 +590,14 @@ def _restart_mesh_services(
     for agent in mesh.agents:
         full_nick = f"{server_name}-{agent.nick}"
         agent_svc = f"culture-agent-{full_nick}"
-        workdir = os.path.expanduser(agent.workdir)
-        agent_config_path = os.path.join(workdir, CULTURE_DIR, AGENTS_YAML)
+        # Same contract as the install path: rely on the argparse
+        # default (~/.culture/server.yaml) instead of pinning a stale
+        # per-workdir path.
         agent_fallback = [
             culture_bin,
             "agent",
             "start",
             full_nick,
-            "--config",
-            agent_config_path,
         ]
         _restart_single_service(agent_svc, agent_fallback, restart_service)
 

--- a/docs/reference/cli/agent-systemd.md
+++ b/docs/reference/cli/agent-systemd.md
@@ -26,9 +26,9 @@ argparse default — `~/.culture/server.yaml`, the manifest the rest of
 the CLI uses. Anything specified in that manifest (workdir, channels,
 backend) is what the daemon reads.
 
-## Recovering from stale 10.3.x units
+## Recovering from stale pre-10.3.5 units
 
-Up to and including culture 10.3.5, the unit generator pinned a legacy
+Before culture 10.3.5, the unit generator pinned a legacy
 `--config <workdir>/.culture/agents.yaml` path that culture had
 already migrated away from. On machines where that per-workdir file no
 longer exists, the daemon exited 1 immediately, systemd restarted it 5

--- a/docs/reference/cli/agent-systemd.md
+++ b/docs/reference/cli/agent-systemd.md
@@ -1,0 +1,78 @@
+---
+title: "Agent systemd units"
+parent: "CLI"
+grand_parent: "Reference"
+nav_order: 20
+sites: [agentirc, culture]
+description: "How `culture mesh setup`/`update` install agent systemd units, and how to recover from stale 10.3.x units that pinned a legacy --config path."
+permalink: /reference/cli/agent-systemd/
+---
+
+# Agent systemd units
+
+`culture mesh setup` and `culture mesh update` write per-agent systemd
+user units to `~/.config/systemd/user/culture-agent-<nick>.service` so
+the agents come up automatically after reboot under
+`Restart=on-failure`.
+
+The unit's `ExecStart` is intentionally minimal:
+
+```text
+ExecStart=/usr/bin/culture agent start <nick> --foreground
+```
+
+No `--config` is passed. `culture agent start` falls through to the
+argparse default — `~/.culture/server.yaml`, the manifest the rest of
+the CLI uses. Anything specified in that manifest (workdir, channels,
+backend) is what the daemon reads.
+
+## Recovering from stale 10.3.x units
+
+Up to and including culture 10.3.5, the unit generator pinned a legacy
+`--config <workdir>/.culture/agents.yaml` path that culture had
+already migrated away from. On machines where that per-workdir file no
+longer exists, the daemon exited 1 immediately, systemd restarted it 5
+seconds later, and the cycle repeated indefinitely (real deployments
+hit restart counters in the tens of thousands). To the user it looked
+like "agents not awake" — every mention landed during a 5-second
+restart window with no daemon listening.
+
+If `journalctl --user -u culture-agent-<nick>.service` shows a tight
+loop of `[Errno 2] No such file or directory: '<workdir>/.culture/agents.yaml'`
+followed by `Scheduled restart job, restart counter is at NNNN`, you
+have a stale unit. Recover with:
+
+```bash
+# Stop and remove the stale unit:
+systemctl --user disable --now culture-agent-<nick>.service
+rm ~/.config/systemd/user/culture-agent-<nick>.service
+systemctl --user daemon-reload
+
+# Confirm it's gone:
+systemctl --user status culture-agent-<nick>.service   # should say "not-found"
+
+# If the manifest at ~/.culture/server.yaml is also stale (e.g. the
+# nick's workdir was renamed or its culture.yaml deleted), tidy it up:
+culture agent unregister <suffix>     # see `culture agent status` for hints
+culture agent register <workdir>      # if the workdir's culture.yaml is fresh
+
+# Start the agent manually to confirm it works without systemd in the way:
+culture agent start <nick>
+
+# If you want systemd auto-start back, re-run mesh setup for a populated
+# mesh.yaml:
+culture mesh setup --config ~/.culture/mesh.yaml
+```
+
+`culture mesh setup` only re-installs units for agents listed in the
+`agents:` block of `mesh.yaml`. If your `mesh.yaml` has an empty
+`agents: []`, the recovery stops at the manual `culture agent start`
+step — there is currently no per-agent install command decoupled from
+`mesh.yaml`.
+
+## See also
+
+- [`culture mesh setup` / `update`](./index.html) — top-level mesh
+  lifecycle that owns unit installation.
+- [`culture agent register` / `unregister`](./index.html) — manifest
+  management for the `~/.culture/server.yaml` source of truth.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.4"
+version = "10.3.5"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_setup_update_cli.py
+++ b/tests/test_setup_update_cli.py
@@ -218,6 +218,72 @@ def test_resolve_uses_mesh_yaml_when_name_matches(tmp_path):
     assert len(result.server.links) == 1
 
 
+# ---- _install_mesh_services regression tests ----
+#
+# Regression guard for the 10.3.x crashloop bug: systemd units used to
+# pin --config <workdir>/.culture/agents.yaml — a layout culture
+# migrated away from. On a real machine the units crashed 38000+ times
+# under systemd's restart-on-failure policy because the path didn't
+# exist. The fix drops --config so `culture agent start` falls through
+# to its argparse default (~/.culture/server.yaml).
+
+
+def _captured_install_calls(install_mock) -> list:
+    """Pull (svc_name, command, description) tuples out of a mocked
+    install_service callable. install_service is called as
+    install_service(name, command, description) — extract the kwargs
+    or positional args uniformly."""
+    out = []
+    for call in install_mock.call_args_list:
+        args, kwargs = call
+        if len(args) >= 3:
+            out.append((args[0], args[1], args[2]))
+        else:
+            out.append((kwargs["name"], kwargs["command"], kwargs.get("description", "")))
+    return out
+
+
+def test_install_mesh_services_omits_legacy_config_path():
+    """Generated agent unit ExecStart must not pin <workdir>/.culture/agents.yaml.
+
+    The systemd unit body should only carry `culture agent start <nick>
+    --foreground`; any --config token would re-introduce the crashloop
+    when the legacy per-workdir layout doesn't exist.
+    """
+    from culture.cli.mesh import _install_mesh_services
+
+    mesh = MeshConfig(
+        server=MeshServerConfig(name="spark", host="127.0.0.1", port=6667),
+        agents=[
+            MeshAgentConfig(nick="claude", workdir="/home/u/work"),
+            MeshAgentConfig(nick="codex", workdir="/home/u/work2"),
+        ],
+    )
+
+    # install_service is imported inside the function (`from
+    # culture.persistence import install_service`), so patch the source
+    # module rather than the attribute on culture.cli.mesh.
+    with (
+        patch("culture.persistence.install_service") as mock_install,
+        patch(f"{_MESH_MOD}.build_server_start_cmd", return_value=["culture", "server", "start"]),
+    ):
+        _install_mesh_services(mesh, "spark", "/usr/bin/culture", "/etc/mesh.yaml")
+
+    calls = _captured_install_calls(mock_install)
+    agent_calls = [c for c in calls if c[0].startswith("culture-agent-")]
+    assert len(agent_calls) == 2, f"expected 2 agent units, got {len(agent_calls)}"
+    for svc_name, command, _desc in agent_calls:
+        assert "--config" not in command, (
+            f"{svc_name} ExecStart still carries --config: {command}. "
+            "Regression: the legacy <workdir>/.culture/agents.yaml pin must stay out."
+        )
+        assert not any(
+            ".culture/agents.yaml" in tok for tok in command
+        ), f"{svc_name} ExecStart references the legacy agents.yaml path: {command}"
+        # Sanity: the command is still a valid agent-start invocation.
+        assert "agent" in command and "start" in command and "--foreground" in command
+
+
 def test_resolve_rebuilds_from_agents_yaml_preserving_links(tmp_path):
     """When mesh.yaml has wrong name, rebuild from agents.yaml and keep links."""
     from culture.cli.mesh import _resolve_mesh_for_server

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.4"
+version = "10.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Fixes the "agents not awake" symptom by killing the systemd unit
crashloop at the source.

`culture mesh setup` and `culture mesh update` were generating
`ExecStart` values that pin
`--config <workdir>/.culture/agents.yaml` — a layout culture migrated
away from when per-directory `culture.yaml` became the format. On
real deployments where the legacy file doesn't exist, the daemon
exits 1 immediately, systemd respawns 5 s later, and the cycle
repeats indefinitely. On this contributor's host the restart counter
hit **38058** across `spark-culture` and `spark-daria` before the
diagnostic ran. To the user it looked like "agents not awake" —
every mention landed during a 5-second restart window with no daemon
listening.

Three call sites in `culture/cli/mesh.py` emitted the bad path:
- `_install_mesh_services` (L308-323)
- `_cmd_update`'s service rewrite (L548-561)
- `_cmd_update`'s service-fallback restart helper (L591-604)

All three now emit `culture agent start <nick> --foreground`, relying
on the argparse default (`~/.culture/server.yaml`) the rest of the
CLI treats as source of truth.

Recovery runbook for users with existing stale units lives in
`docs/reference/cli/agent-systemd.md`.

## Test plan

- [x] New regression test
      `tests/test_setup_update_cli.py::test_install_mesh_services_omits_legacy_config_path`
      verifies generated `agent_cmd` carries no `--config` and no
      `.culture/agents.yaml` token. Confirmed to **fail on stock main**
      with the exact crashloop-causing argv before the fix lands, and
      to pass on this branch.
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` —
      1101 passed (was 1100; +1 new test).
- [x] `markdownlint-cli2 CHANGELOG.md docs/reference/cli/agent-systemd.md`
      — clean.
- [x] pre-commit hooks (black, isort, flake8, pylint, bandit,
      markdownlint) passed locally on commit.

## Out of scope (deferred follow-ups)

- Removing `_generate_agent_configs` (mesh.py:260-296) and the
  `CULTURE_DIR` / `AGENTS_YAML` constants. The function still writes
  per-workdir `.culture/agents.yaml` files that nothing reads
  anymore, but deleting it touches more code and the user picked
  "minimal" scope.
- Adding `culture agent install/uninstall <nick>` decoupled from
  `mesh.yaml`, for users whose `mesh.yaml` has `agents: []`.
- Auto-unpause for the supervisor escalation path and a per-turn
  timeout around the SDK `query()` call. Both are latent bugs but
  **not the cause** of the current symptom; defer until they bite.

- Claude
