### PR TITLE
Phase 0a: integration test for IRC transport traceparent propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.5.9] - 2026-05-09
+
+### Added
+
+- `tests/test_integration_irc_transport.py` — Phase 0a Task 4: end-to-end integration coverage for IRC transport's IRCv3 inbound traceparent propagation. Sends `@culture.dev/traceparent=<valid> PRIVMSG #general :traced hello` from a real human IRC client, verifies via the `tracing_exporter` fixture that `IRCTransport._handle` emits a `harness.irc.message.handle` span with `culture.trace.origin: "remote"` and a `trace_id` matching the inbound traceparent. Adopts Tasks 2/3 hardening (`tmp_path` for sock_dir, monkeypatched `culture.pidfile.PID_DIR`, bounded `_wait_for_daemon_joined` and `_wait_for_span` polls). The harness unit test in `tests/harness/test_irc_transport_propagation.py` will move to cultureagent in Phase 1; reconnect coverage is already provided at integration shape by `tests/test_irc_transport.py::test_reconnect_retries_after_connection_error`, so Task 4's reconnect ask is met without a new test.
+
 ## [10.5.8] - 2026-05-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.5.8"
+version = "10.5.9"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_integration_irc_transport.py
+++ b/tests/test_integration_irc_transport.py
@@ -1,0 +1,127 @@
+"""End-to-end IRC transport behavior — IRCv3 message-tag inbound propagation.
+
+Sends a tagged PRIVMSG with a W3C traceparent through the real
+``agentirc.IRCd``, observes the daemon's harness tracer emit a child span
+parented to the inbound trace_id with ``culture.trace.origin: "remote"``.
+Replaces the integration-shaped half of
+``tests/harness/test_irc_transport_propagation.py`` (the harness unit
+test moves to cultureagent in Phase 1).
+
+**Reconnect coverage** lives in
+``tests/test_irc_transport.py::test_reconnect_retries_after_connection_error``
+— it already drives ``IRCTransport._reconnect()`` against the real
+``server`` fixture, so a daemon-level duplicate would be churn. The
+audit's Task 4 reconnect ask cites that exact file.
+"""
+
+import asyncio
+
+import pytest
+
+from culture.clients.claude.config import (
+    AgentConfig,
+    DaemonConfig,
+    ServerConnConfig,
+    WebhookConfig,
+)
+from culture.clients.claude.daemon import AgentDaemon
+
+# Standard W3C traceparent: version-trace_id-span_id-flags. See
+# https://www.w3.org/TR/trace-context/#traceparent-header.
+VALID_TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+EXPECTED_TRACE_ID = int("4bf92f3577b34da6a3ce929d0e0e4736", 16)
+
+
+def _redirect_pidfile(monkeypatch, tmp_path):
+    """Redirect ``culture.pidfile.PID_DIR`` so daemons don't write into the
+    real ``~/.culture/pids`` from a unit test."""
+    monkeypatch.setattr("culture.pidfile.PID_DIR", str(tmp_path / "pids"))
+
+
+async def _wait_for_daemon_joined(server, channel, nick, timeout=5.0):
+    """Poll until the daemon's IRC nick appears in ``server.channels[channel].members``.
+
+    ``ch.members`` is a ``set[Client]``, so we compare ``m.nick``. Avoids
+    racy fixed sleeps for the welcome → JOIN handshake — the server
+    processes JOIN synchronously on receipt, so observing the daemon in
+    the membership set is a deterministic readiness signal.
+    """
+    async with asyncio.timeout(timeout):
+        while True:
+            ch = server.channels.get(channel)
+            if ch is not None and any(getattr(m, "nick", None) == nick for m in ch.members):
+                return
+            await asyncio.sleep(0.05)
+
+
+async def _wait_for_span(exporter, predicate, timeout=5.0):
+    """Bounded poll on ``exporter.get_finished_spans()`` for the first span
+    matching ``predicate``. The conftest ``tracing_exporter`` fixture
+    installs a ``SimpleSpanProcessor`` so finished spans land in the
+    exporter synchronously, but the test still has to wait for the
+    daemon's read loop to handle the inbound line."""
+    async with asyncio.timeout(timeout):
+        while True:
+            for span in exporter.get_finished_spans():
+                if predicate(span):
+                    return span
+            await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_inbound_traceparent_creates_remote_origin_span(
+    server, make_client, tracing_exporter, tmp_path, monkeypatch
+):
+    """A PRIVMSG with @culture.dev/traceparent=<valid> creates a span with
+    ``culture.trace.origin: "remote"`` whose trace_id matches the inbound
+    traceparent's trace-id."""
+    _redirect_pidfile(monkeypatch, tmp_path)
+
+    # Reset the harness telemetry module's cached _tracer so this test's
+    # tracing_exporter provider — not a stale one from a sibling worker —
+    # is what daemon.start() picks up. The reset also clears the OTel
+    # global, so we must re-install the test provider afterwards.
+    from opentelemetry import trace as _otel_trace
+
+    from culture.clients.shared import telemetry as harness_tel
+
+    captured_provider = _otel_trace.get_tracer_provider()
+    harness_tel.reset_for_tests()
+    _otel_trace.set_tracer_provider(captured_provider)
+
+    config = DaemonConfig(
+        server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
+        webhooks=WebhookConfig(url=None),
+    )
+    agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general"])
+    sock_dir = tmp_path / "sock"
+    sock_dir.mkdir()
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
+    await daemon.start()
+    try:
+        await _wait_for_daemon_joined(server, "#general", agent.nick)
+
+        human = await make_client(nick="testserv-ori", user="ori")
+        await human.send("CAP REQ :message-tags")
+        await human.recv_all(timeout=0.3)
+        await human.send("JOIN #general")
+        await human.recv_all(timeout=0.3)
+
+        line = f"@culture.dev/traceparent={VALID_TRACEPARENT} PRIVMSG #general :traced hello"
+        await human.send(line)
+
+        span = await _wait_for_span(
+            tracing_exporter,
+            lambda s: (
+                s.name == "harness.irc.message.handle"
+                and s.attributes.get("irc.command") == "PRIVMSG"
+                and s.attributes.get("culture.trace.origin") == "remote"
+                and s.context.trace_id == EXPECTED_TRACE_ID
+            ),
+        )
+        assert span is not None
+        # Sanity: the dropped_reason attribute must be absent on the
+        # valid-traceparent path (only set when status is malformed/too_long).
+        assert "culture.trace.dropped_reason" not in span.attributes
+    finally:
+        await daemon.stop()

--- a/tests/test_integration_irc_transport.py
+++ b/tests/test_integration_irc_transport.py
@@ -102,7 +102,16 @@ async def test_inbound_traceparent_creates_remote_origin_span(
         await _wait_for_daemon_joined(server, "#general", agent.nick)
 
         human = await make_client(nick="testserv-ori", user="ori")
+        # Complete the CAP negotiation handshake before sending tagged
+        # PRIVMSGs. The server doesn't strip tags from inbound non-CAP
+        # clients today, but the explicit REQ + ACK + END pattern
+        # matches tests/test_irc_transport_tags.py and avoids relying
+        # on that internal behavior. Wait for the ACK line so the
+        # capability is actually negotiated before END.
         await human.send("CAP REQ :message-tags")
+        ack = await human.recv_until("ACK")
+        assert "message-tags" in ack, f"expected CAP ACK :message-tags, got {ack!r}"
+        await human.send("CAP END")
         await human.recv_all(timeout=0.3)
         await human.send("JOIN #general")
         await human.recv_all(timeout=0.3)

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.5.8"
+version = "10.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 0a Task 4 of the cultureagent extraction. Adds `tests/test_integration_irc_transport.py` — a single integration test that exercises IRC transport's IRCv3 inbound message-tag path:

1. Daemon connects with default config (telemetry off → uses the OTel global tracer = the `tracing_exporter` fixture's provider).
2. Real human IRC client sends `@culture.dev/traceparent=<valid> PRIVMSG #general :traced hello`.
3. Test asserts via `tracing_exporter.get_finished_spans()` that `IRCTransport._handle` emitted a `harness.irc.message.handle` span with `culture.trace.origin: "remote"` and `trace_id` matching the inbound traceparent. Also asserts no `culture.trace.dropped_reason` attribute on the valid path.

`culture/clients/shared/irc_transport.py` coverage lifts to **57%** from this single file (against the audit's 63% integration-only baseline — focused on the traceparent-extract lines specifically).

## Scope decisions

The in-repo plan's Task 4 scaffold had two issues this PR corrects:

- **Tag-propagation as the scaffold wrote it cannot pass.** The scaffold expected tags to survive in the `SkillClient.irc_read` response, but the daemon's buffer stores `BufferedMessage(nick, text, timestamp, thread)` only — there's no `tags` field. What the transport actually does with inbound IRCv3 tags is **extract `culture.dev/traceparent` and emit an OTel span** (`irc_transport.py:264-298`). The new test asserts the span, which is the integration version of the harness unit test (`tests/harness/test_irc_transport_propagation.py`).
- **Reconnect test is redundant.** `tests/test_irc_transport.py::test_reconnect_retries_after_connection_error` already drives `IRCTransport._reconnect()` against the real `server` fixture. The audit's Task 4 reconnect ask cites that exact file. A daemon-level duplicate would be churn — so this PR documents the existing coverage in the new file's docstring instead of duplicating.

## Adopts Tasks 2/3 hardening

- `tmp_path` for socket dir.
- `monkeypatch.setattr("culture.pidfile.PID_DIR", ...)` so daemons don't write into the real `~/.culture/pids`.
- Bounded `_wait_for_daemon_joined(server, channel, nick)` (server-side membership signal) before sending tagged PRIVMSG.
- New `_wait_for_span(exporter, predicate)` poll on `tracing_exporter.get_finished_spans()` — converges as soon as the right span lands, no fixed sleeps.

## Notes for reviewers

- The test calls `culture.clients.shared.telemetry.reset_for_tests()` to flush the harness tracer module cache, then re-installs the fixture's provider. Without this, a stale `_tracer` from a sibling test could route spans to the wrong exporter under xdist.
- The traceparent string is the standard W3C example; the trace_id (`4bf92f3577b34da6a3ce929d0e0e4736`) parses to a deterministic int that the test asserts against `span.context.trace_id`.

## Test plan

- [x] `uv run pytest tests/test_integration_irc_transport.py -v` — 1 passed in 1.44s
- [x] `uv run pytest ... --cov=culture.clients.shared.irc_transport` — 57%
- [x] Pre-commit hooks (black, isort, flake8, pylint, bandit, markdownlint) — all green
- [x] No implicit f-string concatenation (the python:S5799 SonarCloud rule that bit a previous PR)
- [ ] Full CI (Qodo, Copilot, SonarCloud, pytest matrix)

Tasks 5, 6, 8 ship in separate PRs. Task 9 (gate flip) closes Phase 0a.

- culture (Claude)