### PR TITLE
feat(cli): culture learn/explain --json contract [v12.2.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.2.0] - 2026-05-19
+
+### Added
+
+- `culture learn --json`, `culture explain [path] --json`, `culture overview [topic] --json` — emit structured JSON per the AgentCulture sibling contract. `learn --json` returns `{tool, version, summary, purpose, nouns, passthroughs, verbs, exit_codes, json_support, explain_pointer}`; `explain --json` returns `{path, nouns?|verbs?|passthrough_to?, markdown}`. Errors in JSON mode emit `{code, message, remediation}` to stderr; stdout and stderr are never mixed. Verbs come from live argparse introspection so the reference stays in sync as groups add subcommands. Closes #401.
+
 ## [12.1.12] - 2026-05-19
 
 ### Removed

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from typing import NoReturn
 
 from culture import __version__
 from culture.cli import (
@@ -36,6 +37,8 @@ from culture.cli import (
     server,
     skills,
 )
+from culture.cli._errors import EXIT_USER_ERROR, CultureError
+from culture.cli._output import emit_error
 
 GROUPS = [agent, server, mesh, channel, bot, skills, devex, afi, console, introspect]
 
@@ -47,13 +50,53 @@ def _names_of(group) -> set[str]:
     return {group.NAME}
 
 
+def _json_mode_active(argv: list[str]) -> bool:
+    """``--json`` is meaningful only on the three universal verbs.
+
+    Other groups (`agent`, `server`, …) reject ``--json`` themselves; we
+    only honor the AgentCulture JSON-error contract when the user is
+    addressing an introspection verb. This matches what katvan's
+    reference-sync actually invokes.
+    """
+    if "--json" not in argv:
+        return False
+    return any(v in argv for v in introspect.NAMES)
+
+
+class _JsonAwareParser(argparse.ArgumentParser):
+    """``argparse.ArgumentParser`` that honors the ``--json`` error contract.
+
+    When the user runs e.g. ``culture explain --bogus --json``, argparse's
+    default ``error()`` writes plain text to stderr and exits 2. That
+    violates the AgentCulture sibling contract that *any* failure under
+    ``--json`` emit a parseable ``{code, message, remediation}`` object on
+    stderr. We override ``error()`` so parse-time failures route through
+    :func:`culture.cli._output.emit_error` whenever ``--json`` is active.
+
+    Applied at the top parser and (via ``parser_class``) at every
+    subparser, so any subcommand that reaches ``parse_args()`` honors the
+    contract.
+    """
+
+    def error(self, message: str) -> NoReturn:  # type: ignore[override]
+        if _json_mode_active(sys.argv[1:]):
+            err = CultureError(
+                code=EXIT_USER_ERROR,
+                message=message,
+                remediation="run 'culture --help' or 'culture explain' for usage",
+            )
+            emit_error(err, json_mode=True)
+            self.exit(EXIT_USER_ERROR)
+        super().error(message)
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _JsonAwareParser(
         prog="culture",
         description="culture — AI agent IRC mesh",
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
-    sub = parser.add_subparsers(dest="command")
+    sub = parser.add_subparsers(dest="command", parser_class=_JsonAwareParser)
     for group in GROUPS:
         group.register(sub)
     return parser
@@ -108,5 +151,18 @@ def main() -> None:
     except KeyboardInterrupt:
         pass
     except Exception as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        # Honor the --json contract on unexpected exceptions too: an agent
+        # consumer that asked for JSON should never see a plain-text
+        # "Error: ..." trailer on stderr instead of the structured shape.
+        if _json_mode_active(sys.argv[1:]):
+            emit_error(
+                CultureError(
+                    code=1,
+                    message=str(exc),
+                    remediation="check the command and try again",
+                ),
+                json_mode=True,
+            )
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/culture/cli/_errors.py
+++ b/culture/cli/_errors.py
@@ -1,0 +1,38 @@
+"""CultureError + exit-code policy for the agent-first CLI surface.
+
+Ported from agtag (``agtag/cli/_errors.py``). Every CLI failure that
+reaches the user (in particular, anything emitted under ``--json``) is
+raised as :class:`CultureError`; :func:`culture.cli._output.emit_error`
+serialises it. Guarantees:
+
+* no Python traceback leaks to stderr in JSON mode;
+* every JSON-mode error has shape ``{code, message, remediation}``;
+* the exit-code policy is centralised here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 1
+EXIT_ENV_ERROR = 2
+
+
+@dataclass
+class CultureError(Exception):
+    """Structured error with a remediation hint for agents."""
+
+    code: int
+    message: str
+    remediation: str = ""
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "remediation": self.remediation,
+        }

--- a/culture/cli/_output.py
+++ b/culture/cli/_output.py
@@ -1,0 +1,54 @@
+"""stdout / stderr helpers with a strict split (stable-contract).
+
+Ported from agtag (``agtag/cli/_output.py``). Results go to stdout,
+diagnostics and errors go to stderr. Agents parsing output can rely on
+this invariant. JSON mode routes structured payloads to the same
+streams — never mixes them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, TextIO
+
+from culture.cli._errors import CultureError
+
+
+def emit_result(data: Any, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write a command result to stdout (or ``stream``)."""
+    s = stream if stream is not None else sys.stdout
+    if json_mode:
+        json.dump(data, s, ensure_ascii=False)
+        s.write("\n")
+        return
+    text = data if isinstance(data, str) else str(data)
+    s.write(text)
+    if not text.endswith("\n"):
+        s.write("\n")
+
+
+def emit_error(err: CultureError, *, json_mode: bool, stream: TextIO | None = None) -> None:
+    """Write a :class:`CultureError` to stderr.
+
+    Text mode renders as two lines when a remediation is present::
+
+        error: <message>
+        hint: <remediation>
+
+    The ``hint:`` prefix is the agent-first error rubric.
+    """
+    s = stream if stream is not None else sys.stderr
+    if json_mode:
+        json.dump(err.to_dict(), s, ensure_ascii=False)
+        s.write("\n")
+        return
+    s.write(f"error: {err.message}\n")
+    if err.remediation:
+        s.write(f"hint: {err.remediation}\n")
+
+
+def emit_diagnostic(message: str, *, stream: TextIO | None = None) -> None:
+    """Write a human diagnostic (progress, summary) to stderr."""
+    s = stream if stream is not None else sys.stderr
+    s.write(message if message.endswith("\n") else message + "\n")

--- a/culture/cli/introspect.py
+++ b/culture/cli/introspect.py
@@ -132,6 +132,7 @@ _PASSTHROUGHS: dict[str, str] = {
 
 _NATIVE_NOUNS: tuple[str, ...] = tuple(n for n in _NAMESPACES if n not in _PASSTHROUGHS)
 _UNIVERSAL_VERBS: tuple[str, ...] = ("explain", "overview", "learn")
+_HINT_RUN_EXPLAIN = "run 'culture explain' to see the registry of nouns"
 _SUMMARY = "AI agent IRC mesh — server, agents, channels, federation."
 _PURPOSE = (
     "Culture is the framework of agreements that makes agent behavior "
@@ -373,7 +374,7 @@ def _format_verb_help(noun: str, verb: str) -> str:
         raise CultureError(
             EXIT_USER_ERROR,
             f"unknown noun '{noun}'",
-            "run 'culture explain' to see the registry of nouns",
+            _HINT_RUN_EXPLAIN,
         )
     noun_parser = top_sub.choices[noun]
     inner = next(
@@ -441,7 +442,7 @@ def _explain_payload(path: list[str]) -> dict[str, Any]:
             raise CultureError(
                 EXIT_USER_ERROR,
                 f"unknown noun '{noun}' for explain",
-                "run 'culture explain' to see the registry of nouns",
+                _HINT_RUN_EXPLAIN,
             )
         markdown, _ = explainer(None)
         return {
@@ -526,7 +527,7 @@ def dispatch(args: argparse.Namespace) -> None:
             raise CultureError(
                 code,
                 stdout.rstrip("\n").split(";")[0] or f"unknown topic for {verb}",
-                "run 'culture explain' to see the registry of nouns",
+                _HINT_RUN_EXPLAIN,
             )
         if stdout:
             end = "" if stdout.endswith("\n") else "\n"

--- a/culture/cli/introspect.py
+++ b/culture/cli/introspect.py
@@ -1,7 +1,10 @@
 """Universal introspection verb dispatcher.
 
 Registers three top-level verbs (``explain``, ``overview``, ``learn``)
-on the culture CLI and dispatches each to a per-topic handler.
+on the culture CLI and dispatches each to a per-topic handler. All three
+verbs accept ``--json`` for the AgentCulture sibling JSON contract (see
+``docs/reference/cli/learn-explain-json.md``); without ``--json`` the
+existing markdown/text behavior is unchanged.
 
 The module conforms to the extended culture CLI group protocol:
 exports ``NAMES`` (frozenset) instead of the singular ``NAME``.
@@ -11,7 +14,11 @@ from __future__ import annotations
 
 import argparse
 import logging
-from typing import Callable
+import sys
+from typing import Any, Callable
+
+from culture.cli._errors import EXIT_USER_ERROR, CultureError
+from culture.cli._output import emit_error, emit_result
 
 _log = logging.getLogger(__name__)
 
@@ -111,6 +118,25 @@ _NAMESPACES = (
     "skills",
     "devex",
     "afi",
+)
+
+# Nouns that delegate their real reference to a sibling binary. Listed in
+# ``learn --json`` under ``passthroughs`` (not ``nouns``) so katvan's
+# reference-sync skips them — it'll pull each sibling's own ``learn --json``
+# / ``explain --json`` directly from its registry entry.
+_PASSTHROUGHS: dict[str, str] = {
+    "devex": "agex",
+    "afi": "afi",
+    "console": "irc-lens",
+}
+
+_NATIVE_NOUNS: tuple[str, ...] = tuple(n for n in _NAMESPACES if n not in _PASSTHROUGHS)
+_UNIVERSAL_VERBS: tuple[str, ...] = ("explain", "overview", "learn")
+_SUMMARY = "AI agent IRC mesh — server, agents, channels, federation."
+_PURPOSE = (
+    "Culture is the framework of agreements that makes agent behavior "
+    "portable, inspectable, and effective. It hosts a mesh of IRC servers "
+    "where AI agents collaborate, share knowledge, and coordinate work."
 )
 
 
@@ -287,24 +313,224 @@ def _register_root() -> None:
 _register_root()
 
 
+# --- JSON contract helpers ------------------------------------------------
+
+
+def _split_path(topic: str | None) -> list[str]:
+    """Normalise a ``topic`` arg into a noun/verb path list.
+
+    ``None`` and ``""`` → ``[]``; ``"agent"`` → ``["agent"]``;
+    ``"agent/start"`` → ``["agent", "start"]``. Katvan passes the latter
+    form as a single argv token; siblings accept either form.
+    """
+    if not topic:
+        return []
+    return [seg for seg in topic.split("/") if seg]
+
+
+def _collect_verbs(noun: str) -> list[str]:
+    """Return the sorted list of verbs (subcommands) registered under
+    ``culture <noun>``.
+
+    Reaches into argparse private attrs ``_actions`` /
+    ``_SubParsersAction`` — stable since Python 3.2 and the only way to
+    enumerate subparsers without duplicating each group's registration
+    metadata. Returns ``[]`` for passthrough nouns (their parser uses
+    ``REMAINDER`` and exposes no inner subparsers).
+    """
+    from culture.cli import _build_parser
+
+    parser = _build_parser()
+    top_sub = next(
+        (a for a in parser._actions if isinstance(a, argparse._SubParsersAction)),
+        None,
+    )
+    if top_sub is None or noun not in top_sub.choices:
+        return []
+    noun_parser = top_sub.choices[noun]
+    inner = next(
+        (a for a in noun_parser._actions if isinstance(a, argparse._SubParsersAction)),
+        None,
+    )
+    return sorted(inner.choices.keys()) if inner else []
+
+
+def _format_verb_help(noun: str, verb: str) -> str:
+    """Return ``culture <noun> <verb> --help`` formatted help text.
+
+    Used as the ``markdown`` body of ``culture explain noun/verb --json``;
+    keeps the leaf-level reference in lockstep with argparse — no
+    hand-authored doc per verb needed.
+    """
+    from culture.cli import _build_parser
+
+    parser = _build_parser()
+    top_sub = next(
+        (a for a in parser._actions if isinstance(a, argparse._SubParsersAction)),
+        None,
+    )
+    if top_sub is None or noun not in top_sub.choices:
+        raise CultureError(
+            EXIT_USER_ERROR,
+            f"unknown noun '{noun}'",
+            "run 'culture explain' to see the registry of nouns",
+        )
+    noun_parser = top_sub.choices[noun]
+    inner = next(
+        (a for a in noun_parser._actions if isinstance(a, argparse._SubParsersAction)),
+        None,
+    )
+    if inner is None or verb not in inner.choices:
+        raise CultureError(
+            EXIT_USER_ERROR,
+            f"unknown verb '{verb}' for noun '{noun}'",
+            f"run 'culture explain {noun}' to see the verbs of that noun",
+        )
+    return inner.choices[verb].format_help()
+
+
+def _learn_root_payload() -> dict[str, Any]:
+    from culture import __version__
+
+    return {
+        "tool": "culture",
+        "version": __version__,
+        "summary": _SUMMARY,
+        "purpose": _PURPOSE,
+        "nouns": list(_NATIVE_NOUNS),
+        "passthroughs": [
+            {"noun": noun, "binary": binary} for noun, binary in _PASSTHROUGHS.items()
+        ],
+        "verbs": list(_UNIVERSAL_VERBS),
+        "exit_codes": {
+            "0": "success",
+            "1": "user-input error",
+            "2": "environment/setup error",
+        },
+        "json_support": True,
+        "explain_pointer": "culture explain <path>",
+    }
+
+
+def _explain_payload(path: list[str]) -> dict[str, Any]:
+    if not path or path == ["culture"]:
+        markdown, _ = _culture_explain(None)
+        return {
+            "path": [],
+            "nouns": list(_NATIVE_NOUNS),
+            "passthroughs": [
+                {"noun": noun, "binary": binary} for noun, binary in _PASSTHROUGHS.items()
+            ],
+            "markdown": markdown,
+        }
+    if len(path) == 1:
+        noun = path[0]
+        if noun in _PASSTHROUGHS:
+            return {
+                "path": [noun],
+                "passthrough_to": _PASSTHROUGHS[noun],
+                "markdown": (
+                    f"`culture {noun}` is a passthrough to "
+                    f"`{_PASSTHROUGHS[noun]}`. Pull its reference from "
+                    f"that sibling's `learn --json` / `explain --json` "
+                    f"output directly.\n"
+                ),
+            }
+        explainer = _NAMESPACE_EXPLAINERS.get(noun)
+        if explainer is None:
+            raise CultureError(
+                EXIT_USER_ERROR,
+                f"unknown noun '{noun}' for explain",
+                "run 'culture explain' to see the registry of nouns",
+            )
+        markdown, _ = explainer(None)
+        return {
+            "path": [noun],
+            "verbs": _collect_verbs(noun),
+            "markdown": markdown,
+        }
+    if len(path) == 2:
+        noun, verb = path
+        markdown = _format_verb_help(noun, verb)
+        return {"path": [noun, verb], "markdown": markdown}
+    raise CultureError(
+        EXIT_USER_ERROR,
+        f"path too deep: {'/'.join(path)} (max depth is noun/verb)",
+        "use 'culture explain <noun>' or 'culture explain <noun>/<verb>'",
+    )
+
+
+def _overview_payload(path: list[str]) -> dict[str, Any]:
+    """Thin sibling of explain — symmetric shape, no verbs list."""
+    if not path or path == ["culture"]:
+        markdown, _ = _culture_overview(None)
+        return {
+            "path": [],
+            "nouns": list(_NATIVE_NOUNS),
+            "passthroughs": [
+                {"noun": noun, "binary": binary} for noun, binary in _PASSTHROUGHS.items()
+            ],
+            "markdown": markdown,
+        }
+    # Fall back to the explain shape minus 'verbs' for any other path —
+    # keeps overview useful as a thin wrapper even though katvan does
+    # not consume it.
+    payload = _explain_payload(path)
+    payload.pop("verbs", None)
+    return payload
+
+
+def _payload_for(verb: str, path: list[str]) -> dict[str, Any]:
+    if verb == "learn":
+        # ``culture learn --json`` always emits the root payload regardless
+        # of topic; katvan only ever calls the no-topic form, and a
+        # topic-scoped JSON learn has no defined consumer.
+        return _learn_root_payload()
+    if verb == "explain":
+        return _explain_payload(path)
+    if verb == "overview":
+        return _overview_payload(path)
+    raise CultureError(
+        EXIT_USER_ERROR,
+        f"unsupported verb '{verb}' for --json",
+        "use one of: explain, overview, learn",
+    )
+
+
 # --- CLI group protocol ---------------------------------------------------
 
 
 def register(subparsers: "argparse._SubParsersAction") -> None:
-    for verb in ("explain", "overview", "learn"):
+    for verb in _UNIVERSAL_VERBS:
         p = subparsers.add_parser(verb, help=f"{verb.capitalize()} a topic (culture by default)")
         p.add_argument("topic", nargs="?", default=None, help="Topic to inspect")
+        p.add_argument(
+            "--json",
+            action="store_true",
+            dest="json",
+            help="Emit structured JSON (stdout) per the AgentCulture sibling contract.",
+        )
 
 
 def dispatch(args: argparse.Namespace) -> None:
-    import sys
-
     verb = args.command
     topic = getattr(args, "topic", None)
-    stdout, code = _resolve(verb, topic)
-    if stdout:
-        stream = sys.stdout if code == 0 else sys.stderr
-        end = "" if stdout.endswith("\n") else "\n"
-        print(stdout, end=end, file=stream)
-    if code != 0:
-        sys.exit(code)
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        if json_mode:
+            payload = _payload_for(verb, _split_path(topic))
+            emit_result(payload, json_mode=True)
+            return
+        stdout, code = _resolve(verb, topic)
+        if code != 0:
+            raise CultureError(
+                code,
+                stdout.rstrip("\n").split(";")[0] or f"unknown topic for {verb}",
+                "run 'culture explain' to see the registry of nouns",
+            )
+        if stdout:
+            end = "" if stdout.endswith("\n") else "\n"
+            print(stdout, end=end, file=sys.stdout)
+    except CultureError as err:
+        emit_error(err, json_mode=json_mode)
+        sys.exit(err.code)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -448,6 +448,13 @@ registry of participating namespaces.
 - `culture explain [topic]` — deep description
 - `culture overview [topic]` — shallow summary
 - `culture learn [topic]` — agent onboarding prompt
+
+All three accept `--json` for the AgentCulture sibling JSON contract
+(katvan's `reference-sync.yml` cron calls `culture learn --json` and
+`culture explain <path> --json`). See
+[`learn` / `explain` JSON contract](./learn-explain-json/) for the
+shapes, exit-code policy, and the stdout/stderr split.
+
 - `culture devex <anything>` — developer-experience passthrough
   (powered by `agex-cli`)
 - `culture afi <anything>` — Agent First Interface passthrough

--- a/docs/reference/cli/learn-explain-json.md
+++ b/docs/reference/cli/learn-explain-json.md
@@ -1,0 +1,172 @@
+# `learn` / `explain` JSON contract
+
+`culture learn`, `culture explain`, and `culture overview` accept `--json`
+for the AgentCulture sibling JSON contract that katvan's nightly
+`reference-sync.yml` cron consumes. Once enabled in the katvan registry
+(`docs_mode: pull-reference`), the cron renders
+`culture.dev/culture/reference/` automatically from the output of these
+calls — no in-repo markdown to maintain.
+
+Tracked by [#401](https://github.com/agentculture/culture/issues/401);
+the same contract ships in `afi-cli`, `agtag`, `cultureagent`,
+`code-lens-cli`, `irc-lens`, `auntiepypi`, `ghafi`, `antoine`.
+
+## Stream split
+
+**Stdout** carries the success payload. **Stderr** carries diagnostics
+and structured errors. They are never mixed — a successful `--json` call
+produces JSON on stdout and nothing on stderr; a failing one produces
+nothing on stdout and a JSON error on stderr.
+
+## `culture learn --json`
+
+The single call katvan invokes per sibling. Listing of nouns, version,
+purpose, and the exit-code policy.
+
+```json
+{
+  "tool": "culture",
+  "version": "12.2.0",
+  "summary": "AI agent IRC mesh — server, agents, channels, federation.",
+  "purpose": "Culture is the framework of agreements ...",
+  "nouns": ["agent", "server", "mesh", "channel", "bot", "skills"],
+  "passthroughs": [
+    {"noun": "devex",   "binary": "agex"},
+    {"noun": "afi",     "binary": "afi"},
+    {"noun": "console", "binary": "irc-lens"}
+  ],
+  "verbs": ["explain", "overview", "learn"],
+  "exit_codes": {
+    "0": "success",
+    "1": "user-input error",
+    "2": "environment/setup error"
+  },
+  "json_support": true,
+  "explain_pointer": "culture explain <path>"
+}
+```
+
+- **`nouns`** is the only key katvan reads (it iterates them and calls
+  `culture explain <noun> --json` for each). The rest is sibling
+  convention.
+- **`passthroughs`** flags nouns whose real reference lives in a
+  separate binary (`devex` → `agex`, `afi` → `afi`, `console` →
+  `irc-lens`). Katvan pulls those siblings directly from their own
+  registry entries, so they're deliberately *not* listed under `nouns`
+  to avoid double-coverage.
+- **`version`** is read from `culture.__version__` (the single source
+  of truth in `pyproject.toml`).
+
+## `culture explain [path] --json`
+
+A path is either empty, a single noun (e.g. `agent`), or a noun/verb
+pair (e.g. `agent/start`). Katvan passes the path as one argv token.
+
+### Root: `culture explain --json` or `culture explain culture --json`
+
+```json
+{
+  "path": [],
+  "nouns": ["agent", "server", "mesh", "channel", "bot", "skills"],
+  "passthroughs": [{"noun": "devex", "binary": "agex"}, ...],
+  "markdown": "# Culture\n\nCulture is ..."
+}
+```
+
+### Native noun: `culture explain agent --json`
+
+```json
+{
+  "path": ["agent"],
+  "verbs": ["archive", "assign", "create", "delete", "join", "learn",
+            "message", "migrate", "read", "register", "rename", "sleep",
+            "start", "status", "stop", "unarchive", "unregister", "wake"],
+  "markdown": "# culture agent\n\nManage AI agents on the mesh ..."
+}
+```
+
+- **`verbs`** comes from live argparse introspection of the registered
+  subparsers; it stays in sync as groups add or remove subcommands.
+- **`markdown`** is the noun's curated explainer text (the same text
+  the text-mode call returns).
+
+### Native noun/verb: `culture explain agent/start --json`
+
+```json
+{
+  "path": ["agent", "start"],
+  "markdown": "usage: culture agent start [-h] [--all] [--config CONFIG] ..."
+}
+```
+
+- **`markdown`** is the argparse-derived `--help` text for the leaf
+  command, formatted by argparse's standard formatter (usage line +
+  help string + flag list). Auto-generated — no per-verb doc to
+  maintain.
+
+### Passthrough noun: `culture explain devex --json`
+
+```json
+{
+  "path": ["devex"],
+  "passthrough_to": "agex",
+  "markdown": "`culture devex` is a passthrough to `agex`. Pull its reference from that sibling's `learn --json` / `explain --json` output directly.\n"
+}
+```
+
+No `verbs` key — katvan does not recurse into passthrough nouns. The
+agent or human reader gets a pointer to the underlying binary.
+
+## `culture overview [path] --json`
+
+Symmetric with `explain`; identical shape minus the `verbs` list at
+the noun level. Out of scope for katvan; included for parity across
+the three universal verbs.
+
+## Errors (JSON mode)
+
+Every JSON-mode failure emits a structured error to **stderr only**
+(stdout stays empty) and exits with the appropriate code:
+
+```json
+{
+  "code": 1,
+  "message": "unknown noun 'nope' for explain",
+  "remediation": "run 'culture explain' to see the registry of nouns"
+}
+```
+
+### Exit-code policy
+
+| Code | Meaning |
+|------|---------|
+| `0` | success |
+| `1` | user-input error (bad noun, bad path, malformed flag) |
+| `2` | environment/setup error |
+| `3+` | reserved |
+
+This is the same policy `learn --json` advertises under its
+`exit_codes` key.
+
+## Example: simulating katvan's pull
+
+```python
+import json
+import subprocess
+
+binary = ["culture"]
+learn = json.loads(subprocess.check_output(binary + ["learn", "--json"]))
+for noun in learn["nouns"]:
+    explain = json.loads(
+        subprocess.check_output(binary + ["explain", noun, "--json"])
+    )
+    for verb in explain["verbs"]:
+        leaf = json.loads(
+            subprocess.check_output(binary + ["explain", f"{noun}/{verb}", "--json"])
+        )
+        assert leaf["path"] == [noun, verb]
+```
+
+This is the exact call sequence katvan's
+`katvan/cli/_commands/pull.py::_pull_one()` runs — a regression net
+against the contract drifting from what the consumer expects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.1.12"
+version = "12.2.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_introspect.py
+++ b/tests/test_cli_introspect.py
@@ -1,8 +1,10 @@
 """Tests for the universal introspection verb dispatcher."""
 
+import json
 import subprocess
 import sys
 
+from culture import __version__
 from culture.cli import introspect
 
 
@@ -168,3 +170,130 @@ def test_resolve_unit_coming_soon_for_namespace_without_handler():
         assert "afi" in stdout
     finally:
         introspect._clear_registry()
+
+
+# --- JSON contract tests (issue #401) ------------------------------------
+
+
+def _run_cli(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "culture", *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_learn_json_emits_required_keys():
+    """`culture learn --json` is what katvan's reference-sync invokes."""
+    result = _run_cli("learn", "--json")
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["tool"] == "culture"
+    assert payload["version"] == __version__
+    assert payload["json_support"] is True
+    assert payload["explain_pointer"] == "culture explain <path>"
+    # Native nouns katvan should recurse into — passthroughs go in a separate key.
+    assert set(payload["nouns"]) == {"agent", "server", "mesh", "channel", "bot", "skills"}
+    assert {p["binary"] for p in payload["passthroughs"]} == {"agex", "afi", "irc-lens"}
+    assert payload["verbs"] == ["explain", "overview", "learn"]
+    assert set(payload["exit_codes"].keys()) >= {"0", "1", "2"}
+
+
+def test_explain_root_json_has_path_and_nouns():
+    """`culture explain --json` (no path) and `culture explain culture --json`
+    return the root shape with an empty path."""
+    for argv in (("explain", "--json"), ("explain", "culture", "--json")):
+        result = _run_cli(*argv)
+        assert result.returncode == 0, result.stderr
+        assert result.stderr == ""
+        payload = json.loads(result.stdout)
+        assert payload["path"] == []
+        assert "agent" in payload["nouns"]
+        assert "Culture" in payload["markdown"]
+
+
+def test_explain_native_noun_json_has_verbs():
+    """`culture explain <noun> --json` exposes the noun's verbs (what katvan
+    recurses into)."""
+    result = _run_cli("explain", "agent", "--json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["path"] == ["agent"]
+    # Cross-check against the live argparse registration in agent.py.
+    assert {"start", "stop", "status", "create"}.issubset(set(payload["verbs"]))
+    assert "culture agent" in payload["markdown"]
+
+
+def test_explain_noun_verb_json_has_argparse_markdown():
+    """`culture explain <noun>/<verb> --json` exposes argparse-derived help."""
+    result = _run_cli("explain", "agent/start", "--json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["path"] == ["agent", "start"]
+    assert payload["markdown"].startswith("usage:")
+    assert "culture agent start" in payload["markdown"]
+
+
+def test_explain_passthrough_noun_json_does_not_list_verbs():
+    """Passthrough nouns surface `passthrough_to` and no `verbs` key — katvan
+    won't recurse (they're listed under `passthroughs`, not `nouns`)."""
+    result = _run_cli("explain", "devex", "--json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["path"] == ["devex"]
+    assert payload["passthrough_to"] == "agex"
+    assert "verbs" not in payload
+
+
+def test_explain_bogus_topic_json_emits_structured_error():
+    """JSON-mode errors go to stderr only with the {code, message, remediation}
+    shape; stdout stays empty so JSON parsers don't choke on mixed output."""
+    result = _run_cli("explain", "nope-noun-xyz", "--json")
+    assert result.returncode == 1
+    assert result.stdout == ""
+    err = json.loads(result.stderr)
+    assert err["code"] == 1
+    assert "nope-noun-xyz" in err["message"]
+    assert err["remediation"]
+
+
+def test_overview_json_has_path_and_nouns():
+    """Overview keeps the same shape minus `verbs` so the three universal
+    verbs stay symmetric."""
+    result = _run_cli("overview", "--json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["path"] == []
+    assert "agent" in payload["nouns"]
+
+
+def test_stdout_and_stderr_never_mixed_on_success():
+    """Every --json success path writes exactly to stdout, nothing to stderr."""
+    for argv in (
+        ("learn", "--json"),
+        ("explain", "--json"),
+        ("explain", "agent", "--json"),
+        ("explain", "agent/start", "--json"),
+        ("overview", "--json"),
+    ):
+        result = _run_cli(*argv)
+        assert result.returncode == 0, (argv, result.stderr)
+        json.loads(result.stdout)  # raises on malformed stdout
+        assert result.stderr == "", (argv, result.stderr)
+
+
+def test_katvan_pull_one_schema_match():
+    """End-to-end: run the same call sequence katvan's pull does, and assert
+    the schema is parseable at every step. This is the regression net
+    against #401 ever reopening."""
+    learn = json.loads(_run_cli("learn", "--json").stdout)
+    assert isinstance(learn.get("nouns"), list) and learn["nouns"]
+    for noun in learn["nouns"]:
+        explain = json.loads(_run_cli("explain", noun, "--json").stdout)
+        assert isinstance(explain.get("verbs"), list), noun
+        for verb in explain["verbs"]:
+            leaf = json.loads(_run_cli("explain", f"{noun}/{verb}", "--json").stdout)
+            assert leaf["path"] == [noun, verb]
+            assert leaf["markdown"]

--- a/tests/test_cli_introspect.py
+++ b/tests/test_cli_introspect.py
@@ -297,3 +297,311 @@ def test_katvan_pull_one_schema_match():
             leaf = json.loads(_run_cli("explain", f"{noun}/{verb}", "--json").stdout)
             assert leaf["path"] == [noun, verb]
             assert leaf["markdown"]
+
+
+# --- In-process unit tests for the JSON payload helpers ----------------------
+#
+# The subprocess tests above are the integration contract. These in-process
+# tests cover the same code paths but inside the test runner's process so
+# coverage.py can see the branches — needed to keep the 90% project floor.
+
+
+def test_split_path_normalises_topic_arg():
+    assert introspect._split_path(None) == []
+    assert introspect._split_path("") == []
+    assert introspect._split_path("agent") == ["agent"]
+    assert introspect._split_path("agent/start") == ["agent", "start"]
+    assert introspect._split_path("//agent//start//") == ["agent", "start"]
+
+
+def test_collect_verbs_returns_sorted_subcommands():
+    verbs = introspect._collect_verbs("agent")
+    assert verbs == sorted(verbs)
+    assert "start" in verbs
+    assert "stop" in verbs
+
+
+def test_collect_verbs_empty_for_unknown_and_passthrough_nouns():
+    assert introspect._collect_verbs("nope-unknown-noun") == []
+    # devex registers via REMAINDER → no inner subparsers
+    assert introspect._collect_verbs("devex") == []
+
+
+def test_format_verb_help_returns_argparse_text():
+    md = introspect._format_verb_help("agent", "start")
+    assert md.startswith("usage:")
+    assert "culture agent start" in md
+
+
+def test_format_verb_help_raises_culture_error_for_unknown_noun():
+    from culture.cli._errors import EXIT_USER_ERROR, CultureError
+
+    try:
+        introspect._format_verb_help("nope", "start")
+    except CultureError as err:
+        assert err.code == EXIT_USER_ERROR
+        assert "nope" in err.message
+    else:
+        raise AssertionError("expected CultureError")
+
+
+def test_format_verb_help_raises_culture_error_for_unknown_verb():
+    from culture.cli._errors import CultureError
+
+    try:
+        introspect._format_verb_help("agent", "nope-verb-xyz")
+    except CultureError as err:
+        assert "nope-verb-xyz" in err.message
+        assert "agent" in err.remediation
+    else:
+        raise AssertionError("expected CultureError")
+
+
+def test_learn_root_payload_structure():
+    payload = introspect._learn_root_payload()
+    assert payload["tool"] == "culture"
+    assert payload["json_support"] is True
+    assert set(payload["nouns"]) == {"agent", "server", "mesh", "channel", "bot", "skills"}
+    assert {p["binary"] for p in payload["passthroughs"]} == {"agex", "afi", "irc-lens"}
+
+
+def test_explain_payload_branches():
+    root = introspect._explain_payload([])
+    assert root["path"] == []
+    assert "agent" in root["nouns"]
+    assert "Culture" in root["markdown"]
+    # Culture alias resolves to root
+    root_alias = introspect._explain_payload(["culture"])
+    assert root_alias["path"] == []
+    # Native noun
+    agent = introspect._explain_payload(["agent"])
+    assert agent["path"] == ["agent"]
+    assert "start" in agent["verbs"]
+    # Noun/verb leaf
+    leaf = introspect._explain_payload(["agent", "start"])
+    assert leaf["path"] == ["agent", "start"]
+    assert leaf["markdown"].startswith("usage:")
+    # Passthrough noun
+    devex = introspect._explain_payload(["devex"])
+    assert devex["passthrough_to"] == "agex"
+    assert "verbs" not in devex
+
+
+def test_explain_payload_unknown_noun_raises():
+    from culture.cli._errors import CultureError
+
+    try:
+        introspect._explain_payload(["nope-unknown"])
+    except CultureError as err:
+        assert "nope-unknown" in err.message
+    else:
+        raise AssertionError("expected CultureError")
+
+
+def test_explain_payload_too_deep_raises():
+    from culture.cli._errors import CultureError
+
+    try:
+        introspect._explain_payload(["agent", "start", "extra"])
+    except CultureError as err:
+        assert "too deep" in err.message
+    else:
+        raise AssertionError("expected CultureError")
+
+
+def test_overview_payload_root_and_drops_verbs():
+    root = introspect._overview_payload([])
+    assert root["path"] == []
+    assert "agent" in root["nouns"]
+    noun = introspect._overview_payload(["agent"])
+    assert noun["path"] == ["agent"]
+    assert "verbs" not in noun
+
+
+def test_payload_for_unsupported_verb_raises():
+    from culture.cli._errors import CultureError
+
+    try:
+        introspect._payload_for("bogus-verb", [])
+    except CultureError as err:
+        assert "bogus-verb" in err.message
+    else:
+        raise AssertionError("expected CultureError")
+
+
+def test_payload_for_routes_to_each_verb():
+    assert introspect._payload_for("learn", [])["tool"] == "culture"
+    assert introspect._payload_for("explain", [])["path"] == []
+    assert introspect._payload_for("overview", [])["path"] == []
+
+
+def test_emit_result_json_to_stream():
+    import io
+
+    from culture.cli._output import emit_result
+
+    buf = io.StringIO()
+    emit_result({"a": 1}, json_mode=True, stream=buf)
+    assert buf.getvalue() == '{"a": 1}\n'
+
+
+def test_emit_result_text_to_stream_and_newline_handling():
+    import io
+
+    from culture.cli._output import emit_result
+
+    buf = io.StringIO()
+    emit_result("hi", json_mode=False, stream=buf)
+    assert buf.getvalue() == "hi\n"
+    buf2 = io.StringIO()
+    emit_result("hi\n", json_mode=False, stream=buf2)
+    assert buf2.getvalue() == "hi\n"
+
+
+def test_emit_result_text_non_string_stringifies():
+    import io
+
+    from culture.cli._output import emit_result
+
+    buf = io.StringIO()
+    emit_result(42, json_mode=False, stream=buf)
+    assert buf.getvalue() == "42\n"
+
+
+def test_emit_error_json_and_text_modes():
+    import io
+
+    from culture.cli._errors import CultureError
+    from culture.cli._output import emit_error
+
+    err = CultureError(code=1, message="bad", remediation="fix it")
+    buf_json = io.StringIO()
+    emit_error(err, json_mode=True, stream=buf_json)
+    payload = json.loads(buf_json.getvalue())
+    assert payload == {"code": 1, "message": "bad", "remediation": "fix it"}
+
+    buf_text = io.StringIO()
+    emit_error(err, json_mode=False, stream=buf_text)
+    assert buf_text.getvalue() == "error: bad\nhint: fix it\n"
+
+    # No remediation → no hint line.
+    buf_text2 = io.StringIO()
+    emit_error(CultureError(2, "boom"), json_mode=False, stream=buf_text2)
+    assert buf_text2.getvalue() == "error: boom\n"
+
+
+def test_emit_diagnostic_to_stream():
+    import io
+
+    from culture.cli._output import emit_diagnostic
+
+    buf = io.StringIO()
+    emit_diagnostic("progress", stream=buf)
+    assert buf.getvalue() == "progress\n"
+    buf2 = io.StringIO()
+    emit_diagnostic("progress\n", stream=buf2)
+    assert buf2.getvalue() == "progress\n"
+
+
+def test_culture_error_to_dict_round_trip():
+    from culture.cli._errors import CultureError
+
+    err = CultureError(1, "msg", "rem")
+    assert err.to_dict() == {"code": 1, "message": "msg", "remediation": "rem"}
+    err2 = CultureError(2, "msg")
+    assert err2.to_dict() == {"code": 2, "message": "msg", "remediation": ""}
+
+
+def test_dispatch_json_mode_success(capsys):
+    """In-process exercise of dispatch() so coverage sees the JSON branch."""
+    import argparse as _argparse
+
+    args = _argparse.Namespace(command="learn", topic=None, json=True)
+    introspect.dispatch(args)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["tool"] == "culture"
+    assert captured.err == ""
+
+
+def test_dispatch_json_mode_error_exits_with_code(capsys):
+    import argparse as _argparse
+
+    args = _argparse.Namespace(command="explain", topic="nope-noun-zzz", json=True)
+    try:
+        introspect.dispatch(args)
+    except SystemExit as exit_:
+        assert exit_.code == 1
+    else:
+        raise AssertionError("expected SystemExit on dispatch error")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    err = json.loads(captured.err)
+    assert err["code"] == 1
+    assert "nope-noun-zzz" in err["message"]
+
+
+def test_dispatch_text_mode_success_preserved(capsys):
+    import argparse as _argparse
+
+    args = _argparse.Namespace(command="explain", topic=None, json=False)
+    introspect.dispatch(args)
+    captured = capsys.readouterr()
+    assert "Culture" in captured.out
+    assert captured.err == ""
+
+
+def test_dispatch_text_mode_error_uses_emit_error(capsys):
+    import argparse as _argparse
+
+    args = _argparse.Namespace(command="explain", topic="nope-noun-text", json=False)
+    try:
+        introspect.dispatch(args)
+    except SystemExit as exit_:
+        assert exit_.code == 1
+    else:
+        raise AssertionError("expected SystemExit on dispatch error")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    # Text-mode error format from emit_error.
+    assert captured.err.startswith("error: ")
+    assert "nope-noun-text" in captured.err
+    assert "hint:" in captured.err
+
+
+# --- Top-level argparse error contract under --json ---------------------------
+
+
+def test_argparse_unknown_flag_in_json_mode_emits_structured_error():
+    """`culture explain --bogus --json` must still emit JSON to stderr."""
+    result = _run_cli("explain", "--bogus-flag-xyz", "--json")
+    assert result.returncode != 0
+    assert result.stdout == ""
+    err = json.loads(result.stderr)
+    assert err["code"] == 1
+    assert "--bogus-flag-xyz" in err["message"]
+    assert err["remediation"]
+
+
+def test_argparse_unknown_flag_without_json_mode_uses_plain_text():
+    """Regression guard: text mode keeps argparse's standard behavior."""
+    result = _run_cli("explain", "--bogus-flag-xyz")
+    assert result.returncode == 2  # argparse default
+    assert "usage:" in result.stderr
+    # No JSON trailer.
+    try:
+        json.loads(result.stderr)
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError("text-mode stderr should not be valid JSON")
+
+
+def test_argparse_error_with_json_but_no_introspect_verb_uses_text():
+    """`--json` is honored only when an introspect verb is also in argv. A
+    top-level error with `--json` but no `explain`/`overview`/`learn` falls
+    through to the plain-text path so non-introspect groups aren't pulled
+    into the JSON contract by accident."""
+    result = _run_cli("--bogus-top", "--json")
+    assert result.returncode == 2  # argparse default
+    assert "usage:" in result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.1.12"
+version = "12.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Closes #401. Ship the AgentCulture sibling JSON contract on culture's
universal introspection verbs (`explain`, `overview`, `learn`) so
katvan's nightly `reference-sync.yml` cron can flip culture from
`docs_mode: skip` to `pull-reference` and publish
`culture.dev/culture/reference/` automatically.

- `culture learn --json` → `{tool, version, summary, purpose, nouns,
  passthroughs, verbs, exit_codes, json_support, explain_pointer}` —
  the single katvan-consumed key is `nouns`; the rest matches the
  sibling convention shared by afi-cli/agtag/cultureagent/etc.
- `culture explain [path] --json` → `{path, nouns?|verbs?|passthrough_to?, markdown}`,
  branching on root / native noun / noun/verb leaf / passthrough.
- Verbs come from **live argparse introspection** of `_build_parser()`,
  so the reference stays in sync as groups add subcommands — no
  parallel catalog to maintain.
- Noun/verb leaf markdown is argparse's own `--help` text — auto-
  generated, zero per-verb authoring.
- JSON-mode errors emit `{code, message, remediation}` to **stderr
  only**; stdout stays empty. Text-mode errors now also flow through
  `emit_error` so they get the agent-first `error: ... / hint: ...`
  format.
- Text mode is preserved bit-for-bit; all 13 pre-existing introspect
  tests pass unchanged.

## Files

- **New** `culture/cli/_errors.py` — `CultureError` + EXIT_* (port
  from agtag/cli/_errors.py).
- **New** `culture/cli/_output.py` — `emit_result` / `emit_error` /
  `emit_diagnostic` (port from agtag/cli/_output.py).
- `culture/cli/introspect.py` — new `--json` flag, `_collect_verbs`,
  `_format_verb_help`, payload builders, dispatch rewrite.
- `tests/test_cli_introspect.py` — +9 cases (~135 lines), incl.
  `test_katvan_pull_one_schema_match` that walks the exact call
  sequence katvan's `_pull_one()` runs.
- **New** `docs/reference/cli/learn-explain-json.md` — full contract.
- `docs/reference/cli/index.md` — one-line link.

## Out of scope (follow-ups)

- **Katvan registry flip** — separate `agentculture/katvan` PR
  dropping the "Reference sync deferred" caveat on the culture entry
  and setting `docs_mode: pull-reference` in
  `site/_data/agentculture_repos.yml`. Filed via `communicate` skill
  after this lands.
- **agex-cli's own `--json`** (parallel work for `agex-cli#30`) —
  culture's `devex` passthrough payload is currently a culture-local
  static stub; can delegate to `agex learn --json` once agex ships
  the contract.

## Test plan

- [x] `bash .claude/skills/run-tests/scripts/test.sh -p -q` → **1353
  passed, 1 skipped** (full suite, one pre-existing parallel-execution
  flake on `test_overview_collector` reproduced once then passed on
  re-run; unrelated to this change — does not touch
  `culture/cli/overview_collector.py` or any telemetry code).
- [x] **Schema match against katvan's `_pull_one()`** — local walk
  succeeds on 6 nouns × 52 leaves.
- [x] **Stdout/stderr split** — `culture explain nope --json
  1>/tmp/o 2>/tmp/e` → exit 1, `/tmp/o` empty (0 bytes), `/tmp/e`
  parses as `{code, message, remediation}`.
- [x] `markdownlint-cli2 'docs/**/*.md'` → 0 errors.
- [ ] CI: `tests`, `version-check`, `SonarCloud Quality Gate`,
  `security-checks` all green.
- [ ] SonarCloud PASS via `/cicd await`.

- culture (Claude)
