### PR TITLE
ci(sonar): trigger Tests on push to main so coverage reaches the dashboard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,24 +13,15 @@ on:
       - "culture/**"
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - run: uv python install 3.12
-
-      - run: uv sync
-
-      - run: uv run pytest -n auto -v
-
+  # No `test` job here: pytest (with coverage + SonarCloud) runs in tests.yml
+  # on both pull_request and push:[main]. Branch protection makes tests.yml
+  # required on PRs, so a PR can't merge with red tests. publish-* jobs
+  # below run in parallel with tests.yml on push to main; both fire on the
+  # same merge commit, so if tests.yml goes red the failure is visible on
+  # the merge SHA even though it doesn't block this workflow's publish.
+  # Mirrors agex-cli/.github/workflows/publish.yml — see culture#382.
   test-publish:
     if: github.event_name == 'pull_request'
-    needs: test
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -65,7 +56,6 @@ jobs:
 
   publish:
     if: github.event_name == 'push'
-    needs: test
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,8 @@ name: Tests
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   test:
@@ -40,6 +42,11 @@ jobs:
           SONAR_HOST_URL: https://sonarcloud.io
 
   version-check:
+    # Only run on PR events. On push to main after a merged PR, the
+    # comparison would always fail (PR_VERSION == MAIN_VERSION because HEAD
+    # and origin/main point at the same commit) and `gh pr comment` would
+    # have no PR to target. Mirrors steward/.github/workflows/tests.yml.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [11.1.1] - 2026-05-12
+
+### Fixed
+
+- SonarCloud coverage now appears on agentculture_culture main-branch dashboard — Tests workflow now also runs on push to main, mirroring steward. The CI scanner already produces coverage.xml correctly on PR builds (PR #380 reported 60.1% line coverage), but main was never re-scanned after merge, so the project view stayed at 0%.
+
 ## [11.1.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - SonarCloud coverage now appears on agentculture_culture main-branch dashboard — Tests workflow now also runs on push to main, mirroring steward. The CI scanner already produces coverage.xml correctly on PR builds (PR #380 reported 60.1% line coverage), but main was never re-scanned after merge, so the project view stayed at 0%.
 
+### Changed
+
+- `publish.yml` no longer has its own `test` job. pytest (with coverage + SonarCloud scan) runs once in `tests.yml` on both pull_request and push:[main]; branch protection makes that the required gate on PRs. Mirrors `agex-cli/.github/workflows/publish.yml` and closes #382. Cuts ~3.5 min of redundant CI per main merge that touches `pyproject.toml` or `culture/**`.
+
 ## [11.1.0] - 2026-05-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "11.1.0"
+version = "11.1.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Add `push: branches: [main]` to `.github/workflows/tests.yml` so the SonarCloud scanner runs after merges and uploads `coverage.xml` for the main branch.
- Guard `version-check` with `if: github.event_name == 'pull_request'` so it skips cleanly on push events (mirrors `steward/.github/workflows/tests.yml`).

## Why

The new SonarCloud CI scanner (`c746ede`, 2026-05-09) is wired correctly — PR scans upload coverage and PR #380 reports **60.1% line coverage** to SonarCloud. But the `agentculture_culture` dashboard shows no coverage on main because the Tests workflow only triggered on `pull_request`. After a PR merges, the job never re-ran on the new main commit, so the scanner was never invoked with a `coverage.xml` for main.

Evidence (SonarCloud API, 2026-05-12):

| Surface | Last analysis | Coverage |
|---|---|---|
| `agentculture_culture` / main | 2026-05-09 (`d285b8b`) | _absent_ |
| `agentculture_culture` / PR #380 | 2026-05-12 | **60.1%** |
| `agentculture_steward` / main (control, has `push: [main]`) | 2026-05-11 | **94.3%** |

The 9 historical main-branch analyses on SonarCloud all came from Automatic Analysis (`ciName: "Autoscan"`), which doesn't ingest coverage. Automatic Analysis is now disabled (`autoscanEnabled: false`), so the dashboard has been silently empty.

Steward is the AgentCulture-wide template (per `CLAUDE.md` § "Sibling alignment") — this PR brings culture's `tests.yml` in line with it.

## Test plan

- [ ] CI Tests job runs successfully on this PR (regression check — PR trigger still works).
- [ ] SonarCloud PR analysis posts on this PR with a clean quality gate.
- [ ] After merge: `gh run list --workflow=tests.yml --branch=main --limit=3` shows a successful run on the merge commit (currently returns empty).
- [ ] After merge: `curl -sL "https://sonarcloud.io/api/measures/component?component=agentculture_culture&metricKeys=coverage,line_coverage,ncloc"` returns a `coverage` value (~60%), not just `ncloc`.
- [ ] After merge: the SonarCloud project overview (https://sonarcloud.io/project/overview?id=agentculture_culture) shows a coverage percentage on main instead of "—".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- culture (Claude)