### PR TITLE
Phase 0a: integration test for attention behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.5.7] - 2026-05-09
+
+### Added
+
+- `tests/test_integration_attention.py` — Phase 0a Task 2: end-to-end integration coverage for attention behaviors. Three tests prove `Band.HOT` promotion via direct `@mention`, decay one band cooler past `hold_s` (with `attention_overrides` shrinking band timings to 1s), and per-channel state divergence under different stimuli. Exercises the full `AgentDaemon` → `IRCTransport` → `AttentionTracker` chain through real `agentirc.IRCd`. Lifts `culture/clients/shared/attention.py` coverage to 72% from this file alone (vs. 0% integration-only baseline). The harness unit test in `tests/harness/test_attention.py` will move to cultureagent in Phase 1.
+
 ## [10.5.6] - 2026-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- `tests/test_integration_attention.py` — Phase 0a Task 2: end-to-end integration coverage for attention behaviors. Three tests prove `Band.HOT` promotion via direct `@mention`, decay one band cooler past `hold_s` (with `attention_overrides` shrinking band timings to 1s), and per-channel state divergence under different stimuli. Exercises the full `AgentDaemon` → `IRCTransport` → `AttentionTracker` chain through real `agentirc.IRCd`. Lifts `culture/clients/shared/attention.py` coverage to 72% from this file alone (vs. 0% integration-only baseline). The harness unit test in `tests/harness/test_attention.py` will move to cultureagent in Phase 1.
+- `tests/test_integration_attention.py` — Phase 0a Task 2: end-to-end integration coverage for attention behaviors. Three tests prove `Band.HOT` promotion via direct `@mention` (asserted via a bounded `_wait_for_band` poll, not a fixed sleep), exact one-step decay past `hold_s` with `attention_overrides` (`hold_s=2`/`tick_s=2`/sleep=3.0s leaves remaining elapsed ≤ hold so the decay loop terminates deterministically at `Band.WARM`), and per-channel state divergence under different stimuli. Uses `tmp_path` for socket dirs and monkeypatches `culture.pidfile.PID_DIR` so test runs don't write into the real `~/.culture/pids`. Exercises the full `AgentDaemon` → `IRCTransport` → `AttentionTracker` chain through real `agentirc.IRCd`. Lifts `culture/clients/shared/attention.py` coverage to 72% from this file alone (vs. 0% integration-only baseline). The harness unit test in `tests/harness/test_attention.py` will move to cultureagent in Phase 1.
 
 ## [10.5.6] - 2026-05-09
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.5.6"
+version = "10.5.7"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_integration_attention.py
+++ b/tests/test_integration_attention.py
@@ -7,7 +7,6 @@ unit tests themselves move to cultureagent in Phase 1.
 """
 
 import asyncio
-import tempfile
 import time
 
 import pytest
@@ -21,34 +20,65 @@ from culture.clients.claude.config import (
 from culture.clients.claude.daemon import AgentDaemon
 from culture.clients.shared.attention import Band
 
-# Fast-decay overrides: 1s hold/interval/tick across all bands. Validates
-# monotonicity (HOT≤WARM≤COOL≤IDLE intervals) and tick_s ≤ min(intervals).
-# Shape mirrors `_build_attention_config` parsing in
-# culture/clients/claude/config.py.
-FAST_DECAY_OVERRIDES = {
-    "tick_s": 1,
+# Decay overrides: hold_s=2 across HOT/WARM/COOL with tick_s=2 and
+# interval_s=2. Validates monotonicity (HOT≤WARM≤COOL≤IDLE intervals)
+# and tick_s ≤ min(intervals). Shape mirrors `_build_attention_config`
+# parsing in culture/clients/claude/config.py. With hold_s=2 and a
+# 3-second sleep, exactly one decay step fires (HOT → WARM): the
+# tracker advances `last_promote_at += hold_s`, leaving ~1s of
+# remaining elapsed time, which is ≤ hold_s and so terminates the
+# decay loop. Picking 3s of sleep against 2s of hold leaves a full
+# second of CI slack before a second step would fire.
+DECAY_OVERRIDES = {
+    "tick_s": 2,
     "bands": {
-        "hot": {"interval_s": 1, "hold_s": 1},
-        "warm": {"interval_s": 1, "hold_s": 1},
-        "cool": {"interval_s": 1, "hold_s": 1},
-        "idle": {"interval_s": 1},
+        "hot": {"interval_s": 2, "hold_s": 2},
+        "warm": {"interval_s": 2, "hold_s": 2},
+        "cool": {"interval_s": 2, "hold_s": 2},
+        "idle": {"interval_s": 2},
     },
 }
 
 
+def _redirect_pidfile(monkeypatch, tmp_path):
+    """Redirect ``culture.pidfile.PID_DIR`` so daemons don't write into the
+    real ``~/.culture/pids`` from a unit test. ``write_pid`` reads
+    ``PID_DIR`` from its own module at call time, so an attribute patch
+    is sufficient — no other modules cache the value."""
+    monkeypatch.setattr("culture.pidfile.PID_DIR", str(tmp_path / "pids"))
+
+
+async def _wait_for_band(daemon, target, expected, timeout=5.0):
+    """Bounded poll until ``daemon._attention.snapshot()[target].band == expected``.
+
+    Replaces fixed ``asyncio.sleep`` waits for IRC processing — those are
+    racy on slow CI because PRIVMSG → on_mention → AttentionTracker is
+    asynchronous. A short polling loop bounded by a timeout converges as
+    soon as the state is correct, with a deterministic upper bound.
+    """
+    async with asyncio.timeout(timeout):
+        while True:
+            state = daemon._attention.snapshot().get(target)
+            if state is not None and state.band == expected:
+                return
+            await asyncio.sleep(0.05)
+
+
 @pytest.mark.asyncio
-async def test_mention_bumps_attention_band(server, make_client):
+async def test_mention_bumps_attention_band(server, make_client, tmp_path, monkeypatch):
     """A direct @mention promotes the channel to Band.HOT."""
+    _redirect_pidfile(monkeypatch, tmp_path)
     config = DaemonConfig(
         server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
         webhooks=WebhookConfig(url=None),
     )
     agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general"])
-    sock_dir = tempfile.mkdtemp()
-    daemon = AgentDaemon(config, agent, socket_dir=sock_dir, skip_claude=True)
+    sock_dir = tmp_path / "sock1"
+    sock_dir.mkdir()
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
     await daemon.start()
-    await asyncio.sleep(0.5)
     try:
+        # Initial state: channel seeded at IDLE.
         snapshot = daemon._attention.snapshot()
         assert snapshot["#general"].band == Band.IDLE
 
@@ -58,61 +88,58 @@ async def test_mention_bumps_attention_band(server, make_client):
         # Mention requires `@nick` syntax — see _detect_and_fire_mention in
         # culture/clients/shared/irc_transport.py.
         await human.send("PRIVMSG #general :@testserv-bot are you there?")
-        await asyncio.sleep(0.5)
 
-        snapshot = daemon._attention.snapshot()
-        assert snapshot["#general"].band == Band.HOT
+        await _wait_for_band(daemon, "#general", Band.HOT)
     finally:
         await daemon.stop()
 
 
 @pytest.mark.asyncio
-async def test_attention_decays_after_hold_window(server, make_client):
-    """Without further stimulus, attention walks one band cooler past hold_s.
+async def test_attention_decays_after_hold_window(server, make_client, tmp_path, monkeypatch):
+    """A direct stimulus followed by a 3s pause walks exactly one band cooler.
 
-    Decay is applied lazily inside `due_targets(now)` (not snapshot()). The
-    daemon's poll loop calls due_targets at every tick, so sleeping past
-    hold_s is sufficient — but we also call due_targets directly to force
-    decay deterministically (avoids races with the tick scheduler).
+    Decay is applied lazily inside ``due_targets(now)`` (not ``snapshot()``).
+    Calling ``due_targets`` directly forces decay deterministically, avoiding
+    races with the daemon's own tick scheduler.
     """
+    _redirect_pidfile(monkeypatch, tmp_path)
     agent = AgentConfig(
         nick="testserv-bot",
         directory="/tmp",
         channels=["#general"],
-        attention_overrides=FAST_DECAY_OVERRIDES,
+        attention_overrides=DECAY_OVERRIDES,
     )
     config = DaemonConfig(
         server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
         webhooks=WebhookConfig(url=None),
     )
-    sock_dir = tempfile.mkdtemp()
-    daemon = AgentDaemon(config, agent, socket_dir=sock_dir, skip_claude=True)
+    sock_dir = tmp_path / "sock2"
+    sock_dir.mkdir()
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
     await daemon.start()
-    await asyncio.sleep(0.5)
     try:
         human = await make_client(nick="testserv-ori", user="ori")
         await human.send("JOIN #general")
         await human.recv_all(timeout=0.3)
         await human.send("PRIVMSG #general :@testserv-bot ping")
-        await asyncio.sleep(0.5)
+        await _wait_for_band(daemon, "#general", Band.HOT)
 
-        snapshot = daemon._attention.snapshot()
-        assert snapshot["#general"].band == Band.HOT
-
-        # Sleep past hold_s=1, then force decay evaluation. _apply_decay
-        # walks one band per hold window; with all holds at 1s, two
-        # seconds is enough for HOT → WARM (and possibly further).
-        await asyncio.sleep(2.0)
+        # Sleep past hold_s=2; after exactly one decay iteration the tracker
+        # advances last_promote_at += hold_s, leaving ~1s of remaining
+        # elapsed time which is ≤ hold_s — so the loop terminates at WARM.
+        await asyncio.sleep(3.0)
         daemon._attention.due_targets(time.monotonic())
 
         snapshot = daemon._attention.snapshot()
-        assert snapshot["#general"].band > Band.HOT
+        assert snapshot["#general"].band == Band.WARM
     finally:
         await daemon.stop()
 
 
 @pytest.mark.asyncio
-async def test_per_channel_state_diverges_under_different_stimuli(server, make_client):
+async def test_per_channel_state_diverges_under_different_stimuli(
+    server, make_client, tmp_path, monkeypatch
+):
     """Two channels develop different attention states from different stimuli.
 
     AttentionTracker maintains per-target TargetState, so a mention on one
@@ -120,15 +147,16 @@ async def test_per_channel_state_diverges_under_different_stimuli(server, make_c
     proxy for "dynamic levels per channel" — the per-channel state machine,
     not the config-level overrides (which are per-agent, not per-channel).
     """
+    _redirect_pidfile(monkeypatch, tmp_path)
     config = DaemonConfig(
         server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
         webhooks=WebhookConfig(url=None),
     )
     agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general", "#quiet"])
-    sock_dir = tempfile.mkdtemp()
-    daemon = AgentDaemon(config, agent, socket_dir=sock_dir, skip_claude=True)
+    sock_dir = tmp_path / "sock3"
+    sock_dir.mkdir()
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
     await daemon.start()
-    await asyncio.sleep(0.5)
     try:
         human = await make_client(nick="testserv-ori", user="ori")
         await human.send("JOIN #general")
@@ -136,10 +164,9 @@ async def test_per_channel_state_diverges_under_different_stimuli(server, make_c
         await human.recv_all(timeout=0.3)
         # Stimulate only #general; #quiet stays IDLE.
         await human.send("PRIVMSG #general :@testserv-bot here")
-        await asyncio.sleep(0.5)
 
-        snapshot = daemon._attention.snapshot()
-        assert snapshot["#general"].band == Band.HOT
-        assert snapshot["#quiet"].band == Band.IDLE
+        await _wait_for_band(daemon, "#general", Band.HOT)
+        # #quiet has had no stimulus — assert it's still IDLE (the seed band).
+        assert daemon._attention.snapshot()["#quiet"].band == Band.IDLE
     finally:
         await daemon.stop()

--- a/tests/test_integration_attention.py
+++ b/tests/test_integration_attention.py
@@ -1,0 +1,145 @@
+"""End-to-end attention behaviors — proves the AttentionTracker state
+machine through the full daemon → IRCTransport → tracker chain.
+
+Replaces the integration-shaped portions of tests/harness/test_attention.py
+and tests/harness/test_attention_config.py at the integration layer; the
+unit tests themselves move to cultureagent in Phase 1.
+"""
+
+import asyncio
+import tempfile
+import time
+
+import pytest
+
+from culture.clients.claude.config import (
+    AgentConfig,
+    DaemonConfig,
+    ServerConnConfig,
+    WebhookConfig,
+)
+from culture.clients.claude.daemon import AgentDaemon
+from culture.clients.shared.attention import Band
+
+# Fast-decay overrides: 1s hold/interval/tick across all bands. Validates
+# monotonicity (HOT≤WARM≤COOL≤IDLE intervals) and tick_s ≤ min(intervals).
+# Shape mirrors `_build_attention_config` parsing in
+# culture/clients/claude/config.py.
+FAST_DECAY_OVERRIDES = {
+    "tick_s": 1,
+    "bands": {
+        "hot": {"interval_s": 1, "hold_s": 1},
+        "warm": {"interval_s": 1, "hold_s": 1},
+        "cool": {"interval_s": 1, "hold_s": 1},
+        "idle": {"interval_s": 1},
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_mention_bumps_attention_band(server, make_client):
+    """A direct @mention promotes the channel to Band.HOT."""
+    config = DaemonConfig(
+        server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
+        webhooks=WebhookConfig(url=None),
+    )
+    agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general"])
+    sock_dir = tempfile.mkdtemp()
+    daemon = AgentDaemon(config, agent, socket_dir=sock_dir, skip_claude=True)
+    await daemon.start()
+    await asyncio.sleep(0.5)
+    try:
+        snapshot = daemon._attention.snapshot()
+        assert snapshot["#general"].band == Band.IDLE
+
+        human = await make_client(nick="testserv-ori", user="ori")
+        await human.send("JOIN #general")
+        await human.recv_all(timeout=0.3)
+        # Mention requires `@nick` syntax — see _detect_and_fire_mention in
+        # culture/clients/shared/irc_transport.py.
+        await human.send("PRIVMSG #general :@testserv-bot are you there?")
+        await asyncio.sleep(0.5)
+
+        snapshot = daemon._attention.snapshot()
+        assert snapshot["#general"].band == Band.HOT
+    finally:
+        await daemon.stop()
+
+
+@pytest.mark.asyncio
+async def test_attention_decays_after_hold_window(server, make_client):
+    """Without further stimulus, attention walks one band cooler past hold_s.
+
+    Decay is applied lazily inside `due_targets(now)` (not snapshot()). The
+    daemon's poll loop calls due_targets at every tick, so sleeping past
+    hold_s is sufficient — but we also call due_targets directly to force
+    decay deterministically (avoids races with the tick scheduler).
+    """
+    agent = AgentConfig(
+        nick="testserv-bot",
+        directory="/tmp",
+        channels=["#general"],
+        attention_overrides=FAST_DECAY_OVERRIDES,
+    )
+    config = DaemonConfig(
+        server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
+        webhooks=WebhookConfig(url=None),
+    )
+    sock_dir = tempfile.mkdtemp()
+    daemon = AgentDaemon(config, agent, socket_dir=sock_dir, skip_claude=True)
+    await daemon.start()
+    await asyncio.sleep(0.5)
+    try:
+        human = await make_client(nick="testserv-ori", user="ori")
+        await human.send("JOIN #general")
+        await human.recv_all(timeout=0.3)
+        await human.send("PRIVMSG #general :@testserv-bot ping")
+        await asyncio.sleep(0.5)
+
+        snapshot = daemon._attention.snapshot()
+        assert snapshot["#general"].band == Band.HOT
+
+        # Sleep past hold_s=1, then force decay evaluation. _apply_decay
+        # walks one band per hold window; with all holds at 1s, two
+        # seconds is enough for HOT → WARM (and possibly further).
+        await asyncio.sleep(2.0)
+        daemon._attention.due_targets(time.monotonic())
+
+        snapshot = daemon._attention.snapshot()
+        assert snapshot["#general"].band > Band.HOT
+    finally:
+        await daemon.stop()
+
+
+@pytest.mark.asyncio
+async def test_per_channel_state_diverges_under_different_stimuli(server, make_client):
+    """Two channels develop different attention states from different stimuli.
+
+    AttentionTracker maintains per-target TargetState, so a mention on one
+    channel must leave a sibling channel untouched. This is the integration
+    proxy for "dynamic levels per channel" — the per-channel state machine,
+    not the config-level overrides (which are per-agent, not per-channel).
+    """
+    config = DaemonConfig(
+        server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
+        webhooks=WebhookConfig(url=None),
+    )
+    agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general", "#quiet"])
+    sock_dir = tempfile.mkdtemp()
+    daemon = AgentDaemon(config, agent, socket_dir=sock_dir, skip_claude=True)
+    await daemon.start()
+    await asyncio.sleep(0.5)
+    try:
+        human = await make_client(nick="testserv-ori", user="ori")
+        await human.send("JOIN #general")
+        await human.send("JOIN #quiet")
+        await human.recv_all(timeout=0.3)
+        # Stimulate only #general; #quiet stays IDLE.
+        await human.send("PRIVMSG #general :@testserv-bot here")
+        await asyncio.sleep(0.5)
+
+        snapshot = daemon._attention.snapshot()
+        assert snapshot["#general"].band == Band.HOT
+        assert snapshot["#quiet"].band == Band.IDLE
+    finally:
+        await daemon.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.5.2"
+version = "10.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 0a Task 2 of the cultureagent extraction. Adds `tests/test_integration_attention.py` with three end-to-end integration tests that exercise the attention state machine through the full `AgentDaemon` → `IRCTransport` → `AttentionTracker` chain (real `agentirc.IRCd`, real PRIVMSG over TCP, no mocks).

- `test_mention_bumps_attention_band` — `@testserv-bot` mention promotes `#general` to `Band.HOT`.
- `test_attention_decays_after_hold_window` — with 1s hold/interval/tick `attention_overrides`, `Band.HOT` decays one band cooler past the hold window. Calls `due_targets(time.monotonic())` directly to force the lazy decay path deterministically.
- `test_per_channel_state_diverges_under_different_stimuli` — stimulating one channel leaves a sibling channel at `Band.IDLE`. This is the integration proxy for "dynamic levels per channel" (the per-target state machine, since config-level overrides are per-agent in the current schema).

Coverage of `culture/clients/shared/attention.py` rises from 0% (integration-only baseline) to **72%** from this file alone. The harness unit test in `tests/harness/test_attention.py` will move to cultureagent in Phase 1; this integration test is the replacement that stays.

## Notes for reviewers

- The in-repo plan's [Task 2 scaffold](docs/superpowers/plans/2026-05-09-cultureagent-extraction-phase-0a.md) put `attention_overrides` on `DaemonConfig`; the real field lives on `AgentConfig` (`culture/clients/claude/config.py:73`). Test fixes that.
- Mention requires `@nick` syntax per `_detect_and_fire_mention` in `culture/clients/shared/irc_transport.py`; tests use `@testserv-bot`.
- Decay is applied lazily inside `due_targets(now)`, not `snapshot()` — see comment in test 2.

## Test plan

- [x] `uv run pytest tests/test_integration_attention.py -v` — 3 passed in 7.93s
- [x] `uv run pytest tests/test_integration_attention.py --cov=culture.clients.shared.attention --cov-report=term-missing` — 72% coverage
- [x] Pre-commit hooks (black, isort, flake8, pylint, bandit, markdownlint) — all green
- [ ] Full CI (Qodo, Copilot, SonarCloud, pytest matrix)

Tasks 3, 4, 5, 6, 8 ship in separate PRs per the plan's sequential cadence. Task 9 (gate flip) closes Phase 0a.

- culture (Claude)