### PR TITLE
fix: clear SonarCloud S7483 (observer + collector) and S5332 hotspot [v12.1.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.1.6] - 2026-05-13
+
+### Fixed
+
+- Guard `_recv_until` in `culture/overview/collector.py` against EOF spin: break immediately when `reader.readline()` returns `b""`, instead of hot-looping until `RECV_TIMEOUT` (Qodo PR review #396).
+
 ## [12.1.5] - 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.1.5] - 2026-05-13
+
+### Fixed
+
+- SonarCloud S7483: drop dead `timeout` parameter from `culture/observer.py:_recv_lines` and `culture/overview/collector.py:_recv_until`; express the bound with an `asyncio.timeout` context manager and a module-level constant (`JOIN_DRAIN_TIMEOUT` / `RECV_TIMEOUT`).
+
 ## [12.1.4] - 2026-05-13
 
 ### Fixed

--- a/culture/observer.py
+++ b/culture/observer.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 RECV_TIMEOUT = 5.0
 # Timeout for the full connect + register cycle
 REGISTER_TIMEOUT = 10.0
+# Timeout for draining JOIN responses before sending PRIVMSG
+JOIN_DRAIN_TIMEOUT = 1.0
 
 
 def _sanitize_for_irc(value: str) -> str:
@@ -165,25 +167,22 @@ class IRCObserver:
         except OSError:
             pass
 
-    async def _recv_lines(
-        self, reader: asyncio.StreamReader, timeout: float = RECV_TIMEOUT
-    ) -> list[Message]:
-        """Read all available lines from the reader until timeout."""
+    async def _recv_lines(self, reader: asyncio.StreamReader) -> list[Message]:
+        """Drain all available lines from the reader for up to JOIN_DRAIN_TIMEOUT seconds."""
         messages: list[Message] = []
         buffer = ""
         try:
-            while True:
-                async with asyncio.timeout(timeout):
+            async with asyncio.timeout(JOIN_DRAIN_TIMEOUT):
+                while True:
                     data = await reader.read(4096)
-                if not data:
-                    break
-                buffer += data.decode(errors="replace")
-                while "\r\n" in buffer:
-                    line, buffer = buffer.split("\r\n", 1)
-                    if line.strip():
-                        messages.append(Message.parse(line))
+                    if not data:
+                        break
+                    buffer += data.decode(errors="replace")
+                    while "\r\n" in buffer:
+                        line, buffer = buffer.split("\r\n", 1)
+                        if line.strip():
+                            messages.append(Message.parse(line))
         except asyncio.TimeoutError:
-            # Parse anything remaining in buffer
             if buffer.strip():
                 messages.append(Message.parse(buffer.strip()))
         return messages
@@ -321,7 +320,7 @@ class IRCObserver:
                 writer.write(f"JOIN {target}\r\n".encode())
                 await writer.drain()
                 # Drain join responses
-                await self._recv_lines(reader, timeout=1.0)
+                await self._recv_lines(reader)
 
             for line in lines:
                 writer.write(f"PRIVMSG {target} :{line}\r\n".encode())

--- a/culture/overview/collector.py
+++ b/culture/overview/collector.py
@@ -225,35 +225,30 @@ async def _disconnect(writer: asyncio.StreamWriter) -> None:
         pass
 
 
-async def _recv_until(  # NOSONAR S7483 — timeout sets the per-call recv budget; removing the param removes caller control
+async def _recv_until(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
     stop_commands: set[str],
-    timeout: float = RECV_TIMEOUT,
 ) -> list[IRCMessage]:
-    """Read IRC messages until a stop command is seen."""
-    messages = []
-    deadline = asyncio.get_event_loop().time() + timeout
-    while True:
-        remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:
-            break
-        try:
-            async with asyncio.timeout(remaining):
+    """Read IRC messages until a stop command is seen or RECV_TIMEOUT elapses."""
+    messages: list[IRCMessage] = []
+    try:
+        async with asyncio.timeout(RECV_TIMEOUT):
+            while True:
                 data = await reader.readline()
-        except asyncio.TimeoutError:
-            break
-        line = data.decode().strip()
-        if not line:
-            continue
-        msg = IRCMessage.parse(line)
-        if msg.command == "PING":
-            writer.write(f"PONG :{msg.params[0]}\r\n".encode())
-            await writer.drain()
-            continue
-        messages.append(msg)
-        if msg.command in stop_commands:
-            break
+                line = data.decode().strip()
+                if not line:
+                    continue
+                msg = IRCMessage.parse(line)
+                if msg.command == "PING":
+                    writer.write(f"PONG :{msg.params[0]}\r\n".encode())
+                    await writer.drain()
+                    continue
+                messages.append(msg)
+                if msg.command in stop_commands:
+                    break
+    except asyncio.TimeoutError:
+        pass
     return messages
 
 

--- a/culture/overview/collector.py
+++ b/culture/overview/collector.py
@@ -236,6 +236,8 @@ async def _recv_until(
         async with asyncio.timeout(RECV_TIMEOUT):
             while True:
                 data = await reader.readline()
+                if not data:
+                    break
                 line = data.decode().strip()
                 if not line:
                     continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.1.5"
+version = "12.1.6"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.1.4"
+version = "12.1.5"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -403,7 +403,7 @@ async def test_observer_send_message_strips_target_crlf(monkeypatch):
         captured["writer"] = fake_writer
         return _FakeReader(), fake_writer, "nick"
 
-    async def _fake_recv(_reader, timeout=0.0):
+    async def _fake_recv(_reader):
         return []
 
     monkeypatch.setattr(obs, "_connect_and_register", _fake_connect)

--- a/tests/test_overview_collector.py
+++ b/tests/test_overview_collector.py
@@ -320,7 +320,7 @@ class _FakeReader:
 async def test_recv_until_stops_on_stop_command():
     reader = _FakeReader([b":srv 322 me #room 0 :topic\r\n", b":srv 323 me :End\r\n"])
     writer = _CollectorWriter()
-    msgs = await _recv_until(reader, writer, {"323"}, timeout=1.0)  # type: ignore[arg-type]
+    msgs = await _recv_until(reader, writer, {"323"})  # type: ignore[arg-type]
     cmds = [m.command for m in msgs]
     assert "322" in cmds
     assert cmds[-1] == "323"
@@ -330,7 +330,7 @@ async def test_recv_until_stops_on_stop_command():
 async def test_recv_until_ponging_a_ping_does_not_emit_message():
     reader = _FakeReader([b"PING :tok\r\n", b":srv 323 me :End\r\n"])
     writer = _CollectorWriter()
-    msgs = await _recv_until(reader, writer, {"323"}, timeout=1.0)  # type: ignore[arg-type]
+    msgs = await _recv_until(reader, writer, {"323"})  # type: ignore[arg-type]
     cmds = [m.command for m in msgs]
     assert "PING" not in cmds
     assert "323" in cmds
@@ -338,10 +338,11 @@ async def test_recv_until_ponging_a_ping_does_not_emit_message():
 
 
 @pytest.mark.asyncio
-async def test_recv_until_skips_blank_lines_and_returns_on_timeout():
+async def test_recv_until_skips_blank_lines_and_returns_on_timeout(monkeypatch):
+    monkeypatch.setattr("culture.overview.collector.RECV_TIMEOUT", 0.1)
     reader = _FakeReader([b"\r\n"], block_after=True)
     writer = _CollectorWriter()
-    msgs = await _recv_until(reader, writer, {"323"}, timeout=0.1)  # type: ignore[arg-type]
+    msgs = await _recv_until(reader, writer, {"323"})  # type: ignore[arg-type]
     assert msgs == []
 
 

--- a/tests/test_overview_collector.py
+++ b/tests/test_overview_collector.py
@@ -346,6 +346,16 @@ async def test_recv_until_skips_blank_lines_and_returns_on_timeout(monkeypatch):
     assert msgs == []
 
 
+@pytest.mark.asyncio
+async def test_recv_until_breaks_on_eof_without_spinning():
+    """A closed stream (readline returns b'') must exit immediately, not hot-loop."""
+    reader = _FakeReader([b":srv 322 me #room 0 :topic\r\n"], block_after=False)
+    writer = _CollectorWriter()
+    msgs = await _recv_until(reader, writer, {"323"})  # type: ignore[arg-type]
+    # We got the one line we had; EOF then triggered the break.
+    assert [m.command for m in msgs] == ["322"]
+
+
 # ---- _query_roommeta / _query_tags via stubbed reader -----------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.1.5"
+version = "12.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.1.4"
+version = "12.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Clears the three SonarCloud findings left after #395:

- **python:S7483** in `culture/observer.py:169` — `_recv_lines` exposed a `timeout` parameter.
- **python:S7483** in `culture/overview/collector.py:232` — `_recv_until` exposed a `timeout` parameter (with a misplaced `# NOSONAR` line comment whose rationale didn't hold — no caller ever overrode it).
- **python:S5332** hotspot in `culture/overview/renderer_web.py:267` — resolved administratively (server binds to `127.0.0.1`; HTTP traffic never leaves loopback), no source change.

### What changed

| File | Change |
|------|--------|
| `culture/observer.py` | New `JOIN_DRAIN_TIMEOUT = 1.0`. `_recv_lines` drops the `timeout` kwarg and bounds its receive loop with `async with asyncio.timeout(JOIN_DRAIN_TIMEOUT)`, preserving partial-buffer parse on `TimeoutError`. One call site updated. |
| `culture/overview/collector.py` | `_recv_until` drops the `timeout` kwarg; deadline math replaced with `async with asyncio.timeout(RECV_TIMEOUT)`. Same overall budget, in the context-manager form S7483 wants. Removes the misplaced `# NOSONAR S7483`. |
| `tests/test_overview_collector.py` | Drops `timeout=…` kwargs from three call sites; the fast-timeout test now `monkeypatch.setattr`s `RECV_TIMEOUT = 0.1`. |
| `tests/test_observer.py` | Drops `timeout` kwarg from the `_fake_recv` stub. |

Patch bump → **v12.1.5**.

## Test plan

- [x] `uv run pytest tests/test_overview_collector.py tests/test_observer.py -v` — 61 passed
- [x] `uv run pytest -n auto -q` (full suite) — 1337 passed, 1 skipped
- [x] `uv run black` + `uv run isort` on edited files
- [x] pre-commit hooks pass on commit
- [ ] CI green
- [ ] `.claude/skills/cicd/scripts/pr-status.sh <this PR>` shows clean SonarCloud gate and the two S7483 issues gone
- [ ] S5332 hotspot resolved as SAFE via SonarCloud API (admin action — see comment below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- culture (Claude)