### PR TITLE
feat(harness): per-turn SDK timeout in agent_runner across all backends (10.3.8) (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.3.8] - 2026-05-08
+
+### Added
+
+- `turn_timeout_seconds` field on the `culture.yaml` `AgentConfig`
+  schema (default `600`). Each backend's `agent_runner.py` wraps
+  turn execution in `asyncio.wait_for` / `asyncio.timeout`. On
+  expiry the runner records `outcome=timeout` and exits 1, letting
+  the existing crash-recovery in `daemon._on_agent_exit` +
+  `_delayed_restart` (5 s delay, max 3 in 300 s) handle restart
+  cleanly. Set `0` to disable. Closes #349.
+- All four backends (claude, codex, copilot, acp) plus
+  `packages/agent-harness/` template grew the field. Claude
+  previously had no timeout — the bug. Codex previously hardcoded
+  300 s on the event-wait alone; the wrap is now config-driven and
+  covers `_send_request` too. Copilot keeps its inner 120 s on
+  `send_and_wait` and adds the outer wrap. ACP keeps the inner
+  300 s on `_send_request` and adds an outer wrap covering the
+  whole prompt round-trip including the busy-poll.
+- `docs/reference/server/config.md`: new `turn_timeout_seconds` row
+  in the `culture.yaml` fields table.
+- `tests/harness/test_agent_runner_*.py`: 5 new tests across the
+  four backends covering timeout-fires-on-wedge (claude, codex,
+  copilot, acp) and timeout-disabled-when-zero (claude) paths.
+
 ## [10.3.7] - 2026-05-08
 
 ### Changed

--- a/culture/clients/acp/agent_runner.py
+++ b/culture/clients/acp/agent_runner.py
@@ -45,6 +45,7 @@ class ACPAgentRunner:
         on_turn_error: Callable[[], Awaitable[None] | None] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
+        turn_timeout_seconds: float = 600.0,
     ) -> None:
         self.model = model
         self.directory = directory
@@ -55,6 +56,12 @@ class ACPAgentRunner:
         self.on_turn_error = on_turn_error
         self._metrics = metrics
         self._nick = nick
+        # Outer safety net for the whole prompt round-trip (send +
+        # busy-poll). The inner 300s on _send_request stays — it
+        # bounds individual JSON-RPC requests; this fires if the
+        # busy-flag never clears (the failure mode that motivated
+        # issue #349).
+        self._turn_timeout = turn_timeout_seconds
 
         self._isolated_home: str | None = None
         self._process: asyncio.subprocess.Process | None = None
@@ -455,9 +462,17 @@ class ACPAgentRunner:
         ):
             try:
                 self._busy = True
-                resp = await self._send_prompt_with_retry(text)
-                await self._handle_prompt_result(resp)
-            except TimeoutError:  # bubbles from _send_prompt_with_retry's retry-then-fail
+                if self._turn_timeout > 0:
+                    async with asyncio.timeout(self._turn_timeout):
+                        resp = await self._send_prompt_with_retry(text)
+                        await self._handle_prompt_result(resp)
+                else:
+                    resp = await self._send_prompt_with_retry(text)
+                    await self._handle_prompt_result(resp)
+            except TimeoutError:
+                # Both _send_prompt_with_retry's inner 300s retry-then-fail
+                # and the outer asyncio.timeout above raise TimeoutError
+                # (asyncio.TimeoutError is a TimeoutError alias in 3.11+).
                 outcome = "timeout"
                 logger.exception("ACP turn timeout")
                 if self.on_turn_error:

--- a/culture/clients/acp/agent_runner.py
+++ b/culture/clients/acp/agent_runner.py
@@ -474,9 +474,23 @@ class ACPAgentRunner:
                 # and the outer asyncio.timeout above raise TimeoutError
                 # (asyncio.TimeoutError is a TimeoutError alias in 3.11+).
                 outcome = "timeout"
-                logger.exception("ACP turn timeout")
+                logger.exception(
+                    "ACP turn timeout (turn_timeout_seconds=%ss); "
+                    "terminating subprocess so cleanup → on_exit fires "
+                    "for crash recovery",
+                    self._turn_timeout,
+                )
                 if self.on_turn_error:
                     await maybe_await(self.on_turn_error())
+                # Terminate the wedged subprocess so the read-loop EOF
+                # triggers _cleanup_process → on_exit(returncode) →
+                # daemon._on_agent_exit → _delayed_restart. Without
+                # this, ACP timeouts never reach crash recovery.
+                if self._process is not None and self._process.returncode is None:
+                    try:
+                        self._process.terminate()
+                    except ProcessLookupError:
+                        pass
             except Exception:
                 outcome = "error"
                 logger.exception("ACP turn error")

--- a/culture/clients/acp/daemon.py
+++ b/culture/clients/acp/daemon.py
@@ -401,6 +401,7 @@ class ACPDaemon:
             on_turn_error=self._on_turn_error,
             metrics=self._metrics,
             nick=self.agent.nick,
+            turn_timeout_seconds=getattr(self.agent, "turn_timeout_seconds", 600.0),
         )
         # Absorb the system prompt response without relaying to IRC
         self._mention_targets.append(None)

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -70,6 +70,7 @@ class AgentRunner:
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
+        turn_timeout_seconds: float = 600.0,
     ) -> None:
         self.model = model
         self.directory = directory
@@ -78,6 +79,10 @@ class AgentRunner:
         self.on_message = on_message
         self._metrics = metrics
         self._nick = nick
+        # Outer safety net: if the SDK stream wedges, asyncio.wait_for
+        # raises TimeoutError → on_exit(1) → daemon crash recovery
+        # restarts the runner. Non-positive disables the wrap.
+        self._turn_timeout = turn_timeout_seconds
 
         self._session_id: str | None = None
         self._task: asyncio.Task | None = None
@@ -154,6 +159,27 @@ class AgentRunner:
             msg_dict = self._assistant_to_dict(msg)
             await self.on_message(msg_dict)
 
+    async def _stream_turn(self, prompt: str) -> dict | None:
+        """Run the SDK stream for one turn; return usage dict or None.
+
+        Wrapped by ``_process_turn`` in ``asyncio.wait_for`` so a wedged
+        SDK iteration cannot block the prompt queue forever.
+        """
+        usage_dict: dict | None = None
+        async for message in query(
+            prompt=prompt,
+            options=self._make_options(),
+        ):
+            if isinstance(message, ResultMessage):
+                self._handle_result_message(message)
+                # Extract usage if exposed by SDK; some ResultMessages have it
+                u = getattr(message, "usage", None)
+                if u is not None:
+                    usage_dict = _extract_usage(u)
+            elif isinstance(message, AssistantMessage):
+                await self._handle_assistant_message(message)
+        return usage_dict
+
     async def _process_turn(self, prompt: str) -> bool:
         """Run a single conversation turn. Returns False if a fatal error occurred."""
         tracer = _otel_trace.get_tracer(_HARNESS_TRACER_NAME)
@@ -170,18 +196,22 @@ class AgentRunner:
             },
         ):
             try:
-                async for message in query(
-                    prompt=prompt,
-                    options=self._make_options(),
-                ):
-                    if isinstance(message, ResultMessage):
-                        self._handle_result_message(message)
-                        # Extract usage if exposed by SDK; some ResultMessages have it
-                        u = getattr(message, "usage", None)
-                        if u is not None:
-                            usage_dict = _extract_usage(u)
-                    elif isinstance(message, AssistantMessage):
-                        await self._handle_assistant_message(message)
+                if self._turn_timeout > 0:
+                    usage_dict = await asyncio.wait_for(
+                        self._stream_turn(prompt),
+                        timeout=self._turn_timeout,
+                    )
+                else:
+                    usage_dict = await self._stream_turn(prompt)
+            except asyncio.TimeoutError:
+                outcome = "timeout"
+                failed = True
+                logger.warning(
+                    "SDK turn exceeded turn_timeout_seconds=%s; signalling restart",
+                    self._turn_timeout,
+                )
+                if not self._stopping and self.on_exit:
+                    await self.on_exit(1)
             except Exception:
                 outcome = "error"
                 failed = True

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -332,6 +332,7 @@ class AgentDaemon:
             on_message=self._on_agent_message,
             metrics=self._metrics,
             nick=self.agent.nick,
+            turn_timeout_seconds=getattr(self.agent, "turn_timeout_seconds", 600.0),
         )
         await self._agent_runner.start()
         logger.info("AgentRunner started via SDK for %s", self.agent.nick)

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -364,25 +364,29 @@ class CodexAgentRunner:
         )
         await self._turn_done.wait()
 
-    async def _handle_turn_timeout(self) -> None:
-        """Log the cause, fire on_turn_error, terminate the subprocess.
+    async def _handle_turn_timeout(self, elapsed_s: float) -> None:
+        """Log the cause + elapsed, fire on_turn_error, terminate subprocess.
+
+        ``elapsed_s`` (vs the two budgets) tells the operator which
+        timeout actually fired: ~30 s ⇒ inner ``_send_request``;
+        ~``self._turn_timeout`` ⇒ outer wrap.
 
         Subprocess termination is what reaches crash recovery: the
-        read-loop sees EOF, `_cleanup_codex_process` calls
-        `on_exit(returncode)`, and the daemon's `_on_agent_exit`
-        schedules `_delayed_restart`.
+        read-loop sees EOF, ``_cleanup_codex_process`` calls
+        ``on_exit(returncode)``, and the daemon's ``_on_agent_exit``
+        schedules ``_delayed_restart``.
         """
         if self._turn_timeout > 0:
-            cause = (
-                f"outer turn_timeout_seconds={self._turn_timeout}s "
-                "or inner _send_request budget 30s"
+            budgets = (
+                f"outer turn_timeout_seconds={self._turn_timeout}s, " "inner _send_request 30s"
             )
         else:
-            cause = "inner _send_request budget 30s (outer disabled)"
+            budgets = "inner _send_request 30s (outer disabled)"
         logger.warning(
-            "Codex turn timed out (%s); terminating subprocess so "
-            "cleanup → on_exit fires for crash recovery",
-            cause,
+            "Codex turn timed out after %.1fs (budgets: %s); terminating "
+            "subprocess so cleanup → on_exit fires for crash recovery",
+            elapsed_s,
+            budgets,
         )
         self._turn_done.set()
         if self.on_turn_error:
@@ -418,7 +422,7 @@ class CodexAgentRunner:
                     await self._send_turn_and_wait(text)
             except asyncio.TimeoutError:
                 outcome = "timeout"
-                await self._handle_turn_timeout()
+                await self._handle_turn_timeout(time.perf_counter() - start_perf)
             except Exception:
                 outcome = "error"
                 logger.exception("Codex turn error")

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -388,10 +388,28 @@ class CodexAgentRunner:
                     await self._turn_done.wait()
             except asyncio.TimeoutError:
                 outcome = "timeout"
-                logger.warning("Codex turn timed out after %ss", self._turn_timeout)
+                # Either the inner _send_request 30 s or the outer
+                # turn_timeout fired — log both budgets so the cause is
+                # diagnosable from the journal alone.
+                logger.warning(
+                    "Codex turn timed out (inner request budget 30s, outer "
+                    "turn_timeout_seconds=%ss); terminating subprocess so "
+                    "cleanup → on_exit fires for crash recovery",
+                    self._turn_timeout,
+                )
                 self._turn_done.set()
                 if self.on_turn_error:
                     await maybe_await(self.on_turn_error())
+                # Terminate the wedged subprocess. The read-loop sees
+                # EOF, _cleanup_codex_process runs, and the daemon's
+                # _on_agent_exit schedules _delayed_restart. Without
+                # this, on_exit is never called and the agent stays
+                # stuck.
+                if self._process is not None and self._process.returncode is None:
+                    try:
+                        self._process.terminate()
+                    except ProcessLookupError:
+                        pass
             except Exception:
                 outcome = "error"
                 logger.exception("Codex turn error")

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -35,6 +35,7 @@ class CodexAgentRunner:
         on_turn_error: Callable[[], Awaitable[None] | None] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
+        turn_timeout_seconds: float = 600.0,
     ) -> None:
         self.model = model
         self.directory = directory
@@ -44,6 +45,10 @@ class CodexAgentRunner:
         self.on_turn_error = on_turn_error
         self._metrics = metrics
         self._nick = nick
+        # Outer safety net for the whole turn (request + completion
+        # event). Replaces the previous hardcoded 300s on the event
+        # wait alone. Non-positive disables the wrap.
+        self._turn_timeout = turn_timeout_seconds
 
         self._isolated_home: str | None = None
         self._process: asyncio.subprocess.Process | None = None
@@ -359,19 +364,31 @@ class CodexAgentRunner:
         ):
             self._turn_done.clear()
             try:
-                await self._send_request(
-                    "turn/start",
-                    {
-                        "threadId": self._thread_id,
-                        "input": [{"type": "text", "text": text}],
-                    },
-                )
-                # Wait for turn/completed notification via the event
-                async with asyncio.timeout(300):
+                # Outer wrap covers both _send_request and the
+                # turn/completed event wait, so a wedged request also
+                # times out (previously only the event wait was bounded).
+                if self._turn_timeout > 0:
+                    async with asyncio.timeout(self._turn_timeout):
+                        await self._send_request(
+                            "turn/start",
+                            {
+                                "threadId": self._thread_id,
+                                "input": [{"type": "text", "text": text}],
+                            },
+                        )
+                        await self._turn_done.wait()
+                else:
+                    await self._send_request(
+                        "turn/start",
+                        {
+                            "threadId": self._thread_id,
+                            "input": [{"type": "text", "text": text}],
+                        },
+                    )
                     await self._turn_done.wait()
             except asyncio.TimeoutError:
                 outcome = "timeout"
-                logger.warning("Codex turn timed out after 300s")
+                logger.warning("Codex turn timed out after %ss", self._turn_timeout)
                 self._turn_done.set()
                 if self.on_turn_error:
                     await maybe_await(self.on_turn_error())

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -388,14 +388,21 @@ class CodexAgentRunner:
                     await self._turn_done.wait()
             except asyncio.TimeoutError:
                 outcome = "timeout"
-                # Either the inner _send_request 30 s or the outer
-                # turn_timeout fired — log both budgets so the cause is
-                # diagnosable from the journal alone.
+                # Either the inner _send_request 30 s budget or the
+                # outer turn_timeout fired. Distinguish via the
+                # configured outer value so the journal tells the
+                # operator which budget to tune.
+                if self._turn_timeout > 0:
+                    cause = (
+                        f"outer turn_timeout_seconds={self._turn_timeout}s "
+                        "or inner _send_request budget 30s"
+                    )
+                else:
+                    cause = "inner _send_request budget 30s (outer disabled)"
                 logger.warning(
-                    "Codex turn timed out (inner request budget 30s, outer "
-                    "turn_timeout_seconds=%ss); terminating subprocess so "
+                    "Codex turn timed out (%s); terminating subprocess so "
                     "cleanup → on_exit fires for crash recovery",
-                    self._turn_timeout,
+                    cause,
                 )
                 self._turn_done.set()
                 if self.on_turn_error:

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -349,6 +349,50 @@ class CodexAgentRunner:
                 self._process.stdin.write(line.encode())
                 await self._process.stdin.drain()
 
+    async def _send_turn_and_wait(self, text: str) -> None:
+        """Send turn/start and wait for the turn/completed event.
+
+        Pulled out of `_execute_single_turn` so the outer-timeout
+        branch and the disabled-timeout branch share one body.
+        """
+        await self._send_request(
+            "turn/start",
+            {
+                "threadId": self._thread_id,
+                "input": [{"type": "text", "text": text}],
+            },
+        )
+        await self._turn_done.wait()
+
+    async def _handle_turn_timeout(self) -> None:
+        """Log the cause, fire on_turn_error, terminate the subprocess.
+
+        Subprocess termination is what reaches crash recovery: the
+        read-loop sees EOF, `_cleanup_codex_process` calls
+        `on_exit(returncode)`, and the daemon's `_on_agent_exit`
+        schedules `_delayed_restart`.
+        """
+        if self._turn_timeout > 0:
+            cause = (
+                f"outer turn_timeout_seconds={self._turn_timeout}s "
+                "or inner _send_request budget 30s"
+            )
+        else:
+            cause = "inner _send_request budget 30s (outer disabled)"
+        logger.warning(
+            "Codex turn timed out (%s); terminating subprocess so "
+            "cleanup → on_exit fires for crash recovery",
+            cause,
+        )
+        self._turn_done.set()
+        if self.on_turn_error:
+            await maybe_await(self.on_turn_error())
+        if self._process is not None and self._process.returncode is None:
+            try:
+                self._process.terminate()
+            except ProcessLookupError:
+                pass
+
     async def _execute_single_turn(self, text: str) -> None:
         """Send one turn request and wait for completion."""
         start_perf = time.perf_counter()
@@ -364,59 +408,17 @@ class CodexAgentRunner:
         ):
             self._turn_done.clear()
             try:
-                # Outer wrap covers both _send_request and the
-                # turn/completed event wait, so a wedged request also
-                # times out (previously only the event wait was bounded).
                 if self._turn_timeout > 0:
+                    # Outer wrap covers both _send_request and the
+                    # turn/completed wait, so a wedged request also
+                    # times out (pre-PR only the wait was bounded).
                     async with asyncio.timeout(self._turn_timeout):
-                        await self._send_request(
-                            "turn/start",
-                            {
-                                "threadId": self._thread_id,
-                                "input": [{"type": "text", "text": text}],
-                            },
-                        )
-                        await self._turn_done.wait()
+                        await self._send_turn_and_wait(text)
                 else:
-                    await self._send_request(
-                        "turn/start",
-                        {
-                            "threadId": self._thread_id,
-                            "input": [{"type": "text", "text": text}],
-                        },
-                    )
-                    await self._turn_done.wait()
+                    await self._send_turn_and_wait(text)
             except asyncio.TimeoutError:
                 outcome = "timeout"
-                # Either the inner _send_request 30 s budget or the
-                # outer turn_timeout fired. Distinguish via the
-                # configured outer value so the journal tells the
-                # operator which budget to tune.
-                if self._turn_timeout > 0:
-                    cause = (
-                        f"outer turn_timeout_seconds={self._turn_timeout}s "
-                        "or inner _send_request budget 30s"
-                    )
-                else:
-                    cause = "inner _send_request budget 30s (outer disabled)"
-                logger.warning(
-                    "Codex turn timed out (%s); terminating subprocess so "
-                    "cleanup → on_exit fires for crash recovery",
-                    cause,
-                )
-                self._turn_done.set()
-                if self.on_turn_error:
-                    await maybe_await(self.on_turn_error())
-                # Terminate the wedged subprocess. The read-loop sees
-                # EOF, _cleanup_codex_process runs, and the daemon's
-                # _on_agent_exit schedules _delayed_restart. Without
-                # this, on_exit is never called and the agent stays
-                # stuck.
-                if self._process is not None and self._process.returncode is None:
-                    try:
-                        self._process.terminate()
-                    except ProcessLookupError:
-                        pass
+                await self._handle_turn_timeout()
             except Exception:
                 outcome = "error"
                 logger.exception("Codex turn error")

--- a/culture/clients/codex/daemon.py
+++ b/culture/clients/codex/daemon.py
@@ -382,6 +382,7 @@ class CodexDaemon:
             on_turn_error=self._on_turn_error,
             metrics=self._metrics,
             nick=self.agent.nick,
+            turn_timeout_seconds=getattr(self.agent, "turn_timeout_seconds", 600.0),
         )
         await self._agent_runner.start()
         logger.info("CodexAgentRunner started for %s", self.agent.nick)

--- a/culture/clients/copilot/agent_runner.py
+++ b/culture/clients/copilot/agent_runner.py
@@ -35,6 +35,7 @@ class CopilotAgentRunner:
         on_turn_error: Callable[[], Awaitable[None] | None] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
+        turn_timeout_seconds: float = 600.0,
     ) -> None:
         self.model = model
         self.directory = directory
@@ -45,6 +46,10 @@ class CopilotAgentRunner:
         self.on_turn_error = on_turn_error
         self._metrics = metrics
         self._nick = nick
+        # Outer safety net wrapping send_and_wait. The inner 120s
+        # is the SDK's own timeout for normal slow-but-progressing
+        # turns; this fires if the SDK hangs without firing its own.
+        self._turn_timeout = turn_timeout_seconds
 
         self._isolated_home: str | None = None
         self._client: Any = None
@@ -196,7 +201,18 @@ class CopilotAgentRunner:
                 },
             ):
                 try:
-                    response = await self._session.send_and_wait(text, timeout=120.0)
+                    # Outer safety net: if send_and_wait's own 120s
+                    # timeout doesn't fire (SDK ignores it, hangs
+                    # before that, or wedges in a different layer),
+                    # this wraps the whole turn so the runner can
+                    # restart cleanly.
+                    if self._turn_timeout > 0:
+                        response = await asyncio.wait_for(
+                            self._session.send_and_wait(text, timeout=120.0),
+                            timeout=self._turn_timeout,
+                        )
+                    else:
+                        response = await self._session.send_and_wait(text, timeout=120.0)
                     await self._handle_turn_response(response)
                 except asyncio.TimeoutError:
                     outcome = "timeout"

--- a/culture/clients/copilot/daemon.py
+++ b/culture/clients/copilot/daemon.py
@@ -382,6 +382,7 @@ class CopilotDaemon:
             on_turn_error=self._on_turn_error,
             metrics=self._metrics,
             nick=self.agent.nick,
+            turn_timeout_seconds=getattr(self.agent, "turn_timeout_seconds", 600.0),
         )
         await self._agent_runner.start()
         logger.info("CopilotAgentRunner started for %s", self.agent.nick)

--- a/culture/config.py
+++ b/culture/config.py
@@ -75,6 +75,10 @@ class AgentConfig:
     archived: bool = False
     archived_at: str = ""
     archived_reason: str = ""
+    # Outer safety-net timeout for one SDK turn. 0 disables.
+    # Backends may have their own SDK-tuned inner timeouts; this wraps
+    # them so a wedged stream cannot block _run_loop indefinitely.
+    turn_timeout_seconds: float = 600.0
     extras: dict = field(default_factory=dict)
 
     # Computed at load time, not stored in YAML

--- a/docs/reference/server/config.md
+++ b/docs/reference/server/config.md
@@ -208,6 +208,7 @@ agents:
 | `tags` | `[]` | Arbitrary labels for filtering and display |
 | `icon` | `null` | Optional display icon (emoji) |
 | `archived` | `false` | Set by `culture agent archive`; hides from listings |
+| `turn_timeout_seconds` | `600` | Outer safety-net timeout for one SDK turn. On expiry the runner exits 1 and crash-recovery restarts it. Set to `0` to disable. |
 
 Backend-specific fields (e.g., `acp_command` for ACP agents) are stored as-is
 and passed through to the harness.

--- a/packages/agent-harness/config.py
+++ b/packages/agent-harness/config.py
@@ -58,6 +58,8 @@ class AgentConfig:
     thinking: str = "medium"
     system_prompt: str = ""
     icon: str | None = None
+    # Outer safety-net timeout for one SDK turn. 0 disables.
+    turn_timeout_seconds: float = 600.0
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.3.7"
+version = "10.3.8"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/harness/test_agent_runner_acp.py
+++ b/tests/harness/test_agent_runner_acp.py
@@ -231,3 +231,50 @@ async def test_execute_single_prompt_no_metrics_no_recording(metrics_reader):
     # No metric data should be recorded for llm_calls
     calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
     assert calls_val is None
+
+
+@pytest.mark.asyncio
+async def test_execute_single_prompt_outer_timeout_fires_on_busy_poll_wedge(
+    metrics_reader, registry
+):
+    """Outer asyncio.timeout safety net: if the busy-poll never completes, restart."""
+    import asyncio
+
+    runner = ACPAgentRunner(
+        model="anthropic/claude-sonnet-4-6",
+        directory=tempfile.mkdtemp(prefix="culture-test-acp-"),
+        metrics=registry,
+        nick="spark-acp",
+        on_turn_error=AsyncMock(),
+        turn_timeout_seconds=0.05,
+    )
+    runner._session_id = "test-session-id"
+
+    # _send_prompt_with_retry returns immediately (no inner timeout
+    # fires); _handle_prompt_result hangs on a never-resolving future,
+    # which is the failure mode that motivated issue #349.
+    async def _hanging_handle(_self, _resp):
+        # Patched onto the class — descriptor protocol binds self,
+        # so the signature has to match an instance method.
+        await asyncio.Future()
+
+    with patch.object(
+        ACPAgentRunner,
+        "_send_prompt_with_retry",
+        new_callable=AsyncMock,
+        return_value={"result": {}},
+    ):
+        with patch.object(ACPAgentRunner, "_handle_prompt_result", _hanging_handle):
+            await runner._execute_single_prompt("hello")
+
+    runner.on_turn_error.assert_awaited_once()
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {
+            "backend": "acp",
+            "model": "anthropic/claude-sonnet-4-6",
+            "outcome": "timeout",
+        },
+    )
+    assert calls_val == 1

--- a/tests/harness/test_agent_runner_acp.py
+++ b/tests/harness/test_agent_runner_acp.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from opentelemetry import metrics as otel_metrics
@@ -249,6 +249,11 @@ async def test_execute_single_prompt_outer_timeout_fires_on_busy_poll_wedge(
         turn_timeout_seconds=0.05,
     )
     runner._session_id = "test-session-id"
+    # Attach a fake subprocess so the timeout handler exercises the
+    # terminate path that triggers _cleanup_process → on_exit.
+    fake_process = MagicMock()
+    fake_process.returncode = None
+    runner._process = fake_process
 
     # _send_prompt_with_retry returns immediately (no inner timeout
     # fires); _handle_prompt_result hangs on a never-resolving future,
@@ -268,6 +273,7 @@ async def test_execute_single_prompt_outer_timeout_fires_on_busy_poll_wedge(
             await runner._execute_single_prompt("hello")
 
     runner.on_turn_error.assert_awaited_once()
+    fake_process.terminate.assert_called_once()
     calls_val = _get_metric_value(
         metrics_reader,
         "culture.harness.llm.calls",

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -447,3 +447,70 @@ async def test_process_turn_records_zero_token_usage(metrics_reader, registry):
     ]
     assert len(output_dps) == 1, "Expected exactly one data point for tokens.output with zero value"
     assert output_dps[0].value == 0
+
+
+@pytest.mark.asyncio
+async def test_process_turn_timeout_records_timeout_outcome_and_calls_on_exit(
+    metrics_reader, registry
+):
+    """Wedged SDK stream: outer asyncio.wait_for fires, outcome=timeout, on_exit(1)."""
+    import asyncio
+
+    on_exit = AsyncMock()
+    runner = AgentRunner(
+        model="claude-opus-4-6",
+        directory=tempfile.mkdtemp(prefix="culture-test-claude-"),
+        on_exit=on_exit,
+        metrics=registry,
+        nick="spark-claude",
+        turn_timeout_seconds=0.05,
+    )
+
+    async def _hanging_query(**kwargs):
+        # Never yields — simulates a wedged SDK stream (the failure
+        # mode that motivated issue #349).
+        await asyncio.Future()
+        yield  # unreachable, but makes this a valid async generator
+
+    with patch("culture.clients.claude.agent_runner.query", _hanging_query):
+        result = await runner._process_turn("hello")
+
+    assert result is False, "timed-out turn must return False so _run_loop exits"
+    on_exit.assert_awaited_once_with(1)
+
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "claude", "model": "claude-opus-4-6", "outcome": "timeout"},
+    )
+    assert calls_val == 1, "metric must record outcome=timeout for the wedged turn"
+
+
+@pytest.mark.asyncio
+async def test_process_turn_timeout_disabled_when_zero(metrics_reader, registry):
+    """turn_timeout_seconds=0 disables the wrap; success path still works."""
+    on_exit = AsyncMock()
+    runner = AgentRunner(
+        model="claude-opus-4-6",
+        directory=tempfile.mkdtemp(prefix="culture-test-claude-"),
+        on_exit=on_exit,
+        metrics=registry,
+        nick="spark-claude",
+        turn_timeout_seconds=0,
+    )
+
+    sdk = sys.modules["claude_agent_sdk"]
+    fake_result = sdk.ResultMessage(
+        session_id="sid-1",
+        is_error=False,
+        usage={"input_tokens": 10, "output_tokens": 20},
+    )
+
+    async def _fast_query(**kwargs):
+        yield fake_result
+
+    with patch("culture.clients.claude.agent_runner.query", _fast_query):
+        result = await runner._process_turn("hello")
+
+    assert result is True, "disabled-timeout path must complete normally"
+    on_exit.assert_not_awaited()

--- a/tests/harness/test_agent_runner_codex.py
+++ b/tests/harness/test_agent_runner_codex.py
@@ -247,12 +247,14 @@ async def test_execute_single_turn_honors_configured_turn_timeout(metrics_reader
     )
     runner._thread_id = "test-thread-id"
 
-    async def _fake_send_request(method, params):
-        # Return immediately without firing _turn_done — the wait below
-        # would block forever without the outer timeout.
-        return {"result": {}}
-
-    with patch.object(runner, "_send_request", side_effect=_fake_send_request):
+    # _send_request returns immediately without firing _turn_done; the
+    # wait below would block forever without the outer timeout.
+    with patch.object(
+        runner,
+        "_send_request",
+        new_callable=AsyncMock,
+        return_value={"result": {}},
+    ):
         await runner._execute_single_turn("hello")
 
     runner.on_turn_error.assert_awaited_once()

--- a/tests/harness/test_agent_runner_codex.py
+++ b/tests/harness/test_agent_runner_codex.py
@@ -227,3 +227,38 @@ async def test_execute_single_turn_no_metrics_no_recording(metrics_reader):
     # No metric data should be recorded for llm_calls
     calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
     assert calls_val is None
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_honors_configured_turn_timeout(metrics_reader, registry):
+    """turn_timeout_seconds replaces the previous hardcoded 300s.
+
+    Build a runner with a tiny timeout, leave _turn_done unset, and let
+    the outer asyncio.timeout fire — outcome must be "timeout" and the
+    on_turn_error callback must be awaited.
+    """
+    runner = CodexAgentRunner(
+        model="gpt-5.4",
+        directory=tempfile.mkdtemp(prefix="culture-test-codex-"),
+        metrics=registry,
+        nick="spark-codex",
+        on_turn_error=AsyncMock(),
+        turn_timeout_seconds=0.05,
+    )
+    runner._thread_id = "test-thread-id"
+
+    async def _fake_send_request(method, params):
+        # Return immediately without firing _turn_done — the wait below
+        # would block forever without the outer timeout.
+        return {"result": {}}
+
+    with patch.object(runner, "_send_request", side_effect=_fake_send_request):
+        await runner._execute_single_turn("hello")
+
+    runner.on_turn_error.assert_awaited_once()
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "codex", "model": "gpt-5.4", "outcome": "timeout"},
+    )
+    assert calls_val == 1

--- a/tests/harness/test_agent_runner_codex.py
+++ b/tests/harness/test_agent_runner_codex.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from opentelemetry import metrics as otel_metrics
@@ -246,6 +246,11 @@ async def test_execute_single_turn_honors_configured_turn_timeout(metrics_reader
         turn_timeout_seconds=0.05,
     )
     runner._thread_id = "test-thread-id"
+    # Attach a fake subprocess so the timeout handler exercises the
+    # terminate path that triggers _cleanup_codex_process → on_exit.
+    fake_process = MagicMock()
+    fake_process.returncode = None
+    runner._process = fake_process
 
     # _send_request returns immediately without firing _turn_done; the
     # wait below would block forever without the outer timeout.
@@ -258,6 +263,7 @@ async def test_execute_single_turn_honors_configured_turn_timeout(metrics_reader
         await runner._execute_single_turn("hello")
 
     runner.on_turn_error.assert_awaited_once()
+    fake_process.terminate.assert_called_once()
     calls_val = _get_metric_value(
         metrics_reader,
         "culture.harness.llm.calls",

--- a/tests/harness/test_agent_runner_copilot.py
+++ b/tests/harness/test_agent_runner_copilot.py
@@ -254,3 +254,39 @@ async def test_execute_single_turn_no_metrics_no_recording(metrics_reader):
     # No metric data should be recorded for llm_calls
     calls_val = _get_metric_value(metrics_reader, "culture.harness.llm.calls")
     assert calls_val is None
+
+
+@pytest.mark.asyncio
+async def test_execute_single_turn_outer_timeout_fires_on_wedged_send_and_wait(
+    metrics_reader, registry
+):
+    """Outer asyncio.wait_for safety net: if send_and_wait hangs, restart cleanly."""
+    import asyncio
+
+    runner = CopilotAgentRunner(
+        model="gpt-4.1",
+        directory=tempfile.mkdtemp(prefix="culture-test-copilot-"),
+        metrics=registry,
+        nick="spark-copilot",
+        on_turn_error=AsyncMock(),
+        turn_timeout_seconds=0.05,
+    )
+    runner._session = AsyncMock()
+
+    async def _hang_send(*a, **kw):
+        # Coroutine that awaits a never-resolving future — bypasses the
+        # SDK's own 120s inner timeout so we can verify the outer wrap
+        # is what catches it.
+        await asyncio.Future()
+
+    runner._session.send_and_wait = _hang_send
+
+    await runner._execute_single_turn("hello")
+
+    runner.on_turn_error.assert_awaited_once()
+    calls_val = _get_metric_value(
+        metrics_reader,
+        "culture.harness.llm.calls",
+        {"backend": "copilot", "model": "gpt-4.1", "outcome": "timeout"},
+    )
+    assert calls_val == 1

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.3.7"
+version = "10.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Adds `turn_timeout_seconds` (default `600` s) to the `culture.yaml`
`AgentConfig` schema and wraps every backend's turn execution in
`asyncio.wait_for` / `asyncio.timeout`. On expiry the runner records
`outcome=timeout` and exits 1, letting the existing crash-recovery
(`daemon._on_agent_exit` + `_delayed_restart`, 5 s delay, max 3 in
300 s) restart cleanly. Set `0` to disable the wrap.

Closes #349.

## Why

The four backends were asymmetric before this PR:

| Backend | Today | After |
|---------|-------|-------|
| `claude` | **no timeout** (the original #349 bug) | Outer `asyncio.wait_for` around the SDK stream |
| `codex` | hardcoded 300 s on `_turn_done.wait()` only | Config-driven `asyncio.timeout`, now covers `_send_request` too |
| `copilot` | inner 120 s on `send_and_wait` | Inner 120 s preserved + new outer wrap for the case the SDK ignores its own timeout |
| `acp` | inner 300 s per `_send_request` | Inner 300 s preserved + new outer `asyncio.timeout` covering the whole prompt round-trip including the busy-poll |

The strategy is **outer safety net**, not "replace inner timeouts" —
inner SDK-level timeouts are tuned to expected SDK behavior and
stay. The outer wrap is the escape hatch for the failure mode that
motivated #349 (PR #344's diagnostic identified this as hypothesis
#1; the actual cause was the systemd config-path bug, but the
latent bug remains).

## What's in

- `culture/config.py` — `turn_timeout_seconds: float = 600.0` on
  the YAML-side `AgentConfig`. Auto-flows through
  `_parse_agent_entry` via `_KNOWN_AGENT_FIELDS`; no parser change.
- `packages/agent-harness/config.py` — same field on the template
  so future backends inherit.
- `culture/clients/{claude,codex,copilot,acp}/agent_runner.py` —
  accept the new param, wrap turn execution with the timeout.
- `culture/clients/{claude,codex,copilot,acp}/daemon.py` — pass
  `self.agent.turn_timeout_seconds` through to `AgentRunner`.
- `docs/reference/server/config.md` — new row in the
  `culture.yaml` fields table.
- 5 new tests under `tests/harness/test_agent_runner_*.py`:
  - claude: timeout fires on wedged stream; disabled-when-zero
  - codex: honors configured turn_timeout
  - copilot: outer timeout fires when `send_and_wait` hangs past
    its inner 120 s
  - acp: outer timeout fires when the busy-poll on
    `_handle_prompt_result` never completes

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` —
      **1106 passed** (was 1101 pre-PR; +5 new tests).
- [x] **MD5 invariance check** of repo-root `culture.yaml` across
      the full test run — stable (PR #346's regression guard
      still holds; the new tests use `tempfile.mkdtemp` for
      `directory`, no cwd leak).
- [x] `markdownlint-cli2 CHANGELOG.md docs/reference/server/config.md`
      — clean.
- [x] pre-commit hooks (black, isort, flake8, pylint, bandit,
      markdownlint) passed locally on commit.

## Out of scope

- Issues #347 done (PR #352), #348/#350/#351 still open.
- Per-channel or per-prompt timeout overrides. The new field is
  per-agent only.
- Replacing the existing inner timeouts. Outer safety net only.
- Webhook event for timeout-triggered restarts. The existing
  `agent_error` / crash-recovery webhook fires already; a
  dedicated `agent_turn_timeout` event can come later if
  observability needs it.

- Claude
