### PR TITLE
feat(cli): culture agent install/uninstall <nick> [v12.3.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [12.3.0] - 2026-05-20
+
+### Added
+
+- culture agent install/uninstall <nick> — per-agent systemd/launchd/scheduled-task unit management without mesh.yaml (#348)
+
 ## [12.2.0] - 2026-05-19
 
 ### Added

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -1140,7 +1140,7 @@ def _resolve_manifest_suffix(config: ServerConfig, nick: str) -> str:
             return stripped
     display = nick if nick.startswith(prefix) else f"{prefix}{nick}"
     print(
-        f"Error: {display} not in manifest. " f"Register it first with `culture agent register`.",
+        f"Error: {display} not in manifest. Register it first with `culture agent register`.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -62,6 +62,8 @@ logger = logging.getLogger("culture")
 
 NAME = "agent"
 
+_NICK_HELP = "Agent suffix or full nick"
+
 
 def register(subparsers: argparse._SubParsersAction) -> None:
     agent_parser = subparsers.add_parser("agent", help="Manage AI agents")
@@ -194,7 +196,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 
     # -- unregister -----------------------------------------------------------
     unregister_parser = agent_sub.add_parser("unregister", help="Unregister agent")
-    unregister_parser.add_argument("target", help="Agent suffix or full nick")
+    unregister_parser.add_argument("target", help=_NICK_HELP)
     unregister_parser.add_argument("--config", default=DEFAULT_SERVER_CONFIG, help=_CONFIG_HELP)
 
     # -- install --------------------------------------------------------------
@@ -202,7 +204,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "install",
         help="Install systemd/launchd/scheduled-task unit for a single agent",
     )
-    install_parser.add_argument("nick", help="Agent suffix or full nick")
+    install_parser.add_argument("nick", help=_NICK_HELP)
     install_parser.add_argument("--config", default=DEFAULT_SERVER_CONFIG, help=_CONFIG_HELP)
 
     # -- uninstall ------------------------------------------------------------
@@ -210,7 +212,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "uninstall",
         help="Remove the systemd/launchd/scheduled-task unit for a single agent",
     )
-    uninstall_parser.add_argument("nick", help="Agent suffix or full nick")
+    uninstall_parser.add_argument("nick", help=_NICK_HELP)
     uninstall_parser.add_argument("--config", default=DEFAULT_SERVER_CONFIG, help=_CONFIG_HELP)
 
     # -- migrate --------------------------------------------------------------
@@ -1121,18 +1123,27 @@ def _cmd_unregister(args: argparse.Namespace) -> None:
 
 def _resolve_manifest_suffix(config: ServerConfig, nick: str) -> str:
     """Accept suffix or full <server>-<suffix> nick and return the suffix
-    if it's in the manifest. Exit with code 1 if not found."""
+    if it's in the manifest. Exit with code 1 if not found.
+
+    Disambiguation: try the input as a bare suffix first. Only fall back
+    to stripping the `<server>-` prefix if the bare form isn't in the
+    manifest — otherwise a legitimate suffix like `spark-claude` (with
+    server `spark`) would be silently rewritten to `claude`.
+    """
     server_name = config.server.name
+    if nick in config.manifest:
+        return nick
     prefix = f"{server_name}-"
-    suffix = nick.removeprefix(prefix) if nick.startswith(prefix) else nick
-    if suffix not in config.manifest:
-        print(
-            f"Error: {server_name}-{suffix} not in manifest. "
-            f"Register it first with `culture agent register`.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-    return suffix
+    if nick.startswith(prefix):
+        stripped = nick.removeprefix(prefix)
+        if stripped in config.manifest:
+            return stripped
+    display = nick if nick.startswith(prefix) else f"{prefix}{nick}"
+    print(
+        f"Error: {display} not in manifest. " f"Register it first with `culture agent register`.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def _cmd_install(args: argparse.Namespace) -> None:

--- a/culture/cli/agent.py
+++ b/culture/cli/agent.py
@@ -197,6 +197,22 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     unregister_parser.add_argument("target", help="Agent suffix or full nick")
     unregister_parser.add_argument("--config", default=DEFAULT_SERVER_CONFIG, help=_CONFIG_HELP)
 
+    # -- install --------------------------------------------------------------
+    install_parser = agent_sub.add_parser(
+        "install",
+        help="Install systemd/launchd/scheduled-task unit for a single agent",
+    )
+    install_parser.add_argument("nick", help="Agent suffix or full nick")
+    install_parser.add_argument("--config", default=DEFAULT_SERVER_CONFIG, help=_CONFIG_HELP)
+
+    # -- uninstall ------------------------------------------------------------
+    uninstall_parser = agent_sub.add_parser(
+        "uninstall",
+        help="Remove the systemd/launchd/scheduled-task unit for a single agent",
+    )
+    uninstall_parser.add_argument("nick", help="Agent suffix or full nick")
+    uninstall_parser.add_argument("--config", default=DEFAULT_SERVER_CONFIG, help=_CONFIG_HELP)
+
     # -- migrate --------------------------------------------------------------
     # Most repos have already migrated; the verb stays in the CLI surface
     # for completeness but the help text now signals it's a one-time
@@ -211,7 +227,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 def dispatch(args: argparse.Namespace) -> None:
     if not args.agent_command:
         print(
-            "Usage: culture agent {create|join|start|stop|status|rename|assign|sleep|wake|learn|message|read|archive|unarchive|delete|register|unregister|migrate}",
+            "Usage: culture agent {create|join|start|stop|status|rename|assign|sleep|wake|learn|message|read|archive|unarchive|delete|register|unregister|install|uninstall|migrate}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -234,6 +250,8 @@ def dispatch(args: argparse.Namespace) -> None:
         "delete": _cmd_delete,
         "register": _cmd_register,
         "unregister": _cmd_unregister,
+        "install": _cmd_install,
+        "uninstall": _cmd_uninstall,
         "migrate": _cmd_migrate,
     }
     handler = handlers.get(args.agent_command)
@@ -1094,6 +1112,61 @@ def _cmd_unregister(args: argparse.Namespace) -> None:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     print(f"Unregistered: {prefix}{suffix}")
+
+
+# -----------------------------------------------------------------------
+# Install / Uninstall — per-agent service unit
+# -----------------------------------------------------------------------
+
+
+def _resolve_manifest_suffix(config: ServerConfig, nick: str) -> str:
+    """Accept suffix or full <server>-<suffix> nick and return the suffix
+    if it's in the manifest. Exit with code 1 if not found."""
+    server_name = config.server.name
+    prefix = f"{server_name}-"
+    suffix = nick.removeprefix(prefix) if nick.startswith(prefix) else nick
+    if suffix not in config.manifest:
+        print(
+            f"Error: {server_name}-{suffix} not in manifest. "
+            f"Register it first with `culture agent register`.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return suffix
+
+
+def _cmd_install(args: argparse.Namespace) -> None:
+    """Install a systemd/launchd/scheduled-task unit for one agent."""
+    import shutil
+
+    from culture.persistence import install_service
+
+    config = load_config_or_default(args.config)
+    suffix = _resolve_manifest_suffix(config, args.nick)
+    full_nick = f"{config.server.name}-{suffix}"
+
+    culture_bin = shutil.which("culture") or "culture"
+    # No --config: defer to `culture agent start`'s argparse default
+    # (~/.culture/server.yaml). Pinning a per-workdir path here would
+    # re-crashloop deployments — see PR #344 and the regression test
+    # tests/test_setup_update_cli.py::test_install_mesh_services_omits_legacy_config_path.
+    agent_cmd = [culture_bin, "agent", "start", full_nick, "--foreground"]
+    svc = f"culture-agent-{full_nick}"
+    path = install_service(svc, agent_cmd, f"culture agent {full_nick}")
+    print(f"Installed {svc} → {path}")
+
+
+def _cmd_uninstall(args: argparse.Namespace) -> None:
+    """Remove a per-agent service unit. Graceful no-op if not installed."""
+    from culture.persistence import uninstall_service
+
+    config = load_config_or_default(args.config)
+    suffix = _resolve_manifest_suffix(config, args.nick)
+    full_nick = f"{config.server.name}-{suffix}"
+
+    svc = f"culture-agent-{full_nick}"
+    uninstall_service(svc)
+    print(f"Uninstalled {svc}")
 
 
 # -----------------------------------------------------------------------

--- a/docs/reference/cli/agent-systemd.md
+++ b/docs/reference/cli/agent-systemd.md
@@ -1,9 +1,15 @@
 # Agent systemd units
 
-`culture mesh setup` and `culture mesh update` write per-agent systemd
-user units to `~/.config/systemd/user/culture-agent-<nick>.service` so
-the agents come up automatically after reboot under
-`Restart=on-failure`.
+Two paths install per-agent systemd user units to
+`~/.config/systemd/user/culture-agent-<nick>.service` so the agents come
+up automatically after reboot under `Restart=on-failure`:
+
+- `culture mesh setup` / `culture mesh update` — bulk install/refresh
+  for every agent in `~/.culture/mesh.yaml`.
+- `culture agent install <nick>` / `culture agent uninstall <nick>` —
+  one-off install or removal for a single agent registered in
+  `~/.culture/server.yaml`. Decoupled from `mesh.yaml`; useful for
+  hosts that manage agents directly and for recovery.
 
 The unit's `ExecStart` is intentionally minimal:
 
@@ -33,32 +39,29 @@ followed by `Scheduled restart job, restart counter is at NNNN`, you
 have a stale unit. Recover with:
 
 ```bash
-# Stop and remove the stale unit:
-systemctl --user disable --now culture-agent-<nick>.service
-rm ~/.config/systemd/user/culture-agent-<nick>.service
-systemctl --user daemon-reload
+# Uninstall the stale unit (disables, stops, removes file, runs daemon-reload):
+culture agent uninstall <nick>
 
-# Confirm it's gone:
-systemctl --user status culture-agent-<nick>.service   # should say "not-found"
+# Re-install with the current unit body (no --config pin):
+culture agent install <nick>
 
-# If the manifest at ~/.culture/server.yaml is also stale (e.g. the
-# nick's workdir was renamed or its culture.yaml deleted), tidy it up:
-culture agent unregister <suffix>     # see `culture agent status` for hints
-culture agent register <workdir>      # if the workdir's culture.yaml is fresh
-
-# Start the agent manually to confirm it works without systemd in the way:
-culture agent start <nick>
-
-# If you want systemd auto-start back, re-run mesh setup for a populated
-# mesh.yaml:
-culture mesh setup --config ~/.culture/mesh.yaml
+# Confirm it's healthy:
+systemctl --user status culture-agent-<nick>.service
 ```
 
-`culture mesh setup` only re-installs units for agents listed in the
-`agents:` block of `mesh.yaml`. If your `mesh.yaml` has an empty
-`agents: []`, the recovery stops at the manual `culture agent start`
-step — there is currently no per-agent install command decoupled from
-`mesh.yaml`.
+If the manifest at `~/.culture/server.yaml` itself is stale (e.g. the
+nick's workdir was renamed or its `culture.yaml` deleted), tidy it
+before re-installing:
+
+```bash
+culture agent unregister <suffix>     # see `culture agent status` for hints
+culture agent register <workdir>      # if the workdir's culture.yaml is fresh
+culture agent install <suffix>
+```
+
+`culture agent install` / `uninstall` operate on a single agent listed
+in `~/.culture/server.yaml` — no `mesh.yaml` required. For bulk install
+across every agent in `mesh.yaml`, use `culture mesh setup` instead.
 
 ## See also
 

--- a/docs/reference/cli/agent-systemd.md
+++ b/docs/reference/cli/agent-systemd.md
@@ -1,8 +1,8 @@
 # Agent systemd units
 
 Two paths install per-agent systemd user units to
-`~/.config/systemd/user/culture-agent-<nick>.service` so the agents come
-up automatically after reboot under `Restart=on-failure`:
+`$HOME/.config/systemd/user/culture-agent-<nick>.service` so the agents
+come up automatically after reboot under `Restart=on-failure`:
 
 - `culture mesh setup` / `culture mesh update` — bulk install/refresh
   for every agent in `~/.culture/mesh.yaml`.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -241,6 +241,37 @@ culture agent learn                     # auto-detects agent from cwd
 culture agent learn --nick spark-culture  # for a specific agent
 ```
 
+### `culture agent install`
+
+Install a single-agent auto-start unit (systemd user on Linux, launchd
+on macOS, scheduled task on Windows) for an agent already registered in
+`~/.culture/server.yaml`.
+
+```bash
+culture agent install spark-claude    # full nick
+culture agent install claude          # bare suffix — resolved against server.yaml
+```
+
+The generated `ExecStart` is `culture agent start <full-nick>
+--foreground` with no `--config` flag — the daemon falls through to
+the manifest at `~/.culture/server.yaml`. Decoupled from `mesh.yaml`:
+use this when you manage agents directly rather than via
+`culture mesh setup`. See
+[Agent systemd units](./agent-systemd.html) for unit-body details and
+recovery.
+
+### `culture agent uninstall`
+
+Remove the auto-start unit for a single agent. Graceful no-op if the
+unit was never installed; cleans up file, disables, stops, and runs
+`systemctl --user daemon-reload` on Linux.
+
+```bash
+culture agent uninstall spark-claude
+```
+
+The agent must still be in the manifest — uninstall before unregister.
+
 ## Messaging
 
 ### `culture channel message`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "12.2.0"
+version = "12.3.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_agent_install_cli.py
+++ b/tests/test_agent_install_cli.py
@@ -1,0 +1,181 @@
+# tests/test_agent_install_cli.py
+"""Tests for `culture agent install/uninstall <nick>` (#348)."""
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_manifest(tmp_path, server_name="spark", suffixes=("claude",)):
+    """Write a minimal server.yaml manifest with the given suffixes."""
+    from culture.config import (
+        ServerConfig,
+        ServerConnConfig,
+        save_server_config,
+    )
+
+    server_yaml = tmp_path / "server.yaml"
+    workdir = tmp_path / "proj"
+    workdir.mkdir(exist_ok=True)
+    config = ServerConfig(
+        server=ServerConnConfig(name=server_name),
+        manifest={suffix: str(workdir.resolve()) for suffix in suffixes},
+    )
+    save_server_config(str(server_yaml), config)
+    return server_yaml
+
+
+def test_install_passes_correct_argv_to_install_service(tmp_path):
+    """`culture agent install <suffix>` builds argv = ['culture','agent','start',<full>,'--foreground']."""
+    from culture.cli.agent import _cmd_install
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="claude")
+
+    with (
+        patch("culture.persistence.install_service") as mock_install,
+        patch("shutil.which", return_value="/usr/bin/culture"),
+    ):
+        mock_install.return_value = Path("/tmp/fake.service")
+        _cmd_install(args)
+
+    assert mock_install.call_count == 1
+    args_, _kwargs = mock_install.call_args
+    svc_name, command, description = args_[0], args_[1], args_[2]
+
+    assert svc_name == "culture-agent-spark-claude"
+    assert command == ["/usr/bin/culture", "agent", "start", "spark-claude", "--foreground"]
+    assert description == "culture agent spark-claude"
+
+
+def test_install_accepts_full_nick(tmp_path):
+    """The verb also accepts the full <server>-<suffix> nick form."""
+    from culture.cli.agent import _cmd_install
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="spark-claude")
+
+    with (
+        patch("culture.persistence.install_service") as mock_install,
+        patch("shutil.which", return_value="/usr/bin/culture"),
+    ):
+        mock_install.return_value = Path("/tmp/fake.service")
+        _cmd_install(args)
+
+    svc_name = mock_install.call_args[0][0]
+    assert svc_name == "culture-agent-spark-claude"
+
+
+def test_install_omits_config_flag_in_argv(tmp_path):
+    """Regression guard: ExecStart argv must NOT carry --config.
+
+    Pinning a per-workdir agents.yaml here re-introduces the crashloop
+    fixed in PR #344. Mirrors
+    test_setup_update_cli.py::test_install_mesh_services_omits_legacy_config_path.
+    """
+    from culture.cli.agent import _cmd_install
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="claude")
+
+    with (
+        patch("culture.persistence.install_service") as mock_install,
+        patch("shutil.which", return_value="/usr/bin/culture"),
+    ):
+        mock_install.return_value = Path("/tmp/fake.service")
+        _cmd_install(args)
+
+    command = mock_install.call_args[0][1]
+    assert "--config" not in command, (
+        f"install argv carries --config: {command}. "
+        "Regression: the legacy <workdir>/.culture/agents.yaml pin must stay out."
+    )
+    assert not any(".culture/agents.yaml" in tok for tok in command)
+
+
+def test_install_rejects_unknown_nick(tmp_path, capsys):
+    """An agent not in the manifest is rejected with exit code 1."""
+    from culture.cli.agent import _cmd_install
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="ghost")
+
+    with (
+        patch("culture.persistence.install_service") as mock_install,
+        pytest.raises(SystemExit) as exc,
+    ):
+        _cmd_install(args)
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert "spark-ghost" in captured.err
+    assert "not in manifest" in captured.err
+    mock_install.assert_not_called()
+
+
+def test_uninstall_calls_uninstall_service_with_correct_name(tmp_path):
+    """`culture agent uninstall <suffix>` calls uninstall_service('culture-agent-<full>')."""
+    from culture.cli.agent import _cmd_uninstall
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="claude")
+
+    with patch("culture.persistence.uninstall_service") as mock_uninstall:
+        _cmd_uninstall(args)
+
+    mock_uninstall.assert_called_once_with("culture-agent-spark-claude")
+
+
+def test_uninstall_accepts_full_nick(tmp_path):
+    """uninstall also accepts <server>-<suffix>."""
+    from culture.cli.agent import _cmd_uninstall
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="spark-claude")
+
+    with patch("culture.persistence.uninstall_service") as mock_uninstall:
+        _cmd_uninstall(args)
+
+    mock_uninstall.assert_called_once_with("culture-agent-spark-claude")
+
+
+def test_uninstall_rejects_unknown_nick(tmp_path, capsys):
+    """uninstall against a non-manifest agent exits 1 instead of silently no-op'ing."""
+    from culture.cli.agent import _cmd_uninstall
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="ghost")
+
+    with (
+        patch("culture.persistence.uninstall_service") as mock_uninstall,
+        pytest.raises(SystemExit) as exc,
+    ):
+        _cmd_uninstall(args)
+
+    assert exc.value.code == 1
+    mock_uninstall.assert_not_called()
+
+
+def test_install_uninstall_parsers_registered():
+    """Both verbs appear in the argparse surface."""
+    from culture.cli import _build_parser
+
+    p = _build_parser()
+    args = p.parse_args(["agent", "install", "claude"])
+    assert args.command == "agent"
+    assert args.agent_command == "install"
+    assert args.nick == "claude"
+
+    args = p.parse_args(["agent", "uninstall", "claude"])
+    assert args.agent_command == "uninstall"
+    assert args.nick == "claude"
+
+
+def test_install_uninstall_in_dispatch():
+    """Handlers are wired into the dispatch table."""
+    from culture.cli import agent
+
+    assert callable(agent._cmd_install)
+    assert callable(agent._cmd_uninstall)

--- a/tests/test_agent_install_cli.py
+++ b/tests/test_agent_install_cli.py
@@ -158,6 +158,28 @@ def test_uninstall_rejects_unknown_nick(tmp_path, capsys):
     mock_uninstall.assert_not_called()
 
 
+def test_install_disambiguates_suffix_that_starts_with_server_prefix(tmp_path):
+    """Regression: a bare suffix like `spark-claude` (server `spark`) must
+    not be silently stripped to `claude`. The manifest lookup takes priority
+    over prefix stripping."""
+    from culture.cli.agent import _cmd_install
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("spark-claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="spark-claude")
+
+    with (
+        patch("culture.persistence.install_service") as mock_install,
+        patch("shutil.which", return_value="/usr/bin/culture"),
+    ):
+        mock_install.return_value = Path("/tmp/fake.service")
+        _cmd_install(args)
+
+    svc_name = mock_install.call_args[0][0]
+    command = mock_install.call_args[0][1]
+    assert svc_name == "culture-agent-spark-spark-claude"
+    assert "spark-spark-claude" in command
+
+
 def test_install_uninstall_parsers_registered():
     """Both verbs appear in the argparse surface."""
     from culture.cli import _build_parser

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "12.2.0"
+version = "12.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Adds `culture agent install <nick>` and `culture agent uninstall <nick>`
— first-class CLI verbs for managing a single agent's auto-start unit
(systemd user on Linux, launchd on macOS, scheduled task on Windows).

Today, only `culture mesh setup` / `update` install per-agent units,
and both require a populated `~/.culture/mesh.yaml`. Hosts managed via
`server.yaml` (the manifest the rest of the CLI uses) had no first-class
path — operators hand-edited `~/.config/systemd/user/`.

The new verbs wrap the existing platform-level `install_service` /
`uninstall_service` helpers from `culture/persistence.py` (already
battle-tested by the mesh flow) and emit the exact same `ExecStart`
shape: `culture agent start <full-nick> --foreground`, no `--config`
token — the no-`--config` invariant from PR #344 is regression-guarded
in the new test.

After this lands, the recovery runbook in
`docs/reference/cli/agent-systemd.md` collapses from a 6-line
`systemctl disable/rm/daemon-reload` sequence to:

```bash
culture agent uninstall <nick> && culture agent install <nick>
```

Closes #348.

## Changes

- `culture/cli/agent.py` — new `install` / `uninstall` subparsers,
  `_cmd_install` / `_cmd_uninstall` handlers, `_resolve_manifest_suffix`
  helper, updated dispatch table and usage banner.
- `tests/test_agent_install_cli.py` (new, 9 tests) — argv shape, full-
  nick vs suffix resolution, manifest-membership check, parser wiring,
  dispatch wiring, and the `--config`-stays-out regression guard.
- `docs/reference/cli/index.md` — agent verb reference entries.
- `docs/reference/cli/agent-systemd.md` — rewritten recovery runbook
  using the new verbs.
- Version bump 12.2.0 → 12.3.0 (minor: new feature).

## Notes

- All-backends rule does **not** apply — this is shared CLI surface,
  not a per-backend harness path (issue #348 says so explicitly).
- `install_service` already handles `daemon-reload` and `enable` on
  Linux; `uninstall_service` already handles `disable`, `stop`, file
  removal, and `daemon-reload`. No new platform logic.
- Both verbs require the agent be in the manifest (typo-safety). To
  remove a stale unit for an already-unregistered agent, fall back to
  `systemctl --user disable --now …` for now — happy to loosen this
  if reviewers prefer.

## Test plan

- [x] `pytest tests/test_agent_install_cli.py` (9 new tests pass)
- [x] `pytest tests/test_register_cli.py tests/test_migrate_cli.py tests/test_setup_update_cli.py` (31 CLI siblings pass)
- [x] Full suite via `/run-tests` (1388 passed, 1 skipped)
- [x] `culture agent install --help` / `uninstall --help` smoke
- [ ] Manual e2e on a host with a registered agent — not run on this
      shared dev box to avoid touching systemd; mesh flow's existing
      install path is identical code.

- culture (Claude)
