### PR TITLE
test(coverage): Phase 4b — observer + collector + bots/* [v12.0.9]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.0.10] - 2026-05-13
+
+### Fixed
+
+- test_start_creates_http_listener now uses the real HttpListener against an OS-assigned port and probes /health to confirm the bind (Qodo)
+- test_start_swallows_listener_oserror retains the OSError-raising patch (forced because OSError cannot be deterministically reproduced on a real listener) but applies it at the HttpListener.start method seam instead of swapping the entire class
+
 ## [12.0.9] - 2026-05-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.0.9] - 2026-05-13
+
+### Added
+
+- `tests/test_observer.py` — 28 tests for `IRCObserver` query cycle, parsers, and public API (`read_channel` / `who` / `send_message` / `list_channels`) against the real `server` fixture
+- Phase 4b coverage additions in `tests/test_overview_collector.py` (23 tests for `_query_roommeta`, `_query_tags`, `_enrich_via_ipc`, `_inject_stopped_agents`, `_handle_registration_line`, `_recv_until`)
+- Phase 4b coverage additions in `tests/test_bot.py` (21 tests for `_DynamicEventType`, `_check_rate`, `_render_data_values`, `_maybe_fire_event`, `_run_custom_handler`, `_deliver`, `_resolve_channels`)
+- Phase 4b coverage additions in `tests/test_bot_manager.py` (24 tests for start/stop lifecycle, `load_bots` edge paths, `register_bot` filter error, `_try_start_bot`, `_matches_event`, `_dispatch_to_bot`, `load_system_bots`)
+
+### Changed
+
+- test coverage floor raised from 79 to 83 (Phase 4b ratchet, measured 83.93%)
+
 ## [12.0.8] - 2026-05-13
 
 ### Fixed

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -111,6 +111,15 @@ Notable findings (deferred to later phases):
 
 Note: this PR landed 0.3pp short of the original 80% target. The gap is absorbed by the existing Phase 7 sweep.
 
+### Phase 4b — `observer.py` + `overview/collector.py` + `bots/*` (2026-05-13)
+
+**Measured: 83.93%** (6260 statements, 1006 missing) → `fail_under = 83`. The four IRCd-integrated modules picked up substantial coverage; the project floor jumps 4pp in a single PR and hits the original Phase 4b target (83) exactly, while soaking up most of the Phase 4a 0.3pp shortfall as a side effect:
+
+- `culture/observer.py` — 28% → **92%** (183 statements, 14 missing). New `tests/test_observer.py` (28 tests) covers the pure parsers (`_parse_history_line` / `_parse_who_line` / `_parse_list_line` table-driven), the registration/query state machines (`_process_registration_line`, `_process_query_line`, `_drain_query_buffer` exercised with a `_RecordingWriter` + canned bytes), and the full public API (`list_channels` / `who` / `read_channel` / `send_message`) round-tripped against the real `server` fixture. The CRLF-in-target injection test pins the strip behavior — the smuggled `JOIN` collapses into the channel name rather than starting a second protocol line. The remaining 14 missing lines are the `_disconnect` writer-close swallow paths and a recv-empty-line fall-through that fires only on socket close.
+- `culture/overview/collector.py` — 71% → **98%** (255 statements, 6 missing). 23 new tests appended to `tests/test_overview_collector.py` covering `_inject_stopped_agents` (manifest archived skip + already-present pass-through + non-list channels fallback), `_handle_registration_line` (PING / 001 / 433-retry / unknown), `_recv_until` (stop-command termination + PING absorption + blank-line skip + timeout), `_query_roommeta` (every key parsed: `room_id` / `owner` / `purpose` / `tags` CSV / `persistent` truthy + ERR_UNKNOWNCOMMAND short-circuit), `_query_tags` (parsed list + ERR_NOSUCHNICK empty), `_collect_bots` (missing dir / missing yaml / malformed yaml swallow), and `_enrich_via_ipc` against a real tmp_path Unix socket — happy status, `circuit_open` / `paused` status flips, stranger-socket skip, foreign-server skip, malformed-not-a-socket connection-refused swallow, and `ok: False` response no-mutation. End-to-end `collect_mesh_state` injects stopped manifest agents.
+- `culture/bots/bot.py` — 62% → **98%** (155 statements, 3 missing). 21 new tests appended to `tests/test_bot.py` covering `_DynamicEventType.__str__`, `_check_rate` (burst + release-after-window with pinned `time.monotonic`), `_render_data_values` (templated strings + non-string passthrough + sandbox-rejected dunder fall-through), `start()` idempotency, `handle()` empty-message short-circuit, `_resolve_channels` (dynamic-from-event + empty fallback + non-dict ctx), `_deliver` re-join branch when the channel was dropped, the full `_maybe_fire_event` matrix (happy enum-typed emit / dynamic-typed emit / no-spec early-return / invalid type regex skip / rate-limited skip / emit-raises log-and-swallow), and `_run_custom_handler` against a real `importlib.util` load (handler-on-disk happy / no `handle()` fallback / handler raises fallback / handler returns `None` → empty). The 3 missing lines are inside the `relative_to`-fails security guard that can't be reached without forging an out-of-tree path.
+- `culture/bots/bot_manager.py` — 65% → **99%** (175 statements, 1 missing). 24 new tests appended to `tests/test_bot_manager.py` covering `start()` listener wiring + crash-safe teardown when `load_bots` raises + `OSError` listener-bind swallow, `stop()` exception-tolerant listener teardown, `load_bots` (missing dir / dir-without-yaml / archived skip / invalid filter / malformed yaml exception swallow), `register_bot` filter compile-error raise, `_try_start_bot` (mid-start re-entrancy guard + start-fails log-and-return-false), `_matches_event` (non-event triggers / no compiled filter / evaluate raises), `_dispatch_to_bot` (try-start-fails short-circuit + handle-raises span error), `on_event` event matching, `start_bot` load-from-disk fallback + unknown-name raise, `stop_all` per-bot exception swallow, and `load_system_bots` (collision skip + register raises + server-config forwarding). The one remaining missing line is a single guard branch inside `_dispatch_to_bot`'s span context.
+
 ### Phase target table
 
 | Phase | Floor | Measured | PR | Status |
@@ -120,8 +129,8 @@ Note: this PR landed 0.3pp short of the original 80% target. The gap is absorbed
 | 3a | 67 | 67.89% | [#385](https://github.com/agentculture/culture/pull/385) | ✅ merged |
 | 3b | 73 | 73.40% | [#386](https://github.com/agentculture/culture/pull/386) | ✅ merged |
 | 3c | 77 | 77.30% | [#387](https://github.com/agentculture/culture/pull/387) | ✅ merged |
-| 4a | 79 | 79.68% | (this PR) | in flight |
-| 4b | 83 | — | `observer.py`, `overview/collector.py`, `bots/*` | pending |
+| 4a | 79 | 79.68% | [#388](https://github.com/agentculture/culture/pull/388) | ✅ merged |
+| 4b | 83 | 83.93% | (this PR) | in flight |
 | 5 | 86 | — | `transport/client.py` (or its deletion) | pending |
 | 6 | 89 | — | Long tail | pending |
 | 7 | 90 | — | Final sweep | pending |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.0.8"
+version = "12.0.9"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -93,12 +93,14 @@ omit = [
 
 [tool.coverage.report]
 # Ratchet floor — see docs/coverage-baseline.md for the per-phase log.
-# Phase 4a (2026-05-13): added tests for culture/persistence.py (now 98%),
-# culture/config.py (now 90%), culture/telemetry/audit.py (now 92%).
-# Project-wide measured: 79.68%. Floor = floor(measured); 0.3pp short of
-# the original Phase 4a target of 80. Phase 4b targets the IRCd-integrated
-# modules (observer.py, overview/collector.py, bots/*).
-fail_under = 79
+# Phase 4b (2026-05-13): added tests for culture/observer.py (now 92%),
+# culture/overview/collector.py (now 98%), culture/bots/bot.py (now 98%),
+# culture/bots/bot_manager.py (now 99%). Project-wide measured: 83.93%
+# (rounds to 84 with cov-report's two-decimal rounding; floor uses the
+# unrounded floor(measured)). Phase 5 targets culture/transport/client.py
+# (currently 25%, largely dead post-cultureagent-extraction — re-evaluate
+# backfill vs. deletion).
+fail_under = 83
 show_missing = true
 exclude_lines = [
     "pragma: no cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.0.9"
+version = "12.0.10"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,9 +1,14 @@
 """Tests for the Bot entity."""
 
+import asyncio
+import sys
+import time
+
 import pytest
 
-from culture.bots.bot import Bot
-from culture.bots.config import BotConfig
+from culture.bots import bot as bot_mod
+from culture.bots.bot import Bot, _check_rate, _DynamicEventType, _render_data_values
+from culture.bots.config import BotConfig, EmitEventSpec
 
 
 @pytest.fixture
@@ -171,4 +176,396 @@ async def test_bot_no_template_uses_json(server, make_client):
 
     result = await bot.handle({"raw": "data"})
     assert '"raw"' in result
+    await bot.stop()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4b additions — dynamic event type, rate limiter, render helper,
+# custom-handler.py loader, _maybe_fire_event, _deliver edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_event_type_str_returns_value():
+    ev = _DynamicEventType("custom.event")
+    assert str(ev) == "custom.event"
+    assert ev.value == "custom.event"
+
+
+def test_check_rate_allows_first_burst_then_blocks(monkeypatch):
+    # Use a fresh module-level dict by patching the state.
+    fresh: dict[str, list[float]] = {}
+    monkeypatch.setattr(bot_mod, "_rate_state", fresh)
+
+    # Pin time to a fixed value.
+    monkeypatch.setattr(bot_mod.time, "monotonic", lambda: 100.0)
+    # _RATE_MAX_PER_SEC is 10; the 11th call within 1s is rate-limited.
+    for _ in range(bot_mod._RATE_MAX_PER_SEC):
+        assert _check_rate("ratebot") is True
+    assert _check_rate("ratebot") is False
+
+
+def test_check_rate_releases_after_window(monkeypatch):
+    fresh: dict[str, list[float]] = {}
+    monkeypatch.setattr(bot_mod, "_rate_state", fresh)
+
+    times = iter([100.0] * 10 + [102.0])  # 11th call after window expires
+    monkeypatch.setattr(bot_mod.time, "monotonic", lambda: next(times))
+
+    for _ in range(bot_mod._RATE_MAX_PER_SEC):
+        assert _check_rate("releasebot") is True
+    # 2 seconds later → window is empty, 11th call allowed.
+    assert _check_rate("releasebot") is True
+
+
+def test_render_data_values_handles_strings_and_non_strings():
+    rendered = _render_data_values(
+        {"greeting": "hello {{name}}", "count": 7, "list": [1, 2]},
+        {"name": "world"},
+    )
+    assert rendered["greeting"] == "hello world"
+    assert rendered["count"] == 7
+    assert rendered["list"] == [1, 2]
+
+
+def test_render_data_values_falls_back_on_template_error():
+    # Sandbox should reject access to dunder attrs → render fails → fallback.
+    bad = _render_data_values({"x": "{{ obj.__class__.__name__ }}"}, {"obj": object()})
+    # Sandbox might either rebuild or return raw — both are acceptable. We
+    # only care that no exception escapes.
+    assert "x" in bad
+
+
+@pytest.mark.asyncio
+async def test_bot_start_when_already_active_is_idempotent(server, bot_config):
+    bot = Bot(bot_config, server)
+    await bot.start()
+    # Calling again is a no-op (covers the early-return at line 95).
+    await bot.start()
+    assert bot.active
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_handle_empty_message_returns_empty(server, bot_config):
+    """If `_resolve_message` returns "", `handle()` returns "" without
+    sending or firing events."""
+    bot = Bot(bot_config, server)
+    await bot.start()
+
+    # Patch _resolve_message to return empty.
+    async def _empty(_payload):
+        return ""
+
+    bot._resolve_message = _empty  # type: ignore[assignment]
+    result = await bot.handle({"action": "noop"})
+    assert result == ""
+    await bot.stop()
+
+
+def test_bot_resolve_channels_dynamic_from_event(server):
+    """Empty `channels` + `trigger_type=event` + event ctx with channel →
+    `_resolve_channels` returns the event channel + dynamic flag True."""
+    config = BotConfig(
+        name="testserv-ori-evbot",
+        channels=[],
+        trigger_type="event",
+    )
+    bot = Bot(config, server)
+    payload = {"event": {"channel": "#dynamic-room"}}
+    channels, dynamic = bot._resolve_channels(payload)
+    assert channels == ["#dynamic-room"]
+    assert dynamic is True
+
+
+def test_bot_resolve_channels_empty_when_no_event_channel(server):
+    config = BotConfig(
+        name="testserv-ori-evempty",
+        channels=[],
+        trigger_type="event",
+    )
+    bot = Bot(config, server)
+    channels, dynamic = bot._resolve_channels({"event": {}})
+    assert channels == []
+    assert dynamic is False
+
+
+def test_bot_resolve_channels_event_with_non_dict_ctx(server):
+    """payload['event'] not a dict → fall back to no channels."""
+    config = BotConfig(
+        name="testserv-ori-evbad",
+        channels=[],
+        trigger_type="event",
+    )
+    bot = Bot(config, server)
+    channels, dynamic = bot._resolve_channels({"event": "not-a-dict"})
+    assert channels == []
+    assert dynamic is False
+
+
+@pytest.mark.asyncio
+async def test_bot_deliver_joins_channel_when_not_a_member(server, make_client):
+    """If a channel is not yet joined (e.g. it was created after start),
+    `_deliver` triggers a JOIN before sending. This covers the
+    not-in-channel branch at line 170."""
+    config = BotConfig(
+        name="testserv-ori-join",
+        channels=["#joined-at-start"],
+        template="hello {body.who}",
+    )
+    bot = Bot(config, server)
+    await bot.start()
+
+    # The bot joined #joined-at-start at start. Now manually remove it
+    # from the channel so `_deliver` will re-join.
+    ch = server.channels.get("#joined-at-start")
+    if ch is not None and bot.virtual_client in ch.members:
+        ch.members.discard(bot.virtual_client)
+        # Also drop the channel from the virtual client's set so the
+        # `is None or not in members` predicate trips correctly.
+        for vch in list(bot.virtual_client.channels):
+            if vch.name == "#joined-at-start":
+                bot.virtual_client.channels.discard(vch)
+
+    listener = await make_client("testserv-listen", "listen")
+    await listener.send("JOIN #joined-at-start")
+    await listener.recv_all(timeout=0.3)
+
+    await bot.handle({"who": "world"})
+    lines = await listener.recv_all(timeout=0.5)
+    assert any("hello world" in ln for ln in lines)
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_maybe_fire_event_emits(server, monkeypatch):
+    config = BotConfig(
+        name="testserv-ori-emit",
+        channels=["#emit"],
+        template="ignored",
+        fires_event=EmitEventSpec(type="bot.command", data={"k": "{{body.action}}"}),
+    )
+    bot = Bot(config, server)
+    await bot.start()
+
+    captured: list = []
+
+    async def _fake_emit(event):
+        captured.append(event)
+
+    monkeypatch.setattr(server, "emit_event", _fake_emit)
+    await bot._maybe_fire_event({"body": {"action": "deploy"}})
+    assert len(captured) == 1
+    event = captured[0]
+    # event.type is the EventType enum value or DynamicEventType
+    assert str(event.type) == "bot.command" or event.type.value == "bot.command"
+    assert event.data == {"k": "deploy"}
+    assert event.nick == "testserv-ori-emit"
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_maybe_fire_event_falls_back_to_dynamic_type(server, monkeypatch):
+    """Unknown event type → wrapped in `_DynamicEventType`."""
+    config = BotConfig(
+        name="testserv-ori-dyn",
+        channels=["#dyn"],
+        fires_event=EmitEventSpec(type="custom.thing", data={}),
+    )
+    bot = Bot(config, server)
+    await bot.start()
+
+    captured: list = []
+
+    async def _fake_emit(event):
+        captured.append(event)
+
+    monkeypatch.setattr(server, "emit_event", _fake_emit)
+    await bot._maybe_fire_event({})
+    assert isinstance(captured[0].type, _DynamicEventType)
+    assert captured[0].type.value == "custom.thing"
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_maybe_fire_event_skips_when_no_spec(server, bot_config):
+    bot = Bot(bot_config, server)
+    await bot.start()
+    # fires_event is None on bot_config; this should early-return cleanly.
+    await bot._maybe_fire_event({})
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_maybe_fire_event_rejects_invalid_event_type(server, monkeypatch, caplog):
+    config = BotConfig(
+        name="testserv-ori-badtype",
+        channels=["#x"],
+        fires_event=EmitEventSpec(type="!!bad", data={}),
+    )
+    bot = Bot(config, server)
+    await bot.start()
+    called: list = []
+
+    async def _fake_emit(event):
+        called.append(event)
+
+    monkeypatch.setattr(server, "emit_event", _fake_emit)
+    with caplog.at_level("WARNING"):
+        await bot._maybe_fire_event({})
+    assert called == []
+    assert any("invalid fires_event.type" in r.message for r in caplog.records)
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_maybe_fire_event_rate_limited(server, monkeypatch, caplog):
+    """If `_check_rate` says no, the event is dropped with a warning."""
+    config = BotConfig(
+        name="testserv-ori-ratelim",
+        channels=["#rl"],
+        fires_event=EmitEventSpec(type="bot.command", data={}),
+    )
+    bot = Bot(config, server)
+    await bot.start()
+    monkeypatch.setattr(bot_mod, "_check_rate", lambda _n: False)
+
+    called: list = []
+
+    async def _fake_emit(event):
+        called.append(event)
+
+    monkeypatch.setattr(server, "emit_event", _fake_emit)
+    with caplog.at_level("WARNING"):
+        await bot._maybe_fire_event({})
+    assert called == []
+    assert any("rate-limited" in r.message for r in caplog.records)
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_maybe_fire_event_logs_when_emit_raises(server, monkeypatch, caplog):
+    config = BotConfig(
+        name="testserv-ori-emiterr",
+        channels=["#err"],
+        fires_event=EmitEventSpec(type="bot.command", data={}),
+    )
+    bot = Bot(config, server)
+    await bot.start()
+
+    # Raise only for the explicit fires_event call so the bot/server can
+    # still emit their normal lifecycle events during teardown.
+    real_emit = server.emit_event
+
+    async def _bad_emit(event):
+        # bot.command is the fires_event we want to fail; everything
+        # else (bot.start, user.part on stop) gets the real emitter.
+        if str(getattr(event.type, "value", event.type)) == "bot.command":
+            raise RuntimeError("boom")
+        await real_emit(event)
+
+    monkeypatch.setattr(server, "emit_event", _bad_emit)
+    with caplog.at_level("ERROR"):
+        await bot._maybe_fire_event({})
+    assert any("failed to emit fires_event" in r.message for r in caplog.records)
+    await bot.stop()
+
+
+# ---- _run_custom_handler — real importlib.util load -------------------------
+
+
+@pytest.fixture
+def bots_dir_with_handler(tmp_path, monkeypatch, request):
+    """Redirect BOTS_DIR to tmp_path and write a `handler.py` for the bot.
+
+    The fixture finalizer drops the imported module from `sys.modules` to
+    avoid bleed across tests (importlib caches by name).
+    """
+    monkeypatch.setattr(bot_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+
+    def _make(bot_name: str, handler_src: str) -> None:
+        bot_dir = tmp_path / bot_name
+        bot_dir.mkdir(parents=True, exist_ok=True)
+        (bot_dir / "handler.py").write_text(handler_src)
+        # Drop any prior import of this module name.
+        mod_name = f"bot_handler_{bot_name}"
+        sys.modules.pop(mod_name, None)
+
+        def _finalize():
+            sys.modules.pop(mod_name, None)
+
+        request.addfinalizer(_finalize)
+
+    return _make
+
+
+@pytest.mark.asyncio
+async def test_bot_run_custom_handler_happy_path(server, bots_dir_with_handler):
+    bots_dir_with_handler(
+        "testserv-ori-hh1",
+        "async def handle(payload, bot):\n    return f'got {payload[\"x\"]}'\n",
+    )
+    config = BotConfig(
+        name="testserv-ori-hh1",
+        channels=["#hh"],
+    )
+    bot = Bot(config, server)
+    await bot.start()
+    result = await bot._resolve_message({"x": "ping"})
+    assert result == "got ping"
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_run_custom_handler_no_handle_function_falls_back(server, bots_dir_with_handler):
+    bots_dir_with_handler(
+        "testserv-ori-hh2",
+        "# no handle()\n",
+    )
+    config = BotConfig(
+        name="testserv-ori-hh2",
+        channels=["#hh2"],
+        template="fallback {body.k}",
+    )
+    bot = Bot(config, server)
+    await bot.start()
+    result = await bot._resolve_message({"k": "v"})
+    assert result == "fallback v"
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_run_custom_handler_raises_falls_back(server, bots_dir_with_handler):
+    bots_dir_with_handler(
+        "testserv-ori-hh3",
+        "async def handle(payload, bot):\n    raise RuntimeError('boom')\n",
+    )
+    config = BotConfig(
+        name="testserv-ori-hh3",
+        channels=["#hh3"],
+        template="fallback for {body.action}",
+    )
+    bot = Bot(config, server)
+    await bot.start()
+    result = await bot._resolve_message({"action": "ping"})
+    assert result == "fallback for ping"
+    await bot.stop()
+
+
+@pytest.mark.asyncio
+async def test_bot_run_custom_handler_returns_none_treated_as_empty(server, bots_dir_with_handler):
+    """handler returning None → `_resolve_message` returns "" (and `handle()`
+    short-circuits to empty)."""
+    bots_dir_with_handler(
+        "testserv-ori-hh4",
+        "async def handle(payload, bot):\n    return None\n",
+    )
+    config = BotConfig(
+        name="testserv-ori-hh4",
+        channels=["#hh4"],
+    )
+    bot = Bot(config, server)
+    await bot.start()
+    result = await bot._resolve_message({})
+    assert result == ""
     await bot.stop()

--- a/tests/test_bot_manager.py
+++ b/tests/test_bot_manager.py
@@ -1,9 +1,14 @@
 """Tests for BotManager — bot lifecycle and dispatch."""
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 
+from culture.bots import bot_manager as bm_mod
 from culture.bots.bot_manager import BotManager
 from culture.bots.config import BotConfig, save_bot_config
+from culture.bots.filter_dsl import FilterParseError
 
 
 @pytest.fixture
@@ -145,3 +150,487 @@ async def test_stop_unknown_bot(server):
     mgr = BotManager(server)
     with pytest.raises(ValueError, match="not found"):
         await mgr.stop_bot("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Phase 4b additions — start/stop, load edge cases, dispatch error paths,
+# system bot loading, event matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_http_listener(server, tmp_path, monkeypatch):
+    """`BotManager.start()` loads bots + system bots + binds HTTP listener."""
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    started: list = []
+    stopped: list = []
+
+    class _FakeListener:
+        def __init__(self, mgr, host, port):
+            self.mgr = mgr
+            self.host = host
+            self.port = port
+
+        async def start(self):
+            started.append((self.host, self.port))
+
+        async def stop(self):
+            stopped.append(True)
+
+    monkeypatch.setattr("culture.bots.http_listener.HttpListener", _FakeListener)
+
+    mgr = BotManager(server)
+    await mgr.start()
+    assert started and started[0][0] == "127.0.0.1"
+    assert mgr._http_listener is not None
+    await mgr.stop()
+    assert stopped == [True]
+
+
+@pytest.mark.asyncio
+async def test_start_swallows_listener_oserror(server, tmp_path, monkeypatch, caplog):
+    """Listener bind failure (EADDRINUSE etc.) is logged, not fatal."""
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    class _BadListener:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def start(self):
+            raise OSError("address already in use")
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr("culture.bots.http_listener.HttpListener", _BadListener)
+
+    mgr = BotManager(server)
+    with caplog.at_level("WARNING"):
+        await mgr.start()
+    assert any("Could not start webhook listener" in r.message for r in caplog.records)
+    assert mgr._http_listener is None
+    await mgr.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_tears_down_on_load_failure(server, tmp_path, monkeypatch):
+    """If anything after `load_bots` raises (other than the listener OSError),
+    `stop()` is invoked before the exception bubbles. Covers lines 74-78."""
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    mgr = BotManager(server)
+
+    async def _bad_load_bots():
+        raise RuntimeError("disk gone")
+
+    mgr.load_bots = _bad_load_bots  # type: ignore[assignment]
+    with pytest.raises(RuntimeError, match="disk gone"):
+        await mgr.start()
+    # stop() was invoked → listener stayed None.
+    assert mgr._http_listener is None
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_listener_stop_errors(server, monkeypatch, caplog):
+    """`stop()` logs but doesn't propagate listener.stop() exceptions."""
+
+    class _ExplodingListener:
+        async def stop(self):
+            raise RuntimeError("kaboom")
+
+    mgr = BotManager(server)
+    mgr._http_listener = _ExplodingListener()
+    with caplog.at_level("ERROR"):
+        await mgr.stop()
+    assert any("Failed to stop webhook listener" in r.message for r in caplog.records)
+    assert mgr._http_listener is None
+
+
+@pytest.mark.asyncio
+async def test_load_bots_missing_dir_returns_quietly(server, tmp_path, monkeypatch):
+    """`load_bots` early-returns when BOTS_DIR isn't a directory."""
+    missing = tmp_path / "no-such-dir"
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", missing)
+    mgr = BotManager(server)
+    await mgr.load_bots()  # no exception
+    assert mgr.bots == {}
+
+
+@pytest.mark.asyncio
+async def test_load_bots_skips_dirs_without_yaml(server, tmp_path, monkeypatch):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    (tmp_path / "empty-bot").mkdir()
+    mgr = BotManager(server)
+    await mgr.load_bots()
+    assert mgr.bots == {}
+
+
+@pytest.mark.asyncio
+async def test_load_bots_skips_archived(server, tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+    cfg = BotConfig(
+        name="testserv-ori-archived",
+        owner="testserv-ori",
+        channels=["#a"],
+        archived=True,
+    )
+    save_bot_config(tmp_path / cfg.name / "bot.yaml", cfg)
+    mgr = BotManager(server)
+    with caplog.at_level("INFO"):
+        await mgr.load_bots()
+    assert cfg.name not in mgr.bots
+    assert any("Skipping archived bot" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_load_bots_skips_invalid_event_filter(
+    server,
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+    cfg = BotConfig(
+        name="testserv-ori-badfilter",
+        owner="testserv-ori",
+        trigger_type="event",
+        event_filter="this is not a valid filter (((",
+        channels=["#x"],
+    )
+    save_bot_config(tmp_path / cfg.name / "bot.yaml", cfg)
+    mgr = BotManager(server)
+    with caplog.at_level("ERROR"):
+        await mgr.load_bots()
+    assert cfg.name not in mgr.bots
+    assert any("invalid filter" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_load_bots_swallows_exception_per_bot(
+    server,
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    # Write a bot.yaml that load_bot_config will choke on.
+    bot_dir = tmp_path / "broken-bot"
+    bot_dir.mkdir()
+    (bot_dir / "bot.yaml").write_text("not: valid: bot: config: garbage\n")
+    mgr = BotManager(server)
+    with caplog.at_level("ERROR"):
+        await mgr.load_bots()
+    assert "broken-bot" not in mgr.bots
+    assert any("Failed to load bot" in r.message for r in caplog.records)
+
+
+def test_register_bot_raises_on_invalid_filter(server, monkeypatch):
+    monkeypatch.setattr(
+        bm_mod,
+        "compile_filter",
+        lambda _s: (_ for _ in ()).throw(FilterParseError("bad")),
+    )
+    mgr = BotManager(server)
+    cfg = BotConfig(
+        name="testserv-ori-regbad",
+        trigger_type="event",
+        event_filter="bogus",
+    )
+    with pytest.raises(ValueError, match="invalid filter"):
+        mgr.register_bot(cfg)
+
+
+@pytest.mark.asyncio
+async def test_try_start_bot_idempotent_when_already_starting(server, tmp_path, monkeypatch):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    cfg = BotConfig(name="testserv-ori-starting", channels=["#st"])
+    mgr = BotManager(server)
+    bot = await mgr.create_bot(cfg)
+    bot.active = False  # force not-yet-started
+    bot._starting = True  # mid-start
+    assert await mgr._try_start_bot(bot) is False
+    bot._starting = False
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_try_start_bot_logs_and_returns_false_when_start_fails(
+    server,
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    cfg = BotConfig(name="testserv-ori-starterror", channels=["#se"])
+    mgr = BotManager(server)
+    bot = mgr.register_bot(cfg)
+
+    async def _bad_start():
+        raise RuntimeError("nope")
+
+    bot.start = _bad_start  # type: ignore[assignment]
+    with caplog.at_level("ERROR"):
+        result = await mgr._try_start_bot(bot)
+    assert result is False
+    assert any("failed to start" in r.message for r in caplog.records)
+
+
+def test_matches_event_skips_non_event_triggers(server):
+    """A bot with `trigger_type=webhook` never matches events."""
+    mgr = BotManager(server)
+    cfg = BotConfig(name="testserv-ori-wh", trigger_type="webhook")
+    bot = mgr.register_bot(cfg)
+    assert (
+        mgr._matches_event(bot, {"type": "anything", "channel": None, "nick": None, "data": {}})
+        is False
+    )
+
+
+def test_matches_event_skips_when_no_compiled_filter(server):
+    """Event-trigger bot with no filter compiled → no match."""
+    mgr = BotManager(server)
+    cfg = BotConfig(name="testserv-ori-nofilter", trigger_type="event")
+    # register_bot only compiles if event_filter is truthy; here it's None.
+    bot = mgr.register_bot(cfg)
+    assert (
+        mgr._matches_event(bot, {"type": "x", "channel": None, "nick": None, "data": {}}) is False
+    )
+
+
+def test_matches_event_swallows_evaluate_exception(server, monkeypatch, caplog):
+    mgr = BotManager(server)
+    cfg = BotConfig(
+        name="testserv-ori-evalerr",
+        trigger_type="event",
+        event_filter="type == 'foo'",
+    )
+    bot = mgr.register_bot(cfg)
+    monkeypatch.setattr(
+        bm_mod, "evaluate", lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("eval"))
+    )
+    with caplog.at_level("ERROR"):
+        result = mgr._matches_event(bot, {"type": "foo", "channel": None, "nick": None, "data": {}})
+    assert result is False
+    assert any("Filter evaluation failed" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_to_bot_returns_when_start_fails(
+    server,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    mgr = BotManager(server)
+    cfg = BotConfig(name="testserv-ori-startfail", trigger_type="event")
+    bot = mgr.register_bot(cfg)
+    bot.active = False  # not active
+
+    async def _no_start(_bot):
+        return False  # _try_start_bot returns False
+
+    monkeypatch.setattr(mgr, "_try_start_bot", _no_start)
+
+    # Should silently return without calling bot.handle.
+    handled: list = []
+
+    async def _spy_handle(_payload):
+        handled.append(True)
+        return ""
+
+    bot.handle = _spy_handle  # type: ignore[assignment]
+    await mgr._dispatch_to_bot(bot, {"type": "foo", "channel": None, "nick": None, "data": {}})
+    assert handled == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_to_bot_logs_handle_exception(
+    server,
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    cfg = BotConfig(
+        name="testserv-ori-handlefail",
+        trigger_type="event",
+        channels=["#hf"],
+    )
+    mgr = BotManager(server)
+    bot = await mgr.create_bot(cfg)
+
+    async def _bad_handle(_payload):
+        raise RuntimeError("handler boom")
+
+    bot.handle = _bad_handle  # type: ignore[assignment]
+    with caplog.at_level("ERROR"):
+        await mgr._dispatch_to_bot(bot, {"type": "foo", "channel": None, "nick": None, "data": {}})
+    assert any("handle() failed" in r.message for r in caplog.records)
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_on_event_dispatches_matching_bots(
+    server_with_bot,
+    server,
+    tmp_path,
+    monkeypatch,
+):
+    """An event matching the bot filter triggers `_dispatch_to_bot`."""
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    server, cfg = server_with_bot(
+        bot_name="testserv-ori-fire",
+        trigger_type="event",
+        event_filter="type == 'user.join'",
+        channels=["#fire"],
+    )
+
+    dispatched: list = []
+
+    async def _spy(bot, ctx):
+        dispatched.append(ctx)
+
+    monkeypatch.setattr(server.bot_manager, "_dispatch_to_bot", _spy)
+    fake_event = SimpleNamespace(
+        type=SimpleNamespace(value="user.join"),
+        channel="#fire",
+        nick="testserv-claude",
+        data={},
+    )
+    await server.bot_manager.on_event(fake_event)
+    assert dispatched and dispatched[0]["type"] == "user.join"
+
+
+@pytest.mark.asyncio
+async def test_start_bot_loads_from_disk_when_not_in_registry(
+    server,
+    tmp_path,
+    monkeypatch,
+):
+    """Calling `start_bot(name)` for a name not in the registry → load from
+    disk + start."""
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+
+    cfg = BotConfig(name="testserv-ori-fromdisk", channels=["#fd"])
+    save_bot_config(tmp_path / cfg.name / "bot.yaml", cfg)
+
+    mgr = BotManager(server)
+    await mgr.start_bot(cfg.name)
+    assert cfg.name in mgr.bots
+    assert mgr.bots[cfg.name].active
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_start_bot_unknown_raises(server, tmp_path, monkeypatch):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    mgr = BotManager(server)
+    with pytest.raises(ValueError, match="not found"):
+        await mgr.start_bot("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_stop_all_swallows_exceptions(server, tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+
+    cfg = BotConfig(name="testserv-ori-stopfail", channels=["#sf"])
+    mgr = BotManager(server)
+    bot = await mgr.create_bot(cfg)
+
+    async def _bad_stop():
+        raise RuntimeError("stop kaboom")
+
+    bot.stop = _bad_stop  # type: ignore[assignment]
+    with caplog.at_level("ERROR"):
+        await mgr.stop_all()
+    assert any("Failed to stop bot" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_load_system_bots_skips_duplicate(server, monkeypatch, caplog):
+    """If a system bot's name collides with one already registered, skip it."""
+
+    class _DummyCfg:
+        def __init__(self, name):
+            self.name = name
+            self.trigger_type = "event"
+            self.event_filter = None
+
+    monkeypatch.setattr(
+        "culture.bots.system.discover_system_bots",
+        lambda _name, _cfg: [_DummyCfg("testserv-system-x")],
+    )
+
+    mgr = BotManager(server)
+    # Pre-register the same name.
+    mgr.bots["testserv-system-x"] = SimpleNamespace(name="testserv-system-x")
+    with caplog.at_level("INFO"):
+        mgr.load_system_bots()
+    assert any("name already registered" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_load_system_bots_logs_register_failure(server, monkeypatch, caplog):
+    """If `register_bot` raises, the failure is logged, not propagated."""
+
+    class _DummyCfg:
+        def __init__(self, name):
+            self.name = name
+            self.trigger_type = "event"
+            self.event_filter = None
+
+    monkeypatch.setattr(
+        "culture.bots.system.discover_system_bots",
+        lambda _name, _cfg: [_DummyCfg("testserv-system-bad")],
+    )
+
+    mgr = BotManager(server)
+
+    def _bad_register(_cfg):
+        raise RuntimeError("regfail")
+
+    monkeypatch.setattr(mgr, "register_bot", _bad_register)
+    with caplog.at_level("ERROR"):
+        mgr.load_system_bots()
+    assert any("Failed to register system bot" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_load_system_bots_reads_server_config(server, monkeypatch):
+    """When `server.config.system_bots` is set, it's forwarded to discover."""
+    captured: dict = {}
+
+    def _capture(server_name, cfg):
+        captured["server_name"] = server_name
+        captured["cfg"] = cfg
+        return []
+
+    monkeypatch.setattr("culture.bots.system.discover_system_bots", _capture)
+    server.config.system_bots = {"welcome": {"enabled": False}}
+    mgr = BotManager(server)
+    mgr.load_system_bots()
+    assert captured["server_name"] == "testserv"
+    assert captured["cfg"] == {"system_bots": {"welcome": {"enabled": False}}}

--- a/tests/test_bot_manager.py
+++ b/tests/test_bot_manager.py
@@ -160,52 +160,49 @@ async def test_stop_unknown_bot(server):
 
 @pytest.mark.asyncio
 async def test_start_creates_http_listener(server, tmp_path, monkeypatch):
-    """`BotManager.start()` loads bots + system bots + binds HTTP listener."""
+    """`BotManager.start()` loads bots + system bots + binds a real HTTP listener.
+
+    Uses the real `HttpListener` against an OS-assigned port (the `server`
+    fixture sets `webhook_port=0`) and probes `/health` to confirm the
+    listener actually bound.
+    """
+    import aiohttp
+
     monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
     monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
 
-    started: list = []
-    stopped: list = []
-
-    class _FakeListener:
-        def __init__(self, mgr, host, port):
-            self.mgr = mgr
-            self.host = host
-            self.port = port
-
-        async def start(self):
-            started.append((self.host, self.port))
-
-        async def stop(self):
-            stopped.append(True)
-
-    monkeypatch.setattr("culture.bots.http_listener.HttpListener", _FakeListener)
-
     mgr = BotManager(server)
     await mgr.start()
-    assert started and started[0][0] == "127.0.0.1"
     assert mgr._http_listener is not None
+
+    # Confirm the listener actually bound by hitting /health.
+    bound_host = mgr._http_listener.host
+    bound_port = mgr._http_listener._runner.addresses[0][1]
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"http://{bound_host}:{bound_port}/health") as resp:
+            assert resp.status == 200
+
     await mgr.stop()
-    assert stopped == [True]
+    # After stop the runner is gone.
+    assert mgr._http_listener is None
 
 
 @pytest.mark.asyncio
 async def test_start_swallows_listener_oserror(server, tmp_path, monkeypatch, caplog):
-    """Listener bind failure (EADDRINUSE etc.) is logged, not fatal."""
+    """Listener bind failure (EADDRINUSE etc.) is logged, not fatal.
+
+    OSError can't be deterministically forced on a real `HttpListener`
+    without racing another process for a port, so we patch
+    `HttpListener.start` itself to raise. The rest of the manager flow
+    runs against the real `server` fixture.
+    """
     monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
     monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
 
-    class _BadListener:
-        def __init__(self, *a, **kw):
-            pass
+    async def _bad_start(self):
+        raise OSError("address already in use")
 
-        async def start(self):
-            raise OSError("address already in use")
-
-        async def stop(self):
-            return None
-
-    monkeypatch.setattr("culture.bots.http_listener.HttpListener", _BadListener)
+    monkeypatch.setattr("culture.bots.http_listener.HttpListener.start", _bad_start)
 
     mgr = BotManager(server)
     with caplog.at_level("WARNING"):

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,0 +1,462 @@
+"""Tests for culture.observer — query cycle + public API + parsers.
+
+`test_observer_peek_nick.py` covers parent-aware nick attribution. This
+file covers the broader observer surface against a real IRCd: the async
+connect/register handshake, the query cycle around `_irc_query`, and the
+public `read_channel` / `who` / `send_message` / `list_channels`
+methods. Pure parsers (`_parse_history_line`, `_parse_who_line`,
+`_parse_list_line`) get table-driven unit tests since they are static.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from culture.observer import IRCObserver
+from culture.protocol.message import Message
+
+# ---------------------------------------------------------------------------
+# Pure parsers — table-driven
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line, expected_contains",
+    [
+        # Four-param HISTORY with float timestamp
+        (
+            "HISTORY #room nick1 1715000000.0 :hello there",
+            "<nick1> hello there",
+        ),
+        # Four-param HISTORY with non-numeric timestamp falls back to raw label
+        (
+            "HISTORY #room nick2 someday :legacy line",
+            "[someday] <nick2> legacy line",
+        ),
+        # Three-param HISTORY (legacy no-timestamp form)
+        ("HISTORY #room nick3 :older line", "<nick3> older line"),
+    ],
+)
+def test_parse_history_line_renders(line: str, expected_contains: str):
+    msg = Message.parse(line)
+    result = IRCObserver._parse_history_line(msg)
+    assert result is not None
+    assert expected_contains in result
+
+
+def test_parse_history_line_returns_none_for_non_history():
+    assert IRCObserver._parse_history_line(Message.parse("PRIVMSG #foo :bar")) is None
+
+
+def test_parse_history_line_returns_none_for_too_few_params():
+    # Only 1 param: HISTORY <something> — nothing to render.
+    assert IRCObserver._parse_history_line(Message.parse("HISTORY #room")) is None
+
+
+def test_parse_who_line_extracts_nick():
+    # 352 server :you nick user host server target H :hops realname
+    line = ":server 352 you #room user host srv target H :0 realname"
+    assert IRCObserver._parse_who_line(Message.parse(line)) == "target"
+
+
+def test_parse_who_line_returns_none_for_non_352():
+    assert IRCObserver._parse_who_line(Message.parse(":srv 353 you = #room :nick1 nick2")) is None
+
+
+def test_parse_list_line_extracts_channel():
+    # 322 server :you #channel 3 :topic
+    line = ":srv 322 you #foo 3 :a topic"
+    assert IRCObserver._parse_list_line(Message.parse(line)) == "#foo"
+
+
+def test_parse_list_line_returns_none_for_other_numerics():
+    assert IRCObserver._parse_list_line(Message.parse(":srv 323 you :End")) is None
+
+
+# ---------------------------------------------------------------------------
+# _process_registration_line / _process_query_line — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class _RecordingWriter:
+    """Minimal StreamWriter stand-in that captures bytes written.
+
+    The observer only calls `write` + `drain`; `drain` is async. Close is
+    also called from `_disconnect` but those tests use the real server.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_process_registration_line_001_signals_done():
+    obs = IRCObserver(host="x", port=0, server_name="srv")
+    writer = _RecordingWriter()
+    done, nick = await obs._process_registration_line(
+        ":srv 001 mynick :Welcome",
+        writer,  # type: ignore[arg-type]
+        "mynick",
+    )
+    assert done is True
+    assert nick == "mynick"
+    assert writer.sent == []
+
+
+@pytest.mark.asyncio
+async def test_process_registration_line_433_retries_with_new_nick():
+    obs = IRCObserver(host="x", port=0, server_name="srv", parent_nick="srv-claude")
+    writer = _RecordingWriter()
+    done, nick = await obs._process_registration_line(
+        ":srv 433 * oldnick :Nickname is already in use",
+        writer,  # type: ignore[arg-type]
+        "oldnick",
+    )
+    assert done is False
+    # New nick was generated and re-sent.
+    assert nick != "oldnick"
+    assert writer.sent and writer.sent[0].startswith(b"NICK ")
+
+
+@pytest.mark.asyncio
+async def test_process_registration_line_unknown_command_is_skipped():
+    obs = IRCObserver(host="x", port=0, server_name="srv")
+    writer = _RecordingWriter()
+    done, nick = await obs._process_registration_line(
+        ":srv 002 mynick :Your host is...",
+        writer,  # type: ignore[arg-type]
+        "mynick",
+    )
+    assert done is False
+    assert nick == "mynick"
+    assert writer.sent == []
+
+
+@pytest.mark.asyncio
+async def test_process_query_line_end_numeric_stops():
+    writer = _RecordingWriter()
+    msg = Message.parse(":srv 315 me #room :End of WHO")
+    results: list[str] = []
+    done = await IRCObserver._process_query_line(
+        msg,
+        {"315"},
+        lambda _m: "ignored",
+        results,
+        writer,  # type: ignore[arg-type]
+    )
+    assert done is True
+    # parser is short-circuited on end numerics — nothing collected.
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_process_query_line_responds_to_ping():
+    writer = _RecordingWriter()
+    msg = Message.parse("PING :token123")
+    done = await IRCObserver._process_query_line(
+        msg,
+        {"315"},
+        lambda _m: None,
+        [],
+        writer,  # type: ignore[arg-type]
+    )
+    assert done is False
+    assert writer.sent == [b"PONG :token123\r\n"]
+
+
+@pytest.mark.asyncio
+async def test_process_query_line_collects_parsed_value():
+    writer = _RecordingWriter()
+    msg = Message.parse(":srv 352 me #room user host srv target H :0 rn")
+    results: list[str] = []
+    done = await IRCObserver._process_query_line(
+        msg,
+        {"315"},
+        IRCObserver._parse_who_line,
+        results,
+        writer,  # type: ignore[arg-type]
+    )
+    assert done is False
+    assert results == ["target"]
+
+
+@pytest.mark.asyncio
+async def test_drain_query_buffer_returns_unfinished_partial():
+    obs = IRCObserver(host="x", port=0, server_name="srv")
+    writer = _RecordingWriter()
+    # "PING :ok\r\n" plus a half line.
+    buffer = "PING :ok\r\nHISTORY #room nick 1715"
+    remainder, done = await obs._drain_query_buffer(
+        buffer,
+        {"315"},
+        IRCObserver._parse_history_line,
+        [],
+        writer,  # type: ignore[arg-type]
+    )
+    assert done is False
+    assert remainder == "HISTORY #room nick 1715"
+
+
+@pytest.mark.asyncio
+async def test_drain_query_buffer_skips_blank_lines():
+    obs = IRCObserver(host="x", port=0, server_name="srv")
+    writer = _RecordingWriter()
+    # Blank-line-only payload; no PRIVMSGs, no end numeric.
+    remainder, done = await obs._drain_query_buffer(
+        "\r\n\r\n",
+        {"END"},
+        IRCObserver._parse_who_line,
+        [],
+        writer,  # type: ignore[arg-type]
+    )
+    assert done is False
+    assert remainder == ""
+
+
+# ---------------------------------------------------------------------------
+# Public API — round-trip against the real IRCd `server` fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observer_list_channels_sees_active_channel(server, make_client):
+    """`list_channels` returns the user-created channel after a client joins."""
+    client = await make_client(nick="testserv-c1", user="c1")
+    await client.send("JOIN #obs-room")
+    await client.recv_all(timeout=0.5)
+
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+    )
+    channels = await obs.list_channels()
+    assert "#obs-room" in channels
+
+
+@pytest.mark.asyncio
+async def test_observer_list_channels_empty_server(server):
+    """No user-joined channels → `list_channels` may be empty or only #system."""
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+    )
+    channels = await obs.list_channels()
+    # No user channel was created — the only thing that could show up is
+    # the system-internal #system room, and even that may be filtered
+    # depending on server LIST policy. Just assert the call returns a
+    # list (which it does) and no user-named room snuck in.
+    assert isinstance(channels, list)
+    assert "#obs-room" not in channels
+
+
+@pytest.mark.asyncio
+async def test_observer_who_returns_member_nicks(server, make_client):
+    client = await make_client(nick="testserv-w1", user="w1")
+    await client.send("JOIN #who-room")
+    await client.recv_all(timeout=0.5)
+
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+    )
+    nicks = await obs.who("#who-room")
+    assert "testserv-w1" in nicks
+
+
+@pytest.mark.asyncio
+async def test_observer_read_channel_returns_history(server, make_client):
+    client = await make_client(nick="testserv-h1", user="h1")
+    await client.send("JOIN #hist-room")
+    await client.recv_all(timeout=0.5)
+    await client.send("PRIVMSG #hist-room :first observed message")
+    await client.send("PRIVMSG #hist-room :second observed message")
+    await asyncio.sleep(0.3)
+
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+    )
+    lines = await obs.read_channel("#hist-room", limit=20)
+    assert any("first observed message" in ln for ln in lines)
+    assert any("second observed message" in ln for ln in lines)
+
+
+@pytest.mark.asyncio
+async def test_observer_send_message_lands_on_channel(server, make_client):
+    listener = await make_client(nick="testserv-listen", user="listen")
+    await listener.send("JOIN #send-room")
+    await listener.recv_all(timeout=0.5)
+
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+        parent_nick="testserv-ori",
+    )
+    await obs.send_message("#send-room", "hello from observer")
+
+    # Give the message a moment to round-trip.
+    lines = await listener.recv_all(timeout=0.5)
+    assert any("hello from observer" in ln for ln in lines)
+
+
+@pytest.mark.asyncio
+async def test_observer_send_message_splits_on_newlines(server, make_client):
+    listener = await make_client(nick="testserv-multi", user="multi")
+    await listener.send("JOIN #multi-room")
+    await listener.recv_all(timeout=0.5)
+
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+    )
+    await obs.send_message("#multi-room", "line one\nline two\n\nline three")
+
+    lines = await listener.recv_all(timeout=0.5)
+    text = "\n".join(lines)
+    assert "line one" in text
+    assert "line two" in text
+    assert "line three" in text
+
+
+@pytest.mark.asyncio
+async def test_observer_send_message_empty_payload_skips_connect(monkeypatch):
+    """All-empty lines → return without opening a connection."""
+    obs = IRCObserver(host="127.0.0.1", port=1, server_name="srv")
+
+    called: list[bool] = []
+
+    async def _fake_connect():
+        called.append(True)
+        raise AssertionError("should not connect when all lines empty")
+
+    monkeypatch.setattr(obs, "_connect_and_register", _fake_connect)
+    await obs.send_message("#room", "\r\n\n")
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_observer_send_message_to_nick_skips_join(server, make_client):
+    """When target is a nick (not a channel), no JOIN is sent."""
+    recipient = await make_client(nick="testserv-recv", user="recv")
+    # No channel join — receive a DM directly.
+
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+    )
+    await obs.send_message("testserv-recv", "direct hello")
+
+    lines = await recipient.recv_all(timeout=0.5)
+    assert any("direct hello" in ln for ln in lines)
+
+
+@pytest.mark.asyncio
+async def test_observer_send_message_strips_target_crlf(monkeypatch):
+    """CR/LF in target is stripped before any PRIVMSG/JOIN is composed.
+
+    Without the strip, a malformed target would let a caller smuggle a
+    second IRC line. After the strip, the target collapses into a single
+    (bogus) channel name — no second protocol line is ever emitted.
+    """
+    obs = IRCObserver(host="127.0.0.1", port=1, server_name="srv")
+    captured: dict[str, object] = {}
+
+    class _FakeWriter:
+        def __init__(self):
+            self.sent: list[bytes] = []
+
+        def write(self, data: bytes) -> None:
+            self.sent.append(data)
+
+        async def drain(self):
+            return None
+
+        def close(self):
+            return None
+
+        async def wait_closed(self):
+            return None
+
+    class _FakeReader:
+        async def read(self, _n: int):
+            return b""
+
+    fake_writer = _FakeWriter()
+
+    async def _fake_connect():
+        captured["writer"] = fake_writer
+        return _FakeReader(), fake_writer, "nick"
+
+    async def _fake_recv(_reader, timeout=0.0):
+        return []
+
+    monkeypatch.setattr(obs, "_connect_and_register", _fake_connect)
+    monkeypatch.setattr(obs, "_recv_lines", _fake_recv)
+
+    await obs.send_message("#strip-room\r\nJOIN #danger", "smuggled")
+
+    sent = b"".join(fake_writer.sent)
+    # JOIN + PRIVMSG + QUIT (from _disconnect) — exactly 3 CRLFs. The
+    # injected JOIN payload becomes part of the channel name, which the
+    # server will reject; no extra IRC line is smuggled past the strip.
+    assert sent.count(b"\r\n") == 3, sent
+    assert b"#strip-roomJOIN #danger" in sent
+    assert b"smuggled" in sent
+    # Critical: nothing in the sent bytes opens an extra protocol line.
+    assert b"\nJOIN" not in sent
+
+
+@pytest.mark.asyncio
+async def test_observer_registration_timeout_raises(monkeypatch):
+    """Opening the TCP connection times out → ConnectionError."""
+
+    async def _slow_open(*_a, **_kw):
+        await asyncio.sleep(10)
+        raise AssertionError("should have timed out")
+
+    import culture.observer as obs_mod
+
+    monkeypatch.setattr(obs_mod, "REGISTER_TIMEOUT", 0.05)
+    monkeypatch.setattr(obs_mod.asyncio, "open_connection", _slow_open)
+
+    obs = IRCObserver(host="127.0.0.1", port=1, server_name="srv")
+    with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+        await obs._connect_and_register()
+
+
+@pytest.mark.asyncio
+async def test_observer_realname_carries_parent_attribution(server, make_client):
+    """Cross-server peeks fall back to opaque nick but realname keeps the parent."""
+    # Use a parent that doesn't match the server prefix → opaque nick form.
+    obs = IRCObserver(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+        parent_nick="thor-claude",
+    )
+    # A list_channels call exercises connect+register+disconnect. After
+    # it completes the server should have seen the USER realname embedding
+    # the parent attribution. We can't easily intercept the USER line on
+    # the server side without mocks, so just confirm the call works and
+    # the parent attribution is preserved on the observer.
+    await obs.list_channels()
+    assert obs.parent_nick == "thor-claude"
+    # `_parent_suffix()` returns None for cross-server parents, which is
+    # what falls the nick back to the opaque shape.
+    assert obs._parent_suffix() is None

--- a/tests/test_overview_collector.py
+++ b/tests/test_overview_collector.py
@@ -1,13 +1,26 @@
 """Tests for overview collector against a real IRC server."""
 
 import asyncio
+import os
 from unittest.mock import patch
 
 import pytest
 
 from culture.constants import SYSTEM_CHANNEL, SYSTEM_USER_PREFIX
-from culture.overview.collector import _collect_bots, collect_mesh_state
-from culture.overview.model import MeshState
+from culture.overview import collector as collector_mod
+from culture.overview.collector import (
+    _collect_bots,
+    _enrich_via_ipc,
+    _handle_registration_line,
+    _inject_stopped_agents,
+    _query_roommeta,
+    _query_tags,
+    _recv_until,
+    _temp_nick,
+    collect_mesh_state,
+)
+from culture.overview.model import Agent, MeshState
+from culture.protocol.message import Message as IRCMessage
 
 
 @pytest.mark.asyncio
@@ -159,3 +172,569 @@ def test_collect_bots_passes_archived_flag(tmp_path):
     active_bot = next(b for b in bots if b.name == "active-bot")
     assert archived_bot.archived is True
     assert active_bot.archived is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 4b additions — pure helpers, registration handler, IPC enrichment
+# ---------------------------------------------------------------------------
+
+
+def test_temp_nick_shape():
+    nick = _temp_nick("spark")
+    assert nick.startswith("spark-_overview")
+    assert len(nick) == len("spark-_overview") + 4
+
+
+def test_inject_stopped_agents_adds_missing_with_manifest_metadata():
+    all_agents: dict[str, Agent] = {}
+
+    class _Cfg:
+        def __init__(self, nick, channels, archived=False, backend=None, directory=None):
+            self.nick = nick
+            self.channels = channels
+            self.archived = archived
+            self.backend = backend
+            self.directory = directory
+
+    manifest = [
+        _Cfg("srv-claude", ["#general"], backend="claude", directory="/tmp/c"),
+        _Cfg("srv-archived", ["#general"], archived=True),  # skipped
+    ]
+    _inject_stopped_agents(all_agents, manifest, "srv")
+    assert "srv-claude" in all_agents
+    assert all_agents["srv-claude"].status == "stopped"
+    assert all_agents["srv-claude"].backend == "claude"
+    assert all_agents["srv-claude"].directory == "/tmp/c"
+    assert all_agents["srv-claude"].channels == ["#general"]
+    assert "srv-archived" not in all_agents
+
+
+def test_inject_stopped_agents_skips_when_already_present():
+    all_agents = {
+        "srv-claude": Agent(
+            nick="srv-claude", status="active", activity="", channels=[], server="srv"
+        ),
+    }
+
+    class _Cfg:
+        def __init__(self):
+            self.nick = "srv-claude"
+            self.channels = []
+            self.archived = False
+            self.backend = "claude"
+            self.directory = None
+
+    _inject_stopped_agents(all_agents, [_Cfg()], "srv")
+    assert all_agents["srv-claude"].status == "active"  # not overwritten
+
+
+def test_inject_stopped_agents_non_list_channels_falls_back():
+    all_agents: dict[str, Agent] = {}
+
+    class _Cfg:
+        def __init__(self):
+            self.nick = "srv-bot"
+            self.channels = None  # not a list
+            self.archived = False
+            self.backend = None
+            self.directory = None
+
+    _inject_stopped_agents(all_agents, [_Cfg()], "srv")
+    assert all_agents["srv-bot"].channels == []
+
+
+# ---- _handle_registration_line direct unit tests ----------------------------
+
+
+class _CollectorWriter:
+    def __init__(self):
+        self.sent: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def drain(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_handle_registration_line_responds_to_ping():
+    writer = _CollectorWriter()
+    msg = IRCMessage.parse("PING :tok")
+    done, nick = await _handle_registration_line(msg, writer, "n", "srv")  # type: ignore[arg-type]
+    assert done is False
+    assert nick == "n"
+    assert writer.sent == [b"PONG :tok\r\n"]
+
+
+@pytest.mark.asyncio
+async def test_handle_registration_line_001_signals_done():
+    writer = _CollectorWriter()
+    msg = IRCMessage.parse(":srv 001 me :Welcome")
+    done, nick = await _handle_registration_line(msg, writer, "n", "srv")  # type: ignore[arg-type]
+    assert done is True
+    assert nick == "n"
+    assert writer.sent == []
+
+
+@pytest.mark.asyncio
+async def test_handle_registration_line_433_retries_new_nick():
+    writer = _CollectorWriter()
+    msg = IRCMessage.parse(":srv 433 * me :Nickname in use")
+    done, nick = await _handle_registration_line(msg, writer, "old", "srv")  # type: ignore[arg-type]
+    assert done is False
+    assert nick != "old"
+    assert nick.startswith("srv-_overview")
+    assert writer.sent and writer.sent[0].startswith(b"NICK ")
+
+
+@pytest.mark.asyncio
+async def test_handle_registration_line_unknown_command_passes_through():
+    writer = _CollectorWriter()
+    msg = IRCMessage.parse(":srv 002 me :Your host is")
+    done, nick = await _handle_registration_line(msg, writer, "n", "srv")  # type: ignore[arg-type]
+    assert done is False
+    assert nick == "n"
+    assert writer.sent == []
+
+
+# ---- _recv_until direct unit tests ------------------------------------------
+
+
+class _FakeReader:
+    """Yields canned lines, then blocks (simulating no more data)."""
+
+    def __init__(self, lines: list[bytes], block_after: bool = True):
+        self._lines = list(lines)
+        self._block_after = block_after
+
+    async def readline(self) -> bytes:
+        if self._lines:
+            return self._lines.pop(0)
+        if self._block_after:
+            await asyncio.sleep(10)  # forces _recv_until's timeout
+        return b""
+
+
+@pytest.mark.asyncio
+async def test_recv_until_stops_on_stop_command():
+    reader = _FakeReader([b":srv 322 me #room 0 :topic\r\n", b":srv 323 me :End\r\n"])
+    writer = _CollectorWriter()
+    msgs = await _recv_until(reader, writer, {"323"}, timeout=1.0)  # type: ignore[arg-type]
+    cmds = [m.command for m in msgs]
+    assert "322" in cmds
+    assert cmds[-1] == "323"
+
+
+@pytest.mark.asyncio
+async def test_recv_until_ponging_a_ping_does_not_emit_message():
+    reader = _FakeReader([b"PING :tok\r\n", b":srv 323 me :End\r\n"])
+    writer = _CollectorWriter()
+    msgs = await _recv_until(reader, writer, {"323"}, timeout=1.0)  # type: ignore[arg-type]
+    cmds = [m.command for m in msgs]
+    assert "PING" not in cmds
+    assert "323" in cmds
+    assert writer.sent and writer.sent[0] == b"PONG :tok\r\n"
+
+
+@pytest.mark.asyncio
+async def test_recv_until_skips_blank_lines_and_returns_on_timeout():
+    reader = _FakeReader([b"\r\n"], block_after=True)
+    writer = _CollectorWriter()
+    msgs = await _recv_until(reader, writer, {"323"}, timeout=0.1)  # type: ignore[arg-type]
+    assert msgs == []
+
+
+# ---- _query_roommeta / _query_tags via stubbed reader -----------------------
+
+
+@pytest.mark.asyncio
+async def test_query_roommeta_parses_all_keys(monkeypatch):
+    """Cover the ROOMMETA key parser: room_id / owner / purpose / tags / persistent."""
+    reader = _FakeReader(
+        [
+            b":srv ROOMMETA #room room_id :abc123\r\n",
+            b":srv ROOMMETA #room owner :srv-ori\r\n",
+            b":srv ROOMMETA #room purpose :for testing\r\n",
+            b":srv ROOMMETA #room tags :alpha, beta ,gamma\r\n",
+            b":srv ROOMMETA #room persistent :true\r\n",
+            b":srv ROOMETAEND #room\r\n",
+        ]
+    )
+    writer = _CollectorWriter()
+    result = await _query_roommeta(reader, writer, "me", "#room")  # type: ignore[arg-type]
+    assert result["room_id"] == "abc123"
+    assert result["owner"] == "srv-ori"
+    assert result["purpose"] == "for testing"
+    assert result["tags"] == ["alpha", "beta", "gamma"]
+    assert result["persistent"] is True
+
+
+@pytest.mark.asyncio
+async def test_query_roommeta_unknown_command_terminates_empty():
+    reader = _FakeReader([b":srv ERR_UNKNOWNCOMMAND ROOMMETA :Unknown\r\n"])
+    writer = _CollectorWriter()
+    result = await _query_roommeta(reader, writer, "me", "#room")  # type: ignore[arg-type]
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_query_roommeta_persistent_false_for_anything_else():
+    reader = _FakeReader(
+        [
+            b":srv ROOMMETA #room persistent :no\r\n",
+            b":srv ROOMETAEND #room\r\n",
+        ]
+    )
+    writer = _CollectorWriter()
+    result = await _query_roommeta(reader, writer, "me", "#room")  # type: ignore[arg-type]
+    assert result["persistent"] is False
+
+
+@pytest.mark.asyncio
+async def test_query_tags_returns_list():
+    reader = _FakeReader(
+        [
+            b":srv TAGS srv-bot :focus, async , devops\r\n",
+            b":srv TAGSEND srv-bot\r\n",
+        ]
+    )
+    writer = _CollectorWriter()
+    tags = await _query_tags(reader, writer, "me", "srv-bot")  # type: ignore[arg-type]
+    assert tags == ["focus", "async", "devops"]
+
+
+@pytest.mark.asyncio
+async def test_query_tags_returns_empty_when_no_such_nick():
+    reader = _FakeReader([b":srv ERR_NOSUCHNICK srv-bot :No such nick\r\n"])
+    writer = _CollectorWriter()
+    tags = await _query_tags(reader, writer, "me", "srv-bot")  # type: ignore[arg-type]
+    assert tags == []
+
+
+# ---- _collect_bots edge cases -----------------------------------------------
+
+
+def test_collect_bots_returns_empty_when_dir_missing(tmp_path):
+    missing = tmp_path / "no-such-dir"
+    with patch("culture.bots.config.BOTS_DIR", missing):
+        assert _collect_bots() == []
+
+
+def test_collect_bots_skips_dirs_without_yaml(tmp_path):
+    (tmp_path / "no-yaml-here").mkdir()
+    with patch("culture.bots.config.BOTS_DIR", tmp_path):
+        assert _collect_bots() == []
+
+
+def test_collect_bots_swallows_malformed_yaml(tmp_path):
+    bot_dir = tmp_path / "broken-bot"
+    bot_dir.mkdir()
+    (bot_dir / "bot.yaml").write_text("this is: not: a valid: bot: config\n")
+    with patch("culture.bots.config.BOTS_DIR", tmp_path):
+        # The malformed entry is silently dropped, not raised.
+        assert _collect_bots() == []
+
+
+# ---- _enrich_via_ipc with a real Unix socket --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_status_response_populates_agent(tmp_path, monkeypatch):
+    """Happy path: socket returns a status response → agent fields populated."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    sock_path = runtime / "culture-srv-claude.sock"
+
+    async def handler(reader, writer):
+        try:
+            await reader.readline()
+            from culture.clients.shared.ipc import encode_message
+
+            writer.write(
+                encode_message(
+                    {
+                        "type": "response",
+                        "ok": True,
+                        "data": {
+                            "description": "thinking",
+                            "turn_count": 7,
+                            "circuit_open": False,
+                            "paused": False,
+                        },
+                    }
+                )
+            )
+            await writer.drain()
+            writer.close()
+        except Exception:
+            pass
+
+    srv = await asyncio.start_unix_server(handler, path=str(sock_path))
+    try:
+        monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+
+        agents = {
+            "srv-claude": Agent(
+                nick="srv-claude",
+                status="active",
+                activity="",
+                channels=[],
+                server="srv",
+            ),
+        }
+        await _enrich_via_ipc(agents, "srv")
+        assert agents["srv-claude"].activity == "thinking"
+        assert agents["srv-claude"].turns == 7
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_circuit_open_sets_status(tmp_path, monkeypatch):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    sock_path = runtime / "culture-srv-codex.sock"
+
+    async def handler(reader, writer):
+        try:
+            await reader.readline()
+            from culture.clients.shared.ipc import encode_message
+
+            writer.write(
+                encode_message(
+                    {
+                        "type": "response",
+                        "ok": True,
+                        "data": {"description": "waiting", "circuit_open": True},
+                    }
+                )
+            )
+            await writer.drain()
+            writer.close()
+        except Exception:
+            pass
+
+    srv = await asyncio.start_unix_server(handler, path=str(sock_path))
+    try:
+        monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+        agents = {
+            "srv-codex": Agent(
+                nick="srv-codex",
+                status="active",
+                activity="",
+                channels=[],
+                server="srv",
+            ),
+        }
+        await _enrich_via_ipc(agents, "srv")
+        assert agents["srv-codex"].status == "circuit-open"
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_paused_sets_status(tmp_path, monkeypatch):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    sock_path = runtime / "culture-srv-acp.sock"
+
+    async def handler(reader, writer):
+        try:
+            await reader.readline()
+            from culture.clients.shared.ipc import encode_message
+
+            writer.write(
+                encode_message(
+                    {
+                        "type": "response",
+                        "ok": True,
+                        "data": {"description": "idle", "paused": True},
+                    }
+                )
+            )
+            await writer.drain()
+            writer.close()
+        except Exception:
+            pass
+
+    srv = await asyncio.start_unix_server(handler, path=str(sock_path))
+    try:
+        monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+        agents = {
+            "srv-acp": Agent(
+                nick="srv-acp",
+                status="active",
+                activity="",
+                channels=[],
+                server="srv",
+            ),
+        }
+        await _enrich_via_ipc(agents, "srv")
+        assert agents["srv-acp"].status == "paused"
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_skips_unknown_agent_socket(tmp_path, monkeypatch):
+    """Socket name doesn't match any agent → no error, no mutation."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    # Touch a socket file via an actual UNIX server so glob() sees it.
+    sock_path = runtime / "culture-stranger.sock"
+
+    async def handler(_r, w):
+        w.close()
+
+    srv = await asyncio.start_unix_server(handler, path=str(sock_path))
+    try:
+        monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+        agents = {
+            "srv-claude": Agent(
+                nick="srv-claude",
+                status="active",
+                activity="",
+                channels=[],
+                server="srv",
+            ),
+        }
+        before = agents["srv-claude"].activity
+        await _enrich_via_ipc(agents, "srv")
+        assert agents["srv-claude"].activity == before  # unchanged
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_skips_remote_agent(tmp_path, monkeypatch):
+    """Agent on a foreign server is skipped even if a socket exists."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    sock_path = runtime / "culture-thor-claude.sock"
+
+    called: list[bool] = []
+
+    async def handler(reader, writer):
+        called.append(True)
+        try:
+            await reader.readline()
+            writer.close()
+        except Exception:
+            pass
+
+    srv = await asyncio.start_unix_server(handler, path=str(sock_path))
+    try:
+        monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+        agents = {
+            "thor-claude": Agent(
+                nick="thor-claude",
+                status="active",
+                activity="",
+                channels=[],
+                server="thor",
+            ),
+        }
+        await _enrich_via_ipc(agents, "srv")
+        # Server short-circuits before reading; agent unchanged.
+        assert agents["thor-claude"].activity == ""
+        assert called == []
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_swallows_connection_refused(tmp_path, monkeypatch):
+    """A dangling sock file that can't be connected to is silently skipped."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    sock_path = runtime / "culture-srv-stale.sock"
+    # Create a regular file at the socket path so glob picks it up but
+    # open_unix_connection fails.
+    sock_path.write_text("not a socket")
+
+    monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+
+    agents = {
+        "srv-stale": Agent(
+            nick="srv-stale",
+            status="active",
+            activity="",
+            channels=[],
+            server="srv",
+        ),
+    }
+    # Should not raise — the broad except in _enrich_via_ipc swallows.
+    await _enrich_via_ipc(agents, "srv")
+    assert agents["srv-stale"].activity == ""
+
+
+@pytest.mark.asyncio
+async def test_enrich_via_ipc_skips_when_response_not_ok(tmp_path, monkeypatch):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    sock_path = runtime / "culture-srv-noop.sock"
+
+    async def handler(reader, writer):
+        try:
+            await reader.readline()
+            from culture.clients.shared.ipc import encode_message
+
+            writer.write(encode_message({"type": "response", "ok": False, "data": {}}))
+            await writer.drain()
+            writer.close()
+        except Exception:
+            pass
+
+    srv = await asyncio.start_unix_server(handler, path=str(sock_path))
+    try:
+        monkeypatch.setattr(collector_mod, "culture_runtime_dir", lambda: str(runtime))
+        agents = {
+            "srv-noop": Agent(
+                nick="srv-noop",
+                status="active",
+                activity="",
+                channels=[],
+                server="srv",
+            ),
+        }
+        await _enrich_via_ipc(agents, "srv")
+        # Response was not ok — activity stays empty.
+        assert agents["srv-noop"].activity == ""
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+# ---- collect_mesh_state with manifest_agents end-to-end ----------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_mesh_state_injects_stopped_manifest_agents(server):
+    """Stopped agents from manifest_agents appear in `mesh.agents` even though
+    they're not on IRC."""
+
+    class _ManifestCfg:
+        def __init__(self, nick):
+            self.nick = nick
+            self.channels = ["#general"]
+            self.archived = False
+            self.backend = "claude"
+            self.directory = None
+
+    mesh = await collect_mesh_state(
+        host="127.0.0.1",
+        port=server.config.port,
+        server_name=server.config.name,
+        message_limit=4,
+        ipc_enabled=False,
+        manifest_agents=[_ManifestCfg("testserv-stopped")],
+    )
+    found = next((a for a in mesh.agents if a.nick == "testserv-stopped"), None)
+    assert found is not None
+    assert found.status == "stopped"

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.0.9"
+version = "12.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.0.8"
+version = "12.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 4b of the 60→90 coverage ratchet. 96 new tests across four IRCd-integrated modules; project floor jumps from 79 to 83 (measured **83.93%**, +4.25pp).

| File | Before | After | New tests |
|---|---|---|---|
| `culture/observer.py` | 28% | **92%** | 28 (new `tests/test_observer.py`) |
| `culture/overview/collector.py` | 71% | **98%** | 23 (appended) |
| `culture/bots/bot.py` | 62% | **98%** | 21 (appended) |
| `culture/bots/bot_manager.py` | 65% | **99%** | 24 (appended) |

## Strategy

Every target uses the existing real-IRCd fixtures (`server`, `make_client`, `server_with_bot`) from `tests/conftest.py:177–451` for round-trips, plus direct unit tests for pure logic (parsers, predicates, factories). No new conftest additions.

Notable patterns:

- **`_run_custom_handler`**: real `importlib.util.spec_from_file_location` against a `handler.py` written into tmp_path. `sys.modules` cleanup via a request-finalizer prevents cross-test bleed (importlib caches by name).
- **`_enrich_via_ipc`**: real `asyncio.start_unix_server` in tmp_path covers happy status, `circuit_open` / `paused` status flips, stranger-socket skip, foreign-server skip, connection-refused (regular file as fake socket) swallow, and `ok: False` no-mutation.
- **`_query_roommeta` / `_query_tags`**: canned-bytes `_FakeReader` since these are culture protocol extensions that the IRCd doesn't emit organically in test mode.
- **`_maybe_fire_event`**: full matrix — happy enum emit, dynamic-typed emit, no-spec early-return, invalid type regex skip, rate-limited skip, emit-raises log-and-swallow.
- **`BotManager.start()`**: covers crash-safe teardown — if `load_bots` raises after init, `stop()` is invoked before the exception bubbles.

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -c` — 1292 passed, 1 skipped; coverage 83.93%, floor 83 reached
- [x] black / isort / flake8 / pylint / bandit / markdownlint — all clean
- [x] Per-file coverage verified against `--cov-report=term-missing`
- [ ] SonarCloud Quality Gate (will check after CI)
- [ ] Qodo / Copilot review pass

## Phase log

`docs/coverage-baseline.md` records the full Phase 4b entry and updates the per-phase target table. Phase 5 next: `culture/transport/client.py` (currently 25%, largely dead post-cultureagent-extraction — re-evaluate backfill vs. deletion).

- culture (Claude)
