### PR TITLE
chore(mesh): remove dead _generate_agent_configs (10.3.7) (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.7] - 2026-05-08
+
+### Removed
+
+- `culture mesh setup` no longer writes per-workdir
+  `<workdir>/.culture/agents.yaml` files. Since PR #344 dropped the
+  legacy `--config` pin from generated systemd units, those files
+  were orphan writes that confused operators inspecting them.
+  Companion cleanup: `_generate_agent_configs` (was at
+  `culture/cli/mesh.py:260-296`), its call from `_cmd_setup`, and
+  the `CULTURE_DIR` / `AGENTS_YAML` constants in
+  `culture/cli/shared/constants.py` are gone. Closes #347.
+
 ## [10.3.6] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [10.3.7] - 2026-05-08
 
-### Removed
+### Changed
 
 - `culture mesh setup` no longer writes per-workdir
   `<workdir>/.culture/agents.yaml` files. Since PR #344 dropped the

--- a/culture/cli/mesh.py
+++ b/culture/cli/mesh.py
@@ -18,7 +18,7 @@ import time
 from culture.cli.console import dispatch_resolved_argv as console_dispatch
 from culture.config import ServerConfig, load_config, load_config_or_default
 
-from .shared.constants import _CONFIG_HELP, AGENTS_YAML, CULTURE_DIR, DEFAULT_CONFIG
+from .shared.constants import _CONFIG_HELP, DEFAULT_CONFIG
 from .shared.mesh import build_server_start_cmd, generate_mesh_from_agents
 from .shared.process import server_stop_by_name, stop_agent
 
@@ -257,45 +257,6 @@ def _store_mesh_credentials(mesh) -> None:
                 )
 
 
-def _generate_agent_configs(mesh, server_name: str) -> None:
-    """Generate agents.yaml for each agent workdir defined in the mesh config."""
-    from culture.clients.claude.config import AgentConfig as BaseAgentConfig
-    from culture.clients.claude.config import (
-        DaemonConfig,
-        ServerConnConfig,
-        save_config,
-    )
-
-    workdir_agents: dict[str, list] = {}
-    for agent in mesh.agents:
-        workdir = os.path.expanduser(agent.workdir)
-        workdir_agents.setdefault(workdir, []).append(agent)
-
-    for workdir, agents in workdir_agents.items():
-        os.makedirs(workdir, exist_ok=True)
-        config_path = os.path.join(workdir, CULTURE_DIR, AGENTS_YAML)
-        os.makedirs(os.path.dirname(config_path), exist_ok=True)
-
-        agent_configs = []
-        for a in agents:
-            full_nick = f"{server_name}-{a.nick}"
-            agent_configs.append(
-                BaseAgentConfig(
-                    nick=full_nick,
-                    agent=a.type,
-                    directory=workdir,
-                    channels=a.channels,
-                )
-            )
-
-        daemon_config = DaemonConfig(
-            server=ServerConnConfig(name=server_name, host="localhost", port=mesh.server.port),
-            agents=agent_configs,
-        )
-        save_config(config_path, daemon_config)
-        print(f"  Wrote {config_path}")
-
-
 def _install_mesh_services(mesh, server_name: str, culture_bin: str, config_path: str) -> None:
     """Install auto-start service entries for the server and all agents."""
     from culture.persistence import install_service
@@ -354,8 +315,6 @@ def _cmd_setup(args: argparse.Namespace) -> None:
         return
 
     _store_mesh_credentials(mesh)
-
-    _generate_agent_configs(mesh, server_name)
 
     culture_bin = shutil.which("culture") or "culture"
     _install_mesh_services(mesh, server_name, culture_bin, args.config)

--- a/culture/cli/shared/constants.py
+++ b/culture/cli/shared/constants.py
@@ -14,8 +14,6 @@ _BOT_NAME_HELP = "Bot name"
 
 DEFAULT_CHANNEL = "#general"
 NO_AGENTS_MSG = "No agents configured"
-CULTURE_DIR = ".culture"
-AGENTS_YAML = "agents.yaml"
 
 DEFAULT_SERVER_CONFIG = os.path.expanduser("~/.culture/server.yaml")
 LEGACY_CONFIG = os.path.expanduser("~/.culture/agents.yaml")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.6"
+version = "10.3.7"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.6"
+version = "10.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Pure cleanup PR. After PR #344 changed the systemd unit generator
to drop `--config <workdir>/.culture/agents.yaml` from generated
`ExecStart` values, nothing read those per-workdir files anymore.
But `_generate_agent_configs` at `culture/cli/mesh.py:260-296`
still wrote them on every `culture mesh setup` — orphan writes
that misled operators inspecting the file (it looked authoritative
when in fact `~/.culture/server.yaml` was source of truth).

This PR removes:
- `_generate_agent_configs` (mesh.py:260-296)
- The call from `_cmd_setup` (mesh.py:358)
- `CULTURE_DIR = ".culture"` and `AGENTS_YAML = "agents.yaml"`
  from `culture/cli/shared/constants.py:17-18`
- The corresponding import in `mesh.py:21`

`LEGACY_CONFIG` (the user-level `~/.culture/agents.yaml` fallback
in `culture/config.py`) stays — that's a different concern, still
used by `load_config_or_default`.

## Test plan

- [x] Repo-wide grep before edits confirmed no other readers of
      `_generate_agent_configs`, `CULTURE_DIR`, or `AGENTS_YAML`
      (no tests, no cross-module imports).
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` —
      1101 passed (same count as pre-change; nothing exercised the
      removed code).
- [x] `culture.yaml` MD5 invariance check across the test run —
      stable (unrelated to this PR but verifies the PR #346
      isolation fix continues to hold).
- [x] `markdownlint-cli2 CHANGELOG.md` — clean.
- [x] pre-commit hooks (black, isort, flake8, pylint, bandit,
      markdownlint) passed locally on commit.

Closes #347.

- Claude
