### PR TITLE
feat: track repo-root culture.yaml + fix test that clobbered it (10.3.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,7 @@ safety-results.json
 # Generated Jekyll output (never commit)
 _site/
 _site_culture/
+
+# Per-host backups of the repo-root culture.yaml (e.g.
+# culture.yaml.daria-acp-bak). The canonical culture.yaml IS tracked.
+/culture.yaml.*-bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.6] - 2026-05-08
+
+### Added
+
+- Track repo-root `culture.yaml` as the canonical declaration of
+  culture's persistence agent (`<server>-culture`). Mirrors the
+  pattern already established at `packages/agent-harness/` and
+  `culture/clients/<backend>/`. The `system_prompt` was rewritten to
+  be host-agnostic (`<server>-culture`, "this repo's working
+  directory") so the file ports cleanly across hosts.
+- `docs/reference/server/config.md`: new subsection on the repo-root
+  vs sub-directory `culture.yaml` convention, explaining that
+  `culture.yaml` at repo root is tracked alongside `CLAUDE.md` and
+  declares intent (registration is still explicit via
+  `culture agent register`).
+- `.gitignore`: exclude `/culture.yaml.*-bak` per-host backups
+  (e.g. `culture.yaml.daria-acp-bak` from the cleanup runbook in
+  10.3.5's recovery docs).
+
+### Fixed
+
+- `tests/test_archive.py::test_cli_create_replaces_archived_agent`:
+  add `monkeypatch.chdir(tmpdir)` so the test no longer leaks
+  `os.getcwd()` into `_create_acp_config`. Without the fix, running
+  the suite from the repo root caused `_save_agent_to_directory` to
+  overwrite the real `culture.yaml` at the project root with a
+  multi-agent merge (the new tracked file made the regression
+  impossible to ignore).
+
 ## [10.3.5] - 2026-05-08
 
 ### Fixed

--- a/culture.yaml
+++ b/culture.yaml
@@ -1,0 +1,17 @@
+suffix: culture
+backend: claude
+model: claude-sonnet-4-6
+channels:
+  - "#general"
+system_prompt: |
+  You are <server>-culture, the persistent claude-backed identity
+  for this culture host. This repo's working directory is your
+  workdir. When the user is not actively chatting with Claude Code
+  via the Claude Agent SDK, you stay on the mesh: observe channels,
+  respond to @mentions and DMs, and collaborate with other agents
+  on the local mesh and any linked peers.
+  See CLAUDE.md in this repo for the project's conventions
+  (all-backends rule, IRC verbs, citation pattern, etc.).
+tags:
+  - persistence
+  - claude

--- a/docs/reference/server/config.md
+++ b/docs/reference/server/config.md
@@ -146,6 +146,23 @@ At startup, `culture agent start` reads this manifest, loads each directory's
 
 Each agent has a `culture.yaml` in its working directory.
 
+### Repo-root vs sub-directory
+
+A `culture.yaml` file is interpreted relative to the directory it lives
+in — that directory becomes the agent's working directory. Most repos
+put one at the repo root: it's the canonical declaration of the
+persistence agent for that repo, tracked in git alongside `CLAUDE.md`.
+The culture repo itself follows this pattern at `culture.yaml`, and
+additionally tracks per-backend declarations at
+`packages/agent-harness/culture.yaml` and
+`culture/clients/<backend>/culture.yaml` for the citation-pattern
+harness agents.
+
+The file declares *intent* — what agent should run if registered.
+Registration is still explicit: run `culture agent register <workdir>`
+from a clone to add the entry to your local `~/.culture/server.yaml`
+manifest, then `culture agent start <server>-<suffix>` to bring it up.
+
 ### Single-agent (flat format)
 
 ```yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.5"
+version = "10.3.6"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -601,7 +601,7 @@ def test_create_blocked_by_active_agent():
 # -----------------------------------------------------------------------
 
 
-def test_cli_create_replaces_archived_agent():
+def test_cli_create_replaces_archived_agent(monkeypatch):
     """culture agent create replaces an archived agent via the CLI path."""
     from culture.cli import _build_parser
     from culture.cli.agent import _cmd_create
@@ -616,6 +616,11 @@ def test_cli_create_replaces_archived_agent():
 
     tmpdir = tempfile.mkdtemp()
     try:
+        # _create_acp_config / _create_default_config use os.getcwd() for the
+        # new agent's `directory`, and _save_agent_to_directory then writes a
+        # culture.yaml there. Without chdir, this test corrupts the real
+        # culture.yaml at whatever directory pytest was invoked from.
+        monkeypatch.chdir(tmpdir)
         path = os.path.join(tmpdir, "agents.yaml")
         save_config(
             path,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -615,6 +615,7 @@ def test_cli_create_replaces_archived_agent(monkeypatch):
     from culture.config import load_config
 
     tmpdir = tempfile.mkdtemp()
+    original_cwd = os.getcwd()
     try:
         # _create_acp_config / _create_default_config use os.getcwd() for the
         # new agent's `directory`, and _save_agent_to_directory then writes a
@@ -662,6 +663,9 @@ def test_cli_create_replaces_archived_agent(monkeypatch):
         assert agent.backend == "acp"
         assert agent.archived is False
     finally:
+        # Restore cwd before rmtree so we're not deleting the directory we're
+        # standing in (Windows refuses, POSIX leaves a stale cwd).
+        os.chdir(original_cwd)
         shutil.rmtree(tmpdir)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.5"
+version = "10.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

The repo-root `culture.yaml` is now tracked in git, alongside
`CLAUDE.md`, as the canonical declaration of culture's persistence
agent (`<server>-culture`). Mirrors the convention already established
at `packages/agent-harness/culture.yaml` and
`culture/clients/<backend>/culture.yaml` — the directory hosts the
agent, and the file declares *intent*; registration stays explicit
via `culture agent register <workdir>`.

The `system_prompt` is host-agnostic (`<server>-culture`, "this
repo's working directory") so the file ports cleanly to any host
running culture from this checkout.

## What's in the PR

- **`culture.yaml` (new, tracked):** `suffix: culture, backend:
  claude, model: claude-sonnet-4-6, channels: ["#general"]`,
  host-agnostic `system_prompt`, `tags: [persistence, claude]`.
- **`docs/reference/server/config.md`:** new "Repo-root vs
  sub-directory" subsection explaining the convention.
- **`.gitignore`:** `/culture.yaml.*-bak` rule so per-host backups
  (e.g. `culture.yaml.daria-acp-bak` from the 10.3.5 cleanup
  runbook) don't pollute `git status`.
- **`tests/test_archive.py` fix:**
  `test_cli_create_replaces_archived_agent` now uses
  `monkeypatch.chdir(tmpdir)`. Without it, the test leaked
  `os.getcwd()` into `_create_acp_config` (which sets
  `directory=os.getcwd()`), and `_save_agent_to_directory` overwrote
  the real `culture.yaml` at the project root with a multi-agent
  merge. The new tracked file made this previously-silent
  regression impossible to ignore — every CI run on this branch
  would have corrupted the file otherwise.

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` —
      1101 passed (no new tests; the test fix is a behavioral fix
      to an existing test).
- [x] **MD5 invariance check:** `md5sum culture.yaml` before and
      after the full test run returns the same hash. Without the
      `monkeypatch.chdir` fix, the file was rewritten and the
      hashes diverged.
- [x] `markdownlint-cli2 CHANGELOG.md docs/reference/server/config.md`
      — clean.
- [x] pre-commit hooks (black, isort, flake8, pylint, bandit,
      markdownlint) passed locally on commit.

## Out of scope (deferred)

- A dedicated test that asserts no test mutates files outside its
  `tmp_path`. Would catch future regressions of this exact shape;
  for now the new tracked file + 10.3.6 fix close the loop.
- Adding repo-root `culture.yaml` to other AgentCulture repos
  (daria, agex, …) — each is its own decision.
- The deferred follow-ups from earlier plans
  (`_generate_agent_configs` removal, supervisor unpause, SDK turn
  timeout, `culture agent install/uninstall`).

- Claude
