### PR TITLE
test(coverage): Phase 3a — cli/shared/mesh + cli/bot + cli/channel [v12.0.4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.0.4] - 2026-05-13
+
+### Added
+
+- `tests/test_cli_shared_mesh.py` — 14 tests covering `culture/cli/shared/mesh.py` (25% → 100%): `parse_link` (defaults, explicit trust, password-with-colons, malformed-spec rejection, non-integer-port rejection); `resolve_links_from_mesh` (no peers, builds-per-peer, skips peers without credentials with warning); `generate_mesh_from_agents` (missing `DEFAULT_CONFIG` returns `None`, happy save path); `build_server_start_cmd` (foreground + mesh-config flags, server name/host/port, port stringification).
+- `tests/test_cli_bot.py` — 35 tests covering `culture/cli/bot.py` (33% → 99%): `dispatch` (no/unknown command exits, route to list), `_should_include_bot` (owner match, archive filter), `_load_and_filter_bots` (missing dir, unfiltered, owner filter, archive filter, skip dirs without YAML), `_bot_create` (empty-name rejection, owner-prefix rewrite, duplicate rejection, channels/mention rendering), `_bot_start` / `_bot_stop` (unknown bot exits, reload notice), `_bot_list` (empty, owner filter empty, table rendering, archived marker), `_bot_inspect` (unknown exits, full metadata, long-template truncation, archive block), `_bot_archive` / `_bot_unarchive` (round-trip, idempotency, error paths). Filesystem isolated via `tmp_path`-backed `BOTS_DIR`.
+- 21 tests appended to `tests/test_channel_cli.py` covering `culture/cli/channel.py` (44% → 99.6%): every `_cmd_*` handler (list/read/message/who/join/part/ask/topic/compact/clear), `_interpret_escapes` (passthrough, n/t, double backslash, unknown escape), `_is_connection_error` classification, `dispatch` OSError wrapping with connection-error hint, `_topic_read` daemon-unreachable exit, `_require_ipc` when daemon responds `None`. Uses a new `_stub_ipc` helper that patches `_try_ipc` / `_require_ipc` at the channel-module boundary, sidestepping the nested-`asyncio.run` conflict that would otherwise dead-lock the existing Unix-socket mock pattern.
+
+### Changed
+
+- pyproject.toml: fail_under raised 62 → 67 (Phase 3a floor of the 60→90 ratchet plan). Project-wide measured 67.89%.
+- docs/coverage-baseline.md: Phase 3a entry + updated phase target table (Phase 3 split into 3a + 3b).
+
 ## [12.0.3] - 2026-05-13
 
 ### Fixed
@@ -445,7 +458,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **`culture agent message` no longer treats local config as the source of truth** (#333 item 11). The previous behavior refused to send when the target nick was missing from local `server.yaml`, which broke DMs to agents reachable via federation. The local-config gate is removed; the send is delegated to the IRC server, and `401 NOSUCHNICK` propagates if the nick truly isn't on the mesh.
 - **`culture agent sleep`/`wake` usage errors now use argparse formatting** (#333 item 12). Missing-arg, conflicting-arg, and unknown-nick errors previously went to stdout via `print()` + `sys.exit(1)`, inconsistent with every other CLI verb. They now write `culture agent sleep: error: ...` to stderr with rc 2, matching argparse's standard usage-error path.
 - **`culture agent migrate --help` text now signals it's a one-time op** (#333 item 7). Help reads `Migrate legacy agents.yaml to server.yaml + culture.yaml (one-time, usually a no-op)` instead of advertising it as routine. The verb stays in the CLI surface for completeness — most repos have already migrated.
-- **Channel-existence guard now uses the server-wide `LIST` query** (#341 review). Earlier draft of the #331 guard read the daemon's `irc_channels` IPC, which only returns the daemon's *joined* channels — false-rejecting valid channels the daemon hadn't joined. The guard now always uses the observer's `list_channels()` (a fresh peek `LIST`) regardless of IPC availability.
+- **Channel-existence guard now uses the server-wide `LIST` query** (#341 review). Earlier draft of the #331 guard read the daemon's `irc_channels` IPC, which only returns the daemon's _joined_ channels — false-rejecting valid channels the daemon hadn't joined. The guard now always uses the observer's `list_channels()` (a fresh peek `LIST`) regardless of IPC availability.
 
 ### Deprecated
 

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -80,13 +80,22 @@ Notable findings (deferred to later phases):
 - `culture/cli/shared/process.py` — 12% → **100%** (97 statements, 0 missing). `tests/test_cli_shared_process.py` (24 tests) covers all four functions (`stop_agent`, `_try_ipc_shutdown`, `_try_pid_shutdown`, `server_stop_by_name`) including every branch: IPC success, IPC failure, IPC raises, missing socket, corrupt/stale/non-culture PID, SIGTERM success, SIGTERM `ProcessLookupError`, SIGKILL escalation, and the "aborts kill when PID no longer culture" guard. All OS primitives monkeypatched — no real `os.kill` / `os.fork` / sockets.
 - `culture/protocol/commands.py` — 0% → **100%** (35 statements, 0 missing). `tests/test_protocol_commands.py` (3 tests) discovery-style: iterates `vars(commands)` for uppercase string constants and asserts `value == name`. Adding a new verb does not require a test edit; deletion is caught by the RFC-baseline smoke test.
 
+### Phase 3a — `cli/shared/mesh.py` + `cli/bot.py` + `cli/channel.py` (2026-05-13)
+
+**Measured: 67.89%** (6260 statements, 2010 missing) → `fail_under = 67`. All three target files moved to near-100% coverage:
+
+- `culture/cli/shared/mesh.py` — 25% → **100%** (48 statements, 0 missing). `tests/test_cli_shared_mesh.py` (14 tests) covers all four functions (`parse_link`, `resolve_links_from_mesh`, `generate_mesh_from_agents`, `build_server_start_cmd`) including malformed-spec rejection, password-with-colons preservation, peer-without-credential skip with warning, and the missing-DEFAULT_CONFIG fallback path.
+- `culture/cli/bot.py` — 33% → **99%** (199 statements, 2 missing). `tests/test_cli_bot.py` (35 tests) covers all seven `_bot_*` handlers + the `_should_include_bot` / `_load_and_filter_bots` helpers. Filesystem isolated via tmp_path-backed `BOTS_DIR`; `load_config_or_default` patched. The 2 missing lines are in a small `_bot_list` empty-state branch.
+- `culture/cli/channel.py` — 44% → **99.6%** (260 statements, 1 missing). 21 new tests appended to `tests/test_channel_cli.py` covering every `_cmd_*` handler (list/read/message/who/join/part/ask/topic/compact/clear), `_interpret_escapes`, `_is_connection_error`, the dispatch wrapper for OSError, and the `_topic_read` daemon-unreachable exit path. IPC is stubbed at the `_try_ipc` / `_require_ipc` boundary (the `_cmd_*` handlers call `asyncio.run` internally, so a test-owned event loop would dead-lock the real Unix-socket-mock pattern).
+
 ### Phase target table
 
 | Phase | Floor | Measured | PR | Status |
 |---|---|---|---|---|
 | 1 | 60 | 60.99% | [#383](https://github.com/agentculture/culture/pull/383) | ✅ merged |
-| 2 | 62 | 62.91% | (this PR) | in flight |
-| 3 | 68 | — | CLI handlers (server/agent/bot/channel/mesh) | pending |
+| 2 | 62 | 62.91% | [#384](https://github.com/agentculture/culture/pull/384) | ✅ merged |
+| 3a | 67 | 67.89% | (this PR) | in flight |
+| 3b | 70 | — | `cli/mesh.py`, `cli/server.py`, `cli/agent.py` | pending |
 | 4 | 75 | — | Domain modules via real IRCd | pending |
 | 5 | 82 | — | `transport/client.py` (or its deletion) | pending |
 | 6 | 88 | — | Long tail | pending |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.0.3"
+version = "12.0.4"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -93,11 +93,11 @@ omit = [
 
 [tool.coverage.report]
 # Ratchet floor — see docs/coverage-baseline.md for the per-phase log.
-# Phase 2 (2026-05-13): added tests for culture/cli/shared/process.py and
-# culture/protocol/commands.py (both now 100% covered). Project-wide
-# measured: 62.91%. Floor = floor(measured) to absorb rounding flake.
-# Phase 3 targets the CLI command handlers (server/agent/bot/channel/mesh).
-fail_under = 62
+# Phase 3a (2026-05-13): added tests for culture/cli/shared/mesh.py,
+# culture/cli/bot.py, culture/cli/channel.py (now at 100% / 99% / 99%).
+# Project-wide measured: 67.89%. Floor = floor(measured).
+# Phase 3b targets the remaining CLI handlers (mesh/server/agent).
+fail_under = 67
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/tests/test_channel_cli.py
+++ b/tests/test_channel_cli.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import os
+import sys
 import tempfile
 
 import pytest
@@ -299,3 +300,575 @@ async def _mock_ipc_server_handle(reader, writer, handler):
     writer.write(encode_message(resp))
     await writer.drain()
     writer.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a — handler coverage (channel.py was 44%, target ~80%)
+# ---------------------------------------------------------------------------
+#
+# The tests above pin down the IPC routing/fallback policy; the additions
+# below cover the body of every _cmd_* handler so the project-wide coverage
+# floor can rise. They use the same _make_args helper and the existing
+# CULTURE_NICK + XDG_RUNTIME_DIR monkeypatch pattern for IPC paths, plus a
+# small _StubObserver class for observer-fallback paths so we don't have to
+# stand up a peek connection.
+
+
+class _StubObserver:
+    """In-memory stand-in for IRCObserver — records calls and returns canned data."""
+
+    def __init__(
+        self,
+        channels=None,
+        messages=None,
+        who_nicks=None,
+        sends=None,
+    ):
+        self._channels = channels or []
+        self._messages = messages or []
+        self._who_nicks = who_nicks or []
+        self._sends: list[tuple[str, str]] = [] if sends is None else sends
+
+    async def list_channels(self):
+        return list(self._channels)
+
+    async def read_channel(self, channel, limit=50):
+        return [f"<{m['nick']}> {m['text']}" for m in self._messages]
+
+    async def who(self, target):
+        return list(self._who_nicks)
+
+    async def send_message(self, channel, text):
+        self._sends.append((channel, text))
+
+
+def _stub_ipc(monkeypatch, *, try_resp=None, require_resp=None, capture=None):
+    """Patch `_try_ipc` and `_require_ipc` at the channel module boundary.
+
+    `_cmd_*` handlers call `asyncio.run(ipc_request(...))` internally, which
+    cannot be re-entered from a test-owned event loop — so we patch the
+    explicit IPC boundary instead of standing up a Unix-socket fake. The
+    recorded requests live in ``capture`` (a list); ``try_resp`` /
+    ``require_resp`` can be a dict or a callable ``(msg_type, **kwargs) -> dict``.
+    """
+    from culture.cli import channel as ch_mod
+
+    captured = capture if capture is not None else []
+
+    def _fake_try(msg_type, **kwargs):
+        captured.append((msg_type, kwargs))
+        return try_resp(msg_type, **kwargs) if callable(try_resp) else try_resp
+
+    def _fake_require(msg_type, **kwargs):
+        captured.append((msg_type, kwargs))
+        result = require_resp(msg_type, **kwargs) if callable(require_resp) else require_resp
+        if result is None:
+            # mirror real _require_ipc behavior on unreachable daemon
+            print("Error: cannot reach agent daemon", file=sys.stderr)
+            raise SystemExit(1)
+        return result
+
+    monkeypatch.setattr(ch_mod, "_try_ipc", _fake_try)
+    monkeypatch.setattr(ch_mod, "_require_ipc", _fake_require)
+    return captured
+
+
+class TestIsConnectionError:
+    def test_classifies_known_oserror_strings(self):
+        from culture.cli.channel import _is_connection_error
+
+        assert _is_connection_error("Timed out") is True
+        assert _is_connection_error("Connection refused") is True
+        assert _is_connection_error("Connect call failed: [Errno 111]") is True
+        assert _is_connection_error("") is True  # empty msg → likely network
+
+    def test_does_not_match_unrelated_errors(self):
+        from culture.cli.channel import _is_connection_error
+
+        assert _is_connection_error("Permission denied") is False
+        assert _is_connection_error("File not found") is False
+
+
+class TestInterpretEscapes:
+    def test_passthrough_when_no_backslashes(self):
+        from culture.cli.channel import _interpret_escapes
+
+        assert _interpret_escapes("hello world") == "hello world"
+
+    def test_converts_n_and_t_sequences(self):
+        from culture.cli.channel import _interpret_escapes
+
+        assert _interpret_escapes("a\\nb\\tc") == "a\nb\tc"
+
+    def test_double_backslash_stays_literal(self):
+        from culture.cli.channel import _interpret_escapes
+
+        assert _interpret_escapes("\\\\n") == "\\n"
+
+    def test_unknown_escape_is_preserved_verbatim(self):
+        from culture.cli.channel import _interpret_escapes
+
+        # \x is not in the supported set — neither half is consumed
+        assert _interpret_escapes("a\\xb") == "a\\xb"
+
+
+class TestDispatchWrapsConnectionError:
+    def test_handler_oserror_with_connection_message_exits_with_hint(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        def _boom(_args):
+            raise OSError("Connection refused")
+
+        monkeypatch.setitem(
+            (
+                ch_mod.dispatch.__globals__["handlers"]
+                if "handlers" in ch_mod.dispatch.__globals__
+                else {}
+            ),
+            "list",
+            _boom,
+        )
+
+        # Easier: temporarily replace _cmd_list with a raising stub.
+        monkeypatch.setattr(ch_mod, "_cmd_list", _boom)
+
+        with pytest.raises(SystemExit) as exc:
+            ch_mod.dispatch(_make_args(channel_command="list"))
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "cannot connect to IRC server" in err
+        assert "culture server start" in err
+
+    def test_handler_raises_unrelated_oserror_propagates(self, monkeypatch):
+        from culture.cli import channel as ch_mod
+
+        def _boom(_args):
+            raise OSError("Permission denied")
+
+        monkeypatch.setattr(ch_mod, "_cmd_list", _boom)
+
+        with pytest.raises(OSError, match="Permission denied"):
+            ch_mod.dispatch(_make_args(channel_command="list"))
+
+    def test_unknown_command_exits(self, capsys):
+        from culture.cli.channel import dispatch
+
+        with pytest.raises(SystemExit) as exc:
+            dispatch(_make_args(channel_command="frobnicate"))
+        assert exc.value.code == 1
+        assert "Unknown channel command" in capsys.readouterr().err
+
+
+class TestCmdListBody:
+    def test_ipc_path_renders_channel_list(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_list
+
+        captured = _stub_ipc(
+            monkeypatch,
+            try_resp={"ok": True, "data": {"channels": ["#ops", "#general"]}},
+        )
+
+        _cmd_list(_make_args(channel_command="list"))
+
+        assert captured == [("irc_channels", {})]
+        out = capsys.readouterr().out
+        assert "Active channels" in out and "#ops" in out and "#general" in out
+
+    def test_ipc_path_empty_list(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_list
+
+        _stub_ipc(monkeypatch, try_resp={"ok": True, "data": {"channels": []}})
+        _cmd_list(_make_args(channel_command="list"))
+        assert "No active channels" in capsys.readouterr().out
+
+    def test_observer_fallback_when_no_nick(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        monkeypatch.setattr(
+            ch_mod, "get_observer", lambda _cfg: _StubObserver(channels=["#a", "#b"])
+        )
+
+        ch_mod._cmd_list(_make_args(channel_command="list"))
+
+        out = capsys.readouterr().out
+        assert "#a" in out and "#b" in out
+
+    def test_observer_fallback_empty(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: _StubObserver())
+
+        ch_mod._cmd_list(_make_args(channel_command="list"))
+
+        assert "No active channels" in capsys.readouterr().out
+
+
+class TestCmdReadBody:
+    def test_rejects_empty_target(self, capsys):
+        from culture.cli.channel import _cmd_read
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_read(_make_args(channel_command="read", target="   ", limit=50))
+        assert exc.value.code == 1
+        assert "channel name cannot be empty" in capsys.readouterr().err
+
+    def test_ipc_path_prepends_hash_to_target(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_read
+
+        captured = _stub_ipc(
+            monkeypatch,
+            try_resp={"ok": True, "data": {"messages": [{"nick": "ada", "text": "hi"}]}},
+        )
+
+        _cmd_read(_make_args(channel_command="read", target="ops", limit=50))
+
+        assert captured == [("irc_read", {"channel": "#ops", "limit": 50})]
+        assert "<ada> hi" in capsys.readouterr().out
+
+    def test_ipc_path_empty_messages(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_read
+
+        _stub_ipc(monkeypatch, try_resp={"ok": True, "data": {"messages": []}})
+        _cmd_read(_make_args(channel_command="read", target="#ops", limit=10))
+        assert "No messages in #ops" in capsys.readouterr().out
+
+    def test_observer_fallback_when_no_nick(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        obs = _StubObserver(messages=[{"nick": "ada", "text": "hi"}])
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: obs)
+
+        ch_mod._cmd_read(_make_args(channel_command="read", target="#ops", limit=50))
+
+        assert "<ada> hi" in capsys.readouterr().out
+
+    def test_observer_fallback_empty(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: _StubObserver())
+
+        ch_mod._cmd_read(_make_args(channel_command="read", target="#ops", limit=50))
+
+        assert "No messages in #ops" in capsys.readouterr().out
+
+
+class TestCmdMessageBody:
+    def test_rejects_empty_target(self, capsys):
+        from culture.cli.channel import _cmd_message
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_message(
+                _make_args(channel_command="message", target="   ", text="hello", create=False)
+            )
+        assert exc.value.code == 1
+
+    def test_rejects_empty_text(self, capsys):
+        from culture.cli.channel import _cmd_message
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_message(
+                _make_args(channel_command="message", target="#ops", text="   ", create=False)
+            )
+        assert exc.value.code == 1
+        assert "message text cannot be empty" in capsys.readouterr().err
+
+    def test_rejects_text_with_only_escaped_newlines(self, capsys):
+        from culture.cli.channel import _cmd_message
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_message(
+                _make_args(channel_command="message", target="#ops", text="\\n\\n", create=False)
+            )
+        assert exc.value.code == 1
+        assert "no non-empty line" in capsys.readouterr().err
+
+    def test_rejects_nonexistent_channel_without_create(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: _StubObserver(channels=[]))
+
+        with pytest.raises(SystemExit) as exc:
+            ch_mod._cmd_message(
+                _make_args(channel_command="message", target="#typo", text="hello", create=False)
+            )
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "does not exist" in err
+        assert "--create" in err
+
+    def test_ipc_send_happy_path(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: _StubObserver(channels=["#ops"]))
+        captured = _stub_ipc(monkeypatch, try_resp={"ok": True})
+
+        ch_mod._cmd_message(
+            _make_args(channel_command="message", target="#ops", text="hello", create=False)
+        )
+
+        assert captured == [("irc_send", {"channel": "#ops", "message": "hello"})]
+        assert "Sent to #ops" in capsys.readouterr().out
+
+    def test_create_flag_skips_channel_existence_check(self, monkeypatch, capsys):
+        """With --create, we don't probe the observer; the send proceeds."""
+        from culture.cli import channel as ch_mod
+
+        # If the implementation regresses and probes the observer with --create,
+        # the test fails noisily (asserts False).
+        def _observer_should_not_be_called(_cfg):  # pragma: no cover - guard
+            raise AssertionError("observer should not be consulted with --create")
+
+        monkeypatch.setattr(ch_mod, "get_observer", _observer_should_not_be_called)
+        _stub_ipc(monkeypatch, try_resp={"ok": True})
+
+        ch_mod._cmd_message(
+            _make_args(channel_command="message", target="#typo", text="hi", create=True)
+        )
+
+        assert "Sent to #typo" in capsys.readouterr().out
+
+    def test_observer_send_fallback_when_no_nick(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.delenv("CULTURE_NICK", raising=False)
+        obs = _StubObserver(channels=["#ops"])
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: obs)
+
+        ch_mod._cmd_message(
+            _make_args(channel_command="message", target="#ops", text="hi", create=False)
+        )
+
+        assert obs._sends == [("#ops", "hi")]
+        assert "Sent to #ops" in capsys.readouterr().out
+
+
+class TestCmdWho:
+    def test_rejects_empty_target(self, capsys):
+        from culture.cli.channel import _cmd_who
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_who(_make_args(channel_command="who", target="   "))
+        assert exc.value.code == 1
+
+    def test_renders_user_list(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        obs = _StubObserver(who_nicks=["ada", "bob"])
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: obs)
+
+        ch_mod._cmd_who(_make_args(channel_command="who", target="#ops"))
+
+        out = capsys.readouterr().out
+        assert "Users in #ops" in out and "ada" in out and "bob" in out
+
+    def test_empty_channel(self, monkeypatch, capsys):
+        from culture.cli import channel as ch_mod
+
+        monkeypatch.setattr(ch_mod, "get_observer", lambda _cfg: _StubObserver())
+
+        ch_mod._cmd_who(_make_args(channel_command="who", target="#empty"))
+
+        assert "No users in #empty" in capsys.readouterr().out
+
+
+class TestCmdJoinPart:
+    def test_join_happy_path(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_join
+
+        captured = _stub_ipc(monkeypatch, require_resp={"ok": True})
+
+        _cmd_join(_make_args(channel_command="join", target="ops"))
+
+        assert captured == [("irc_join", {"channel": "#ops"})]
+        assert "Joined #ops" in capsys.readouterr().out
+
+    def test_join_failure_exits_with_error(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_join
+
+        _stub_ipc(monkeypatch, require_resp={"ok": False, "error": "banned"})
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_join(_make_args(channel_command="join", target="#ops"))
+        assert exc.value.code == 1
+        assert "banned" in capsys.readouterr().err
+
+    def test_part_happy_path(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_part
+
+        captured = _stub_ipc(monkeypatch, require_resp={"ok": True})
+
+        _cmd_part(_make_args(channel_command="part", target="#ops"))
+
+        assert captured == [("irc_part", {"channel": "#ops"})]
+        assert "Left #ops" in capsys.readouterr().out
+
+    def test_part_failure_exits_with_error(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_part
+
+        _stub_ipc(monkeypatch, require_resp={"ok": False, "error": "not in channel"})
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_part(_make_args(channel_command="part", target="#ops"))
+        assert exc.value.code == 1
+        assert "not in channel" in capsys.readouterr().err
+
+
+class TestCmdAsk:
+    def test_rejects_empty_target(self, capsys):
+        from culture.cli.channel import _cmd_ask
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_ask(_make_args(channel_command="ask", target="   ", text="?", timeout=30))
+        assert exc.value.code == 1
+
+    def test_rejects_empty_text(self, capsys):
+        from culture.cli.channel import _cmd_ask
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_ask(_make_args(channel_command="ask", target="#ops", text="   ", timeout=30))
+        assert exc.value.code == 1
+        assert "question text cannot be empty" in capsys.readouterr().err
+
+    def test_happy_path_prints_json(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_ask
+
+        captured = _stub_ipc(
+            monkeypatch,
+            require_resp={"ok": True, "data": {"answer": "42"}},
+        )
+
+        _cmd_ask(_make_args(channel_command="ask", target="#ops", text="huh?", timeout=30))
+
+        assert captured == [
+            ("irc_ask", {"channel": "#ops", "message": "huh?", "timeout": 30}),
+        ]
+        out = capsys.readouterr().out
+        assert '"ok": true' in out  # json.dumps output
+        assert '"answer"' in out
+
+    def test_failure_exits(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_ask
+
+        _stub_ipc(monkeypatch, require_resp={"ok": False, "error": "no answer"})
+        with pytest.raises(SystemExit) as exc:
+            _cmd_ask(_make_args(channel_command="ask", target="#ops", text="?", timeout=30))
+        assert exc.value.code == 1
+
+
+class TestCmdTopic:
+    def test_topic_rejects_empty_target(self, capsys):
+        from culture.cli.channel import _cmd_topic
+
+        with pytest.raises(SystemExit) as exc:
+            _cmd_topic(_make_args(channel_command="topic", target="   ", text=None))
+        assert exc.value.code == 1
+
+    def test_topic_set_routes_to_topic_set(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_topic
+
+        captured = _stub_ipc(monkeypatch, require_resp={"ok": True})
+
+        _cmd_topic(_make_args(channel_command="topic", target="#ops", text="new topic"))
+
+        assert captured == [("irc_topic", {"channel": "#ops", "topic": "new topic"})]
+        assert "Topic set for #ops" in capsys.readouterr().out
+
+    def test_topic_set_failure_exits(self, monkeypatch, capsys):
+        from culture.cli.channel import _topic_set
+
+        _stub_ipc(monkeypatch, require_resp={"ok": False, "error": "not op"})
+        with pytest.raises(SystemExit) as exc:
+            _topic_set("#ops", "anything")
+        assert exc.value.code == 1
+        assert "not op" in capsys.readouterr().err
+
+    def test_topic_read_returns_topic_value(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_topic
+
+        _stub_ipc(monkeypatch, try_resp={"ok": True, "data": {"topic": "release week"}})
+
+        _cmd_topic(_make_args(channel_command="topic", target="#ops", text=None))
+
+        assert "Topic for #ops: release week" in capsys.readouterr().out
+
+    def test_topic_read_no_topic_set(self, monkeypatch, capsys):
+        from culture.cli.channel import _topic_read
+
+        _stub_ipc(monkeypatch, try_resp={"ok": True, "data": {"topic": ""}})
+        _topic_read("#ops")
+        assert "No topic set for #ops" in capsys.readouterr().out
+
+    def test_topic_read_async_pending(self, monkeypatch, capsys):
+        from culture.cli.channel import _topic_read
+
+        # daemon ACKs but response carries no topic — async result expected
+        _stub_ipc(monkeypatch, try_resp={"ok": True, "data": {}})
+        _topic_read("#ops")
+        assert "result arrives asynchronously" in capsys.readouterr().out
+
+    def test_topic_read_exits_when_daemon_unreachable(self, monkeypatch, capsys):
+        """_topic_read uses _try_ipc but exits on None response (not silent fallback)."""
+        from culture.cli.channel import _topic_read
+
+        _stub_ipc(monkeypatch, try_resp=None)
+        with pytest.raises(SystemExit) as exc:
+            _topic_read("#ops")
+        assert exc.value.code == 1
+        assert "topic query requires" in capsys.readouterr().err
+
+
+class TestCmdCompactClear:
+    def test_compact_happy_path(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_compact
+
+        captured = _stub_ipc(monkeypatch, require_resp={"ok": True})
+
+        _cmd_compact(_make_args(channel_command="compact"))
+
+        assert captured == [("compact", {})]
+        assert "Context window compacted" in capsys.readouterr().out
+
+    def test_compact_failure_exits(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_compact
+
+        _stub_ipc(monkeypatch, require_resp={"ok": False, "error": "busy"})
+        with pytest.raises(SystemExit) as exc:
+            _cmd_compact(_make_args(channel_command="compact"))
+        assert exc.value.code == 1
+
+    def test_clear_happy_path(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_clear
+
+        captured = _stub_ipc(monkeypatch, require_resp={"ok": True})
+        _cmd_clear(_make_args(channel_command="clear"))
+        assert captured == [("clear", {})]
+        assert "Context window cleared" in capsys.readouterr().out
+
+    def test_clear_failure_exits(self, monkeypatch, capsys):
+        from culture.cli.channel import _cmd_clear
+
+        _stub_ipc(monkeypatch, require_resp={"ok": False, "error": "not ready"})
+        with pytest.raises(SystemExit) as exc:
+            _cmd_clear(_make_args(channel_command="clear"))
+        assert exc.value.code == 1
+
+
+class TestRequireIpcDaemonUnreachable:
+    def test_require_ipc_exits_when_daemon_response_is_none(self, monkeypatch, capsys):
+        """CULTURE_NICK is valid but no socket exists → ipc_request returns None."""
+        from culture.cli.channel import _require_ipc
+
+        monkeypatch.setenv("CULTURE_NICK", "spark-claude")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", tempfile.mkdtemp())  # no daemon
+
+        with pytest.raises(SystemExit) as exc:
+            _require_ipc("irc_join", channel="#ops")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "cannot reach agent daemon" in err
+        assert "culture agent status spark-claude" in err

--- a/tests/test_cli_bot.py
+++ b/tests/test_cli_bot.py
@@ -1,0 +1,416 @@
+"""Tests for `culture.cli.bot` — culture bot {create,start,stop,list,inspect,archive,unarchive}.
+
+Each handler is invoked directly with an `argparse.Namespace`. The bot
+filesystem lives at `culture.bots.config.BOTS_DIR` (a `~/.culture/bots`
+path by default) — every test redirects it via `monkeypatch` to a
+tmp_path so we never touch the user's real config.
+
+`load_config_or_default` and `save_bot_config` are patched at the
+import boundary (the handlers re-import them lazily inside each function)
+so we don't have to write real YAML to test them.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from culture.cli import bot as bot_mod
+from culture.cli.shared.constants import BOT_CONFIG_FILE
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bots_dir(monkeypatch, tmp_path):
+    """Redirect culture.bots.config.BOTS_DIR to a tmp_path."""
+    d = tmp_path / "bots"
+    d.mkdir()
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", d)
+    return d
+
+
+@dataclass
+class _StubServerCfg:
+    name: str = "spark"
+
+
+@dataclass
+class _StubConfig:
+    server: _StubServerCfg = field(default_factory=_StubServerCfg)
+
+
+@pytest.fixture
+def stub_config(monkeypatch):
+    """Patch `culture.config.load_config_or_default` to return a deterministic stub."""
+    cfg = _StubConfig()
+    # bot.py imports load_config_or_default at module top — patch on the module.
+    monkeypatch.setattr(bot_mod, "load_config_or_default", lambda _p: cfg)
+    return cfg
+
+
+def _args(**kwargs) -> argparse.Namespace:
+    """Build a minimal Namespace for any bot subcommand."""
+    defaults = {"config": "~/.culture/server.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _make_bot_yaml(bots_dir: Path, name: str, **fields) -> Path:
+    """Persist a minimal BotConfig YAML so `load_bot_config` can read it back."""
+    from culture.bots.config import BotConfig, save_bot_config
+
+    bot_dir = bots_dir / name
+    bot_dir.mkdir(parents=True, exist_ok=True)
+    cfg = BotConfig(name=name, owner=fields.pop("owner", "spark-ori"), **fields)
+    yaml_path = bot_dir / BOT_CONFIG_FILE
+    save_bot_config(yaml_path, cfg)
+    return yaml_path
+
+
+# ---------------------------------------------------------------------------
+# dispatch (no subcommand)
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_dispatch_with_no_command_exits_with_usage(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod.dispatch(_args(bot_command=None))
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "Usage: culture bot" in err
+
+    def test_dispatch_unknown_command(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod.dispatch(_args(bot_command="frobnicate"))
+        assert exc.value.code == 1
+        assert "Unknown bot command" in capsys.readouterr().err
+
+    def test_dispatch_routes_to_list_handler(self, bots_dir, capsys):
+        bot_mod.dispatch(_args(bot_command="list", owner=None, all=False))
+        # bots_dir is empty → "No bots configured." path
+        assert "No bots configured" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _should_include_bot
+# ---------------------------------------------------------------------------
+
+
+class TestShouldIncludeBot:
+    def _make(self, **overrides):
+        from culture.bots.config import BotConfig
+
+        return BotConfig(**overrides)
+
+    def test_owner_match_passes(self):
+        cfg = self._make(owner="spark-ori")
+        assert bot_mod._should_include_bot(cfg, "spark-ori", show_archived=False) is True
+
+    def test_owner_mismatch_filters_out(self):
+        cfg = self._make(owner="spark-ori")
+        assert bot_mod._should_include_bot(cfg, "spark-claude", show_archived=False) is False
+
+    def test_archived_filtered_out_by_default(self):
+        cfg = self._make(owner="spark-ori", archived=True)
+        assert bot_mod._should_include_bot(cfg, None, show_archived=False) is False
+
+    def test_archived_included_when_show_archived(self):
+        cfg = self._make(owner="spark-ori", archived=True)
+        assert bot_mod._should_include_bot(cfg, None, show_archived=True) is True
+
+
+# ---------------------------------------------------------------------------
+# _load_and_filter_bots
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAndFilterBots:
+    def test_empty_when_bots_dir_missing(self, monkeypatch, tmp_path):
+        ghost = tmp_path / "no-such-dir"
+        monkeypatch.setattr("culture.bots.config.BOTS_DIR", ghost)
+        assert bot_mod._load_and_filter_bots(_args(owner=None, all=False)) == []
+
+    def test_returns_all_when_unfiltered(self, bots_dir):
+        _make_bot_yaml(bots_dir, "spark-ori-alpha")
+        _make_bot_yaml(bots_dir, "spark-ori-beta")
+        bots = bot_mod._load_and_filter_bots(_args(owner=None, all=False))
+        names = sorted(b.name for b in bots)
+        assert names == ["spark-ori-alpha", "spark-ori-beta"]
+
+    def test_respects_owner_filter(self, bots_dir):
+        _make_bot_yaml(bots_dir, "spark-ori-alpha", owner="spark-ori")
+        _make_bot_yaml(bots_dir, "spark-claude-beta", owner="spark-claude")
+        bots = bot_mod._load_and_filter_bots(_args(owner="spark-ori", all=False))
+        assert [b.name for b in bots] == ["spark-ori-alpha"]
+
+    def test_archived_filtered_unless_all_flag_set(self, bots_dir):
+        _make_bot_yaml(bots_dir, "spark-ori-active")
+        _make_bot_yaml(bots_dir, "spark-ori-dead", archived=True)
+
+        active_only = bot_mod._load_and_filter_bots(_args(owner=None, all=False))
+        assert [b.name for b in active_only] == ["spark-ori-active"]
+
+        with_archived = bot_mod._load_and_filter_bots(_args(owner=None, all=True))
+        assert sorted(b.name for b in with_archived) == [
+            "spark-ori-active",
+            "spark-ori-dead",
+        ]
+
+    def test_skips_directories_without_yaml(self, bots_dir):
+        _make_bot_yaml(bots_dir, "spark-ori-real")
+        (bots_dir / "spark-ori-empty").mkdir()  # no bot.yaml inside
+        bots = bot_mod._load_and_filter_bots(_args(owner=None, all=False))
+        assert [b.name for b in bots] == ["spark-ori-real"]
+
+
+# ---------------------------------------------------------------------------
+# _bot_create
+# ---------------------------------------------------------------------------
+
+
+class TestBotCreate:
+    def _create_args(self, name="ghci", **overrides):
+        defaults = dict(
+            name=name,
+            owner="spark-ori",
+            channels=["#ops"],
+            trigger="webhook",
+            mention=None,
+            template=None,
+            dm_owner=False,
+            description="a bot",
+            config="~/.culture/server.yaml",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_rejects_empty_name(self, bots_dir, stub_config, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_create(self._create_args(name="   "))
+        assert exc.value.code == 1
+        assert "bot name cannot be empty" in capsys.readouterr().err
+
+    def test_writes_yaml_with_server_owner_prefix(self, bots_dir, stub_config, capsys):
+        bot_mod._bot_create(self._create_args(name="ghci", owner="spark-ori"))
+
+        # Name is rewritten to <server>-<owner_suffix>-<name>
+        bot_dir = bots_dir / "spark-ori-ghci"
+        assert (bot_dir / BOT_CONFIG_FILE).is_file()
+        out = capsys.readouterr().out
+        assert "Bot 'spark-ori-ghci' created" in out
+        assert "Owner:    spark-ori" in out
+
+    def test_strips_server_prefix_from_owner_when_building_name(
+        self, bots_dir, stub_config, capsys
+    ):
+        bot_mod._bot_create(self._create_args(name="ghci", owner="bare-owner"))
+
+        assert (bots_dir / "spark-bare-owner-ghci" / BOT_CONFIG_FILE).is_file()
+
+    def test_rejects_duplicate(self, bots_dir, stub_config, capsys):
+        bot_mod._bot_create(self._create_args(name="ghci"))
+        capsys.readouterr()  # drain
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_create(self._create_args(name="spark-ori-ghci"))
+        assert exc.value.code == 1
+        assert "already exists" in capsys.readouterr().err
+
+    def test_renders_channels_and_mention_in_summary(self, bots_dir, stub_config, capsys):
+        bot_mod._bot_create(
+            self._create_args(
+                name="ghci",
+                channels=["#ops", "#general"],
+                mention="@spark-claude",
+            )
+        )
+        out = capsys.readouterr().out
+        assert "Channels: #ops, #general" in out
+        assert "Mentions: @spark-claude" in out
+
+
+# ---------------------------------------------------------------------------
+# _bot_start / _bot_stop
+# ---------------------------------------------------------------------------
+
+
+class TestBotStartStop:
+    def test_start_unknown_bot_exits(self, bots_dir, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_start(_args(name="missing"))
+        assert exc.value.code == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_start_existing_bot_prints_reload_notice(self, bots_dir, capsys):
+        _make_bot_yaml(bots_dir, "spark-ori-ghci")
+        bot_mod._bot_start(_args(name="spark-ori-ghci"))
+        out = capsys.readouterr().out
+        assert "spark-ori-ghci" in out
+        assert "next server restart" in out
+
+    def test_stop_unknown_bot_exits(self, bots_dir, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_stop(_args(name="missing"))
+        assert exc.value.code == 1
+
+    def test_stop_existing_bot_prints_unload_notice(self, bots_dir, capsys):
+        _make_bot_yaml(bots_dir, "spark-ori-ghci")
+        bot_mod._bot_stop(_args(name="spark-ori-ghci"))
+        out = capsys.readouterr().out
+        assert "unloaded on next server restart" in out
+
+
+# ---------------------------------------------------------------------------
+# _bot_list
+# ---------------------------------------------------------------------------
+
+
+class TestBotList:
+    def test_empty_when_no_bots_dir(self, monkeypatch, tmp_path, capsys):
+        ghost = tmp_path / "no-such-dir"
+        monkeypatch.setattr("culture.bots.config.BOTS_DIR", ghost)
+        bot_mod._bot_list(_args(owner=None, all=False))
+        assert "No bots configured" in capsys.readouterr().out
+
+    def test_empty_with_owner_filter_says_no_bots_for_owner(self, bots_dir, capsys):
+        bot_mod._bot_list(_args(owner="spark-claude", all=False))
+        assert "No bots found for owner 'spark-claude'" in capsys.readouterr().out
+
+    def test_renders_table_with_each_bot(self, bots_dir, capsys):
+        _make_bot_yaml(bots_dir, "spark-ori-alpha", channels=["#ops"])
+        _make_bot_yaml(bots_dir, "spark-ori-beta", channels=[])
+
+        bot_mod._bot_list(_args(owner=None, all=False))
+
+        out = capsys.readouterr().out
+        assert "NAME" in out and "TRIGGER" in out and "OWNER" in out
+        assert "spark-ori-alpha" in out
+        assert "spark-ori-beta" in out
+
+    def test_archived_marker_appears_in_show_all_mode(self, bots_dir, capsys):
+        _make_bot_yaml(bots_dir, "spark-ori-dead", archived=True)
+        bot_mod._bot_list(_args(owner=None, all=True))
+        assert "[archived]" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _bot_inspect
+# ---------------------------------------------------------------------------
+
+
+class TestBotInspect:
+    def test_unknown_bot_exits(self, bots_dir, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_inspect(_args(name="missing"))
+        assert exc.value.code == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_renders_full_bot_metadata(self, bots_dir, capsys):
+        _make_bot_yaml(
+            bots_dir,
+            "spark-ori-ghci",
+            description="GitHub CI watcher",
+            channels=["#ops", "#general"],
+            mention="@spark-claude",
+            template="Hi {agent} — build {status}",
+            dm_owner=True,
+        )
+
+        bot_mod._bot_inspect(_args(name="spark-ori-ghci"))
+
+        out = capsys.readouterr().out
+        assert "Bot:" in out and "spark-ori-ghci" in out
+        assert "Owner:" in out and "spark-ori" in out
+        assert "GitHub CI watcher" in out
+        assert "Webhook URL:" in out and "spark-ori-ghci" in out
+        assert "#ops" in out and "#general" in out
+        assert "yes" in out  # DM Owner: yes
+        assert "@spark-claude" in out
+        assert "Template:" in out
+
+    def test_truncates_long_template_first_line(self, bots_dir, capsys):
+        long = "X" * 200
+        _make_bot_yaml(bots_dir, "spark-ori-ghci", template=long)
+        bot_mod._bot_inspect(_args(name="spark-ori-ghci"))
+        out = capsys.readouterr().out
+        assert "..." in out  # truncation marker
+
+    def test_renders_archive_block_when_archived(self, bots_dir, capsys):
+        _make_bot_yaml(
+            bots_dir,
+            "spark-ori-dead",
+            archived=True,
+            archived_at="2026-05-01",
+            archived_reason="superseded",
+        )
+        bot_mod._bot_inspect(_args(name="spark-ori-dead"))
+        out = capsys.readouterr().out
+        assert "Archived:    yes" in out
+        assert "2026-05-01" in out
+        assert "superseded" in out
+
+
+# ---------------------------------------------------------------------------
+# _bot_archive / _bot_unarchive
+# ---------------------------------------------------------------------------
+
+
+class TestBotArchive:
+    def test_unknown_bot_exits(self, bots_dir, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_archive(_args(name="missing", reason=""))
+        assert exc.value.code == 1
+
+    def test_marks_bot_archived_and_writes_back(self, bots_dir, capsys):
+        from culture.bots.config import load_bot_config
+
+        yaml_path = _make_bot_yaml(bots_dir, "spark-ori-ghci")
+        bot_mod._bot_archive(_args(name="spark-ori-ghci", reason="superseded"))
+
+        reloaded = load_bot_config(yaml_path)
+        assert reloaded.archived is True
+        assert reloaded.archived_reason == "superseded"
+        assert reloaded.archived_at  # non-empty date string
+        out = capsys.readouterr().out
+        assert "Bot archived: spark-ori-ghci" in out
+        assert "Reason: superseded" in out
+
+    def test_already_archived_is_idempotent(self, bots_dir, capsys):
+        _make_bot_yaml(bots_dir, "spark-ori-dead", archived=True)
+        bot_mod._bot_archive(_args(name="spark-ori-dead", reason=""))
+        out = capsys.readouterr().out
+        assert "already archived" in out
+
+
+class TestBotUnarchive:
+    def test_unknown_bot_exits(self, bots_dir, capsys):
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_unarchive(_args(name="missing"))
+        assert exc.value.code == 1
+
+    def test_not_archived_exits(self, bots_dir, capsys):
+        _make_bot_yaml(bots_dir, "spark-ori-active")
+        with pytest.raises(SystemExit) as exc:
+            bot_mod._bot_unarchive(_args(name="spark-ori-active"))
+        assert exc.value.code == 1
+        assert "not archived" in capsys.readouterr().err
+
+    def test_restores_archived_bot(self, bots_dir, capsys):
+        from culture.bots.config import load_bot_config
+
+        yaml_path = _make_bot_yaml(
+            bots_dir, "spark-ori-dead", archived=True, archived_at="2026-05-01"
+        )
+        bot_mod._bot_unarchive(_args(name="spark-ori-dead"))
+
+        reloaded = load_bot_config(yaml_path)
+        assert reloaded.archived is False
+        assert reloaded.archived_at == ""
+        assert reloaded.archived_reason == ""
+        assert "Bot unarchived: spark-ori-dead" in capsys.readouterr().out

--- a/tests/test_cli_shared_mesh.py
+++ b/tests/test_cli_shared_mesh.py
@@ -1,0 +1,230 @@
+"""Tests for `culture.cli.shared.mesh` — link/mesh helpers for CLI.
+
+The module is a flat utility surface — four functions, no dispatch, no
+IPC, no process management. Tests are unit-level with `tmp_path` for any
+filesystem fixtures and `monkeypatch` for `culture.credentials.lookup_credential`.
+
+Functions under test:
+
+- `parse_link(value)` — argparse type for `name:host:port:password[:trust]` specs.
+- `resolve_links_from_mesh(mesh_config_path)` — reads mesh.yaml + keyring.
+- `generate_mesh_from_agents(mesh_config_path)` — fallback when mesh.yaml missing.
+- `build_server_start_cmd(mesh, culture_bin, mesh_config_path)` — pure argv builder.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+
+import pytest
+
+from culture.cli.shared import mesh as mesh_mod
+
+# ---------------------------------------------------------------------------
+# parse_link
+# ---------------------------------------------------------------------------
+
+
+class TestParseLink:
+    def test_basic_spec_defaults_to_full_trust(self):
+        link = mesh_mod.parse_link("thor:thor.example.com:6667:secret")
+        assert link.name == "thor"
+        assert link.host == "thor.example.com"
+        assert link.port == 6667
+        assert link.password == "secret"
+        assert link.trust == "full"
+
+    def test_explicit_full_trust_suffix(self):
+        link = mesh_mod.parse_link("thor:thor.example.com:6667:secret:full")
+        assert link.trust == "full"
+        assert link.password == "secret"
+
+    def test_explicit_restricted_trust_suffix(self):
+        link = mesh_mod.parse_link("thor:thor.example.com:6667:secret:restricted")
+        assert link.trust == "restricted"
+        assert link.password == "secret"
+
+    def test_password_can_contain_colons(self):
+        """Password is parsed with maxsplit=3 so embedded colons survive."""
+        link = mesh_mod.parse_link("thor:thor.example.com:6667:pass:with:colons")
+        assert link.host == "thor.example.com"
+        assert link.port == 6667
+        assert link.password == "pass:with:colons"
+        assert link.trust == "full"
+
+    def test_rejects_missing_fields(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="Link must be"):
+            mesh_mod.parse_link("only:two")
+
+    def test_rejects_non_integer_port(self):
+        with pytest.raises(argparse.ArgumentTypeError, match="Invalid port"):
+            mesh_mod.parse_link("thor:thor.example.com:not-a-port:secret")
+
+
+# ---------------------------------------------------------------------------
+# resolve_links_from_mesh
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubLink:
+    """Minimal duck of agentirc.config.LinkConfig for mesh_config.links."""
+
+    name: str
+    host: str
+    port: int
+    trust: str = "full"
+
+
+@dataclass
+class _StubServer:
+    name: str = "spark"
+    host: str = "spark.example.com"
+    port: int = 6667
+    links: list = field(default_factory=list)
+
+
+@dataclass
+class _StubMesh:
+    server: _StubServer
+
+
+class TestResolveLinksFromMesh:
+    def test_returns_empty_when_no_peers(self, monkeypatch):
+        monkeypatch.setattr(
+            "culture.mesh_config.load_mesh_config",
+            lambda _p: _StubMesh(server=_StubServer(links=[])),
+        )
+        monkeypatch.setattr("culture.credentials.lookup_credential", lambda _n: "unused")
+        assert mesh_mod.resolve_links_from_mesh("/tmp/mesh.yaml") == []
+
+    def test_builds_one_link_per_peer_with_keyring_password(self, monkeypatch):
+        peers = [
+            _StubLink(name="thor", host="thor.example.com", port=6667),
+            _StubLink(name="zeus", host="zeus.example.com", port=6668, trust="restricted"),
+        ]
+        monkeypatch.setattr(
+            "culture.mesh_config.load_mesh_config",
+            lambda _p: _StubMesh(server=_StubServer(links=peers)),
+        )
+        passwords = {"thor": "thor-pw", "zeus": "zeus-pw"}
+        monkeypatch.setattr(
+            "culture.credentials.lookup_credential",
+            lambda name: passwords.get(name),
+        )
+
+        links = mesh_mod.resolve_links_from_mesh("/tmp/mesh.yaml")
+
+        assert [(l.name, l.host, l.port, l.password, l.trust) for l in links] == [
+            ("thor", "thor.example.com", 6667, "thor-pw", "full"),
+            ("zeus", "zeus.example.com", 6668, "zeus-pw", "restricted"),
+        ]
+
+    def test_skips_peers_without_credentials(self, monkeypatch, caplog):
+        peers = [
+            _StubLink(name="thor", host="thor.example.com", port=6667),
+            _StubLink(name="ghost", host="ghost.example.com", port=6669),
+        ]
+        monkeypatch.setattr(
+            "culture.mesh_config.load_mesh_config",
+            lambda _p: _StubMesh(server=_StubServer(links=peers)),
+        )
+        # ghost has no credential
+        monkeypatch.setattr(
+            "culture.credentials.lookup_credential",
+            lambda name: "thor-pw" if name == "thor" else None,
+        )
+
+        with caplog.at_level("WARNING", logger="culture"):
+            links = mesh_mod.resolve_links_from_mesh("/tmp/mesh.yaml")
+
+        assert [l.name for l in links] == ["thor"]
+        assert any("ghost" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# generate_mesh_from_agents
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMeshFromAgents:
+    def test_returns_none_when_default_config_missing(self, monkeypatch, capsys, tmp_path):
+        # Point DEFAULT_CONFIG at a path that doesn't exist.
+        nonexistent = str(tmp_path / "agents.yaml")
+        monkeypatch.setattr(mesh_mod, "DEFAULT_CONFIG", nonexistent)
+
+        result = mesh_mod.generate_mesh_from_agents("/tmp/mesh.yaml")
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "Mesh config not found" in err
+        assert "Agent config not found" in err
+
+    def test_generates_and_saves_mesh_when_default_config_present(
+        self, monkeypatch, capsys, tmp_path
+    ):
+        agents_path = tmp_path / "agents.yaml"
+        agents_path.write_text("placeholder\n")  # contents don't matter — load_config is mocked
+        mesh_path = tmp_path / "mesh.yaml"
+        monkeypatch.setattr(mesh_mod, "DEFAULT_CONFIG", str(agents_path))
+
+        captured_saves: list[tuple[object, str]] = []
+        fake_mesh = _StubMesh(server=_StubServer(name="spark"))
+
+        # `culture.config.load_config` is bound at import time into mesh_mod —
+        # patch it there. `from_daemon_config` and `save_mesh_config` are
+        # imported lazily inside `generate_mesh_from_agents`, so patching
+        # `culture.mesh_config.*` works for them.
+        monkeypatch.setattr(mesh_mod, "load_config", lambda _p: "daemon-config-obj")
+        monkeypatch.setattr(
+            "culture.mesh_config.from_daemon_config",
+            lambda dc: fake_mesh if dc == "daemon-config-obj" else None,
+        )
+        monkeypatch.setattr(
+            "culture.mesh_config.save_mesh_config",
+            lambda mesh, path: captured_saves.append((mesh, path)),
+        )
+
+        result = mesh_mod.generate_mesh_from_agents(str(mesh_path))
+
+        assert result is fake_mesh
+        assert captured_saves == [(fake_mesh, str(mesh_path))]
+        out = capsys.readouterr().out
+        assert "generated from" in out
+
+
+# ---------------------------------------------------------------------------
+# build_server_start_cmd
+# ---------------------------------------------------------------------------
+
+
+class TestBuildServerStartCmd:
+    def _mesh(self, name="spark", host="0.0.0.0", port=6667):
+        return _StubMesh(server=_StubServer(name=name, host=host, port=port))
+
+    def test_includes_foreground_and_mesh_config(self):
+        cmd = mesh_mod.build_server_start_cmd(self._mesh(), "/usr/bin/culture", "/tmp/mesh.yaml")
+        assert cmd[0] == "/usr/bin/culture"
+        assert cmd[1:3] == ["server", "start"]
+        assert "--foreground" in cmd
+        assert "--mesh-config" in cmd
+        assert cmd[cmd.index("--mesh-config") + 1] == "/tmp/mesh.yaml"
+
+    def test_includes_server_name_host_and_port(self):
+        cmd = mesh_mod.build_server_start_cmd(
+            self._mesh(name="thor", host="10.0.0.5", port=6700),
+            "/usr/bin/culture",
+            "/tmp/mesh.yaml",
+        )
+        assert cmd[cmd.index("--name") + 1] == "thor"
+        assert cmd[cmd.index("--host") + 1] == "10.0.0.5"
+        assert cmd[cmd.index("--port") + 1] == "6700"
+
+    def test_port_is_stringified(self):
+        cmd = mesh_mod.build_server_start_cmd(
+            self._mesh(port=12345), "/usr/bin/culture", "/tmp/mesh.yaml"
+        )
+        port_arg = cmd[cmd.index("--port") + 1]
+        assert port_arg == "12345"
+        assert isinstance(port_arg, str)

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.0.3"
+version = "12.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 3a of the **60 → 90 coverage ratchet** ([plan](/home/spark/.claude/plans/we-re-at-60-coverage-refactored-lark.md)). Three CLI files brought to ~100% coverage; project-wide floor raised **62 → 67**. Measured post-Phase-3a: **67.89%** (+5.0pp from Phase 2).

| File | Before | After |
|---|---|---|
| `culture/cli/shared/mesh.py` | 25% | **100%** |
| `culture/cli/bot.py`         | 33% | **99%** |
| `culture/cli/channel.py`     | 44% | **99.6%** |

### `tests/test_cli_shared_mesh.py` (14 tests)

All four pure functions — `parse_link`, `resolve_links_from_mesh`, `generate_mesh_from_agents`, `build_server_start_cmd`. Notable branches covered: malformed-spec rejection, password-with-colons preservation, peer-without-credential warn-and-skip, missing-`DEFAULT_CONFIG` fallback.

### `tests/test_cli_bot.py` (35 tests)

Every `_bot_*` handler plus `_should_include_bot` / `_load_and_filter_bots`. Filesystem isolated via `tmp_path`-backed `BOTS_DIR`; `load_config_or_default` patched. Covers empty-name rejection, owner-prefix rewrite, duplicate detection, archive cascade round-trip, template truncation, and every "unknown bot" exit path.

### `tests/test_channel_cli.py` (21 new tests appended)

Every `_cmd_*` handler plus `_interpret_escapes`, `_is_connection_error`, the `dispatch` OSError wrapper, the `_topic_read` daemon-unreachable exit, and `_require_ipc` when the daemon responds None.

**New helper**: `_stub_ipc` patches `_try_ipc` / `_require_ipc` at the channel-module boundary. The existing Unix-socket mock pattern can't drive the `_cmd_*` handlers because they call `asyncio.run` internally and can't be re-entered from a test-owned event loop.

### Phase 3 split

The original plan had Phase 3 as a single PR (1,067 missing lines across 6 files). That's too big for one review pass — splitting into 3a (this PR) and 3b (cli/mesh.py + cli/server.py + cli/agent.py, ~752 missing lines, daemon spawn / multi-backend creation / systemd install) keeps each PR reviewable.

## Test plan

- [x] `uv run pytest tests/test_cli_shared_mesh.py tests/test_cli_bot.py tests/test_channel_cli.py -v` — all 115 tests pass
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -c` — full suite green, TOTAL 67.89%, above `fail_under = 67`
- [x] Three target files report ≥ 99% in `coverage report`
- [x] pre-commit (black, isort, flake8, pylint, bandit, markdownlint) clean
- [ ] CI green (pytest, SonarCloud quality gate, version-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- culture (Claude)