### PR TITLE
test(coverage): Phase 2 — cli/shared/process.py + protocol/commands.py [v12.0.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.0.2] - 2026-05-13
+
+### Added
+
+- `tests/test_cli_shared_process.py` — 24 tests covering `culture/cli/shared/process.py` (12% → 100%): `stop_agent` orchestration, `_try_ipc_shutdown` including missing socket / raise / false / poll-exhaustion, `_try_pid_shutdown` including corrupt PID / stale PID / non-culture PID / SIGTERM / SIGKILL escalation / abort-when-no-longer-culture / `ProcessLookupError` mid-kill, `server_stop_by_name` including SIGTERM success / SIGKILL escalation / lookup-error swallow. Fully hermetic: monkeypatches `os.kill`, `time.sleep`, `ipc_shutdown`, and `culture.pidfile.*` — no real signals, sockets, or forks.
+- `tests/test_protocol_commands.py` — 3 discovery-style tests covering `culture/protocol/commands.py` (0% → 100%): asserts every uppercase string constant equals its attribute name, and a baseline RFC 2812 smoke test. Adding a new verb does not require a test edit.
+
+### Changed
+
+- pyproject.toml: fail_under raised 60 → 62 (Phase 2 floor of the 60→90 ratchet plan). Project-wide measured 62.91%.
+- docs/coverage-baseline.md: Phase 2 entry + updated phase target table.
+
 ## [12.0.1] - 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.0.3] - 2026-05-13
+
+### Fixed
+
+- tests/test_cli_shared_process.py: pin sys.platform via monkeypatch in SIGKILL-escalation tests and add explicit win32-branch coverage. Addresses Qodo PR #384 finding that the original tests asserted POSIX-only behavior (SIGKILL + sending SIGKILL message) and would fail on Windows. The docstring incorrectly claimed `exclude_lines` prevents runtime execution — `exclude_lines` only affects reporting.
+
 ## [12.0.2] - 2026-05-13
 
 ### Added

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -73,13 +73,21 @@ Notable findings (deferred to later phases):
 - **`culture/transport/client.py` (569 stmts, 25% covered) is largely dead post-extraction.** `agentirc.ircd.IRCd` uses agentirc's own `Client` class (`.venv/lib/python3.12/site-packages/agentirc/client.py`), not culture's. Only four telemetry tests still import `culture.transport.client.Client` directly. Phase 5 should reconsider: delete the unused code rather than backfill tests for it.
 - **`culture/protocol/commands.py` (35 stmts, 0% covered)** — addressed in Phase 2 as planned.
 
+### Phase 2 — `cli/shared/process.py` + `protocol/commands.py` (2026-05-13)
+
+**Measured: 62.91%** (6260 statements, 2322 missing) → `fail_under = 62`. Both target files moved from low/zero coverage to 100%:
+
+- `culture/cli/shared/process.py` — 12% → **100%** (97 statements, 0 missing). `tests/test_cli_shared_process.py` (24 tests) covers all four functions (`stop_agent`, `_try_ipc_shutdown`, `_try_pid_shutdown`, `server_stop_by_name`) including every branch: IPC success, IPC failure, IPC raises, missing socket, corrupt/stale/non-culture PID, SIGTERM success, SIGTERM `ProcessLookupError`, SIGKILL escalation, and the "aborts kill when PID no longer culture" guard. All OS primitives monkeypatched — no real `os.kill` / `os.fork` / sockets.
+- `culture/protocol/commands.py` — 0% → **100%** (35 statements, 0 missing). `tests/test_protocol_commands.py` (3 tests) discovery-style: iterates `vars(commands)` for uppercase string constants and asserts `value == name`. Adding a new verb does not require a test edit; deletion is caught by the RFC-baseline smoke test.
+
 ### Phase target table
 
-| Phase | Floor | PR | Status |
-|---|---|---|---|
-| 1 | 60 | (this PR) | in flight |
-| 2 | 66 | `cli/shared/process.py`, `protocol/commands.py` | pending |
-| 3 | 73 | CLI handlers (server/agent/bot/channel/mesh) | pending |
-| 4 | 80 | Domain modules via real IRCd | pending |
-| 5 | 88 | `transport/client.py` (or its deletion) | pending |
-| 6 | 90 | Long tail + final exclusions | pending |
+| Phase | Floor | Measured | PR | Status |
+|---|---|---|---|---|
+| 1 | 60 | 60.99% | [#383](https://github.com/agentculture/culture/pull/383) | ✅ merged |
+| 2 | 62 | 62.91% | (this PR) | in flight |
+| 3 | 68 | — | CLI handlers (server/agent/bot/channel/mesh) | pending |
+| 4 | 75 | — | Domain modules via real IRCd | pending |
+| 5 | 82 | — | `transport/client.py` (or its deletion) | pending |
+| 6 | 88 | — | Long tail | pending |
+| 7 | 90 | — | Final sweep | pending |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.0.1"
+version = "12.0.2"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -93,11 +93,11 @@ omit = [
 
 [tool.coverage.report]
 # Ratchet floor — see docs/coverage-baseline.md for the per-phase log.
-# Phase 1 (2026-05-13): coverage plumbing fix + console removal.
-# Post-Phase-1 measured: 60.99% on commit 0322b83 + this PR. Floor set to
-# measured - 1pp to absorb rounding flake. Phase 2 targets cli/shared/process
-# and protocol/commands to reach 66.
-fail_under = 60
+# Phase 2 (2026-05-13): added tests for culture/cli/shared/process.py and
+# culture/protocol/commands.py (both now 100% covered). Project-wide
+# measured: 62.91%. Floor = floor(measured) to absorb rounding flake.
+# Phase 3 targets the CLI command handlers (server/agent/bot/channel/mesh).
+fail_under = 62
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.0.2"
+version = "12.0.3"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_shared_process.py
+++ b/tests/test_cli_shared_process.py
@@ -6,14 +6,19 @@ cover every branch of the four public/private functions:
 
 - `stop_agent(nick)` — dispatcher: IPC then PID.
 - `_try_ipc_shutdown(nick, socket_path)` — IPC + drain-poll.
-- `_try_pid_shutdown(nick)` — PID file → SIGTERM → 5s poll → SIGKILL.
-- `server_stop_by_name(name)` — PID file → SIGTERM → 5s poll → SIGKILL.
+- `_try_pid_shutdown(nick)` — PID file → SIGTERM → 5s poll → SIGKILL/SIGTERM.
+- `server_stop_by_name(name)` — PID file → SIGTERM → 5s poll → SIGKILL/SIGTERM.
 
 All OS-touching primitives (`os.kill`, `os.path.exists`, `time.sleep`,
 `asyncio.run(ipc_shutdown)`, the `culture.pidfile.*` helpers) are
 monkeypatched so the suite is hermetic and the poll loops do not block.
-The win32 branches are excluded from coverage by Phase 1's
-`exclude_lines` rule, so the POSIX path is the only one exercised.
+
+Both the POSIX (SIGKILL escalation) and win32 (SIGTERM-only second
+attempt) branches of the implementation are exercised by pinning
+`sys.platform` via monkeypatch — so the tests are portable across
+hosts. The Phase 1 `exclude_lines = ["if sys\\.platform == .win32."]`
+rule only suppresses *reporting* of the win32 if/body in coverage,
+not its execution at runtime.
 """
 
 from __future__ import annotations
@@ -57,6 +62,18 @@ def fake_os(monkeypatch):
 def no_sleep(monkeypatch):
     """Make the poll loops instant."""
     monkeypatch.setattr(proc_mod.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture
+def posix_platform(monkeypatch):
+    """Pin sys.platform to a POSIX value so SIGKILL-escalation paths run."""
+    monkeypatch.setattr(proc_mod.sys, "platform", "linux")
+
+
+@pytest.fixture
+def win32_platform(monkeypatch):
+    """Pin sys.platform to win32 so the SIGTERM-only fallback runs."""
+    monkeypatch.setattr(proc_mod.sys, "platform", "win32")
 
 
 @pytest.fixture
@@ -304,7 +321,7 @@ def test_pid_shutdown_aborts_kill_when_pid_no_longer_culture(pid_state, capsys, 
     assert "agent-ada" in pid_state.removed
 
 
-def test_pid_shutdown_sigkill_escalation(pid_state, capsys, fake_os):
+def test_pid_shutdown_sigkill_escalation_posix(posix_platform, pid_state, capsys, fake_os):
     pid_state.set_pid("agent-ada", 4242)
     pid_state.alive_sequence(4242, True)  # never dies during polls
     pid_state.culture_sequence(4242, True, True)  # still culture post-poll
@@ -318,7 +335,9 @@ def test_pid_shutdown_sigkill_escalation(pid_state, capsys, fake_os):
     assert "agent-ada" in pid_state.removed
 
 
-def test_pid_shutdown_swallows_sigkill_process_lookup_error(pid_state, capsys, fake_os):
+def test_pid_shutdown_swallows_sigkill_process_lookup_error_posix(
+    posix_platform, pid_state, capsys, fake_os
+):
     pid_state.set_pid("agent-ada", 4242)
     pid_state.alive_sequence(4242, True)
     pid_state.culture_sequence(4242, True, True)
@@ -327,6 +346,24 @@ def test_pid_shutdown_swallows_sigkill_process_lookup_error(pid_state, capsys, f
     proc_mod._try_pid_shutdown("ada")
 
     assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
+    assert "agent-ada" in pid_state.removed
+
+
+def test_pid_shutdown_win32_escalates_with_sigterm_not_sigkill(
+    win32_platform, pid_state, capsys, fake_os
+):
+    """On Windows, the second-attempt signal is SIGTERM, not SIGKILL."""
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, True, True)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGTERM)]
+    out = capsys.readouterr().out
+    assert "terminating" in out
+    assert "sending SIGKILL" not in out
+    assert "killed" in out
     assert "agent-ada" in pid_state.removed
 
 
@@ -373,7 +410,7 @@ def test_server_stop_sigterm_success(pid_state, fake_os):
     assert "server-spark" in pid_state.removed
 
 
-def test_server_stop_sigkill_escalation(pid_state, fake_os):
+def test_server_stop_sigkill_escalation_posix(posix_platform, pid_state, fake_os):
     pid_state.set_pid("server-spark", 4242)
     pid_state.alive_sequence(4242, True)
     pid_state.culture_sequence(4242, True)
@@ -384,7 +421,21 @@ def test_server_stop_sigkill_escalation(pid_state, fake_os):
     assert "server-spark" in pid_state.removed
 
 
-def test_server_stop_sigkill_swallows_process_lookup_error(pid_state, fake_os):
+def test_server_stop_win32_escalates_with_sigterm(win32_platform, pid_state, fake_os):
+    """On Windows, server_stop_by_name re-sends SIGTERM instead of SIGKILL."""
+    pid_state.set_pid("server-spark", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, True)
+
+    proc_mod.server_stop_by_name("spark")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGTERM)]
+    assert "server-spark" in pid_state.removed
+
+
+def test_server_stop_sigkill_swallows_process_lookup_error_posix(
+    posix_platform, pid_state, fake_os
+):
     pid_state.set_pid("server-spark", 4242)
     pid_state.alive_sequence(4242, True)
     pid_state.culture_sequence(4242, True)

--- a/tests/test_cli_shared_process.py
+++ b/tests/test_cli_shared_process.py
@@ -1,0 +1,396 @@
+"""Tests for `culture.cli.shared.process` — agent/server shutdown.
+
+The module orchestrates graceful shutdown for both agents (IPC-first
+with PID/signal fallback) and servers (PID/signal only). The tests
+cover every branch of the four public/private functions:
+
+- `stop_agent(nick)` — dispatcher: IPC then PID.
+- `_try_ipc_shutdown(nick, socket_path)` — IPC + drain-poll.
+- `_try_pid_shutdown(nick)` — PID file → SIGTERM → 5s poll → SIGKILL.
+- `server_stop_by_name(name)` — PID file → SIGTERM → 5s poll → SIGKILL.
+
+All OS-touching primitives (`os.kill`, `os.path.exists`, `time.sleep`,
+`asyncio.run(ipc_shutdown)`, the `culture.pidfile.*` helpers) are
+monkeypatched so the suite is hermetic and the poll loops do not block.
+The win32 branches are excluded from coverage by Phase 1's
+`exclude_lines` rule, so the POSIX path is the only one exercised.
+"""
+
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+from culture.cli.shared import process as proc_mod
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_os(monkeypatch):
+    """Capture os.kill calls and never raise unless asked to."""
+    calls: list[tuple[int, int]] = []
+    raises: dict[int, type[BaseException]] = {}
+
+    def fake_kill(pid: int, sig: int) -> None:
+        calls.append((pid, sig))
+        if (exc := raises.get(len(calls))) is not None:
+            raise exc()
+
+    monkeypatch.setattr(proc_mod.os, "kill", fake_kill)
+
+    class State:
+        def __init__(self) -> None:
+            self.calls = calls
+            self.raises = raises
+
+        def raise_on_call(self, n: int, exc: type[BaseException]) -> None:
+            self.raises[n] = exc
+
+    return State()
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Make the poll loops instant."""
+    monkeypatch.setattr(proc_mod.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture
+def pid_state(monkeypatch):
+    """Bookkeeping for the pidfile helpers + remove_pid calls."""
+    removed: list[str] = []
+    pids: dict[str, int] = {}
+    alive: dict[int, list[bool]] = {}  # pid -> queue of is_process_alive answers
+    culture: dict[int, list[bool]] = {}  # pid -> queue of is_culture_process answers
+
+    def _pop(table: dict[int, list[bool]], pid: int, default: bool) -> bool:
+        seq = table.get(pid)
+        if not seq:
+            return default
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    monkeypatch.setattr(proc_mod, "read_pid", lambda name: pids.get(name))
+    monkeypatch.setattr(proc_mod, "is_process_alive", lambda pid: _pop(alive, pid, True))
+    monkeypatch.setattr(proc_mod, "is_culture_process", lambda pid: _pop(culture, pid, True))
+    monkeypatch.setattr(proc_mod, "remove_pid", lambda name: removed.append(name))
+
+    class State:
+        def __init__(self) -> None:
+            self.removed = removed
+            self.pids = pids
+            self.alive = alive
+            self.culture = culture
+
+        def set_pid(self, name: str, pid: int) -> None:
+            self.pids[name] = pid
+
+        def alive_sequence(self, pid: int, *answers: bool) -> None:
+            """is_process_alive(pid) returns these answers in order."""
+            self.alive[pid] = list(answers)
+
+        def culture_sequence(self, pid: int, *answers: bool) -> None:
+            self.culture[pid] = list(answers)
+
+    return State()
+
+
+# ---------------------------------------------------------------------------
+# stop_agent — orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_stop_agent_uses_ipc_when_socket_exists(monkeypatch, pid_state, capsys):
+    monkeypatch.setattr(proc_mod, "agent_socket_path", lambda nick: f"/tmp/{nick}.sock")
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _ipc_ok(_path):
+        return True
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _ipc_ok)
+
+    proc_mod.stop_agent("ada")
+
+    out = capsys.readouterr().out
+    assert "shutdown requested via IPC" in out
+    assert "stopped" in out
+
+
+def test_stop_agent_falls_back_to_pid_when_socket_missing(monkeypatch, pid_state, capsys):
+    monkeypatch.setattr(proc_mod, "agent_socket_path", lambda nick: f"/tmp/{nick}.sock")
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: False)
+
+    # No pidfile registered → _try_pid_shutdown returns immediately with a notice.
+    proc_mod.stop_agent("ada")
+
+    assert "No PID file for agent 'ada'" in capsys.readouterr().out
+
+
+def test_stop_agent_falls_back_to_pid_when_ipc_returns_false(monkeypatch, pid_state, capsys):
+    monkeypatch.setattr(proc_mod, "agent_socket_path", lambda nick: f"/tmp/{nick}.sock")
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _ipc_no(_path):
+        return False
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _ipc_no)
+
+    proc_mod.stop_agent("ada")
+
+    # IPC said no → pid path runs and complains about no pidfile.
+    assert "No PID file for agent 'ada'" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _try_ipc_shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_ipc_shutdown_returns_false_when_socket_missing(monkeypatch):
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: False)
+    assert proc_mod._try_ipc_shutdown("ada", "/tmp/x.sock") is False
+
+
+def test_ipc_shutdown_returns_false_when_ipc_raises(monkeypatch):
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _boom(_path):
+        raise RuntimeError("broken pipe")
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _boom)
+    assert proc_mod._try_ipc_shutdown("ada", "/tmp/x.sock") is False
+
+
+def test_ipc_shutdown_returns_false_when_ipc_returns_false(monkeypatch):
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _no(_path):
+        return False
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _no)
+    assert proc_mod._try_ipc_shutdown("ada", "/tmp/x.sock") is False
+
+
+def test_ipc_shutdown_returns_true_when_pid_unknown(monkeypatch, pid_state, capsys):
+    """If there's no pidfile to poll, IPC ack is enough to declare success."""
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _ok(_path):
+        return True
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _ok)
+    assert proc_mod._try_ipc_shutdown("ada", "/tmp/x.sock") is True
+    assert "stopped" in capsys.readouterr().out
+
+
+def test_ipc_shutdown_polls_until_process_exits(monkeypatch, pid_state, capsys):
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _ok(_path):
+        return True
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _ok)
+
+    pid_state.set_pid("agent-ada", 4242)
+    # Three "still alive" answers then dead.
+    pid_state.alive_sequence(4242, True, True, True, False)
+
+    assert proc_mod._try_ipc_shutdown("ada", "/tmp/x.sock") is True
+    assert "agent-ada" in pid_state.removed
+    assert "stopped" in capsys.readouterr().out
+
+
+def test_ipc_shutdown_returns_false_when_polls_exhausted(monkeypatch, pid_state):
+    monkeypatch.setattr(proc_mod.os.path, "exists", lambda _p: True)
+
+    async def _ok(_path):
+        return True
+
+    monkeypatch.setattr(proc_mod, "ipc_shutdown", _ok)
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True)  # always alive
+
+    assert proc_mod._try_ipc_shutdown("ada", "/tmp/x.sock") is False
+    assert "agent-ada" not in pid_state.removed
+
+
+# ---------------------------------------------------------------------------
+# _try_pid_shutdown
+# ---------------------------------------------------------------------------
+
+
+def test_pid_shutdown_returns_when_no_pidfile(pid_state, capsys, fake_os):
+    proc_mod._try_pid_shutdown("ada")
+    assert "No PID file for agent 'ada'" in capsys.readouterr().out
+    assert fake_os.calls == []
+
+
+def test_pid_shutdown_removes_corrupt_pidfile(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 0)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    out = capsys.readouterr().out
+    assert "Invalid PID 0" in out
+    assert "agent-ada" in pid_state.removed
+    assert fake_os.calls == []
+
+
+def test_pid_shutdown_removes_stale_pidfile_when_process_not_alive(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, False)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    assert "stale PID 4242" in capsys.readouterr().out
+    assert "agent-ada" in pid_state.removed
+    assert fake_os.calls == []
+
+
+def test_pid_shutdown_removes_non_culture_pidfile(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, False)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    assert "not a culture process" in capsys.readouterr().out
+    assert "agent-ada" in pid_state.removed
+    assert fake_os.calls == []
+
+
+def test_pid_shutdown_handles_sigterm_process_lookup_error(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, True)
+    fake_os.raise_on_call(1, ProcessLookupError)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    # The SIGTERM call happened — and was the only kill attempted.
+    assert fake_os.calls == [(4242, signal.SIGTERM)]
+    assert "agent-ada" in pid_state.removed
+
+
+def test_pid_shutdown_sigterm_success(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True, True, False)
+    pid_state.culture_sequence(4242, True)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM)]
+    out = capsys.readouterr().out
+    assert "Stopping agent 'ada'" in out
+    assert "stopped" in out
+    assert "agent-ada" in pid_state.removed
+
+
+def test_pid_shutdown_aborts_kill_when_pid_no_longer_culture(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    # alive throughout the 50 polls; then post-poll check says "not culture"
+    pid_state.alive_sequence(4242, True)
+    # First call (pre-SIGTERM gate) culture=True; second call (post-poll) culture=False
+    pid_state.culture_sequence(4242, True, False)
+
+    proc_mod._try_pid_shutdown("ada")
+
+    # Only SIGTERM was sent — SIGKILL was aborted.
+    assert fake_os.calls == [(4242, signal.SIGTERM)]
+    assert "no longer a culture process" in capsys.readouterr().out
+    assert "agent-ada" in pid_state.removed
+
+
+def test_pid_shutdown_sigkill_escalation(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True)  # never dies during polls
+    pid_state.culture_sequence(4242, True, True)  # still culture post-poll
+
+    proc_mod._try_pid_shutdown("ada")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
+    out = capsys.readouterr().out
+    assert "sending SIGKILL" in out
+    assert "killed" in out
+    assert "agent-ada" in pid_state.removed
+
+
+def test_pid_shutdown_swallows_sigkill_process_lookup_error(pid_state, capsys, fake_os):
+    pid_state.set_pid("agent-ada", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, True, True)
+    fake_os.raise_on_call(2, ProcessLookupError)  # SIGKILL throws
+
+    proc_mod._try_pid_shutdown("ada")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
+    assert "agent-ada" in pid_state.removed
+
+
+# ---------------------------------------------------------------------------
+# server_stop_by_name
+# ---------------------------------------------------------------------------
+
+
+def test_server_stop_no_pidfile(pid_state, fake_os):
+    proc_mod.server_stop_by_name("spark")
+    assert fake_os.calls == []
+    assert pid_state.removed == []
+
+
+def test_server_stop_removes_pidfile_when_process_not_alive(pid_state, fake_os):
+    pid_state.set_pid("server-spark", 4242)
+    pid_state.alive_sequence(4242, False)
+
+    proc_mod.server_stop_by_name("spark")
+
+    assert fake_os.calls == []
+    assert "server-spark" in pid_state.removed
+
+
+def test_server_stop_removes_pidfile_when_not_culture_process(pid_state, fake_os):
+    pid_state.set_pid("server-spark", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, False)
+
+    proc_mod.server_stop_by_name("spark")
+
+    assert fake_os.calls == []
+    assert "server-spark" in pid_state.removed
+
+
+def test_server_stop_sigterm_success(pid_state, fake_os):
+    pid_state.set_pid("server-spark", 4242)
+    pid_state.alive_sequence(4242, True, True, False)
+    pid_state.culture_sequence(4242, True)
+
+    proc_mod.server_stop_by_name("spark")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM)]
+    assert "server-spark" in pid_state.removed
+
+
+def test_server_stop_sigkill_escalation(pid_state, fake_os):
+    pid_state.set_pid("server-spark", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, True)
+
+    proc_mod.server_stop_by_name("spark")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
+    assert "server-spark" in pid_state.removed
+
+
+def test_server_stop_sigkill_swallows_process_lookup_error(pid_state, fake_os):
+    pid_state.set_pid("server-spark", 4242)
+    pid_state.alive_sequence(4242, True)
+    pid_state.culture_sequence(4242, True)
+    fake_os.raise_on_call(2, ProcessLookupError)  # SIGKILL throws
+
+    proc_mod.server_stop_by_name("spark")
+
+    assert fake_os.calls == [(4242, signal.SIGTERM), (4242, signal.SIGKILL)]
+    assert "server-spark" in pid_state.removed

--- a/tests/test_protocol_commands.py
+++ b/tests/test_protocol_commands.py
@@ -1,0 +1,55 @@
+"""Tests for `culture.protocol.commands` — IRC verb constants.
+
+The module is a flat registry of uppercase string constants (RFC 2812 +
+culture extensions + S2S federation verbs). The contract is: each public
+name maps to a string equal to its own name, so the registry stays in
+sync with the IRC wire format. One discovery-style test covers all
+statements; adding a new verb does not require a test edit.
+"""
+
+from __future__ import annotations
+
+from culture.protocol import commands
+
+
+def _public_constants() -> dict[str, object]:
+    return {
+        name: value
+        for name, value in vars(commands).items()
+        if name.isupper() and not name.startswith("_")
+    }
+
+
+def test_module_exports_at_least_the_known_rfc_verbs():
+    """Smoke-check: a known RFC 2812 baseline must always be present."""
+    rfc_baseline = {
+        "NICK",
+        "USER",
+        "QUIT",
+        "JOIN",
+        "PART",
+        "PRIVMSG",
+        "NOTICE",
+        "PING",
+        "PONG",
+        "TOPIC",
+        "NAMES",
+        "MODE",
+        "WHO",
+        "WHOIS",
+    }
+    exported = set(_public_constants())
+    missing = rfc_baseline - exported
+    assert not missing, f"missing RFC 2812 verbs: {sorted(missing)}"
+
+
+def test_every_command_constant_is_a_nonempty_string():
+    for name, value in _public_constants().items():
+        assert isinstance(value, str), f"{name} is not a str: {type(value)!r}"
+        assert value, f"{name} is empty"
+
+
+def test_every_command_constant_matches_its_name():
+    """The wire verb (value) must equal the python name (attribute)."""
+    for name, value in _public_constants().items():
+        assert value == name, f"{name} = {value!r}, expected {name!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.0.2"
+version = "12.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.0.1"
+version = "12.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 2 of the **60 → 90 coverage ratchet** ([plan](/home/spark/.claude/plans/we-re-at-60-coverage-refactored-lark.md)). Two zero/low-coverage files brought to 100%, project-wide floor raised **60 → 62**. Measured post-Phase-2: **62.91%** (+1.9pp from Phase 1).

| File | Before | After |
|---|---|---|
| `culture/cli/shared/process.py` | 12% | **100%** |
| `culture/protocol/commands.py` | 0% | **100%** |

### `tests/test_cli_shared_process.py` (24 tests)

Covers every branch of all four functions in the module:

- **`stop_agent`** — IPC succeeds, socket missing, IPC returns False.
- **`_try_ipc_shutdown`** — missing socket, IPC raises, IPC returns False, pid unknown, polls succeed, polls exhausted.
- **`_try_pid_shutdown`** — no pidfile, corrupt PID (≤ 0), stale PID, non-culture PID, SIGTERM `ProcessLookupError`, SIGTERM success, abort-when-no-longer-culture guard, SIGKILL escalation, SIGKILL `ProcessLookupError` swallow.
- **`server_stop_by_name`** — no pidfile, not alive, not culture, SIGTERM success, SIGKILL escalation, SIGKILL `ProcessLookupError`.

Fully hermetic — monkeypatches `os.kill`, `time.sleep`, `ipc_shutdown`, and the `culture.pidfile.*` helpers. **No real signals, sockets, or forks.** Poll loops complete instantly via a `no_sleep` autouse fixture.

### `tests/test_protocol_commands.py` (3 tests)

Discovery-style: iterates `vars(commands)` for uppercase string constants and asserts `value == name`. The contract is "the wire verb equals the python name". Adding a new verb does not require a test edit. A separate smoke test asserts the RFC 2812 baseline verbs are all present, so accidentally deleting one fails fast.

### Floor revised — 66 → 62

Phase 2's planned floor of 66 was over-optimistic given Phase 1 landed at **60.99%** (not the 62 estimate). New realistic floor: **62**. The phase-to-PR mapping table in `docs/coverage-baseline.md` now ends with a Phase 7 sweep that absorbs the cumulative gap so phases 2–6 don't have to overpromise per-phase deltas.

## Test plan

- [x] `uv run pytest tests/test_protocol_commands.py tests/test_cli_shared_process.py -v` — 27 passed in 0.06s
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -c` — full suite green, TOTAL 62.91%, above `fail_under = 62`
- [x] `culture/cli/shared/process.py` reports 100% in `coverage report`
- [x] `culture/protocol/commands.py` reports 100% in `coverage report`
- [x] pre-commit (black, isort, flake8, pylint, bandit, markdownlint) clean
- [ ] CI green (pytest, SonarCloud quality gate, version-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- culture (Claude)