### PR TITLE
Phase 0a: integration test for webhook HTTP fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.5.10] - 2026-05-09
+
+### Added
+
+- `tests/test_integration_webhook.py` — Phase 0a Task 5: end-to-end integration coverage for webhook HTTP fanout. Daemon configured with `WebhookConfig(url=<local-capture>)`, real human IRC client, then `skill.irc_ask("#general", ...)` IPC call fires the `agent_question` `AlertEvent`. A stdlib `HTTPServer` thread captures the JSON POST and the test asserts the payload shape (`{"content": "[QUESTION] [testserv-bot] asked in #general: ..."}`). Adopts Tasks 2/3/4 hardening (`tmp_path`, monkeypatched `PID_DIR`, bounded `_wait_for_daemon_joined` and `_wait_for_capture` polls). Lifts `culture/clients/shared/webhook.py` coverage to 89% from this file alone. The harness unit test in `tests/test_webhook.py` will move to cultureagent in Phase 1; the IRC alert channel path is already covered at integration shape by `tests/test_integration_layer5.py::test_webhook_fires_on_question`, so no daemon-level duplicate.
+
 ## [10.5.9] - 2026-05-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.5.9"
+version = "10.5.10"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_integration_webhook.py
+++ b/tests/test_integration_webhook.py
@@ -1,0 +1,134 @@
+"""End-to-end webhook fanout — daemon's irc_ask IPC fires an
+agent_question AlertEvent; WebhookClient POSTs JSON to the configured URL.
+
+Replaces the integration-shaped portion of ``tests/test_webhook.py`` (the
+unit test moves to cultureagent in Phase 1).
+
+**IRC alert channel coverage** lives in
+``tests/test_integration_layer5.py::test_webhook_fires_on_question`` —
+that test already exercises the ``WebhookConfig(irc_channel="#alerts")``
+path against the real ``server`` fixture. Audit row #7 is met by that
+file; no daemon-level duplicate here.
+"""
+
+import asyncio
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from culture.clients.claude.config import (
+    AgentConfig,
+    DaemonConfig,
+    ServerConnConfig,
+    WebhookConfig,
+)
+from culture.clients.claude.daemon import AgentDaemon
+from culture.clients.claude.skill.irc_client import SkillClient
+
+
+def _redirect_pidfile(monkeypatch, tmp_path):
+    """Redirect ``culture.pidfile.PID_DIR`` so daemons don't write into the
+    real ``~/.culture/pids`` from a unit test."""
+    monkeypatch.setattr("culture.pidfile.PID_DIR", str(tmp_path / "pids"))
+
+
+async def _wait_for_daemon_joined(server, channel, nick, timeout=5.0):
+    """Poll ``server.channels[channel].members`` (a ``set[Client]``) for
+    ``nick`` so the test never sends to the channel before the daemon's
+    welcome → JOIN handshake completes."""
+    async with asyncio.timeout(timeout):
+        while True:
+            ch = server.channels.get(channel)
+            if ch is not None and any(getattr(m, "nick", None) == nick for m in ch.members):
+                return
+            await asyncio.sleep(0.05)
+
+
+async def _wait_for_capture(received, count, timeout=5.0):
+    """Bounded poll on the shared ``received`` list until ``count`` POSTs
+    land. Replaces racy fixed-sleep loops — webhook fanout runs the HTTP
+    POST via ``asyncio.to_thread`` so it lands shortly after the IPC
+    response, but ordering vs. the test's next line isn't guaranteed."""
+    async with asyncio.timeout(timeout):
+        while True:
+            if len(received) >= count:
+                return
+            await asyncio.sleep(0.05)
+
+
+def _make_capture_server():
+    """Build a stdlib ``HTTPServer`` on a random port that captures POSTed
+    JSON bodies into a list. Returns ``(httpd, received_list, port)``.
+
+    Uses stdlib instead of aiohttp.web to match the existing pattern in
+    ``tests/test_webhook.py`` — keeps style consistent and avoids
+    dragging another dep style into the test surface for one POST.
+    """
+    received: list = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers["Content-Length"])
+            body = json.loads(self.rfile.read(length))
+            received.append(body)
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args):
+            """Silence stderr noise during tests."""
+
+    httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    return httpd, received, port
+
+
+@pytest.mark.asyncio
+async def test_irc_ask_triggers_http_webhook_post(server, make_client, tmp_path, monkeypatch):
+    """``skill.irc_ask`` fires the ``agent_question`` AlertEvent;
+    ``WebhookClient`` POSTs ``{"content": "[QUESTION] ..."}`` JSON to the
+    configured URL."""
+    _redirect_pidfile(monkeypatch, tmp_path)
+
+    httpd, received, capture_port = _make_capture_server()
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        config = DaemonConfig(
+            server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
+            webhooks=WebhookConfig(url=f"http://127.0.0.1:{capture_port}/hook"),
+        )
+        agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general"])
+        sock_dir = tmp_path / "sock"
+        sock_dir.mkdir()
+        daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
+        await daemon.start()
+        try:
+            await _wait_for_daemon_joined(server, "#general", agent.nick)
+
+            sock_path = os.path.join(str(sock_dir), "culture-testserv-bot.sock")
+            skill = SkillClient(sock_path)
+            await skill.connect()
+            try:
+                # irc_ask fires agent_question webhook (default in WebhookConfig.events)
+                result = await skill.irc_ask("#general", "what cmake flags?", timeout=1)
+                assert result["ok"]
+                await _wait_for_capture(received, 1)
+            finally:
+                await skill.close()
+        finally:
+            await daemon.stop()
+    finally:
+        httpd.shutdown()
+        server_thread.join(timeout=2.0)
+        httpd.server_close()
+
+    assert len(received) == 1
+    payload = received[0]
+    # Webhook payload shape from culture/clients/shared/webhook.py:_http_post
+    assert "content" in payload
+    assert "[QUESTION]" in payload["content"]
+    assert "testserv-bot" in payload["content"]
+    assert "what cmake flags?" in payload["content"]

--- a/tests/test_integration_webhook.py
+++ b/tests/test_integration_webhook.py
@@ -14,6 +14,7 @@ file; no daemon-level duplicate here.
 import asyncio
 import json
 import os
+import queue
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -47,33 +48,24 @@ async def _wait_for_daemon_joined(server, channel, nick, timeout=5.0):
             await asyncio.sleep(0.05)
 
 
-async def _wait_for_capture(received, count, timeout=5.0):
-    """Bounded poll on the shared ``received`` list until ``count`` POSTs
-    land. Replaces racy fixed-sleep loops — webhook fanout runs the HTTP
-    POST via ``asyncio.to_thread`` so it lands shortly after the IPC
-    response, but ordering vs. the test's next line isn't guaranteed."""
-    async with asyncio.timeout(timeout):
-        while True:
-            if len(received) >= count:
-                return
-            await asyncio.sleep(0.05)
-
-
 def _make_capture_server():
     """Build a stdlib ``HTTPServer`` on a random port that captures POSTed
-    JSON bodies into a list. Returns ``(httpd, received_list, port)``.
+    JSON bodies into a thread-safe ``queue.SimpleQueue``. Returns
+    ``(httpd, received_queue, port)``.
 
     Uses stdlib instead of aiohttp.web to match the existing pattern in
-    ``tests/test_webhook.py`` — keeps style consistent and avoids
-    dragging another dep style into the test surface for one POST.
+    ``tests/test_webhook.py``. The capture queue replaces a plain list
+    so the cross-thread handle-thread → asyncio-test handoff is
+    explicitly synchronized (CPython's GIL makes a list "work" today
+    but the queue removes the implicit reliance on it).
     """
-    received: list = []
+    received: queue.SimpleQueue = queue.SimpleQueue()
 
     class Handler(BaseHTTPRequestHandler):
         def do_POST(self):
             length = int(self.headers["Content-Length"])
             body = json.loads(self.rfile.read(length))
-            received.append(body)
+            received.put(body)
             self.send_response(200)
             self.end_headers()
 
@@ -112,10 +104,18 @@ async def test_irc_ask_triggers_http_webhook_post(server, make_client, tmp_path,
             skill = SkillClient(sock_path)
             await skill.connect()
             try:
-                # irc_ask fires agent_question webhook (default in WebhookConfig.events)
-                result = await skill.irc_ask("#general", "what cmake flags?", timeout=1)
+                # irc_ask fires agent_question webhook (default in WebhookConfig.events).
+                # Bound the IPC call ourselves: skill.irc_ask's `timeout` is
+                # echoed in the IPC message but the daemon ignores it, and
+                # SkillClient._request awaits the response with no deadline.
+                async with asyncio.timeout(5.0):
+                    result = await skill.irc_ask("#general", "what cmake flags?", timeout=1)
                 assert result["ok"]
-                await _wait_for_capture(received, 1)
+                # Block until the capture server's handler thread has put
+                # one body on the queue, with an explicit timeout. The
+                # queue handoff replaces a polled-list pattern that
+                # implicitly relied on CPython's GIL for visibility.
+                payload = await asyncio.to_thread(received.get, True, 5.0)
             finally:
                 await skill.close()
         finally:
@@ -125,10 +125,10 @@ async def test_irc_ask_triggers_http_webhook_post(server, make_client, tmp_path,
         server_thread.join(timeout=2.0)
         httpd.server_close()
 
-    assert len(received) == 1
-    payload = received[0]
     # Webhook payload shape from culture/clients/shared/webhook.py:_http_post
     assert "content" in payload
     assert "[QUESTION]" in payload["content"]
     assert "testserv-bot" in payload["content"]
     assert "what cmake flags?" in payload["content"]
+    # No further POSTs expected — the agent_question event fires once per ask.
+    assert received.empty()

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.5.9"
+version = "10.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 0a Task 5 of the cultureagent extraction. Adds `tests/test_integration_webhook.py` — a single integration test that exercises the daemon's webhook HTTP fanout path:

1. Stdlib `HTTPServer` thread captures POSTs at a random local port.
2. Daemon is configured with `WebhookConfig(url=<capture-url>)`; default `events` includes `agent_question`.
3. Test calls `skill.irc_ask("#general", "what cmake flags?")` — daemon's `_ipc_irc_ask` sends the PRIVMSG and fires `WebhookClient.fire(AlertEvent(event_type="agent_question", ...))`, which spawns the HTTP POST via `asyncio.to_thread`.
4. Bounded poll on the capture list, then assert payload shape: `{"content": "[QUESTION] [testserv-bot] asked in #general: what cmake flags?"}`.

`culture/clients/shared/webhook.py` coverage rises to **89%** from this single file (only `_send_irc`/`_send_http` exception paths and the unmatched-event-type early return remain).

## Scope decision: IRC alert path already covered

The audit's row #7 (IRC alert channel) calls for an integration test of `WebhookConfig(irc_channel=..., events=[...])` → human in `#alerts` observes the alert. That's already what `tests/test_integration_layer5.py::test_webhook_fires_on_question` does at integration shape. This PR documents that in the new file's docstring rather than duplicating, matching the Task 4 reconnect precedent.

## Adopts Tasks 2/3/4 hardening

- `tmp_path` for socket dir.
- `monkeypatch.setattr("culture.pidfile.PID_DIR", ...)` so daemons don't write into the real `~/.culture/pids`.
- `_wait_for_daemon_joined` (server-side membership signal) before triggering `irc_ask`.
- New `_wait_for_capture(received, count)` — bounded poll on the captured-POST list. Replaces racy fixed-sleep loops.

## Notes for reviewers

- Stdlib `HTTPServer` over aiohttp.web — matches the existing pattern in `tests/test_webhook.py`. Avoids dragging another test-style dep into one PR for one POST.
- The capture server runs `serve_forever` in a daemon thread; cleanup is `httpd.shutdown()` + `thread.join(timeout=2.0)` + `httpd.server_close()` in `finally`.

## Test plan

- [x] `uv run pytest tests/test_integration_webhook.py -v` — 1 passed in 0.80s
- [x] `uv run pytest ... --cov=culture.clients.shared.webhook` — 89%
- [x] Pre-commit hooks (black, isort, flake8, pylint, bandit, markdownlint) — all green
- [ ] Full CI (Qodo, Copilot, SonarCloud, pytest matrix)

Tasks 6 (telemetry), 8 (per-backend agent_runner timeout) ship in separate PRs. Task 9 (gate flip) closes Phase 0a.

- culture (Claude)