### PR TITLE
culture agents/skills forward to steward (Phase 2, 13.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [13.1.0] - 2026-05-21
+
+### Added
+
+- `culture agents doctor`, `culture agents show`, and `culture agents overview` forward to the bundled steward alignment CLI (new `steward-cli` dependency). `culture agents` is now a hybrid noun — native lifecycle verbs plus forwarded steward alignment verbs, mirroring how `culture server` forwards to agentirc.
+- `culture skills announce-update` forwards to `steward announce-skill-update` (broadcast a vendored-skill migration brief to consumers of a vendored skill).
+
 ## [13.0.0] - 2026-05-21
 
 ### Changed

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -143,7 +143,7 @@ def _maybe_forward_to_steward(argv: list[str]) -> int | None:
     except ImportError as exc:  # pragma: no cover — declared dep
         print(f"steward-cli is not installed: {exc}", file=sys.stderr)
         return 2
-    return steward_main(steward_argv) or 0
+    return steward_main(steward_argv)
 
 
 def main() -> None:

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -120,6 +120,32 @@ def _maybe_forward_to_agentirc(argv: list[str]) -> int | None:
     return _agentirc_dispatch(argv[1:])
 
 
+def _maybe_forward_to_steward(argv: list[str]) -> int | None:
+    """Bypass argparse for steward verbs forwarded under ``agents`` / ``skills``.
+
+    Mirrors ``_maybe_forward_to_agentirc``: argparse REMAINDER can't capture
+    ``--help`` reliably, so forwarded steward verbs are short-circuited here and
+    replayed through ``steward.cli.main`` verbatim (the ``skills`` verb is remapped
+    to steward's canonical name). Returns the exit code, or None to let
+    argparse handle a native verb.
+    """
+    if len(argv) < 2:
+        return None
+    noun, verb = argv[0], argv[1]
+    if noun == "agents" and verb in agents._STEWARD_FORWARDED_VERBS:
+        steward_argv = [verb, *argv[2:]]
+    elif noun == "skills" and verb in skills._STEWARD_FORWARDED:
+        steward_argv = [skills._STEWARD_FORWARDED[verb], *argv[2:]]
+    else:
+        return None
+    try:
+        from steward.cli import main as steward_main
+    except ImportError as exc:  # pragma: no cover — declared dep
+        print(f"steward-cli is not installed: {exc}", file=sys.stderr)
+        return 2
+    return steward_main(steward_argv) or 0
+
+
 def main() -> None:
     # Logging must be configured before any dispatch path runs — including
     # the agentirc forwarder bypass below — so any logs emitted by
@@ -132,6 +158,10 @@ def main() -> None:
 
     try:
         forwarded = _maybe_forward_to_agentirc(sys.argv[1:])
+        if forwarded is not None:
+            sys.exit(forwarded)
+
+        forwarded = _maybe_forward_to_steward(sys.argv[1:])
         if forwarded is not None:
             sys.exit(forwarded)
 

--- a/culture/cli/agents.py
+++ b/culture/cli/agents.py
@@ -62,12 +62,21 @@ logger = logging.getLogger("culture")
 
 NAME = "agents"
 
+# Verbs forwarded verbatim to steward.cli.main. Registered as thin REMAINDER
+# subparsers and short-circuited before argparse (see _maybe_forward_to_steward
+# in culture.cli.__init__) so --help reaches steward's own parser.
+_STEWARD_FORWARDED_VERBS = ("doctor", "show", "overview")
+
 _NICK_HELP = "Agent suffix or full nick"
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
     agent_parser = subparsers.add_parser("agents", help="Manage AI agents")
     agent_sub = agent_parser.add_subparsers(dest="agents_command")
+
+    for verb in _STEWARD_FORWARDED_VERBS:
+        fwd = agent_sub.add_parser(verb, help=f"(forwarded to steward {verb})", add_help=False)
+        fwd.add_argument("argv", nargs=argparse.REMAINDER)
 
     # -- create ---------------------------------------------------------------
     _agent_args = [

--- a/culture/cli/agents.py
+++ b/culture/cli/agents.py
@@ -238,7 +238,7 @@ def register(subparsers: argparse._SubParsersAction) -> None:
 def dispatch(args: argparse.Namespace) -> None:
     if not args.agents_command:
         print(
-            "Usage: culture agents {create|join|start|stop|status|rename|assign|sleep|wake|learn|message|read|archive|unarchive|delete|register|unregister|install|uninstall|migrate}",
+            "Usage: culture agents {create|join|start|stop|status|rename|assign|sleep|wake|learn|message|read|archive|unarchive|delete|register|unregister|install|uninstall|migrate|doctor|show|overview}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/culture/cli/introspect.py
+++ b/culture/cli/introspect.py
@@ -195,7 +195,13 @@ def _agents_explain(_topic: str | None) -> tuple[str, int]:
         "- `install` / `uninstall` — manage the per-agent systemd/launchd unit\n"
         "- `message` / `read` — DM other agents\n"
         "- `learn` — print the onboarding prompt the agent reads on first run\n"
-        "- `rename` / `assign` / `archive` / `unarchive` / `delete` / `migrate` — admin\n",
+        "- `rename` / `assign` / `archive` / `unarchive` / `delete` / `migrate` — admin\n"
+        "\n## Alignment verbs (forwarded to steward)\n\n"
+        "- `doctor` — diagnose this repo or the whole sibling corpus\n"
+        "- `show <target>` — one agent's full configuration in one view\n"
+        "- `overview` — ecosystem inventory + relationship graph\n\n"
+        "Three inspection lenses: `status` (runtime liveness), `show` (static "
+        "config), `overview` (cross-repo graph).\n",
         0,
     )
 
@@ -286,7 +292,9 @@ def _skills_explain(_topic: str | None) -> tuple[str, int]:
         "  - `communicate` (with `scripts/`) — cross-repo + mesh "
         "communication helpers\n"
         "- Targets: `claude`, `codex`, `copilot`, `acp` (with `opencode` "
-        "as an alias for `acp`), or `all` to install for every backend\n",
+        "as an alias for `acp`), or `all` to install for every backend\n"
+        "- `announce-update` — broadcast a vendored-skill migration brief "
+        "(forwarded to `steward announce-skill-update`)\n",
         0,
     )
 

--- a/culture/cli/introspect.py
+++ b/culture/cli/introspect.py
@@ -293,7 +293,7 @@ def _skills_explain(_topic: str | None) -> tuple[str, int]:
         "communication helpers\n"
         "- Targets: `claude`, `codex`, `copilot`, `acp` (with `opencode` "
         "as an alias for `acp`), or `all` to install for every backend\n"
-        "- `announce-update` — broadcast a vendored-skill migration brief "
+        "- `culture skills announce-update` — broadcast a vendored-skill migration brief "
         "(forwarded to `steward announce-skill-update`)\n",
         0,
     )

--- a/culture/cli/skills.py
+++ b/culture/cli/skills.py
@@ -10,6 +10,10 @@ import sys
 
 NAME = "skills"
 
+# culture-facing verb -> steward verb. Forwarded verbatim via
+# _maybe_forward_to_steward (culture.cli.__init__).
+_STEWARD_FORWARDED = {"announce-update": "announce-skill-update"}
+
 _SKILL_FILENAME = "SKILL.md"
 _COMMUNICATE_SCRIPTS = (
     "fetch-issues.sh",
@@ -29,6 +33,12 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         choices=["claude", "codex", "copilot", "acp", "opencode", "all"],
         help="Target agent: claude, codex, copilot, acp, opencode (alias of acp), or all",
     )
+
+    for culture_verb, steward_verb in _STEWARD_FORWARDED.items():
+        fwd = skills_sub.add_parser(
+            culture_verb, help=f"(forwarded to steward {steward_verb})", add_help=False
+        )
+        fwd.add_argument("argv", nargs=argparse.REMAINDER)
 
 
 def dispatch(args: argparse.Namespace) -> None:

--- a/docs/reference/cli/agents.md
+++ b/docs/reference/cli/agents.md
@@ -1,0 +1,116 @@
+# `culture agents` — agent lifecycle and alignment
+
+`culture agents` is a **hybrid noun**: culture-owned lifecycle verbs run
+natively through culture's own argparse + IPC layer, while a set of
+alignment verbs are forwarded verbatim to the
+[`steward-cli`](https://github.com/agentculture/steward) (`steward`
+package). The two sets of verbs share the same top-level noun; the
+split is invisible to the caller.
+
+`steward-cli` is a declared dependency of `culture`, so forwarded verbs
+work out of the box — no separate install is needed.
+
+## Lifecycle verbs (culture-native)
+
+These verbs are implemented directly in `culture/cli/agents.py` and
+dispatched through culture's own argparse tree.
+
+| Verb | Description |
+|------|-------------|
+| `create` | Scaffold an agent directory and register in `~/.culture/server.yaml` |
+| `join` | `create` + `start` in one step |
+| `start` | Start agent daemon(s) |
+| `stop` | Stop agent daemon(s) |
+| `status` | Show runtime state of agents |
+| `sleep` | Pause agent(s) — stays connected but ignores @mentions |
+| `wake` | Resume paused agent(s) |
+| `install` | Install per-agent auto-start unit (systemd / launchd) |
+| `uninstall` | Remove the auto-start unit |
+| `message` | Send a direct message to an agent |
+| `read` | Read an agent's message history |
+| `learn` | Print the agent onboarding prompt |
+| `register` | Add a `culture.yaml` agent to `~/.culture/server.yaml` |
+| `unregister` | Remove an agent from the manifest |
+| `rename` | Rename an agent in the manifest |
+| `assign` | Reassign an agent to a different server |
+| `archive` | Stop + soft-remove an agent |
+| `unarchive` | Restore an archived agent |
+| `delete` | Permanently remove an agent from the manifest |
+| `migrate` | Migrate agents from the legacy `agents.yaml` format |
+
+```bash
+culture agents start spark-claude
+culture agents status
+culture agents status spark-claude
+culture agents stop --all
+culture agents install spark-claude
+```
+
+For full flag details see
+[`culture agents` in the CLI reference](./commands.md#agent-lifecycle).
+
+## Alignment verbs (forwarded to steward)
+
+These verbs are short-circuited before argparse and replayed through
+`steward.cli.main`. All flags and positional arguments are passed
+verbatim; the `--help` flag reaches steward's own parser rather than
+culture's.
+
+| culture verb | steward verb | Description |
+|---|---|---|
+| `culture agents doctor` | `steward doctor` | Diagnose this repo or the whole sibling corpus |
+| `culture agents show <target>` | `steward show` | One agent's full configuration in one view |
+| `culture agents overview` | `steward overview` | Ecosystem inventory + relationship graph |
+
+```bash
+culture agents doctor
+culture agents doctor --scope siblings
+culture agents show spark-claude
+culture agents overview
+culture agents doctor --help   # shows steward's doctor --help, not culture's
+```
+
+### Three inspection lenses
+
+| Verb | Lens | When to use |
+|------|------|-------------|
+| `status` | Runtime liveness | Is the daemon alive? PID? last activity? |
+| `show` | Static config | What does the agent's `culture.yaml` declare? |
+| `overview` | Cross-repo graph | How do agents relate across the whole corpus? |
+
+`status` is culture-native (reads PIDs and IPC sockets). `show` and
+`overview` are alignment verbs forwarded to steward, which has a
+broader view of the multi-repo ecosystem.
+
+## `culture skills announce-update`
+
+The `skills` noun also carries a forwarded verb:
+
+```bash
+culture skills announce-update --skill communicate
+```
+
+This forwards to `steward announce-skill-update`, broadcasting a
+vendored-skill migration brief to sibling repos. All flags pass through
+verbatim.
+
+## Forwarding contract
+
+- **Declared dependency.** `steward-cli>=0.16,<1.0` is in `culture`'s
+  `[project.dependencies]`. No separate install is required.
+- **Verbatim passthrough.** Flags and positional arguments are
+  forwarded as-is. The `skills announce-update` verb is remapped to
+  `steward announce-skill-update`; all other forwarded verbs keep their
+  name.
+- **Exit codes.** steward's exit code propagates unchanged.
+- **`--help` routing.** Because the short-circuit runs before argparse,
+  `culture agents doctor --help` shows steward's help, not culture's
+  top-level or subcommand help.
+
+## See also
+
+- [Agent lifecycle — full flag reference](./commands.md#agent-lifecycle)
+- [Agent systemd units](./agent-systemd.md)
+- [`steward-cli` on GitHub](https://github.com/agentculture/steward)
+- [`culture afi` passthrough](./afi.md) — the same hybrid-noun pattern
+  applied to the afi-cli namespace

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -8,6 +8,11 @@ inspectable via three universal verbs — `explain`, `overview`,
 `learn`. See [`culture devex` and universal verbs](./devex/) for the
 full contract.
 
+`culture agents` is a hybrid noun: lifecycle verbs run natively in
+culture while alignment verbs (`doctor`, `show`, `overview`) forward
+to [`steward-cli`](./agents.md). See
+[`culture agents` reference](./agents.md) for the full verb map.
+
 Install: `uv tool install culture` or `pip install culture`
 
 ## Server (the IRC mesh)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -12,6 +12,9 @@ full contract.
 culture while alignment verbs (`doctor`, `show`, `overview`) forward
 to [`steward-cli`](./agents.md). See
 [`culture agents` reference](./agents.md) for the full verb map.
+`culture skills announce-update` likewise forwards to
+`steward announce-skill-update` (see the
+[`culture agents` reference](./agents.md#culture-skills-announce-update)).
 
 Install: `uv tool install culture` or `pip install culture`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "13.0.0"
+version = "13.1.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "agex-cli>=0.13,<1.0",
     "agtag>=0.1,<1.0",
     "afi-cli>=0.3,<1.0",
+    "steward-cli>=0.16,<1.0",
     "irc-lens>=0.5.3,<1.0",
     "opentelemetry-api>=1.25",
     "opentelemetry-sdk>=1.25",

--- a/tests/test_cli_steward_forwarding.py
+++ b/tests/test_cli_steward_forwarding.py
@@ -50,3 +50,21 @@ def test_agents_doctor_help_reaches_steward():
     )
     assert result.returncode == 0, result.stderr
     assert "doctor" in result.stdout.lower()
+
+
+def test_explain_agents_documents_forwarded_verbs():
+    from culture.cli import introspect
+
+    out, rc = introspect.explain("agents")
+    assert rc == 0
+    # The forwarded alignment verbs must be visible in the noun's explain text.
+    for verb in ("doctor", "show", "overview"):
+        assert verb in out, f"explain agents omits forwarded verb {verb!r}: {out}"
+
+
+def test_explain_skills_documents_announce_update():
+    from culture.cli import introspect
+
+    out, rc = introspect.explain("skills")
+    assert rc == 0
+    assert "announce-update" in out

--- a/tests/test_cli_steward_forwarding.py
+++ b/tests/test_cli_steward_forwarding.py
@@ -5,17 +5,20 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
 
-def test_forwards_agents_doctor_verbatim(monkeypatch):
+
+@pytest.mark.parametrize("verb", ["doctor", "show", "overview"])
+def test_forwards_agents_verb_verbatim(monkeypatch, verb):
     calls = []
     import steward.cli
 
     monkeypatch.setattr(steward.cli, "main", lambda argv: calls.append(argv) or 0)
     from culture.cli import _maybe_forward_to_steward
 
-    rc = _maybe_forward_to_steward(["agents", "doctor", "--scope", "siblings"])
+    rc = _maybe_forward_to_steward(["agents", verb, "--scope", "siblings"])
     assert rc == 0
-    assert calls == [["doctor", "--scope", "siblings"]]
+    assert calls == [[verb, "--scope", "siblings"]]
 
 
 def test_forwards_skills_announce_update_remapped(monkeypatch):

--- a/tests/test_cli_steward_forwarding.py
+++ b/tests/test_cli_steward_forwarding.py
@@ -1,0 +1,49 @@
+"""Tests for steward verbs forwarded through `culture agents` / `culture skills`."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_forwards_agents_doctor_verbatim(monkeypatch):
+    calls = []
+    import steward.cli
+
+    monkeypatch.setattr(steward.cli, "main", lambda argv: calls.append(argv) or 0)
+    from culture.cli import _maybe_forward_to_steward
+
+    rc = _maybe_forward_to_steward(["agents", "doctor", "--scope", "siblings"])
+    assert rc == 0
+    assert calls == [["doctor", "--scope", "siblings"]]
+
+
+def test_forwards_skills_announce_update_remapped(monkeypatch):
+    calls = []
+    import steward.cli
+
+    monkeypatch.setattr(steward.cli, "main", lambda argv: calls.append(argv) or 0)
+    from culture.cli import _maybe_forward_to_steward
+
+    rc = _maybe_forward_to_steward(["skills", "announce-update", "communicate"])
+    assert rc == 0
+    assert calls == [["announce-skill-update", "communicate"]]
+
+
+def test_native_verbs_are_not_forwarded():
+    from culture.cli import _maybe_forward_to_steward
+
+    assert _maybe_forward_to_steward(["agents", "start", "spark-claude"]) is None
+    assert _maybe_forward_to_steward(["skills", "install", "claude"]) is None
+    assert _maybe_forward_to_steward(["agents"]) is None
+
+
+def test_agents_doctor_help_reaches_steward():
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "agents", "doctor", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "doctor" in result.stdout.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -637,6 +637,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "pyyaml" },
+    { name = "steward-cli" },
 ]
 
 [package.optional-dependencies]
@@ -681,6 +682,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.25" },
     { name = "opentelemetry-semantic-conventions", specifier = ">=0.46b0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "steward-cli", specifier = ">=0.16,<1.0" },
 ]
 provides-extras = ["copilot"]
 
@@ -2445,6 +2447,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "steward-cli"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/ce/183c268a79d6461ae14c9d20a1f3254ec82ea6230b3dd493718cf8daeb6a/steward_cli-0.16.0.tar.gz", hash = "sha256:9a8bd558478057f7553b2aba2f02c2b8003b5d1e2cdb2d71804c802f511776fd", size = 206851, upload-time = "2026-05-21T16:48:00.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/b0/02f00df9af6a053224d70d43adefd6c415ac02fc2bfdff9f519c45eb3079/steward_cli-0.16.0-py3-none-any.whl", hash = "sha256:126a8b22a337ef93be77c30fd3e383acf9bbbb123686e1f099d0e6c15507dd82", size = 45048, upload-time = "2026-05-21T16:48:01.489Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "13.0.0"
+version = "13.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Phase 2 of the `culture agents` namespace realignment — see the
[spec](docs/superpowers/specs/2026-05-21-culture-agents-unified-namespace-design.md)
and [plan](docs/superpowers/plans/2026-05-21-culture-agents-namespace.md).
Builds on #405 (Phase 1, merged).

Adds `steward-cli` as a dependency and makes `culture agents` a **hybrid noun**
(the same pattern `culture server` uses to forward to `agentirc`): culture-native
lifecycle verbs plus alignment verbs forwarded verbatim to the steward CLI.

- `culture agents doctor` / `show` / `overview` → forward to `steward doctor` / `show` / `overview`.
- `culture skills announce-update` → forwards (verb-remapped) to `steward announce-skill-update`.
- New `_maybe_forward_to_steward` in `culture/cli/__init__.py`, mirroring
  `_maybe_forward_to_agentirc`; short-circuits before argparse so `--help` reaches steward.
- `steward-cli>=0.16,<1.0` hard dependency (zero new transitive weight — steward needs only `pyyaml`).

Native lifecycle verbs (`start` / `stop` / `status` / …) are **not** forwarded — they stay culture-native.

## Test plan

- [x] Full suite green: **1400 passed, 1 skipped**
- [x] `culture agents doctor --help` → steward's doctor help; `culture agents start --help` → culture's native start help (not forwarded)
- [x] `culture skills announce-update --help` → steward's announce-skill-update help
- [x] Forwarding unit tests: doctor/show/overview verbatim, announce-update remapped, native verbs return `None`, subprocess smoke
- [x] explain-content tests (`explain agents` lists forwarded verbs; `explain skills` lists announce-update)
- [x] `doc-test-alignment` audit run and addressed (`docs/reference/cli/agents.md` reference page added)

## Follow-up (Phase 3, cross-repo — separate)

Brief `agentculture/steward` to add `explain` / `learn` / `--json` (the agent-first
contract) so the forwarded verbs gain a katvan-syncable deep reference.

- culture (Claude)
