### PR TITLE
Phase 0a closeout: document measured coverage, gate stays at 56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.6.0] - 2026-05-09
+
+### Added
+
+- Phase 0a closeout — coverage baseline doc updated with measured per-domain numbers and a closeout section. Audit doc footer filled with final percentages and follow-up list. `culture/clients/shared/` covered to 80% (+22pp via Phase 0a integration tests #364–#369); project-wide at 56.96% (gate stays at 56 since unit tests still cover the same paths; they delete in Phase 1).
+
+### Changed
+
+- `pyproject.toml`'s `[tool.coverage.report]` comment refreshed to reflect Phase 0a closeout. `fail_under` value unchanged at **56** (matches `floor(56.96)` measured project-wide); the project-wide number didn't move materially because the harness unit tests still cover the same code paths the new integration tests exercise.
+- `docs/coverage-baseline.md`: per-domain table now shows measured-actuals; closeout section appended; SonarCloud project-key reference updated from legacy `OriNachum_culture` to current `agentculture_culture`.
+
 ## [10.5.12] - 2026-05-09
 
 ### Added

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -12,7 +12,7 @@ The baseline was measured by `uv run pytest -n auto --cov=culture --cov-report=x
 
 ## Locks
 
-- **pytest CI gate:** [`tool.coverage.report] fail_under = 56`](../pyproject.toml) in `pyproject.toml`. Drops below 56% fail the PR locally / in CI before SonarCloud reports back.
+- **pytest CI gate:** [`[tool.coverage.report] fail_under = 56`](../pyproject.toml) in `pyproject.toml`. Drops below 56% fail the PR locally / in CI before SonarCloud reports back.
 - **SonarCloud Quality Gate:** `sonar.qualitygate.wait=true` in [`sonar-project.properties`](../sonar-project.properties) blocks CI on the gate decision. Gate threshold managed in SonarCloud's project settings (out-of-tree).
 - **CI scanner:** `.github/workflows/tests.yml` runs `SonarSource/sonarqube-scan-action` after pytest, uploading `coverage.xml` to the SonarCloud project (`agentculture_culture`). Fork PRs without `SONAR_TOKEN` skip the scan cleanly.
 

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -14,21 +14,42 @@ The baseline was measured by `uv run pytest -n auto --cov=culture --cov-report=x
 
 - **pytest CI gate:** [`tool.coverage.report] fail_under = 56`](../pyproject.toml) in `pyproject.toml`. Drops below 56% fail the PR locally / in CI before SonarCloud reports back.
 - **SonarCloud Quality Gate:** `sonar.qualitygate.wait=true` in [`sonar-project.properties`](../sonar-project.properties) blocks CI on the gate decision. Gate threshold managed in SonarCloud's project settings (out-of-tree).
-- **CI scanner:** `.github/workflows/tests.yml` runs `SonarSource/sonarqube-scan-action` after pytest, uploading `coverage.xml` to the SonarCloud project (`OriNachum_culture`). Fork PRs without `SONAR_TOKEN` skip the scan cleanly.
+- **CI scanner:** `.github/workflows/tests.yml` runs `SonarSource/sonarqube-scan-action` after pytest, uploading `coverage.xml` to the SonarCloud project (`agentculture_culture`). Fork PRs without `SONAR_TOKEN` skip the scan cleanly.
 
 ## Per-domain growth path (Phase 0a)
 
-| Domain | Today | After Phase 0a (projected) | Gating done by |
-|---|---|---|---|
-| `culture/clients/shared/` | ~58% | ~95% | Tasks 2, 3, 4, 5, 6 |
-| `culture/clients/claude/` | ~85% | ~90% | Tasks 6, 7, 8 |
-| `culture/clients/codex/` | ~25% | ~75% | Tasks 7, 8 (parameterized) |
-| `culture/clients/copilot/` | ~25% | ~75% | Tasks 7, 8 (parameterized) |
-| `culture/clients/acp/` | ~25% | ~70% | Tasks 7, 8 (parameterized) |
-| **Project-wide** | **56.86%** | **~73%** | Sum of above |
+| Domain | Baseline | Phase 0a (projected) | Phase 0a (measured) | Gating done by |
+|---|---|---|---|---|
+| `culture/clients/shared/` | ~58% | ~95% | **80%** | Tasks 2, 3, 4, 5, 6 |
+| `culture/clients/claude/` | ~85% | ~90% | **72%** | Tasks 6, 8 |
+| `culture/clients/codex/` | ~25% | ~75% | **~43%** | (Task 8 narrowed to claude) |
+| `culture/clients/copilot/` | ~25% | ~75% | **~43%** | (Task 8 narrowed to claude) |
+| `culture/clients/acp/` | ~25% | ~70% | **~43%** | (Task 8 narrowed to claude) |
+| **Project-wide** | **56.86%** | **~73%** | **56.96%** | (see below) |
 
-After each Phase 0a task PR lands, the `fail_under` value in `pyproject.toml` ratchets up by the measured delta. Task 9 (closeout) adds per-domain enforcement — e.g., a separate CI step running `uv run pytest --cov=culture/clients --cov-fail-under=80` — when domain floors are at their post-Phase-0a values.
+The project-wide number barely moved because the harness unit tests in `tests/harness/test_*.py` still cover the same code paths the new integration tests exercise — once Phase 1 deletes those unit tests, the integration tests become the *sole* coverage source and the project-wide number reflects what's actually testable through the daemon → IRC → harness chain. Phase 0a's real delivery is the **+22pp on `culture/clients/shared/`** (58% → 80%): the shared-by-import tier that all four backends use is now covered through real `agentirc.IRCd` instances, not just through harness unit tests.
+
+The non-claude backends (`codex`, `copilot`, `acp`) didn't move because Task 7 (supervisor) was dropped during the audit revision and Task 8 (agent_runner timeout) narrowed to claude-only — each non-claude backend has a distinct SDK injection point that warrants its own integration-test PR. Cross-backend integration coverage is a follow-up.
 
 ## Why "Coverage on New Code" alone isn't enough here
 
-SonarCloud's default gate is "Coverage on New Code ≥ 80%" — protects new lines from being added without tests. That stays on as a regression preventer, but it doesn't lock today's overall floor: a delete that removes tested code can raise overall percentage while leaving real coverage gaps. The pytest `fail_under = 56` plus manual ratchets per Task PR is the tighter floor.
+SonarCloud's default gate is "Coverage on New Code ≥ 80%" — protects new lines from being added without tests. That stays on as a regression preventer, but it doesn't lock today's overall floor: a delete that removes tested code can raise overall percentage while leaving real coverage gaps. The pytest `fail_under = 56` is the tighter floor.
+
+## Closeout — Phase 0a complete (2026-05-09)
+
+Phase 0a's six integration-test PRs all merged:
+
+- [#364](https://github.com/agentculture/culture/pull/364) — Task 2 — attention behaviors
+- [#365](https://github.com/agentculture/culture/pull/365) — Task 3 — message buffer overflow
+- [#366](https://github.com/agentculture/culture/pull/366) — Task 4 — IRC transport traceparent propagation
+- [#367](https://github.com/agentculture/culture/pull/367) — Task 5 — webhook HTTP fanout
+- [#368](https://github.com/agentculture/culture/pull/368) — Task 6 — harness telemetry (connect span + transition counter)
+- [#369](https://github.com/agentculture/culture/pull/369) — Task 8 — claude agent_runner timeout
+
+`fail_under` stays at **56** (matching `floor(56.96)`); see the comment in `pyproject.toml`. SonarCloud gate choice: **Path B** (in-tree only — no Sonar UI changes; rely on the in-tree pytest floor for project-wide and on Sonar's default "Coverage on New Code ≥ 80%" for regression prevention).
+
+**Known follow-ups** (each will be its own small PR, not part of Phase 0a):
+
+1. **Task 8.5 — skill_client integration test.** `culture/clients/claude/skill/irc_client.py` shows 54% under integration-only tests; needs a small `tests/test_integration_skill_client.py` before Phase 1 deletes `tests/test_skill_client.py`, otherwise the Phase 1 delete drops the floor.
+2. **Cross-backend integration timeout tests** for `codex`, `copilot`, `acp` (Task 8 narrowing).
+3. **Product fix — `AgentDaemon.stop()` should cancel/await `_background_tasks`** (PR #369 review #2 follow-up).

--- a/docs/reference/server/security.md
+++ b/docs/reference/server/security.md
@@ -36,9 +36,10 @@ The following security checks run automatically on pushes to main, pull requests
 
 [SonarCloud](https://sonarcloud.io/) provides comprehensive code quality and security analysis.
 
-- Uses **Automatic Analysis** (SonarCloud-managed, not CI-based) — scans `main` and PRs automatically
-- Configuration in `sonar-project.properties`
-- Results available in the [SonarCloud dashboard](https://sonarcloud.io/summary/overall?id=OriNachum_culture)
+- Uses **CI-based scanning** via `SonarSource/sonarqube-scan-action` in `.github/workflows/tests.yml` (runs after pytest, uploads `coverage.xml`). Automatic Analysis was disabled in PR #362 in favor of CI-driven scans so the gate decision blocks workflows.
+- Configuration in `sonar-project.properties` (project key: `agentculture_culture`, organization: `agentculture`).
+- `sonar.qualitygate.wait=true` blocks CI on the gate decision; fork PRs without `SONAR_TOKEN` skip the scan cleanly.
+- Results available in the [SonarCloud dashboard](https://sonarcloud.io/summary/overall?id=agentculture_culture).
 
 ### CodeQL
 

--- a/docs/superpowers/notes/2026-05-09-cultureagent-coverage-audit.md
+++ b/docs/superpowers/notes/2026-05-09-cultureagent-coverage-audit.md
@@ -177,6 +177,19 @@ uv run coverage report --include='culture/clients/shared/*,culture/clients/*/dae
 
 ## Closeout (post-merge)
 
-> _To be filled by Task 9 closeout PR._
->
-> Phase 0a complete on YYYY-MM-DD. Final overall coverage: NN.N% (project-wide), NN.N% (`culture/clients/` scope). Gate flipped via PR #XXX. Ready to kick off Phase 0b (cultureagent buildup brief).
+Phase 0a complete on **2026-05-09**. Final measured coverage:
+
+- **Project-wide:** **56.96%** (vs 56.86% baseline — barely moved because harness unit tests still cover the same code paths; they delete in Phase 1).
+- **`culture/clients/shared/`:** **80%** (vs ~58% baseline — **+22pp**, Phase 0a's real delivery).
+- **`culture/clients/claude/`:** **72%** (vs ~85% baseline — measurement appears tighter under the post-Phase-0a full-suite run; the audit's 85% figure may have been optimistic).
+- **`culture/clients/{codex,copilot,acp}/`:** ~43% each (essentially unchanged — Task 7 dropped, Task 8 narrowed to claude only).
+
+Gate stays at **`fail_under = 56`** (matching `floor(56.96)`); SonarCloud gate kept at default Path B. See [`docs/coverage-baseline.md`](../../coverage-baseline.md) for the full per-domain table and follow-up list.
+
+Phase 0a's six integration-test PRs (#364, #365, #366, #367, #368, #369) all merged. Ready to kick off Phase 0b (cultureagent buildup brief — separate writing-plans session).
+
+**Audit-driven follow-ups** (out of Phase 0a; tracked for the cutover and beyond):
+
+- **Task 8.5 — skill_client integration test.** Audit row #20's "ALREADY COVERED" assumed `test_integration_layer5.py` was sufficient; actual integration-only coverage of `culture/clients/claude/skill/irc_client.py` is 54%, below the in-repo plan's 80% threshold. A small `tests/test_integration_skill_client.py` is needed before Phase 1 deletes `tests/test_skill_client.py`.
+- **Cross-backend integration timeout tests** for `codex`, `copilot`, `acp` (Task 8 narrowing).
+- **Product fix — `AgentDaemon.stop()` should cancel/await `_background_tasks`** (PR #369 review #2 follow-up — currently mitigated test-locally by monkeypatching `_on_agent_exit`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.5.12"
+version = "10.6.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -85,8 +85,12 @@ omit = [
 
 [tool.coverage.report]
 # Locked 2026-05-09 at the measured project-wide floor (56.86% — see
-# docs/coverage-baseline.md). Each Phase 0a integration-test PR ratchets
-# this up by the measured delta.
+# docs/coverage-baseline.md). Phase 0a closeout (#370): post-Phase-0a
+# project-wide measured at 56.96% — barely above baseline because the
+# harness unit tests still cover the same code paths the integration
+# tests now exercise (they delete in Phase 1). Phase 0a's real delivery
+# is on `culture/clients/shared/` (58% → 80%). Project-wide gate stays
+# at 56 until Phase 1's unit-test deletion forces a re-baseline.
 fail_under = 56
 show_missing = true
 exclude_lines = [

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.5.12"
+version = "10.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

**Phase 0a closeout.** All six integration-test PRs (#364, #365, #366, #367, #368, #369) merged. This PR is the documentation + gate-decision finalization, not a value ratchet.

## Measured vs projected

| Domain | Baseline | Projected | **Measured** |
|---|---|---|---|
| `culture/clients/shared/` | ~58% | ~95% | **80%** (+22pp) |
| `culture/clients/claude/` | ~85% | ~90% | **72%** |
| `culture/clients/codex/` | ~25% | ~75% | **~43%** |
| `culture/clients/copilot/` | ~25% | ~75% | **~43%** |
| `culture/clients/acp/` | ~25% | ~70% | **~43%** |
| **Project-wide** | **56.86%** | **~73%** | **56.96%** |

The project-wide number barely moved because the harness unit tests still cover the same code paths the new integration tests exercise — they delete in Phase 1. **Phase 0a's real delivery is on `culture/clients/shared/`** (+22pp). The non-claude backends didn't move because Task 7 (supervisor) was dropped during the audit revision and Task 8 (agent_runner timeout) narrowed to claude-only.

## Gate decision

**`fail_under` stays at 56**, matching `floor(56.96)`. The in-repo plan called for `floor(measured) - 1pp` headroom, but applied to 56.96 that would yield 55 — *looser* than the current gate. The right move is to keep 56 with a refreshed comment explaining the situation. Future ratchets become possible once Phase 1 deletes the harness unit tests and exposes the integration-test coverage delta as the real floor.

**SonarCloud gate: Path B** (in-tree only). No SonarCloud UI changes. Default "Coverage on New Code ≥ 80%" remains as the new-code regression preventer; the in-tree pytest `fail_under` is the project-wide floor.

## Follow-ups (out of Phase 0a)

Documented in [`docs/coverage-baseline.md`](https://github.com/agentculture/culture/pull/370/files#diff-1cd1c95b6f5d6cce6ee16e30b3c00a30efe7a01ec1b9ba8d8f1cec4c4f9c98e6) and the audit footer:

1. **Task 8.5 — skill_client integration test.** `culture/clients/claude/skill/irc_client.py` shows 54% under integration-only tests; needs a small `tests/test_integration_skill_client.py` before Phase 1 deletes `tests/test_skill_client.py`.
2. **Cross-backend integration timeout tests** for `codex`, `copilot`, `acp` (Task 8 narrowing).
3. **Product fix — `AgentDaemon.stop()` should cancel/await `_background_tasks`** (PR #369 review #2 follow-up; currently mitigated test-locally by monkeypatching `_on_agent_exit`).

## Files changed

- `pyproject.toml` — `[tool.coverage.report]` comment refreshed; `fail_under` value unchanged.
- `docs/coverage-baseline.md` — measured per-domain table, closeout section, SonarCloud project-key fix (`OriNachum_culture` → `agentculture_culture`).
- `docs/superpowers/notes/2026-05-09-cultureagent-coverage-audit.md` — closeout footer with final percentages and follow-up list.
- `CHANGELOG.md` — `[10.6.0]` entry (minor bump for CI quality-process change per the in-repo plan's convention).
- `pyproject.toml` / `uv.lock` — version bump 10.5.12 → 10.6.0.

## Test plan

- [x] `uv run pytest -n auto --cov=culture --cov-report=term -q` — 1146 passed, total coverage 56.96% (gate satisfied).
- [x] Per-domain `coverage report` for shared/claude/codex/copilot/acp captured and reflected in the docs table.
- [x] Pre-commit hooks — all green.
- [ ] Full CI (Qodo, Copilot, SonarCloud, pytest matrix).

After this merges, Phase 0a is complete. Next workstream: Phase 0b kickoff brief to the cultureagent sibling repo (separate writing-plans session).

- culture (Claude)