### PR TITLE
test(coverage): Phase 3b — cli/mesh + cli/server [v12.0.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.0.5] - 2026-05-13
+
+### Added
+
+- `tests/test_cli_mesh.py` — 54 tests covering `culture/cli/mesh.py` (53% → 99%): `dispatch`, `_collect_mesh_data` (happy + ConnectionRefused/Timeout/OSError exits), `_cmd_overview` (text + clamped messages + serve dispatch), `_cmd_console` deprecation, `_store_mesh_credentials` (keyring hit/miss/store-fail), `_cmd_setup` (uninstall / install / generated fallback / exit on no-mesh), `_find_upgrade_tool` (uv / pip / neither), `_upgrade_timeout_hint`, `_run_upgrade` (success / timeout / non-zero exit), `_upgrade_culture_package` (skip / dry-run / no-tool / exec-reach), `_wait_for_server_port`, `_dry_run_restart`, `_restart_single_service` (service / subprocess fallback / timeout swallow), `_restart_mesh_services` (dry-run / port-down / happy), `_resolve_mesh_for_server`, `_restart_running_servers`, `_restart_from_config`, `_cmd_update`. `_install_mesh_services` (systemd) and the `os.execvp` re-exec body are excluded from coverage.
+- `tests/test_cli_server.py` — 54 tests covering `culture/cli/server.py` (21% → 76%): `_resolve_server_name`, `_cmd_default` (running / unknown), `dispatch` (no verb / unknown / agentirc-forwarded / culture verb), `_wait_for_port` (connect / pid dies / timeout), `_maybe_set_default_server` (idempotent), `_check_server_archived`, `_check_already_running`, `_resolve_server_links`, `_wait_for_graceful_stop`, `_force_kill` (POSIX SIGKILL / win32 SIGTERM / ProcessLookupError swallow), `_server_stop`, `_server_status`, `_validate_config_name`, `_update_single_bot_archive`, `_set_bots_archive_state`, `_server_archive`, `_server_unarchive`, `_server_rename` (every branch), `_server_start` (foreground / daemonize routing). Integration-territory functions `_run_foreground`/`_daemonize_server`/`_run_server` are deliberately skipped — covered by `tests/test_integration_irc_transport.py` against a real IRCd.
+
+### Changed
+
+- pyproject.toml: fail_under raised 67 → 73 (Phase 3b floor of the 60→90 ratchet plan). Project-wide measured 73.40%.
+- docs/coverage-baseline.md: Phase 3b entry + updated phase target table.
+
 ## [12.0.4] - 2026-05-13
 
 ### Added

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -88,15 +88,23 @@ Notable findings (deferred to later phases):
 - `culture/cli/bot.py` — 33% → **99%** (199 statements, 2 missing). `tests/test_cli_bot.py` (35 tests) covers all seven `_bot_*` handlers + the `_should_include_bot` / `_load_and_filter_bots` helpers. Filesystem isolated via tmp_path-backed `BOTS_DIR`; `load_config_or_default` patched. The 2 missing lines are in a small `_bot_list` empty-state branch.
 - `culture/cli/channel.py` — 44% → **99.6%** (260 statements, 1 missing). 21 new tests appended to `tests/test_channel_cli.py` covering every `_cmd_*` handler (list/read/message/who/join/part/ask/topic/compact/clear), `_interpret_escapes`, `_is_connection_error`, the dispatch wrapper for OSError, and the `_topic_read` daemon-unreachable exit path. IPC is stubbed at the `_try_ipc` / `_require_ipc` boundary (the `_cmd_*` handlers call `asyncio.run` internally, so a test-owned event loop would dead-lock the real Unix-socket-mock pattern).
 
+### Phase 3b — `cli/mesh.py` + `cli/server.py` (2026-05-13)
+
+**Measured: 73.40%** (6260 statements, 1665 missing) → `fail_under = 73`. Two more CLI handlers covered:
+
+- `culture/cli/mesh.py` — 53% → **99.3%** (282 statements, 2 missing). `tests/test_cli_mesh.py` (54 tests) covers every dispatched handler (`_cmd_overview`, `_cmd_setup`, `_cmd_update`, `_cmd_console`) plus every reachable helper: `_collect_mesh_data` exit paths, `_find_upgrade_tool`, `_upgrade_timeout_hint`, `_run_upgrade` (timeout + non-zero-exit), `_upgrade_culture_package` (skip / dry-run / no-tool / exec-reach), `_wait_for_server_port` (accept / refuse / non-culture PID), `_restart_single_service` (service path + subprocess fallback + timeout swallow), `_restart_mesh_services`, `_resolve_mesh_for_server`, `_restart_running_servers`, `_restart_from_config`. `_install_mesh_services` is excluded (systemd; Linux + root only); `os.execvp` re-exec is reached by the tests but its body is excluded as an end-of-life branch.
+- `culture/cli/server.py` — 21% → **76%** (396 statements, 96 missing). `tests/test_cli_server.py` (54 tests) covers `_resolve_server_name`, `dispatch` (including the `agentirc.cli.dispatch` passthrough for forwarded verbs), `_cmd_default`, `_server_rename` (every branch), `_check_server_archived`, `_check_already_running`, `_resolve_server_links`, `_wait_for_graceful_stop`, `_force_kill` (POSIX SIGKILL + win32 SIGTERM + `ProcessLookupError` swallow), `_server_stop`, `_server_status`, `_validate_config_name`, `_update_single_bot_archive`, `_set_bots_archive_state`, `_server_archive`, `_server_unarchive`, plus the `_server_start` dispatcher. The 96 missing lines are concentrated in three deliberately-skipped integration-territory functions: `_run_foreground`, `_daemonize_server`, `_run_server` — exercised by `tests/test_integration_irc_transport.py` against a real IRCd, not unit tests.
+
 ### Phase target table
 
 | Phase | Floor | Measured | PR | Status |
 |---|---|---|---|---|
 | 1 | 60 | 60.99% | [#383](https://github.com/agentculture/culture/pull/383) | ✅ merged |
 | 2 | 62 | 62.91% | [#384](https://github.com/agentculture/culture/pull/384) | ✅ merged |
-| 3a | 67 | 67.89% | (this PR) | in flight |
-| 3b | 70 | — | `cli/mesh.py`, `cli/server.py`, `cli/agent.py` | pending |
-| 4 | 75 | — | Domain modules via real IRCd | pending |
-| 5 | 82 | — | `transport/client.py` (or its deletion) | pending |
-| 6 | 88 | — | Long tail | pending |
+| 3a | 67 | 67.89% | [#385](https://github.com/agentculture/culture/pull/385) | ✅ merged |
+| 3b | 73 | 73.40% | (this PR) | in flight |
+| 3c | 78 | — | `cli/agent.py` (1,123 LOC alone) | pending |
+| 4 | 82 | — | Domain modules via real IRCd | pending |
+| 5 | 86 | — | `transport/client.py` (or its deletion) | pending |
+| 6 | 89 | — | Long tail | pending |
 | 7 | 90 | — | Final sweep | pending |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.0.4"
+version = "12.0.5"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -93,11 +93,12 @@ omit = [
 
 [tool.coverage.report]
 # Ratchet floor — see docs/coverage-baseline.md for the per-phase log.
-# Phase 3a (2026-05-13): added tests for culture/cli/shared/mesh.py,
-# culture/cli/bot.py, culture/cli/channel.py (now at 100% / 99% / 99%).
-# Project-wide measured: 67.89%. Floor = floor(measured).
-# Phase 3b targets the remaining CLI handlers (mesh/server/agent).
-fail_under = 67
+# Phase 3b (2026-05-13): added tests for culture/cli/mesh.py (now 99%)
+# and culture/cli/server.py (now 76% — integration-territory helpers
+# `_run_server`/`_daemonize_server`/`_run_foreground` deliberately
+# skipped). Project-wide measured: 73.40%. Floor = floor(measured).
+# Phase 3c targets the last CLI module: culture/cli/agent.py.
+fail_under = 73
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/tests/test_cli_mesh.py
+++ b/tests/test_cli_mesh.py
@@ -1,0 +1,883 @@
+"""Tests for `culture.cli.mesh` — `culture mesh {overview,setup,update,console}`.
+
+Each handler is invoked directly with an `argparse.Namespace`. The OS
+surface (subprocess, sockets, systemd) is monkeypatched at the module
+boundary so the suite is hermetic. `_install_mesh_services` is excluded
+from coverage by `# pragma: no cover` in production code (systemd is
+Linux + root only), and `os.execvp` is excluded the same way.
+
+The tests do NOT exercise:
+- the `--serve` web dashboard path (long-running aiohttp server)
+- `_install_mesh_services` (excluded)
+- the `os.execvp` re-exec inside `_upgrade_culture_package` (excluded)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass, field
+
+import pytest
+
+from culture.cli import mesh as mesh_mod
+
+# ---------------------------------------------------------------------------
+# Stub data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubLink:
+    name: str
+    host: str = "peer.example.com"
+    port: int = 6667
+    trust: str = "full"
+
+
+@dataclass
+class _StubAgent:
+    nick: str
+
+
+@dataclass
+class _StubServerCfg:
+    name: str = "spark"
+    host: str = "127.0.0.1"
+    port: int = 6667
+    links: list = field(default_factory=list)
+
+
+@dataclass
+class _StubMesh:
+    server: _StubServerCfg
+    agents: list = field(default_factory=list)
+
+
+@dataclass
+class _StubFullConfig:
+    """Stand-in for culture.config.ServerConfig returned by load_config_or_default."""
+
+    server: _StubServerCfg = field(default_factory=_StubServerCfg)
+    agents: list = field(default_factory=list)
+
+
+def _args(**kwargs) -> argparse.Namespace:
+    defaults = {"config": "~/.culture/mesh.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_dispatch_no_command_exits_with_usage(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod.dispatch(_args(mesh_command=None))
+        assert exc.value.code == 1
+        assert "Usage: culture mesh" in capsys.readouterr().err
+
+    def test_dispatch_unknown_command_exits(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod.dispatch(_args(mesh_command="frobnicate"))
+        assert exc.value.code == 1
+        assert "Unknown mesh command" in capsys.readouterr().err
+
+    def test_dispatch_routes_to_handler(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(mesh_mod, "_cmd_overview", lambda a: called.append("overview"))
+        mesh_mod.dispatch(_args(mesh_command="overview"))
+        assert called == ["overview"]
+
+
+# ---------------------------------------------------------------------------
+# _collect_mesh_data
+# ---------------------------------------------------------------------------
+
+
+class TestCollectMeshData:
+    def _patch_collector(self, monkeypatch, *, side_effect=None, returns=None):
+        """Patch `culture.overview.collector.collect_mesh_state` to a fake async."""
+
+        async def _fake(*, host, port, server_name, message_limit, manifest_agents=None):
+            if side_effect is not None:
+                raise side_effect
+            return returns or {"host": host, "port": port}
+
+        monkeypatch.setattr("culture.overview.collector.collect_mesh_state", _fake)
+
+    def test_happy_path_returns_mesh(self, monkeypatch):
+        self._patch_collector(monkeypatch, returns={"server": "spark"})
+        result = mesh_mod._collect_mesh_data("127.0.0.1", 6667, "spark", 4)
+        assert result == {"server": "spark"}
+
+    def test_connection_refused_exits_with_hint(self, monkeypatch, capsys):
+        self._patch_collector(monkeypatch, side_effect=ConnectionRefusedError())
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._collect_mesh_data("127.0.0.1", 6667, "spark", 4)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "could not connect" in err
+
+    def test_timeout_exits_with_hint(self, monkeypatch, capsys):
+        self._patch_collector(monkeypatch, side_effect=TimeoutError())
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._collect_mesh_data("127.0.0.1", 6667, "spark", 4)
+        assert exc.value.code == 1
+        assert "not responding" in capsys.readouterr().err
+
+    def test_other_oserror_exits_with_message(self, monkeypatch, capsys):
+        self._patch_collector(monkeypatch, side_effect=OSError("eperm"))
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._collect_mesh_data("127.0.0.1", 6667, "spark", 4)
+        assert exc.value.code == 1
+        assert "eperm" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _cmd_overview (non-serve path)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdOverview:
+    def test_non_serve_path_renders_text(self, monkeypatch, capsys):
+        cfg = _StubFullConfig()
+        monkeypatch.setattr(mesh_mod, "load_config_or_default", lambda _p: cfg)
+        monkeypatch.setattr(mesh_mod, "_collect_mesh_data", lambda *a, **kw: {"x": 1})
+        monkeypatch.setattr(
+            "culture.overview.renderer_text.render_text",
+            lambda mesh, **kw: f"RENDERED({mesh})",
+        )
+
+        mesh_mod._cmd_overview(
+            _args(
+                mesh_command="overview",
+                room=None,
+                agent=None,
+                messages=4,
+                refresh=5,
+                serve=False,
+            )
+        )
+
+        assert "RENDERED" in capsys.readouterr().out
+
+    def test_messages_clamped(self, monkeypatch):
+        captured = {}
+
+        def fake_collect(*args, **kwargs):
+            captured["msgs"] = args[3]
+            return {}
+
+        monkeypatch.setattr(mesh_mod, "load_config_or_default", lambda _p: _StubFullConfig())
+        monkeypatch.setattr(mesh_mod, "_collect_mesh_data", fake_collect)
+        monkeypatch.setattr("culture.overview.renderer_text.render_text", lambda mesh, **kw: "")
+
+        mesh_mod._cmd_overview(
+            _args(
+                mesh_command="overview",
+                room=None,
+                agent=None,
+                messages=50,  # > max 20
+                refresh=5,
+                serve=False,
+            )
+        )
+        assert captured["msgs"] == 20
+
+    def test_serve_path_invokes_web(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(mesh_mod, "load_config_or_default", lambda _p: _StubFullConfig())
+        monkeypatch.setattr(
+            "culture.overview.renderer_web.serve_web",
+            lambda **kw: called.append(kw),
+        )
+
+        mesh_mod._cmd_overview(
+            _args(
+                mesh_command="overview",
+                room=None,
+                agent=None,
+                messages=4,
+                refresh=5,
+                serve=True,
+            )
+        )
+
+        assert called and called[0]["server_name"] == "spark"
+
+
+# ---------------------------------------------------------------------------
+# _cmd_console (deprecation passthrough)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdConsole:
+    def test_emits_deprecation_warning_and_forwards(self, monkeypatch, capsys):
+        forwarded = []
+        monkeypatch.setattr(mesh_mod, "console_dispatch", lambda name: forwarded.append(name))
+
+        mesh_mod._cmd_console(_args(mesh_command="console", server_name="spark"))
+
+        assert "deprecated" in capsys.readouterr().err
+        assert forwarded == ["spark"]
+
+
+# ---------------------------------------------------------------------------
+# _store_mesh_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestStoreMeshCredentials:
+    def test_skips_when_credential_already_in_keyring(self, monkeypatch, capsys):
+        mesh = _StubMesh(server=_StubServerCfg(links=[_StubLink(name="thor")]))
+        monkeypatch.setattr("culture.credentials.lookup_credential", lambda n: "existing")
+        # If getpass is called, the test fails noisily.
+        monkeypatch.setattr("getpass.getpass", lambda _p: pytest.fail("should not prompt"))
+
+        mesh_mod._store_mesh_credentials(mesh)
+        assert "already in keyring" in capsys.readouterr().out
+
+    def test_prompts_and_stores_when_missing(self, monkeypatch, capsys):
+        mesh = _StubMesh(server=_StubServerCfg(links=[_StubLink(name="thor")]))
+        monkeypatch.setattr("culture.credentials.lookup_credential", lambda n: None)
+        monkeypatch.setattr("getpass.getpass", lambda _p: "secret")
+        stored = []
+        monkeypatch.setattr(
+            "culture.credentials.store_credential",
+            lambda name, pw: stored.append((name, pw)) or True,
+        )
+
+        mesh_mod._store_mesh_credentials(mesh)
+
+        assert stored == [("thor", "secret")]
+        assert "Stored credential" in capsys.readouterr().out
+
+    def test_warns_when_store_fails(self, monkeypatch, capsys):
+        mesh = _StubMesh(server=_StubServerCfg(links=[_StubLink(name="thor")]))
+        monkeypatch.setattr("culture.credentials.lookup_credential", lambda n: None)
+        monkeypatch.setattr("getpass.getpass", lambda _p: "secret")
+        monkeypatch.setattr("culture.credentials.store_credential", lambda *a: False)
+
+        mesh_mod._store_mesh_credentials(mesh)
+        err = capsys.readouterr().err
+        assert "failed to store credential" in err
+        assert "secret-tool" in err
+
+
+# ---------------------------------------------------------------------------
+# _cmd_setup
+# ---------------------------------------------------------------------------
+
+
+class TestCmdSetup:
+    def _setup(self, monkeypatch, *, mesh_load=None, generate=None):
+        if mesh_load is not None:
+            monkeypatch.setattr("culture.mesh_config.load_mesh_config", mesh_load)
+        if generate is not None:
+            monkeypatch.setattr(mesh_mod, "generate_mesh_from_agents", generate)
+
+    def test_uninstall_path(self, monkeypatch, capsys):
+        mesh = _StubMesh(
+            server=_StubServerCfg(name="spark"),
+            agents=[_StubAgent(nick="ada")],
+        )
+        self._setup(monkeypatch, mesh_load=lambda _p: mesh)
+        monkeypatch.setattr(
+            "culture.persistence.list_services",
+            lambda: ["culture-server-spark", "culture-agent-spark-ada", "unrelated"],
+        )
+        removed = []
+        monkeypatch.setattr("culture.persistence.uninstall_service", removed.append)
+        stopped_servers = []
+        stopped_agents = []
+        monkeypatch.setattr(mesh_mod, "server_stop_by_name", stopped_servers.append)
+        monkeypatch.setattr(mesh_mod, "stop_agent", stopped_agents.append)
+
+        mesh_mod._cmd_setup(_args(mesh_command="setup", uninstall=True))
+
+        assert sorted(removed) == ["culture-agent-spark-ada", "culture-server-spark"]
+        assert stopped_servers == ["spark"]
+        assert stopped_agents == ["spark-ada"]
+        assert "Uninstalling" in capsys.readouterr().out
+
+    def test_install_path_invokes_credential_and_service_install(self, monkeypatch, capsys):
+        mesh = _StubMesh(
+            server=_StubServerCfg(name="spark", links=[_StubLink(name="thor")]),
+            agents=[_StubAgent(nick="ada")],
+        )
+        self._setup(monkeypatch, mesh_load=lambda _p: mesh)
+        store_calls = []
+        install_calls = []
+        monkeypatch.setattr(mesh_mod, "_store_mesh_credentials", lambda m: store_calls.append(m))
+        monkeypatch.setattr(
+            mesh_mod,
+            "_install_mesh_services",
+            lambda *a, **kw: install_calls.append((a, kw)),
+        )
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+
+        mesh_mod._cmd_setup(_args(mesh_command="setup", uninstall=False))
+
+        assert store_calls == [mesh]
+        assert len(install_calls) == 1
+        assert "Setup complete" in capsys.readouterr().out
+
+    def test_install_falls_back_to_generated_mesh(self, monkeypatch, capsys):
+        # load_mesh_config raises → generate_mesh_from_agents returns a mesh
+        def _missing(_p):
+            raise FileNotFoundError
+
+        generated = _StubMesh(server=_StubServerCfg(name="spark"))
+        self._setup(monkeypatch, mesh_load=_missing, generate=lambda _p: generated)
+        monkeypatch.setattr(mesh_mod, "_store_mesh_credentials", lambda m: None)
+        monkeypatch.setattr(mesh_mod, "_install_mesh_services", lambda *a, **k: None)
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+
+        mesh_mod._cmd_setup(_args(mesh_command="setup", uninstall=False))
+
+        assert "Setup complete" in capsys.readouterr().out
+
+    def test_install_exits_when_no_mesh_and_generation_fails(self, monkeypatch, capsys):
+        def _missing(_p):
+            raise FileNotFoundError
+
+        self._setup(monkeypatch, mesh_load=_missing, generate=lambda _p: None)
+
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._cmd_setup(_args(mesh_command="setup", uninstall=False))
+        assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# _find_upgrade_tool / _upgrade_timeout_hint
+# ---------------------------------------------------------------------------
+
+
+class TestFindUpgradeTool:
+    def test_prefers_uv(self, monkeypatch):
+        monkeypatch.setattr(
+            "shutil.which",
+            lambda name: "/usr/bin/uv" if name == "uv" else None,
+        )
+        result = mesh_mod._find_upgrade_tool()
+        assert result is not None
+        tool_name, cmd = result
+        assert tool_name == "uv"
+        assert cmd == ["/usr/bin/uv", "tool", "upgrade", "culture"]
+
+    def test_falls_back_to_pip(self, monkeypatch):
+        def _which(name):
+            return "/usr/bin/pip" if name == "pip" else None
+
+        monkeypatch.setattr("shutil.which", _which)
+        result = mesh_mod._find_upgrade_tool()
+        assert result is not None
+        tool_name, cmd = result
+        assert tool_name == "pip"
+        assert "install" in cmd and "--upgrade" in cmd
+
+    def test_returns_none_when_neither_present(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _n: None)
+        assert mesh_mod._find_upgrade_tool() is None
+
+
+class TestUpgradeTimeoutHint:
+    @pytest.mark.parametrize(
+        "tool,direct_cmd",
+        [
+            ("uv", "uv tool upgrade culture"),
+            ("pip", "pip install --upgrade culture"),
+        ],
+    )
+    def test_includes_direct_cmd_for_tool(self, tool, direct_cmd):
+        hint = mesh_mod._upgrade_timeout_hint(tool, 600)
+        assert direct_cmd in hint
+        assert "600s" in hint
+        assert "--skip-upgrade" in hint
+
+
+# ---------------------------------------------------------------------------
+# _run_upgrade
+# ---------------------------------------------------------------------------
+
+
+class TestRunUpgrade:
+    def test_success_returns_silently(self, monkeypatch, capsys):
+        fake_result = subprocess.CompletedProcess(args=[], returncode=0)
+        monkeypatch.setattr(mesh_mod.subprocess, "run", lambda *a, **kw: fake_result)
+
+        mesh_mod._run_upgrade("uv", ["uv", "tool", "upgrade", "culture"], 600)
+
+        assert "Upgrading via uv" in capsys.readouterr().out
+
+    def test_timeout_exits_with_hint(self, monkeypatch, capsys):
+        def _raise(*a, **kw):
+            raise subprocess.TimeoutExpired(cmd="uv", timeout=600)
+
+        monkeypatch.setattr(mesh_mod.subprocess, "run", _raise)
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._run_upgrade("uv", ["uv"], 600)
+        assert exc.value.code == 1
+        assert "timed out" in capsys.readouterr().err
+
+    def test_non_zero_exit_exits_with_error(self, monkeypatch, capsys):
+        fake_result = subprocess.CompletedProcess(args=[], returncode=2)
+        monkeypatch.setattr(mesh_mod.subprocess, "run", lambda *a, **kw: fake_result)
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._run_upgrade("pip", ["pip", "install"], 600)
+        assert exc.value.code == 1
+        assert "upgrade failed" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _upgrade_culture_package
+# ---------------------------------------------------------------------------
+
+
+class TestUpgradeCulturePackage:
+    def _args_update(self, **kwargs):
+        defaults = dict(
+            skip_upgrade=False,
+            dry_run=False,
+            upgrade_timeout=600,
+            config="~/.culture/mesh.yaml",
+        )
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_skip_upgrade_returns_true(self):
+        assert mesh_mod._upgrade_culture_package(self._args_update(skip_upgrade=True)) is True
+
+    def test_dry_run_returns_false_after_announcing(self, capsys):
+        result = mesh_mod._upgrade_culture_package(self._args_update(dry_run=True))
+        assert result is False
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+
+    def test_exits_when_no_upgrade_tool(self, monkeypatch, capsys):
+        monkeypatch.setattr(mesh_mod, "_find_upgrade_tool", lambda: None)
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._upgrade_culture_package(self._args_update())
+        assert exc.value.code == 1
+        assert "Neither uv nor pip" in capsys.readouterr().err
+
+    def test_runs_upgrade_then_reexecs(self, monkeypatch):
+        """`_run_upgrade` returns, then `os.execvp` would normally fire.
+
+        We patch `os.execvp` to raise so the function does not actually
+        exec the real CLI in the test process. The branch is excluded
+        from coverage in production (it's an end-of-life re-exec), so we
+        only assert that the function reaches that point.
+        """
+        monkeypatch.setattr(
+            mesh_mod, "_find_upgrade_tool", lambda: ("uv", ["uv", "tool", "upgrade", "culture"])
+        )
+        monkeypatch.setattr(mesh_mod, "_run_upgrade", lambda *a, **kw: None)
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+        execvp_calls: list = []
+
+        def _fake_execvp(prog, argv):
+            execvp_calls.append((prog, argv))
+            raise SystemExit(0)
+
+        monkeypatch.setattr(mesh_mod.os, "execvp", _fake_execvp)
+
+        with pytest.raises(SystemExit):
+            mesh_mod._upgrade_culture_package(self._args_update())
+
+        assert execvp_calls and execvp_calls[0][0] == "/usr/bin/culture"
+        assert "--skip-upgrade" in execvp_calls[0][1]
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_server_port
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForServerPort:
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch):
+        monkeypatch.setattr(mesh_mod.time, "sleep", lambda _s: None)
+
+    def test_returns_true_when_port_accepts(self, monkeypatch):
+        import contextlib
+
+        @contextlib.contextmanager
+        def _fake_socket(*args, **kwargs):
+            class _S:
+                def close(self):
+                    pass
+
+            yield _S()
+
+        monkeypatch.setattr("socket.create_connection", _fake_socket)
+        assert mesh_mod._wait_for_server_port("127.0.0.1", 6667, retries=2) is True
+
+    def test_returns_false_when_port_never_opens(self, monkeypatch):
+        def _refuse(*a, **kw):
+            raise OSError("refused")
+
+        monkeypatch.setattr("socket.create_connection", _refuse)
+        assert mesh_mod._wait_for_server_port("127.0.0.1", 6667, retries=3) is False
+
+    def test_returns_false_when_pid_not_culture(self, monkeypatch):
+        import contextlib
+
+        @contextlib.contextmanager
+        def _fake_socket(*args, **kwargs):
+            class _S:
+                def close(self):
+                    pass
+
+            yield _S()
+
+        monkeypatch.setattr("socket.create_connection", _fake_socket)
+        monkeypatch.setattr("culture.pidfile.read_pid", lambda _n: 4242)
+        monkeypatch.setattr("culture.pidfile.is_culture_process", lambda _pid: False)
+
+        result = mesh_mod._wait_for_server_port("0.0.0.0", 6667, retries=2, server_name="spark")
+        assert result is False
+
+    def test_zero_pid_does_not_disqualify(self, monkeypatch):
+        """read_pid returning None means no pidfile — connection is enough."""
+        import contextlib
+
+        @contextlib.contextmanager
+        def _fake_socket(*args, **kwargs):
+            class _S:
+                def close(self):
+                    pass
+
+            yield _S()
+
+        monkeypatch.setattr("socket.create_connection", _fake_socket)
+        monkeypatch.setattr("culture.pidfile.read_pid", lambda _n: None)
+        monkeypatch.setattr("culture.pidfile.is_culture_process", lambda _pid: True)
+
+        assert (
+            mesh_mod._wait_for_server_port("0.0.0.0", 6667, retries=1, server_name="spark") is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# _dry_run_restart
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunRestart:
+    def test_lists_every_step(self, capsys):
+        mesh = _StubMesh(
+            server=_StubServerCfg(name="spark"),
+            agents=[_StubAgent(nick="ada"), _StubAgent(nick="bob")],
+        )
+        mesh_mod._dry_run_restart(mesh, "spark")
+        out = capsys.readouterr().out
+        for fragment in [
+            "[dry-run] Would stop agent spark-ada",
+            "[dry-run] Would stop agent spark-bob",
+            "[dry-run] Would stop server spark",
+            "[dry-run] Would start server spark",
+            "[dry-run] Would start agent spark-ada",
+            "[dry-run] Would start agent spark-bob",
+        ]:
+            assert fragment in out
+
+
+# ---------------------------------------------------------------------------
+# _restart_single_service
+# ---------------------------------------------------------------------------
+
+
+class TestRestartSingleService:
+    def test_uses_service_when_available(self, monkeypatch, capsys):
+        called = []
+        mesh_mod._restart_single_service(
+            "culture-server-spark",
+            ["culture", "server", "start"],
+            lambda svc: called.append(svc) or True,
+        )
+        assert called == ["culture-server-spark"]
+        # Subprocess was not called — only service restart fired
+        assert "Restarting culture-server-spark" in capsys.readouterr().out
+
+    def test_falls_back_to_subprocess(self, monkeypatch, capsys):
+        runs = []
+
+        def _fake_run(cmd, **kw):
+            runs.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr(mesh_mod.subprocess, "run", _fake_run)
+
+        mesh_mod._restart_single_service(
+            "culture-server-spark", ["culture", "server", "start"], lambda _svc: False
+        )
+        assert runs == [["culture", "server", "start"]]
+        assert "starting via CLI" in capsys.readouterr().out
+
+    def test_fallback_timeout_is_warned_but_not_raised(self, monkeypatch, capsys):
+        def _timeout(cmd, **kw):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kw.get("timeout", 30))
+
+        monkeypatch.setattr(mesh_mod.subprocess, "run", _timeout)
+
+        mesh_mod._restart_single_service(
+            "culture-server-spark", ["culture", "server", "start"], lambda _svc: False
+        )
+        assert "timed out" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _restart_mesh_services
+# ---------------------------------------------------------------------------
+
+
+class TestRestartMeshServices:
+    def test_dry_run_returns_true_and_prints_plan(self, monkeypatch, capsys):
+        mesh = _StubMesh(server=_StubServerCfg(name="spark"))
+        result = mesh_mod._restart_mesh_services(
+            mesh, "spark", "/usr/bin/culture", "/tmp/mesh.yaml", dry_run=True
+        )
+        assert result is True
+        assert "[dry-run]" in capsys.readouterr().out
+
+    def test_returns_false_when_server_does_not_come_up(self, monkeypatch, capsys):
+        mesh = _StubMesh(server=_StubServerCfg(name="spark"))
+        monkeypatch.setattr(mesh_mod, "stop_agent", lambda _n: None)
+        monkeypatch.setattr(mesh_mod, "server_stop_by_name", lambda _n: None)
+        monkeypatch.setattr("culture.persistence.install_service", lambda *a, **kw: None)
+        monkeypatch.setattr("culture.persistence.restart_service", lambda _svc: True)
+        monkeypatch.setattr(mesh_mod, "_wait_for_server_port", lambda *a, **kw: False)
+
+        result = mesh_mod._restart_mesh_services(
+            mesh, "spark", "/usr/bin/culture", "/tmp/mesh.yaml", dry_run=False
+        )
+        assert result is False
+        assert "did not start" in capsys.readouterr().err
+
+    def test_happy_path_returns_true(self, monkeypatch, capsys):
+        mesh = _StubMesh(
+            server=_StubServerCfg(name="spark"),
+            agents=[_StubAgent(nick="ada")],
+        )
+        monkeypatch.setattr(mesh_mod, "stop_agent", lambda _n: None)
+        monkeypatch.setattr(mesh_mod, "server_stop_by_name", lambda _n: None)
+        monkeypatch.setattr("culture.persistence.install_service", lambda *a, **kw: None)
+        monkeypatch.setattr("culture.persistence.restart_service", lambda _svc: True)
+        monkeypatch.setattr(mesh_mod, "_wait_for_server_port", lambda *a, **kw: True)
+
+        result = mesh_mod._restart_mesh_services(
+            mesh, "spark", "/usr/bin/culture", "/tmp/mesh.yaml", dry_run=False
+        )
+        assert result is True
+        # `_restart_single_service` produces a "Restarting ..." line per service.
+        out = capsys.readouterr().out
+        assert "Restarting culture-server-spark" in out
+        assert "Restarting culture-agent-spark-ada" in out
+
+
+# ---------------------------------------------------------------------------
+# _resolve_mesh_for_server
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMeshForServer:
+    def test_returns_loaded_mesh_when_server_matches(self, monkeypatch):
+        mesh = _StubMesh(server=_StubServerCfg(name="spark"))
+        monkeypatch.setattr("culture.mesh_config.load_mesh_config", lambda _p: mesh)
+        result = mesh_mod._resolve_mesh_for_server("spark", "/tmp/mesh.yaml")
+        assert result is mesh
+
+    def test_returns_none_when_neither_path_matches(self, monkeypatch):
+        def _missing(_p):
+            raise FileNotFoundError
+
+        monkeypatch.setattr("culture.mesh_config.load_mesh_config", _missing)
+        # No DEFAULT_CONFIG file
+        monkeypatch.setattr(mesh_mod.os.path, "isfile", lambda _p: False)
+
+        assert mesh_mod._resolve_mesh_for_server("spark", "/tmp/mesh.yaml") is None
+
+    def test_rebuilds_from_default_config(self, monkeypatch):
+        def _missing(_p):
+            raise FileNotFoundError
+
+        monkeypatch.setattr("culture.mesh_config.load_mesh_config", _missing)
+        monkeypatch.setattr(mesh_mod.os.path, "isfile", lambda _p: True)
+        monkeypatch.setattr(
+            mesh_mod, "load_config", lambda _p: _StubFullConfig(server=_StubServerCfg(name="spark"))
+        )
+        rebuilt = _StubMesh(server=_StubServerCfg(name="spark"))
+        monkeypatch.setattr("culture.mesh_config.from_daemon_config", lambda dc: rebuilt)
+        monkeypatch.setattr("culture.mesh_config.merge_links", lambda *a, **kw: None)
+        saved = []
+        monkeypatch.setattr(
+            "culture.mesh_config.save_mesh_config",
+            lambda mesh, path: saved.append((mesh, path)),
+        )
+
+        result = mesh_mod._resolve_mesh_for_server("spark", "/tmp/mesh.yaml")
+
+        assert result is rebuilt
+        assert saved == [(rebuilt, "/tmp/mesh.yaml")]
+
+
+# ---------------------------------------------------------------------------
+# _restart_running_servers / _restart_from_config
+# ---------------------------------------------------------------------------
+
+
+class TestRestartRunningServers:
+    def test_warns_when_no_config_for_server(self, monkeypatch, capsys):
+        monkeypatch.setattr(mesh_mod, "_resolve_mesh_for_server", lambda *a: None)
+
+        result = mesh_mod._restart_running_servers(
+            running=[{"name": "ghost"}],
+            args=argparse.Namespace(config="/tmp/mesh.yaml", dry_run=True),
+            culture_bin="culture",
+        )
+
+        assert result == []
+        assert "no config found" in capsys.readouterr().err
+
+    def test_collects_failed_restarts(self, monkeypatch):
+        mesh = _StubMesh(server=_StubServerCfg(name="spark"))
+        monkeypatch.setattr(mesh_mod, "_resolve_mesh_for_server", lambda *a: mesh)
+        monkeypatch.setattr(mesh_mod, "_restart_mesh_services", lambda *a, **kw: False)
+
+        failed = mesh_mod._restart_running_servers(
+            running=[{"name": "spark"}],
+            args=argparse.Namespace(config="/tmp/mesh.yaml", dry_run=False),
+            culture_bin="culture",
+        )
+        assert failed == ["spark"]
+
+
+class TestRestartFromConfig:
+    def test_uses_loaded_mesh(self, monkeypatch):
+        mesh = _StubMesh(server=_StubServerCfg(name="spark"))
+        monkeypatch.setattr("culture.mesh_config.load_mesh_config", lambda _p: mesh)
+        called = []
+        monkeypatch.setattr(
+            mesh_mod, "_restart_mesh_services", lambda *a, **kw: called.append(a) or True
+        )
+
+        result = mesh_mod._restart_from_config(
+            argparse.Namespace(config="/tmp/mesh.yaml", dry_run=False), "culture"
+        )
+        assert result == []
+        assert called and called[0][1] == "spark"  # server_name in args
+
+    def test_falls_back_to_generated_mesh(self, monkeypatch):
+        def _missing(_p):
+            raise FileNotFoundError
+
+        monkeypatch.setattr("culture.mesh_config.load_mesh_config", _missing)
+        generated = _StubMesh(server=_StubServerCfg(name="spark"))
+        monkeypatch.setattr(mesh_mod, "generate_mesh_from_agents", lambda _p: generated)
+        monkeypatch.setattr(mesh_mod, "_restart_mesh_services", lambda *a, **kw: True)
+
+        result = mesh_mod._restart_from_config(
+            argparse.Namespace(config="/tmp/mesh.yaml", dry_run=False), "culture"
+        )
+        assert result == []
+
+    def test_exits_when_no_mesh_can_be_built(self, monkeypatch):
+        def _missing(_p):
+            raise FileNotFoundError
+
+        monkeypatch.setattr("culture.mesh_config.load_mesh_config", _missing)
+        monkeypatch.setattr(mesh_mod, "generate_mesh_from_agents", lambda _p: None)
+
+        with pytest.raises(SystemExit):
+            mesh_mod._restart_from_config(
+                argparse.Namespace(config="/tmp/mesh.yaml", dry_run=False), "culture"
+            )
+
+
+# ---------------------------------------------------------------------------
+# _cmd_update — orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestCmdUpdate:
+    def _args_update(self, **kwargs):
+        defaults = dict(
+            mesh_command="update",
+            skip_upgrade=True,  # Skip the upgrade path by default — tested separately.
+            dry_run=False,
+            upgrade_timeout=600,
+            config="~/.culture/mesh.yaml",
+        )
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_short_circuits_when_upgrade_returns_false(self, monkeypatch):
+        """Dry-run path: _upgrade_culture_package returns False → function returns."""
+        monkeypatch.setattr(mesh_mod, "_upgrade_culture_package", lambda _a: False)
+        # No further calls should happen — if they do, this would explode.
+        monkeypatch.setattr(
+            "culture.pidfile.list_servers",
+            lambda: pytest.fail("should not be called"),
+        )
+
+        mesh_mod._cmd_update(self._args_update())
+
+    def test_restarts_running_servers_when_present(self, monkeypatch, capsys):
+        monkeypatch.setattr(mesh_mod, "_upgrade_culture_package", lambda _a: True)
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+        monkeypatch.setattr("culture.pidfile.list_servers", lambda: [{"name": "spark"}])
+        called = []
+        monkeypatch.setattr(
+            mesh_mod,
+            "_restart_running_servers",
+            lambda running, args, culture_bin: called.append("running") or [],
+        )
+        monkeypatch.setattr(
+            mesh_mod,
+            "_restart_from_config",
+            lambda args, culture_bin: pytest.fail("should not be called"),
+        )
+
+        mesh_mod._cmd_update(self._args_update())
+
+        assert called == ["running"]
+        assert "Update complete" in capsys.readouterr().out
+
+    def test_falls_back_to_config_when_no_running_servers(self, monkeypatch):
+        monkeypatch.setattr(mesh_mod, "_upgrade_culture_package", lambda _a: True)
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+        monkeypatch.setattr("culture.pidfile.list_servers", lambda: [])
+        called = []
+        monkeypatch.setattr(
+            mesh_mod,
+            "_restart_from_config",
+            lambda args, culture_bin: called.append("config") or [],
+        )
+
+        mesh_mod._cmd_update(self._args_update())
+        assert called == ["config"]
+
+    def test_exits_with_error_on_failed_restart(self, monkeypatch, capsys):
+        monkeypatch.setattr(mesh_mod, "_upgrade_culture_package", lambda _a: True)
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+        monkeypatch.setattr("culture.pidfile.list_servers", lambda: [])
+        monkeypatch.setattr(mesh_mod, "_restart_from_config", lambda args, cb: ["spark"])
+
+        with pytest.raises(SystemExit) as exc:
+            mesh_mod._cmd_update(self._args_update())
+        assert exc.value.code == 1
+        assert "Failed to restart" in capsys.readouterr().err
+
+    def test_dry_run_announces_no_services_restarted(self, monkeypatch, capsys):
+        monkeypatch.setattr(mesh_mod, "_upgrade_culture_package", lambda _a: True)
+        monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/culture")
+        monkeypatch.setattr("culture.pidfile.list_servers", lambda: [])
+        monkeypatch.setattr(mesh_mod, "_restart_from_config", lambda *a: [])
+
+        mesh_mod._cmd_update(self._args_update(dry_run=True))
+        assert "Dry run complete" in capsys.readouterr().out

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -1,0 +1,763 @@
+"""Tests for `culture.cli.server` — `culture server {start,stop,status,default,rename,archive,unarchive}`.
+
+The pid-file and signal layer is covered by `tests/test_cli_shared_process.py`
+and `tests/test_pidfile.py`. These tests focus on dispatch, argument
+resolution, and the archive cascade. Integration-territory functions
+(`_run_server`, `_daemonize_server`, `_run_foreground`) are NOT exercised
+— they're covered by `tests/test_integration_irc_transport.py`.
+
+OS surface mocked at module boundary:
+
+- `culture.pidfile.{read_pid, write_pid, remove_pid, is_process_alive,
+  is_culture_process, read_default_server, write_default_server,
+  rename_pid, list_servers}` — patched on the `culture.cli.server` module
+  (where they're imported at module top).
+- `os.kill`, `time.sleep`, `socket.create_connection`.
+- `culture.config.{load_config_or_default, rename_manifest_server,
+  archive_manifest_server, unarchive_manifest_server, sanitize_agent_name}`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+from dataclasses import dataclass, field
+
+import pytest
+
+from culture.cli import server as srv_mod
+
+# ---------------------------------------------------------------------------
+# Stub config classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubAgent:
+    nick: str
+    archived: bool = False
+
+
+@dataclass
+class _StubServerCfg:
+    name: str = "spark"
+    host: str = "127.0.0.1"
+    port: int = 6667
+    archived: bool = False
+
+
+@dataclass
+class _StubConfig:
+    server: _StubServerCfg = field(default_factory=_StubServerCfg)
+    agents: list = field(default_factory=list)
+
+
+def _args(**kwargs) -> argparse.Namespace:
+    defaults = {"config": "~/.culture/server.yaml"}
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Shared monkeypatch fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(srv_mod.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture
+def pids(monkeypatch):
+    """Bookkeep pidfile + process-alive state. Defaults to "running culture process"."""
+    table: dict[str, int] = {}
+    alive: dict[int, list[bool]] = {}
+    culture_set: set = set()
+    removed: list[str] = []
+    written: list[tuple[str, int]] = []
+    default_server: dict[str, str | None] = {"current": None}
+
+    def _pop_alive(pid):
+        seq = alive.get(pid)
+        if not seq:
+            return True
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    # server.py imports read_pid, write_pid, remove_pid, is_process_alive,
+    # is_culture_process, read_default_server at module top — patch on srv_mod.
+    monkeypatch.setattr(srv_mod, "read_pid", lambda name: table.get(name))
+    monkeypatch.setattr(srv_mod, "write_pid", lambda name, pid: written.append((name, pid)))
+    monkeypatch.setattr(srv_mod, "remove_pid", lambda name: removed.append(name))
+    monkeypatch.setattr(srv_mod, "is_process_alive", _pop_alive)
+    monkeypatch.setattr(
+        srv_mod, "is_culture_process", lambda pid: pid in culture_set or not culture_set
+    )
+    monkeypatch.setattr(srv_mod, "read_default_server", lambda: default_server["current"])
+    # write_default_server and rename_pid are lazy-imported inside handlers —
+    # patch them at the source so the lazy imports pick up the mock.
+    monkeypatch.setattr(
+        "culture.pidfile.write_default_server",
+        lambda name: default_server.update(current=name),
+    )
+
+    class State:
+        def __init__(self):
+            self.table = table
+            self.alive = alive
+            self.culture_set = culture_set
+            self.removed = removed
+            self.written = written
+            self.default_server = default_server
+
+        def set_pid(self, name, pid, *, alive_seq=None, is_culture=True):
+            self.table[name] = pid
+            if alive_seq is not None:
+                self.alive[pid] = list(alive_seq)
+            if is_culture:
+                self.culture_set.add(pid)
+
+    return State()
+
+
+@pytest.fixture
+def fake_os_kill(monkeypatch):
+    calls = []
+    raises = {}
+
+    def _fake(pid, sig):
+        calls.append((pid, sig))
+        if (exc := raises.get(len(calls))) is not None:
+            raise exc()
+
+    monkeypatch.setattr(srv_mod.os, "kill", _fake)
+
+    class State:
+        def __init__(self):
+            self.calls = calls
+            self.raises = raises
+
+        def raise_on_call(self, n, exc):
+            self.raises[n] = exc
+
+    return State()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_server_name
+# ---------------------------------------------------------------------------
+
+
+class TestResolveServerName:
+    def test_explicit_name_wins(self, pids):
+        result = srv_mod._resolve_server_name(_args(name="thor"))
+        assert result == "thor"
+
+    def test_falls_back_to_default_server(self, pids):
+        pids.default_server["current"] = "thor"
+        assert srv_mod._resolve_server_name(_args(name=None)) == "thor"
+
+    def test_falls_back_to_hardcoded_default(self, pids):
+        # No default set
+        assert srv_mod._resolve_server_name(_args(name=None)) == "culture"
+
+
+# ---------------------------------------------------------------------------
+# _cmd_default
+# ---------------------------------------------------------------------------
+
+
+class TestCmdDefault:
+    def test_accepts_running_server(self, monkeypatch, pids, capsys, tmp_path):
+        monkeypatch.setattr("culture.pidfile.list_servers", lambda: [{"name": "spark"}])
+        monkeypatch.setattr("culture.pidfile.PID_DIR", str(tmp_path / "no-pids"))
+        # Configured server is also accepted; stub it.
+        monkeypatch.setattr(
+            "culture.config.load_config_or_default",
+            lambda _p: _StubConfig(),
+        )
+        # Patch write_default_server inside _cmd_default's import (lazy).
+        wrote = []
+        monkeypatch.setattr("culture.pidfile.write_default_server", lambda name: wrote.append(name))
+
+        srv_mod._cmd_default(argparse.Namespace(name="spark"))
+
+        assert wrote == ["spark"]
+        assert "Default server set to 'spark'" in capsys.readouterr().out
+
+    def test_rejects_unknown_server(self, monkeypatch, capsys, tmp_path):
+        monkeypatch.setattr("culture.pidfile.list_servers", lambda: [])
+        monkeypatch.setattr("culture.pidfile.PID_DIR", str(tmp_path))
+        # No configured server name
+        monkeypatch.setattr(
+            "culture.config.load_config_or_default",
+            lambda _p: (_ for _ in ()).throw(OSError()),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._cmd_default(argparse.Namespace(name="ghost"))
+        assert exc.value.code == 1
+        assert "not found" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_no_verb_exits(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            srv_mod.dispatch(_args(server_command=None))
+        assert exc.value.code == 1
+        assert "Usage: culture server" in capsys.readouterr().err
+
+    def test_unknown_verb_exits(self, monkeypatch, capsys, pids):
+        with pytest.raises(SystemExit) as exc:
+            srv_mod.dispatch(_args(server_command="frobnicate", name="spark"))
+        assert exc.value.code == 1
+        assert "Unknown server command" in capsys.readouterr().err
+
+    def test_forwarded_verb_calls_agentirc(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            "agentirc.cli.dispatch",
+            lambda argv: calls.append(argv) or 0,
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            srv_mod.dispatch(_args(server_command="logs", argv=["--tail", "10"]))
+
+        assert exc.value.code == 0
+        assert calls == [["logs", "--tail", "10"]]
+
+    def test_routes_to_status_handler(self, monkeypatch, pids):
+        called = []
+        monkeypatch.setattr(srv_mod, "_server_status", called.append)
+        srv_mod.dispatch(_args(server_command="status", name="spark"))
+        assert len(called) == 1
+
+    def test_default_verb_skips_name_resolution(self, monkeypatch):
+        """`default` verb has a positional `name`, not `--name` — skip _resolve_server_name."""
+        called = []
+        monkeypatch.setattr(srv_mod, "_cmd_default", called.append)
+        srv_mod.dispatch(argparse.Namespace(server_command="default", name="thor"))
+        assert called and called[0].name == "thor"
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_port
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForPort:
+    def test_returns_true_on_first_connect(self, monkeypatch, pids):
+        # Process is alive
+        pids.alive[1234] = [True]
+
+        class _Sock:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(srv_mod.socket, "create_connection", lambda *a, **kw: _Sock())
+
+        ok, msg = srv_mod._wait_for_port("127.0.0.1", 6667, pid=1234, timeout=1)
+        assert ok is True
+        assert msg == ""
+
+    def test_returns_false_when_pid_dies(self, monkeypatch, pids):
+        pids.alive[1234] = [False]
+        # Patch is_process_alive on the module so the loop sees the pid as dead.
+        ok, msg = srv_mod._wait_for_port("127.0.0.1", 6667, pid=1234, timeout=1)
+        assert ok is False
+        assert "failed to start" in msg
+
+    def test_returns_false_on_timeout(self, monkeypatch, pids):
+        pids.alive[1234] = [True]
+
+        def _refuse(*a, **kw):
+            raise OSError("refused")
+
+        monkeypatch.setattr(srv_mod.socket, "create_connection", _refuse)
+        # Push time forward fast: monotonic returns increasing values past the deadline.
+        times = iter([0, 0.5, 1, 1.5, 2, 2.5])
+        monkeypatch.setattr(srv_mod.time, "monotonic", lambda: next(times, 5))
+
+        ok, msg = srv_mod._wait_for_port("127.0.0.1", 6667, pid=1234, timeout=1)
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# _maybe_set_default_server
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeSetDefaultServer:
+    def test_writes_when_no_default(self, monkeypatch):
+        wrote = []
+        monkeypatch.setattr("culture.pidfile.read_default_server", lambda: None)
+        monkeypatch.setattr("culture.pidfile.write_default_server", lambda name: wrote.append(name))
+
+        srv_mod._maybe_set_default_server("spark")
+        assert wrote == ["spark"]
+
+    def test_does_not_overwrite_existing(self, monkeypatch):
+        wrote = []
+        monkeypatch.setattr("culture.pidfile.read_default_server", lambda: "thor")
+        monkeypatch.setattr("culture.pidfile.write_default_server", lambda name: wrote.append(name))
+
+        srv_mod._maybe_set_default_server("spark")
+        assert wrote == []
+
+
+# ---------------------------------------------------------------------------
+# _check_server_archived
+# ---------------------------------------------------------------------------
+
+
+class TestCheckServerArchived:
+    def test_exits_when_archived(self, monkeypatch, capsys):
+        cfg = _StubConfig(server=_StubServerCfg(name="spark", archived=True))
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._check_server_archived(_args(name="spark"))
+        assert exc.value.code == 1
+        assert "is archived" in capsys.readouterr().err
+
+    def test_passes_when_not_archived(self, monkeypatch):
+        cfg = _StubConfig(server=_StubServerCfg(name="spark", archived=False))
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+        srv_mod._check_server_archived(_args(name="spark"))  # no raise
+
+    def test_passes_when_name_mismatches(self, monkeypatch):
+        """Mismatched name → check doesn't apply, just returns."""
+        cfg = _StubConfig(server=_StubServerCfg(name="other", archived=True))
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+        srv_mod._check_server_archived(_args(name="spark"))  # no raise
+
+
+# ---------------------------------------------------------------------------
+# _check_already_running
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAlreadyRunning:
+    def test_exits_when_running(self, pids, capsys):
+        pids.set_pid("server-spark", 4242, alive_seq=[True])
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._check_already_running("server-spark", "spark")
+        assert exc.value.code == 1
+        assert "already running" in capsys.readouterr().out
+
+    def test_passes_when_pid_missing(self, pids):
+        srv_mod._check_already_running("server-spark", "spark")  # no raise
+
+    def test_passes_when_pid_stale(self, pids):
+        pids.set_pid("server-spark", 4242, alive_seq=[False])
+        srv_mod._check_already_running("server-spark", "spark")  # no raise
+
+
+# ---------------------------------------------------------------------------
+# _resolve_server_links
+# ---------------------------------------------------------------------------
+
+
+class TestResolveServerLinks:
+    def test_uses_cli_links_by_default(self):
+        link = object()
+        result = srv_mod._resolve_server_links(_args(link=[link], mesh_config=None))
+        assert result == [link]
+
+    def test_resolves_from_mesh_config_when_given(self, monkeypatch):
+        resolved = [object(), object()]
+        monkeypatch.setattr(srv_mod, "resolve_links_from_mesh", lambda path: resolved)
+        result = srv_mod._resolve_server_links(_args(link=[], mesh_config="/tmp/mesh.yaml"))
+        assert result == resolved
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_graceful_stop
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForGracefulStop:
+    def test_returns_true_when_process_exits(self, pids):
+        pids.alive[1234] = [True, True, False]
+        assert srv_mod._wait_for_graceful_stop(1234, timeout_ticks=5) is True
+
+    def test_returns_false_when_polls_exhausted(self, pids):
+        pids.alive[1234] = [True]  # always alive
+        assert srv_mod._wait_for_graceful_stop(1234, timeout_ticks=3) is False
+
+
+# ---------------------------------------------------------------------------
+# _force_kill
+# ---------------------------------------------------------------------------
+
+
+class TestForceKill:
+    def test_posix_sends_sigkill(self, monkeypatch, fake_os_kill, capsys):
+        monkeypatch.setattr(srv_mod.sys, "platform", "linux")
+        srv_mod._force_kill(1234, "spark")
+        assert fake_os_kill.calls == [(1234, signal.SIGKILL)]
+        assert "sending SIGKILL" in capsys.readouterr().out
+
+    def test_win32_sends_sigterm(self, monkeypatch, fake_os_kill, capsys):
+        monkeypatch.setattr(srv_mod.sys, "platform", "win32")
+        srv_mod._force_kill(1234, "spark")
+        assert fake_os_kill.calls == [(1234, signal.SIGTERM)]
+        assert "terminating" in capsys.readouterr().out
+
+    def test_swallows_process_lookup_error(self, monkeypatch, fake_os_kill):
+        monkeypatch.setattr(srv_mod.sys, "platform", "linux")
+        fake_os_kill.raise_on_call(1, ProcessLookupError)
+        # No exception escapes
+        srv_mod._force_kill(1234, "spark")
+
+
+# ---------------------------------------------------------------------------
+# _server_stop
+# ---------------------------------------------------------------------------
+
+
+class TestServerStop:
+    def test_exits_when_no_pidfile(self, pids, capsys):
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._server_stop(_args(name="spark"))
+        assert exc.value.code == 1
+        assert "No PID file" in capsys.readouterr().out
+
+    def test_removes_stale_pid(self, pids, capsys):
+        pids.set_pid("server-spark", 4242, alive_seq=[False])
+        srv_mod._server_stop(_args(name="spark"))
+        assert "server-spark" in pids.removed
+        assert "stale PID" in capsys.readouterr().out
+
+    def test_removes_non_culture_pid(self, pids, capsys):
+        # alive but not in culture_set → fallback predicate is_culture_process
+        # returns True when set is empty; force the empty-set guard off by
+        # adding a dummy other pid.
+        pids.culture_set.add(9999)
+        pids.set_pid("server-spark", 4242, alive_seq=[True], is_culture=False)
+        srv_mod._server_stop(_args(name="spark"))
+        assert "server-spark" in pids.removed
+        assert "not a culture process" in capsys.readouterr().out
+
+    def test_sigterm_success(self, monkeypatch, pids, fake_os_kill, capsys):
+        pids.set_pid("server-spark", 4242, alive_seq=[True, False])
+        monkeypatch.setattr(srv_mod.sys, "platform", "linux")
+
+        srv_mod._server_stop(_args(name="spark"))
+
+        assert fake_os_kill.calls == [(4242, signal.SIGTERM)]
+        assert "server-spark" in pids.removed
+        assert "stopped" in capsys.readouterr().out
+
+    def test_sigkill_escalation(self, monkeypatch, pids, fake_os_kill, capsys):
+        pids.set_pid("server-spark", 4242, alive_seq=[True])  # never dies
+        monkeypatch.setattr(srv_mod.sys, "platform", "linux")
+
+        srv_mod._server_stop(_args(name="spark"))
+
+        assert fake_os_kill.calls == [
+            (4242, signal.SIGTERM),
+            (4242, signal.SIGKILL),
+        ]
+        assert "killed" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _server_status
+# ---------------------------------------------------------------------------
+
+
+class TestServerStatus:
+    def test_no_pidfile(self, pids, capsys):
+        srv_mod._server_status(_args(name="spark"))
+        assert "not running (no PID file)" in capsys.readouterr().out
+
+    def test_running(self, pids, capsys):
+        pids.set_pid("server-spark", 4242, alive_seq=[True])
+        srv_mod._server_status(_args(name="spark"))
+        assert "running (PID 4242)" in capsys.readouterr().out
+
+    def test_stale_pid_removed(self, pids, capsys):
+        pids.set_pid("server-spark", 4242, alive_seq=[False])
+        srv_mod._server_status(_args(name="spark"))
+        assert "stale PID" in capsys.readouterr().out
+        assert "server-spark" in pids.removed
+
+
+# ---------------------------------------------------------------------------
+# _validate_config_name
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigName:
+    def test_match_returns_name(self):
+        cfg = _StubConfig(server=_StubServerCfg(name="spark"))
+        assert srv_mod._validate_config_name(cfg, "spark") == "spark"
+
+    def test_mismatch_exits(self, capsys):
+        cfg = _StubConfig(server=_StubServerCfg(name="other"))
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._validate_config_name(cfg, "spark")
+        assert exc.value.code == 1
+        assert "name mismatch" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _update_single_bot_archive
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSingleBotArchive:
+    def _bot(self, **overrides):
+        from culture.bots.config import BotConfig
+
+        return BotConfig(**overrides)
+
+    def test_archives_active_bot(self, monkeypatch):
+        saved = []
+        monkeypatch.setattr(
+            "culture.bots.config.save_bot_config",
+            lambda path, cfg: saved.append((path, cfg.archived, cfg.archived_reason)),
+        )
+        bot = self._bot(name="b", archived=False)
+
+        result = srv_mod._update_single_bot_archive(
+            "/tmp/bot.yaml", bot, archive=True, reason="superseded", today="2026-05-13"
+        )
+
+        assert result == "b"
+        assert saved == [("/tmp/bot.yaml", True, "superseded")]
+
+    def test_unarchives_archived_bot(self, monkeypatch):
+        monkeypatch.setattr("culture.bots.config.save_bot_config", lambda *a: None)
+        bot = self._bot(name="b", archived=True, archived_reason="old")
+
+        result = srv_mod._update_single_bot_archive(
+            "/tmp/bot.yaml", bot, archive=False, reason="", today="2026-05-13"
+        )
+
+        assert result == "b"
+        assert bot.archived is False
+        assert bot.archived_reason == ""
+
+    def test_noop_when_already_in_target_state(self, monkeypatch):
+        monkeypatch.setattr(
+            "culture.bots.config.save_bot_config",
+            lambda *a: pytest.fail("should not save"),
+        )
+        bot = self._bot(name="b", archived=True)
+
+        # Already archived; archive=True is a no-op.
+        assert (
+            srv_mod._update_single_bot_archive(
+                "/tmp/bot.yaml", bot, archive=True, reason="", today="2026-05-13"
+            )
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# _set_bots_archive_state
+# ---------------------------------------------------------------------------
+
+
+class TestSetBotsArchiveState:
+    def test_returns_empty_when_bots_dir_missing(self, monkeypatch, tmp_path):
+        ghost = tmp_path / "no-such"
+        monkeypatch.setattr("culture.bots.config.BOTS_DIR", ghost)
+        assert srv_mod._set_bots_archive_state({"spark-ada"}, archive=True) == []
+
+    def test_cascades_to_matching_bots(self, monkeypatch, tmp_path):
+        from culture.bots.config import BotConfig, save_bot_config
+
+        bots = tmp_path / "bots"
+        bots.mkdir()
+        # Owned by spark-ada → should be archived
+        cfg_ada = BotConfig(name="spark-ada-watch", owner="spark-ada")
+        (bots / "spark-ada-watch").mkdir()
+        save_bot_config(bots / "spark-ada-watch" / "bot.yaml", cfg_ada)
+        # Owned by someone else → should be skipped
+        cfg_other = BotConfig(name="spark-bob-watch", owner="spark-bob")
+        (bots / "spark-bob-watch").mkdir()
+        save_bot_config(bots / "spark-bob-watch" / "bot.yaml", cfg_other)
+
+        monkeypatch.setattr("culture.bots.config.BOTS_DIR", bots)
+
+        changed = srv_mod._set_bots_archive_state({"spark-ada"}, archive=True, reason="cleanup")
+
+        assert changed == ["spark-ada-watch"]
+
+
+# ---------------------------------------------------------------------------
+# _server_archive / _server_unarchive (orchestrators)
+# ---------------------------------------------------------------------------
+
+
+class TestServerArchive:
+    def test_already_archived_returns_silently(self, monkeypatch, capsys):
+        cfg = _StubConfig(server=_StubServerCfg(name="spark", archived=True))
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+        srv_mod._server_archive(_args(name="spark", reason=""))
+        assert "already archived" in capsys.readouterr().out
+
+    def test_archives_server_and_cascades(self, monkeypatch, pids, capsys):
+        cfg = _StubConfig(
+            server=_StubServerCfg(name="spark", archived=False),
+            agents=[_StubAgent(nick="spark-ada"), _StubAgent(nick="spark-bob")],
+        )
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+        monkeypatch.setattr(
+            "culture.config.archive_manifest_server",
+            lambda path, reason="": ["spark-ada", "spark-bob"],
+        )
+        # No running pid for the server
+        monkeypatch.setattr(srv_mod, "_set_bots_archive_state", lambda *a, **kw: ["bot1"])
+        # stop_agent shim — agent.archive cascade
+        stopped = []
+        monkeypatch.setattr("culture.cli.shared.process.stop_agent", stopped.append)
+
+        srv_mod._server_archive(_args(name="spark", reason="cleanup"))
+
+        out = capsys.readouterr().out
+        assert "Server archived: spark" in out
+        assert "Agents: spark-ada, spark-bob" in out
+        assert "Bots:   bot1" in out
+        assert "cleanup" in out
+
+
+class TestServerUnarchive:
+    def test_not_archived_exits(self, monkeypatch, capsys):
+        cfg = _StubConfig(server=_StubServerCfg(name="spark", archived=False))
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._server_unarchive(_args(name="spark"))
+        assert exc.value.code == 1
+        assert "is not archived" in capsys.readouterr().err
+
+    def test_unarchives_server_and_cascades(self, monkeypatch, capsys):
+        cfg = _StubConfig(
+            server=_StubServerCfg(name="spark", archived=True),
+            agents=[_StubAgent(nick="spark-ada")],
+        )
+        monkeypatch.setattr("culture.config.load_config_or_default", lambda _p: cfg)
+        monkeypatch.setattr("culture.config.unarchive_manifest_server", lambda path: ["spark-ada"])
+        monkeypatch.setattr(srv_mod, "_set_bots_archive_state", lambda *a, **kw: ["bot1"])
+
+        srv_mod._server_unarchive(_args(name="spark"))
+
+        out = capsys.readouterr().out
+        assert "Server unarchived: spark" in out
+        assert "Agents: spark-ada" in out
+        assert "Bots:   bot1" in out
+
+
+# ---------------------------------------------------------------------------
+# _server_rename
+# ---------------------------------------------------------------------------
+
+
+class TestServerRename:
+    def _setup(self, monkeypatch, *, sanitize_raises=False, rename_raises=None, rename_result=None):
+        if sanitize_raises:
+            monkeypatch.setattr(
+                "culture.config.sanitize_agent_name",
+                lambda n: (_ for _ in ()).throw(ValueError("bad name")),
+            )
+        else:
+            monkeypatch.setattr("culture.config.sanitize_agent_name", lambda n: n)
+        if rename_raises is not None:
+            monkeypatch.setattr(
+                "culture.config.rename_manifest_server",
+                lambda *a, **kw: (_ for _ in ()).throw(rename_raises),
+            )
+        else:
+            monkeypatch.setattr(
+                "culture.config.rename_manifest_server",
+                lambda *a, **kw: rename_result or ("old", []),
+            )
+
+    def test_invalid_name_exits(self, monkeypatch, capsys):
+        self._setup(monkeypatch, sanitize_raises=True)
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._server_rename(_args(new_name="bad name!", config="~/.culture/server.yaml"))
+        assert exc.value.code == 1
+        assert "Invalid server name" in capsys.readouterr().err
+
+    def test_rename_manifest_error_exits(self, monkeypatch, capsys):
+        self._setup(monkeypatch, rename_raises=ValueError("server not found"))
+        with pytest.raises(SystemExit) as exc:
+            srv_mod._server_rename(_args(new_name="thor", config="~/.culture/server.yaml"))
+        assert exc.value.code == 1
+        assert "server not found" in capsys.readouterr().err
+
+    def test_same_name_returns_silently(self, monkeypatch, capsys):
+        self._setup(monkeypatch, rename_result=("thor", []))
+        srv_mod._server_rename(_args(new_name="thor", config="~/.culture/server.yaml"))
+        assert "already named 'thor'" in capsys.readouterr().out
+
+    def test_renames_pid_and_agents(self, monkeypatch, capsys):
+        self._setup(
+            monkeypatch,
+            rename_result=("spark", [("spark-ada", "thor-ada")]),
+        )
+        pid_renames = []
+        monkeypatch.setattr(
+            "culture.pidfile.rename_pid", lambda old, new: pid_renames.append((old, new))
+        )
+        monkeypatch.setattr("culture.pidfile.read_default_server", lambda: "spark")
+        wrote_default = []
+        monkeypatch.setattr("culture.pidfile.write_default_server", wrote_default.append)
+        monkeypatch.setattr("culture.pidfile.read_pid", lambda _n: None)
+        monkeypatch.setattr("culture.pidfile.is_process_alive", lambda _p: False)
+
+        srv_mod._server_rename(_args(new_name="thor", config="~/.culture/server.yaml"))
+
+        assert ("server-spark", "server-thor") in pid_renames
+        assert ("agent-spark-ada", "agent-thor-ada") in pid_renames
+        assert wrote_default == ["thor"]
+        out = capsys.readouterr().out
+        assert "Server renamed: spark → thor" in out
+
+    def test_warns_when_server_still_running(self, monkeypatch, capsys):
+        self._setup(monkeypatch, rename_result=("spark", []))
+        monkeypatch.setattr("culture.pidfile.rename_pid", lambda old, new: None)
+        monkeypatch.setattr("culture.pidfile.read_default_server", lambda: None)
+        monkeypatch.setattr("culture.pidfile.read_pid", lambda _n: 4242)
+        monkeypatch.setattr("culture.pidfile.is_process_alive", lambda _p: True)
+
+        srv_mod._server_rename(_args(new_name="thor", config="~/.culture/server.yaml"))
+
+        out = capsys.readouterr().out
+        assert "still running under the old name" in out
+
+
+# ---------------------------------------------------------------------------
+# _server_start (skip _run_foreground / _daemonize_server)
+# ---------------------------------------------------------------------------
+
+
+class TestServerStart:
+    def test_routes_to_foreground_branch(self, monkeypatch, pids):
+        monkeypatch.setattr(srv_mod, "_check_server_archived", lambda _a: None)
+        monkeypatch.setattr(srv_mod, "_resolve_server_links", lambda _a: [])
+        called = []
+        monkeypatch.setattr(srv_mod, "_run_foreground", lambda *a, **kw: called.append("fg"))
+        monkeypatch.setattr(srv_mod, "_daemonize_server", lambda *a, **kw: called.append("daemon"))
+
+        srv_mod._server_start(_args(name="spark", foreground=True))
+        assert called == ["fg"]
+
+    def test_routes_to_daemonize_when_not_foreground(self, monkeypatch, pids):
+        monkeypatch.setattr(srv_mod, "_check_server_archived", lambda _a: None)
+        monkeypatch.setattr(srv_mod, "_resolve_server_links", lambda _a: [])
+        called = []
+        monkeypatch.setattr(srv_mod, "_run_foreground", lambda *a, **kw: called.append("fg"))
+        monkeypatch.setattr(srv_mod, "_daemonize_server", lambda *a, **kw: called.append("daemon"))
+
+        srv_mod._server_start(_args(name="spark", foreground=False))
+        assert called == ["daemon"]

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.0.4"
+version = "12.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 3b of the **60 → 90 coverage ratchet** ([plan](/home/spark/.claude/plans/we-re-at-60-coverage-refactored-lark.md)). Two more CLI files brought to high coverage; project-wide floor raised **67 → 73**. Measured post-Phase-3b: **73.40%** (+5.5pp from Phase 3a).

| File | Before | After |
|---|---|---|
| `culture/cli/mesh.py`   | 53% | **99.3%** |
| `culture/cli/server.py` | 21% | **76%**   |

### `tests/test_cli_mesh.py` (54 tests)

Every dispatched handler (`_cmd_overview`, `_cmd_setup`, `_cmd_update`, `_cmd_console`) plus every reachable helper: `_collect_mesh_data` exit paths, `_find_upgrade_tool`, `_upgrade_timeout_hint`, `_run_upgrade` (timeout + non-zero-exit), `_upgrade_culture_package` (skip / dry-run / no-tool / exec-reach), `_wait_for_server_port`, `_restart_single_service`, `_restart_mesh_services`, `_resolve_mesh_for_server`, `_restart_running_servers`, `_restart_from_config`. `_install_mesh_services` is excluded (systemd; Linux + root only); the `os.execvp` re-exec body is excluded as an end-of-life branch.

### `tests/test_cli_server.py` (54 tests)

`_resolve_server_name`, `_cmd_default`, `dispatch` (no verb / unknown / agentirc-forwarded passthrough / culture-verb routing), `_wait_for_port`, `_maybe_set_default_server`, `_check_server_archived`, `_check_already_running`, `_resolve_server_links`, `_wait_for_graceful_stop`, `_force_kill` (POSIX SIGKILL + win32 SIGTERM + `ProcessLookupError` swallow), `_server_stop`, `_server_status`, `_validate_config_name`, `_update_single_bot_archive`, `_set_bots_archive_state`, `_server_archive`, `_server_unarchive`, `_server_rename` (every branch), `_server_start` (foreground / daemonize routing).

The 96 missing lines on `cli/server.py` are concentrated in three **deliberately-skipped** integration-territory functions:
- `_run_foreground` (blocking server loop)
- `_daemonize_server` (fork + child arm)
- `_run_server` (async IRCd embedding)

These three are exercised by `tests/test_integration_irc_transport.py` against a real `agentirc.ircd.IRCd` — covering them with mocks would just duplicate the integration test.

### Phase 3 split

Phase 3 ended up three PRs instead of one (3a + 3b + 3c) because lumping `cli/agent.py` (1,123 LOC) in with mesh + server would have been ~220 tests in one PR. Splitting keeps each PR reviewable; Phase 3c targets `cli/agent.py` alone.

## Test plan

- [x] `uv run pytest tests/test_cli_mesh.py tests/test_cli_server.py -v` — all 108 tests pass
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -c` — full suite green, TOTAL 73.40%, above `fail_under = 73`
- [x] `culture/cli/mesh.py` reports 99.3% in `coverage report`
- [x] `culture/cli/server.py` reports 76% in `coverage report` (integration-territory functions deliberately skipped)
- [x] pre-commit (black, isort, flake8, pylint, bandit, markdownlint) clean
- [ ] CI green (pytest, SonarCloud quality gate, version-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- culture (Claude)