### PR TITLE
fix(bots): close BotManager.load_bots race against re-entrant Bot.start() [v12.1.9]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.1.10] - 2026-05-18
+
+### Fixed
+
+- bots: address Qodo review of #399 — declare `_starting: bool = False` on `Bot.__init__` (replacing the dynamic `# type: ignore[attr-defined]` writes) and centralize the start-guard set/clear into a single `BotManager._starting_guard` context manager used by both `load_bots` and `_try_start_bot`.
+
 ## [12.1.9] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.1.9] - 2026-05-17
+
+### Fixed
+
+- bots: close `BotManager.load_bots` race against re-entrant `Bot.start()` (#317). The loader now sets `bot._starting=True` before the await and clears it in a `finally`, so `on_event` dispatches that fire mid-start (e.g. a `user.join` from this bot's own `join_channel`) short-circuit via `_try_start_bot`'s existing guard instead of re-entering `Bot.start()` and tripping the nick-collision check.
+
 ## [12.1.7] - 2026-05-14
 
 ### Changed

--- a/culture/bots/bot.py
+++ b/culture/bots/bot.py
@@ -78,6 +78,11 @@ class Bot:
         self.server = server
         self.virtual_client: VirtualClient | None = None
         self.active: bool = False
+        # Set by BotManager while awaiting start() so a nested event
+        # dispatch can't re-enter Bot.start() and trip the nick-already-in-use
+        # check against the VirtualClient this same call already registered.
+        # See BotManager._starting_guard / _try_start_bot. Closes #317.
+        self._starting: bool = False
 
     @property
     def name(self) -> str:

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -110,7 +110,17 @@ class BotManager:
                         continue
                 bot = Bot(config, self.server)
                 self.bots[config.name] = bot
-                await bot.start()
+                # Mirror the _try_start_bot guard so that an event fired
+                # mid-start() (e.g. user.join from this bot's own
+                # join_channel) can't re-enter Bot.start() from on_event
+                # and trip the "Nick already in use" check on the
+                # VirtualClient this same call already registered.
+                # Closes #317.
+                bot._starting = True  # type: ignore[attr-defined]
+                try:
+                    await bot.start()
+                finally:
+                    bot._starting = False  # type: ignore[attr-defined]
                 logger.info("Loaded bot %s", config.name)
             except Exception:
                 logger.exception("Failed to load bot from %s", bot_dir)

--- a/culture/bots/bot_manager.py
+++ b/culture/bots/bot_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from opentelemetry import trace as _otel_trace
@@ -87,6 +88,23 @@ class BotManager:
             self._http_listener = None
         await self.stop_all()
 
+    @staticmethod
+    @contextmanager
+    def _starting_guard(bot: Bot):
+        """Mark ``bot`` as starting so a re-entrant ``_try_start_bot`` short-circuits.
+
+        Set before awaiting ``Bot.start()`` and cleared in ``finally`` so an
+        event fired mid-start (e.g. ``user.join`` from this bot's own
+        ``join_channel``) can't loop back into ``Bot.start()`` from
+        ``on_event`` and trip the "Nick already in use" check on the
+        ``VirtualClient`` this same call already registered. Closes #317.
+        """
+        bot._starting = True
+        try:
+            yield
+        finally:
+            bot._starting = False
+
     async def load_bots(self) -> None:
         """Scan ~/.culture/bots/ and load all bot definitions."""
         if not BOTS_DIR.is_dir():
@@ -110,17 +128,8 @@ class BotManager:
                         continue
                 bot = Bot(config, self.server)
                 self.bots[config.name] = bot
-                # Mirror the _try_start_bot guard so that an event fired
-                # mid-start() (e.g. user.join from this bot's own
-                # join_channel) can't re-enter Bot.start() from on_event
-                # and trip the "Nick already in use" check on the
-                # VirtualClient this same call already registered.
-                # Closes #317.
-                bot._starting = True  # type: ignore[attr-defined]
-                try:
+                with self._starting_guard(bot):
                     await bot.start()
-                finally:
-                    bot._starting = False  # type: ignore[attr-defined]
                 logger.info("Loaded bot %s", config.name)
             except Exception:
                 logger.exception("Failed to load bot from %s", bot_dir)
@@ -140,17 +149,15 @@ class BotManager:
         """Lazily start a bot on first matching event. Returns True if ready."""
         if bot.active:
             return True
-        if getattr(bot, "_starting", False):
+        if bot._starting:
             return False
-        bot._starting = True  # type: ignore[attr-defined]
-        try:
-            await bot.start()
-            return True
-        except Exception:
-            logger.exception("Bot %s failed to start", bot.config.name)
-            return False
-        finally:
-            bot._starting = False  # type: ignore[attr-defined]
+        with self._starting_guard(bot):
+            try:
+                await bot.start()
+                return True
+            except Exception:
+                logger.exception("Bot %s failed to start", bot.config.name)
+                return False
 
     async def on_event(self, event) -> None:
         """Evaluate event-triggered bots against an event and dispatch matches."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.1.9"
+version = "12.1.10"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.1.7"
+version = "12.1.9"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_bot_manager.py
+++ b/tests/test_bot_manager.py
@@ -349,6 +349,80 @@ def test_register_bot_raises_on_invalid_filter(server, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_load_bots_sets_starting_guard_around_bot_start(
+    server,
+    tmp_path,
+    monkeypatch,
+):
+    """Regression for #317 — load_bots must set `_starting = True`
+    around `await bot.start()` so a synchronous on_event re-entry
+    (triggered by a user.join emitted from join_channel inside the same
+    start()) sees the guard and short-circuits via `_try_start_bot`.
+
+    Pre-fix: the guard was only set by `_try_start_bot`; `load_bots`
+    awaited `bot.start()` with no guard, so a re-entrant call from
+    `on_event → _dispatch_to_bot → _try_start_bot → bot.start()` would
+    trip the nick-collision check on the VirtualClient that the original
+    `start()` had already registered.
+
+    This test inspects state at the precise moment when `Bot.start()`
+    yields control — by monkeypatching `start()` to capture
+    `bot._starting` mid-flight. It also confirms `_try_start_bot` is a
+    no-op while the guard is set.
+    """
+    monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)
+    monkeypatch.setattr("culture.bots.config.BOTS_DIR", tmp_path)
+
+    cfg = BotConfig(
+        name="testserv-guard-probe",
+        owner="testserv-ori",
+        channels=["#guard"],
+        template="x",
+    )
+    save_bot_config(tmp_path / cfg.name / "bot.yaml", cfg)
+
+    mgr = BotManager(server)
+
+    captured: dict = {"starting_mid_call": None, "try_start_result": None}
+
+    from culture.bots.bot import Bot as _Bot
+
+    real_start = _Bot.start
+
+    async def probing_start(self):
+        # Re-entrant probe: simulate on_event walking bots and calling
+        # _try_start_bot on this same bot mid-start(). If load_bots didn't
+        # set the guard, _try_start_bot would await start() again and
+        # the nick-collision check would raise.
+        captured["starting_mid_call"] = getattr(self, "_starting", False)
+        if self in mgr.bots.values():
+            captured["try_start_result"] = await mgr._try_start_bot(self)
+        await real_start(self)
+
+    monkeypatch.setattr(_Bot, "start", probing_start)
+
+    await mgr.load_bots()
+
+    assert captured["starting_mid_call"] is True, (
+        "load_bots failed to set bot._starting=True around bot.start() — "
+        "re-entrant on_event dispatch can race the original start() call (#317)"
+    )
+    # While load_bots holds the guard, _try_start_bot must short-circuit
+    # to False rather than starting the bot a second time.
+    assert captured["try_start_result"] is False, (
+        "_try_start_bot did not honor the _starting guard set by load_bots; "
+        "this would let a second concurrent start() proceed."
+    )
+    assert cfg.name in mgr.bots
+    assert mgr.bots[cfg.name].active
+    # Guard cleared on the way out so a future _try_start_bot can run.
+    assert not getattr(mgr.bots[cfg.name], "_starting", False)
+
+    await mgr.stop_all()
+
+
+@pytest.mark.asyncio
 async def test_try_start_bot_idempotent_when_already_starting(server, tmp_path, monkeypatch):
     monkeypatch.setattr(bm_mod, "BOTS_DIR", tmp_path)
     monkeypatch.setattr("culture.bots.bot.BOTS_DIR", tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.1.9"
+version = "12.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.1.7"
+version = "12.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Fixes #317 — the spurious `ERROR Bot X failed to start` traceback during `culture server start`.

When `load_bots` awaited `bot.start()`, that `start()` could register a VirtualClient and emit `user.join` from `join_channel`. `IRCd.emit_event` synchronously dispatched into `BotManager.on_event`, which walked `self.bots` (the bot was already inserted on the line above), matched a filter, and called `_dispatch_to_bot → _try_start_bot → await bot.start()` *again* on the same instance. The second call saw its own VirtualClient already registered and raised `Nick … already in use`. The bot was still functional afterwards (the original `start()` completed), but the misleading error log was a sharp edge.

This PR applies **option 1** from the issue body — mirror the `_starting` guard from `_try_start_bot` into `load_bots`:

```python
self.bots[config.name] = bot
bot._starting = True
try:
    await bot.start()
finally:
    bot._starting = False
```

Re-entrant calls now hit the existing guard at `culture/bots/bot_manager.py:133` (`if getattr(bot, "_starting", False): return False`) and short-circuit cleanly.

Option 2 (boot-time event suppression) was *not* picked — it would have changed observable behavior for the welcome bot's `user.join` handling. Option 1 preserves boot-time event semantics exactly.

## Test plan

- [x] New `test_load_bots_sets_starting_guard_around_bot_start` regression test that monkeypatches `Bot.start` to probe `bot._starting` mid-call and to invoke `_try_start_bot` re-entrantly. Verified **fails without the fix** (`AssertionError: _try_start_bot did not honor the _starting guard`) and **passes with it**.
- [x] `bash .claude/skills/run-tests/scripts/test.sh -p` — 1339 passed, 1 skipped. No regressions in any existing bot/event/welcome-bot test.
- [x] Guard cleared on success and on exception — verified by the `finally` block and asserted in the test (`not getattr(bot, "_starting", False)` after `load_bots` returns).

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)