### PR TITLE
chore(deps): bump irc-lens to 0.5.3 [v12.1.7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.1.7] - 2026-05-14
+
+### Changed
+
+- Bump `irc-lens` floor `>=0.5.1` -> `>=0.5.3` and refresh `uv.lock` (0.5.1 -> 0.5.3). 0.5.3 is a CI-only release over 0.5.1 (no runtime change) -- a lockfile/pin freshness bump. Cloudflare Access SSO support for `culture console` landed upstream in irc-lens 0.5.x and was already reachable via the prior `>=0.5.1` floor.
+
 ## [12.1.6] - 2026-05-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.1.6"
+version = "12.1.7"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -24,7 +24,7 @@ dependencies = [
     "agex-cli>=0.13,<1.0",
     "agtag>=0.1,<1.0",
     "afi-cli>=0.3,<1.0",
-    "irc-lens>=0.5.1,<1.0",
+    "irc-lens>=0.5.3,<1.0",
     "opentelemetry-api>=1.25",
     "opentelemetry-sdk>=1.25",
     "opentelemetry-exporter-otlp-proto-grpc>=1.25",

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.1.6"
+version = "12.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },
@@ -673,7 +673,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1" },
     { name = "cultureagent", specifier = "~=0.4.0" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot'" },
-    { name = "irc-lens", specifier = ">=0.5.1,<1.0" },
+    { name = "irc-lens", specifier = ">=0.5.3,<1.0" },
     { name = "mistune", specifier = ">=3.0" },
     { name = "opentelemetry-api", specifier = ">=1.25" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25" },
@@ -1072,7 +1072,7 @@ wheels = [
 
 [[package]]
 name = "irc-lens"
-version = "0.5.1"
+version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1080,9 +1080,9 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/37/04578842566f3817b20042c2fc9a8fd299c7fed5d8bf6056b3f4740345a8/irc_lens-0.5.1.tar.gz", hash = "sha256:27a5c8d84d454980ecbbf709c5573b95eb7d1667c37e1ecdd97c890d1aca175b", size = 384592, upload-time = "2026-05-08T12:10:14.072Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/8a/98adace59f94400f93205e83cb6deb88e5136a64d36a867ac3e2276c2357/irc_lens-0.5.3.tar.gz", hash = "sha256:3bfb14e1e452d2c348a3ecb130ff9341439055b9aeb7c98356ebcfa278761b2a", size = 384678, upload-time = "2026-05-09T16:49:53.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/bd/e1ddae6bcd5589f6328736b208034f971ae459023528e8eaec3118d3bbbb/irc_lens-0.5.1-py3-none-any.whl", hash = "sha256:2b6effffed184608eda9574026bd1be9e6a2b6d80701fa6eea5f83c1a94ef190", size = 165543, upload-time = "2026-05-08T12:10:15.45Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ea/8b7e8cddbc5e77ce0393f3ecdbc899551cab4cb74709491f4e914cde5690/irc_lens-0.5.3-py3-none-any.whl", hash = "sha256:de3e11cd32cd21a76b71724aeac30d503a1dabdb50a0faee4d80f5d11d3eae9d", size = 165544, upload-time = "2026-05-09T16:49:54.7Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump the `irc-lens` floor `>=0.5.1` → `>=0.5.3` in `pyproject.toml` and refresh `uv.lock` (0.5.1 → 0.5.3).
- 0.5.3 is a CI-only release over 0.5.1 (irc-lens #42, "align SonarCloud + coverage to steward standard") — **no runtime change**. This is a lockfile/pin freshness bump.
- The Cloudflare Access SSO stack for `culture console` (`web/auth.py`, `web/identity.py`, JWT middleware) landed upstream in irc-lens 0.5.x and was already reachable via the prior `>=0.5.1` floor — verified present in the installed 0.5.3 wheel.
- Version bumped 12.1.6 → 12.1.7.

## Test plan

- [x] `irc-lens` resolves to 0.5.3 in `uv.lock` and the project venv
- [x] Full suite green — `1338 passed, 1 skipped` (skip = opt-in Playwright e2e)
- [x] `culture console --version` → `irc-lens 0.5.3`; `culture console explain` passthrough works
- [ ] CI: version-check + SonarCloud quality gate

- culture (Claude)