### PR TITLE
docs: status update — Phase 0a closed, Phase 0b filed on cultureagent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [10.6.6] - 2026-05-09
+
+### Changed
+
+- `docs/superpowers/specs/2026-05-09-cultureagent-extraction-design.md` status updated from "Design" to "Phase 0a complete; Phase 0b in flight upstream". Added a tracking section listing the Phase 0a integration test PRs (#364–#375) and a link to the Phase 0b kickoff brief on cultureagent ([agentculture/cultureagent#3](https://github.com/agentculture/cultureagent/issues/3)). Phase 0b work itself is tracked on cultureagent's repo per the cross-repo handoff convention; culture's spec only points at the issue.
+
 ## [10.6.5] - 2026-05-09
 
 ### Added

--- a/docs/superpowers/specs/2026-05-09-cultureagent-extraction-design.md
+++ b/docs/superpowers/specs/2026-05-09-cultureagent-extraction-design.md
@@ -1,8 +1,13 @@
 # cultureagent extraction — agent harness moves to a sibling repo
 
-**Status:** Design
+**Status:** Phase 0a complete; Phase 0b in flight upstream
 **Date:** 2026-05-09
 **Author:** Ori Nachum + Claude (culture-side)
+
+**Tracking:**
+
+- Phase 0a integration test PRs (closed): #364, #365, #366, #367, #368, #369, #370, #371, #372, #373, #374, #375
+- Phase 0b kickoff brief filed: [agentculture/cultureagent#3](https://github.com/agentculture/cultureagent/issues/3) — work tracked there, not here
 
 ## Goal
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "10.6.5"
+version = "10.6.6"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "10.6.5"
+version = "10.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 0a of the cultureagent extraction is complete. All four backends now have integration coverage on the `agent_runner` timeout outcome, plus the `daemon.stop()` fix and the parametrized 4-backend shutdown regression. PRs #364–#375.

The Phase 0b kickoff brief — telling cultureagent's agent what to build out so culture can consume it in Phase 1 (cutover) — has been filed as a self-contained issue:

- **agentculture/cultureagent#3** — comprehensive brief: file inventory (shared tier + per-backend), target layout, stable import surface contract, acceptance criteria for "ready", migration invariant (never lose functionality across cutover), round-trip protocol for Phase 1.

This PR updates culture's design spec to reflect the new state:

- **Status** flipped from `Design` to `Phase 0a complete; Phase 0b in flight upstream`
- New **Tracking** section linking the PR list and the cultureagent issue
- CHANGELOG entry summarizing the change

Per the cross-repo handoff convention, Phase 0b work itself is tracked on cultureagent's repo; culture's spec only points at the issue so future readers landing here can find the live tracker.

## Out of scope

- Phase 1 cutover work — waits on cultureagent tagging the ready release
- Façade design for `cultureagent.api` — explicit non-goal in the spec; deferred indefinitely
- Any cultureagent-side implementation — `agentculture/cultureagent#3` owns that

## Test plan

- [x] Markdown lint passes
- [x] No code changes — docs and CHANGELOG only
- [x] Version bumped to 10.6.6 (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- culture (Claude)
