### PR TITLE
Task 8.5(a): integration coverage for SkillClient — pre-handover safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.6.1] - 2026-05-09
+
+### Added
+
+- `tests/test_integration_skill_client.py` — Phase 0a Task 8.5(a): pre-handover integration coverage for `SkillClient`. Four tests drive the verbs not yet covered by `tests/test_integration_layer5.py`: `irc_who`, `irc_topic` (set + get modes), supervisor whisper dispatch (via `daemon._socket_server.send_whisper`) → `SkillClient.pending_whispers` / `drain_whispers()`, and the `close()` cleanup branch (pending requests resolved with `ConnectionError`). Lifts `culture/clients/claude/skill/irc_client.py` from 54% → **~87% on the class itself** (61% headline including the explicitly out-of-scope CLI helpers in lines 189-318). Adopts Tasks 2/3/6's hardening (`tmp_path` sock_dir, monkeypatched `PID_DIR`, bounded polls). Replaces the integration-shaped portion of `tests/test_skill_client.py` (the unit test moves to cultureagent in Phase 1; this file stays as the contract test for culture's daemon ↔ skill IPC surface). `compact` / `clear` SkillClient verbs require a real claude SDK turn — covered by Task 8.5(b) follow-up.
+
 ## [10.6.0] - 2026-05-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.6.0"
+version = "10.6.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_integration_skill_client.py
+++ b/tests/test_integration_skill_client.py
@@ -163,14 +163,25 @@ async def test_close_fails_pending_requests(server, tmp_path, monkeypatch):
     config, agent, sock_dir = _make_daemon_setup(server, tmp_path)
     daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
     await daemon.start()
+
+    # Test-scoped unblock signal — set in finally so the daemon's
+    # SocketServer per-client handler task can unwind before
+    # daemon.stop() runs. Without this, SocketServer.stop() doesn't
+    # cancel in-flight _handle_client tasks (its scope is closing
+    # writers + the server, not handler awaits), so a never-returning
+    # handler would leak a pending task past test teardown.
+    unblock = asyncio.Event()
+
+    async def _never_responds(_req_id, _msg):
+        await unblock.wait()
+        # Returning None is fine — the skill's request future has
+        # already been resolved with ConnectionError by close().
+
+    daemon._ipc_dispatch["irc_send"] = _never_responds
+
     try:
         await _wait_for_daemon_joined(server, "#general", agent.nick)
         skill = await _connect_skill(sock_dir)
-
-        async def _never_responds(_req_id, _msg):
-            await asyncio.Event().wait()  # cancellation-friendly hang
-
-        daemon._ipc_dispatch["irc_send"] = _never_responds
 
         send_task = asyncio.create_task(skill.irc_send("#general", "stuck"))
         # Wait until the request has been written and registered in
@@ -184,4 +195,5 @@ async def test_close_fails_pending_requests(server, tmp_path, monkeypatch):
         with pytest.raises(ConnectionError, match="SkillClient closed|Connection lost"):
             await send_task
     finally:
+        unblock.set()  # let the daemon's IPC handler return cleanly
         await daemon.stop()

--- a/tests/test_integration_skill_client.py
+++ b/tests/test_integration_skill_client.py
@@ -1,0 +1,187 @@
+"""End-to-end SkillClient — drives each high-level IRC verb (the ones
+not already exercised by ``tests/test_integration_layer5.py``) through
+the full daemon ↔ Unix socket ↔ ``agentirc.IRCd`` chain. Plus whisper
+dispatch and close-with-pending-requests lifecycle.
+
+Phase 0a Task 8.5(a): replaces the integration-shaped portion of
+``tests/test_skill_client.py`` (the unit test moves to cultureagent in
+Phase 1; this file stays as the contract test for culture's daemon ↔
+skill IPC surface).
+
+**Out of scope:** ``compact`` / ``clear`` (need a real claude SDK turn —
+Task 8.5(b) territory) and the module-level CLI helpers
+(``_sock_path_from_env``, ``_parse_ask_timeout``, ``_cmd_*``,
+``_main`` — separate ``tests/test_cli_*`` shape).
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from culture.clients.claude.config import (
+    AgentConfig,
+    DaemonConfig,
+    ServerConnConfig,
+    WebhookConfig,
+)
+from culture.clients.claude.daemon import AgentDaemon
+from culture.clients.claude.skill.irc_client import SkillClient
+
+
+def _redirect_pidfile(monkeypatch, tmp_path):
+    """Redirect ``culture.pidfile.PID_DIR`` so daemons don't write into the
+    real ``~/.culture/pids`` from a unit test."""
+    monkeypatch.setattr("culture.pidfile.PID_DIR", str(tmp_path / "pids"))
+
+
+async def _wait_for_daemon_joined(server, channel, nick, timeout=5.0):
+    """Poll ``server.channels[channel].members`` until the daemon's nick
+    appears. Server processes JOIN synchronously on receipt, so this
+    is a deterministic readiness signal — same helper as Tasks 3–6."""
+    async with asyncio.timeout(timeout):
+        while True:
+            ch = server.channels.get(channel)
+            if ch is not None and any(getattr(m, "nick", None) == nick for m in ch.members):
+                return
+            await asyncio.sleep(0.05)
+
+
+def _make_daemon_setup(server, tmp_path):
+    """Build the standard test config + agent + sock dir. Returns
+    ``(config, agent, sock_dir)``."""
+    config = DaemonConfig(
+        server=ServerConnConfig(host="127.0.0.1", port=server.config.port),
+        webhooks=WebhookConfig(url=None),
+    )
+    agent = AgentConfig(nick="testserv-bot", directory="/tmp", channels=["#general"])
+    sock_dir = tmp_path / "sock"
+    sock_dir.mkdir()
+    return config, agent, sock_dir
+
+
+async def _connect_skill(sock_dir):
+    sock_path = os.path.join(str(sock_dir), "culture-testserv-bot.sock")
+    skill = SkillClient(sock_path)
+    await skill.connect()
+    return skill
+
+
+@pytest.mark.asyncio
+async def test_irc_who_returns_ok(server, tmp_path, monkeypatch):
+    """``irc_who`` forwards a WHO query through the daemon. The IPC
+    response is ``ok=True`` once the WHO has been sent — actual numerics
+    arrive via the buffer, not the IPC reply (see daemon.py:916-922)."""
+    _redirect_pidfile(monkeypatch, tmp_path)
+    config, agent, sock_dir = _make_daemon_setup(server, tmp_path)
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
+    await daemon.start()
+    try:
+        await _wait_for_daemon_joined(server, "#general", agent.nick)
+        skill = await _connect_skill(sock_dir)
+        try:
+            result = await skill.irc_who("#general")
+            assert result["ok"]
+        finally:
+            await skill.close()
+    finally:
+        await daemon.stop()
+
+
+@pytest.mark.asyncio
+async def test_irc_topic_set_and_get(server, tmp_path, monkeypatch):
+    """``irc_topic`` in set mode (``topic=<str>``) and get mode (``topic``
+    absent) both return ``ok=True``. Daemon dispatches to
+    ``transport.send_topic(channel, topic|None)`` — see daemon.py:924-933."""
+    _redirect_pidfile(monkeypatch, tmp_path)
+    config, agent, sock_dir = _make_daemon_setup(server, tmp_path)
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
+    await daemon.start()
+    try:
+        await _wait_for_daemon_joined(server, "#general", agent.nick)
+        skill = await _connect_skill(sock_dir)
+        try:
+            set_result = await skill.irc_topic("#general", "Phase 0a complete")
+            assert set_result["ok"]
+            get_result = await skill.irc_topic("#general")
+            assert get_result["ok"]
+        finally:
+            await skill.close()
+    finally:
+        await daemon.stop()
+
+
+@pytest.mark.asyncio
+async def test_supervisor_whisper_routes_to_pending_whispers(server, tmp_path, monkeypatch):
+    """A whisper sent through the daemon's socket_server is queued onto
+    ``SkillClient.pending_whispers`` (via the WHISPER branch of
+    ``_dispatch_message``) and surfaced via ``drain_whispers()``.
+    Drives lines 105-106 + 130-132 of ``irc_client.py``."""
+    _redirect_pidfile(monkeypatch, tmp_path)
+    config, agent, sock_dir = _make_daemon_setup(server, tmp_path)
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
+    await daemon.start()
+    try:
+        await _wait_for_daemon_joined(server, "#general", agent.nick)
+        skill = await _connect_skill(sock_dir)
+        try:
+            # Drive the whisper from the daemon side using the same path
+            # production supervisors use — see daemon.py:666-669.
+            assert daemon._socket_server is not None
+            await daemon._socket_server.send_whisper("Stop retrying", "CORRECTION")
+
+            async with asyncio.timeout(5.0):
+                while not skill.pending_whispers:
+                    await asyncio.sleep(0.05)
+            whispers = skill.drain_whispers()
+            assert len(whispers) == 1
+            assert whispers[0]["whisper_type"] == "CORRECTION"
+            assert "Stop retrying" in whispers[0]["message"]
+            assert skill.pending_whispers == []  # drained
+        finally:
+            await skill.close()
+    finally:
+        await daemon.stop()
+
+
+@pytest.mark.asyncio
+async def test_close_fails_pending_requests(server, tmp_path, monkeypatch):
+    """``SkillClient.close()`` resolves any in-flight request future with
+    a ``ConnectionError`` — drives the cleanup branches at
+    ``irc_client.py:65-69`` (``"SkillClient closed"``) and
+    ``irc_client.py:91-95`` (``"Connection lost"``). In practice the
+    read-loop's ``finally`` (line 91-95) wins the race because
+    ``close()`` cancels the read task first; either message is a valid
+    pending-fail signal so the assertion accepts both.
+
+    Setup: replace one IPC handler in the daemon's ``_ipc_dispatch``
+    table with a non-responding stub; the skill's ``irc_send`` request
+    parks in ``_pending`` indefinitely. ``close()`` must then resolve
+    that pending future with the documented exception.
+    """
+    _redirect_pidfile(monkeypatch, tmp_path)
+    config, agent, sock_dir = _make_daemon_setup(server, tmp_path)
+    daemon = AgentDaemon(config, agent, socket_dir=str(sock_dir), skip_claude=True)
+    await daemon.start()
+    try:
+        await _wait_for_daemon_joined(server, "#general", agent.nick)
+        skill = await _connect_skill(sock_dir)
+
+        async def _never_responds(_req_id, _msg):
+            await asyncio.Event().wait()  # cancellation-friendly hang
+
+        daemon._ipc_dispatch["irc_send"] = _never_responds
+
+        send_task = asyncio.create_task(skill.irc_send("#general", "stuck"))
+        # Wait until the request has been written and registered in
+        # _pending. A bounded poll here replaces fixed sleeps.
+        async with asyncio.timeout(5.0):
+            while not skill._pending:
+                await asyncio.sleep(0.01)
+
+        await skill.close()
+
+        with pytest.raises(ConnectionError, match="SkillClient closed|Connection lost"):
+            await send_task
+    finally:
+        await daemon.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.6.0"
+version = "10.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 0a Task 8.5(a) — pre-handover safety net for the SkillClient ↔ daemon IPC contract. Adds `tests/test_integration_skill_client.py` with four integration tests exercising the verbs and lifecycle branches **not** already covered by `tests/test_integration_layer5.py`.

The PR #370 closeout doc named SkillClient as the highest-priority pre-handover gap: `culture/clients/claude/skill/irc_client.py` was at 54% under integration-only tests, so when Phase 1 deletes `tests/test_skill_client.py` the floor would drop noticeably. This PR closes that gap so the cutover starts with stable safety.

## Tests added

| Test | Verb / branch | Lines covered |
|---|---|---|
| `test_irc_who_returns_ok` | `SkillClient.irc_who` → `daemon._ipc_irc_who` | 162-164 |
| `test_irc_topic_set_and_get` | `irc_topic` set + get modes | 166-171 |
| `test_supervisor_whisper_routes_to_pending_whispers` | `daemon._socket_server.send_whisper` → `_dispatch_message` whisper branch → `pending_whispers` → `drain_whispers()` | 105-106, 130-132 |
| `test_close_fails_pending_requests` | `close()` cleanup resolving pending requests with `ConnectionError` | 65-69 (or 91-95, see note) |

## Coverage delta

`culture/clients/claude/skill/irc_client.py`:

- **54%** → **61% combined integration**
- **~87% on the SkillClient class itself** — the headline number is dragged down by the explicitly out-of-scope module-level CLI helpers in lines 189-318 (`_sock_path_from_env`, `_parse_ask_timeout`, `_cmd_*`, `_main`, argparse). Those are CLI-shape, not integration-shape; they'd warrant their own `tests/test_cli_skill_client.py` if needed.

Project-wide: 56.96% → **57.22%** (+0.26pp).

## Notes for reviewers

- The `close()` test exposed a real behavior worth documenting: `close()` cancels the read task **first**, which fires its `finally` block and resolves pending futures with `"Connection lost"` (line 91-95) — *before* `close()`'s own cleanup at line 65-69 runs (which then finds `_pending` already drained). Both paths are legitimate cleanup branches; the test asserts either message via `match="SkillClient closed|Connection lost"`. Documented in the test docstring.
- The `close()` test mutates `daemon._ipc_dispatch["irc_send"]` to a non-responding handler. This is test-internal coupling, but the alternative (closing during a real verb's slow response) is more flaky. Defensible because `_ipc_dispatch` is the documented dispatch surface.
- The whisper test uses `daemon._socket_server.send_whisper(...)` directly — same path the production supervisor calls into. Avoids needing a real claude SDK turn (Task 8.5(b) territory).

## Adopts Tasks 2/3/6 hardening

- `tmp_path` for socket dir.
- `monkeypatch.setattr("culture.pidfile.PID_DIR", ...)` so daemons don't write into the real `~/.culture/pids`.
- `_wait_for_daemon_joined(server, channel, nick)` (server-side membership signal).
- Bounded `asyncio.timeout(5.0)` polls instead of fixed sleeps.

## Test plan

- [x] `uv run pytest tests/test_integration_skill_client.py -v` — 4 passed in 0.32s
- [x] `uv run pytest tests/test_integration_skill_client.py -n auto` — 4 passed in 1.05s under 20 workers
- [x] `uv run pytest tests/test_integration_*.py --cov=culture.clients.claude.skill.irc_client` — 61% combined
- [x] `uv run pytest -n auto --cov=culture` — 1150 passed, 57.22% project-wide (gate satisfied)
- [x] Pre-commit hooks (black, isort, flake8, pylint, bandit, markdownlint) — all green
- [ ] Full CI (Qodo, Copilot, SonarCloud, pytest matrix)

**Task 8.5(b)** (agent_runner success/error path integration tests) is the follow-up PR after this merges.

- culture (Claude)