### PR TITLE
skills: guildmaster propagation — 7 new skills + steward→guildmaster cutover (#409)

### DIFF
--- a/.claude/skills/agent-config/SKILL.md
+++ b/.claude/skills/agent-config/SKILL.md
@@ -6,8 +6,9 @@ description: >
   culture.yaml, and the agent's local .claude/skills index. Use when an
   operator says "show agent <name>", "what does <agent> look like", or before
   teaching/onboarding an agent and you need to see its current kit + config.
-  Backs the `guild show` verb. Vendored from steward (cite-don't-import);
-  inventory only — it reports, it does not judge alignment or drift.
+  Backs the `guild show` verb. Vendored from guildmaster (cite-don't-import;
+  guildmaster forked it from steward, which keeps an alignment-judgment
+  variant); inventory only — it reports, it does not judge alignment or drift.
 type: command
 ---
 
@@ -76,7 +77,8 @@ truncated to 120 chars).
 - **Per-machine config.** Suffix mode reads `culture_server_yaml` from
   `.claude/skills.local.yaml` (git-ignored), falling back to
   `.claude/skills.local.yaml.example`.
-- **Vendored from steward** (`agent-config`). guildmaster owns this copy and may
-  diverge; re-sync from steward's canonical copy when it changes. Divergences:
-  the SKILL.md is reframed for guildmaster's inventory role and adds
-  `type: command` for the culture backend's skill loader.
+- **Vendored from guildmaster** (`agent-config`; guildmaster forked it from
+  steward, which keeps an alignment-judgment variant). Re-sync from
+  guildmaster's canonical copy when it changes. Divergences: the SKILL.md is
+  reframed for guildmaster's inventory role and adds `type: command` for the
+  culture backend's skill loader.

--- a/.claude/skills/agent-config/SKILL.md
+++ b/.claude/skills/agent-config/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: agent-config
+description: >
+  Show a Culture agent's full configuration in one read-only view: its
+  system-prompt file (CLAUDE.md / AGENTS.md / GEMINI.md), the parallel
+  culture.yaml, and the agent's local .claude/skills index. Use when an
+  operator says "show agent <name>", "what does <agent> look like", or before
+  teaching/onboarding an agent and you need to see its current kit + config.
+  Backs the `guild show` verb. Vendored from steward (cite-don't-import);
+  inventory only — it reports, it does not judge alignment or drift.
+type: command
+---
+
+# agent-config — surface a Culture agent's config in one view
+
+guildmaster is the mesh's skills supplier and owns the **inventory** surfaces:
+"what kit + config does this agent have?" This skill answers exactly that for a
+single agent, showing the three artifacts that together define it:
+
+1. **System-prompt file** (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — the
+   prompt-side guidance for the agent's backend. The script detects which file
+   is present from a backend-fingerprint registry.
+2. **`culture.yaml`** — the runtime-side config (`agents:` list with `suffix`,
+   `backend`, `model`, `system_prompt`, `channels`, `tags`, `acp_command`,
+   `extras`). Lives parallel to the prompt file at the project root.
+3. **`.claude/skills/*/SKILL.md`** — the per-project skills the agent can
+   invoke, one line each (name + truncated description).
+
+This is the **inventory half** of the steward → guildmaster split
+([issue #12](https://github.com/agentculture/guildmaster/issues/12)): it reports
+the config, it does **not** interpret drift or judge alignment. The relationship
+graph and the "is this agent aligned?" judgment stay with `steward overview` /
+`steward doctor`.
+
+## When to use
+
+- Before `guild teach` / `guild onboard` — see an agent's current kit + config.
+- When an operator asks "show me agent `<name>`" or "what does `<agent>` run".
+- Read it, don't guess — before answering a question about what an agent does.
+
+## How to run
+
+One script, two ways to call it (or just run `guild show`, which wraps it):
+
+```bash
+# Path mode — point at any directory with a prompt file + culture.yaml
+.claude/skills/agent-config/scripts/show.sh ../culture
+
+# Suffix mode — resolve a registered agent suffix via the Culture server's
+# manifest (location set by culture_server_yaml in skills.local.yaml)
+.claude/skills/agent-config/scripts/show.sh daria
+```
+
+Output is three sections: the detected system-prompt file, `culture.yaml` (or
+`(missing)`), and a one-line summary per local skill (name + description,
+truncated to 120 chars).
+
+## What to look at in `culture.yaml`
+
+| Field | Why it matters |
+|-------|----------------|
+| `suffix` | Identifies the agent on the mesh. |
+| `backend` | One of `claude` / `codex` / `copilot` / `acp`. The all-backends rule means a feature in one must land in all four. |
+| `model` | Drift here changes behavior silently. |
+| `system_prompt` | Should not contradict the prompt file. |
+| `channels` | Where the agent listens. |
+| `tags`, `extras`, `acp_command` | Backend-specific. |
+
+## Notes
+
+- **Read-only.** The script never edits agent files. It reports; it does not
+  flag or fix drift — that judgment is steward's lane.
+- **Backend-aware.** Prompt-file detection comes from
+  `data/backend-fingerprints.yaml` (the `prompt:` mapping), falling back to the
+  built-in `(CLAUDE.md AGENTS.md GEMINI.md)` list if the registry is absent.
+- **Per-machine config.** Suffix mode reads `culture_server_yaml` from
+  `.claude/skills.local.yaml` (git-ignored), falling back to
+  `.claude/skills.local.yaml.example`.
+- **Vendored from steward** (`agent-config`). guildmaster owns this copy and may
+  diverge; re-sync from steward's canonical copy when it changes. Divergences:
+  the SKILL.md is reframed for guildmaster's inventory role and adds
+  `type: command` for the culture backend's skill loader.

--- a/.claude/skills/agent-config/data/backend-fingerprints.yaml
+++ b/.claude/skills/agent-config/data/backend-fingerprints.yaml
@@ -1,0 +1,30 @@
+# Canonical backend fingerprint registry. Vendored from steward's agent-config
+# skill (cite-don't-import); guildmaster owns this copy. Read by the agent-config
+# show.sh (bash), which `guild show` shells out to. Upstream steward also reads
+# it from a Python detector; guildmaster has no parallel detector, so only the
+# `backends:` prompt mapping below is load-bearing here. Keep that mapping in
+# sync with upstream when re-syncing.
+#
+# `prompt`        — the backend's system-prompt filename at the repo root.
+# `steering`      — files/dirs distinctive enough to attribute to this backend.
+# `shared_steering` — files/dirs that belong to NO specific backend. A repo
+#                   declared as any backend may have these without triggering a
+#                   mismatch. `.agents` is a generic Culture agent-config
+#                   convention. `.claude/settings.json` and
+#                   `.claude/settings.local.json` are generic Claude Code
+#                   (editor/CLI) workspace config files — they appear in any
+#                   repo that uses Claude Code as the development tool,
+#                   regardless of the agent backend, so they must never be used
+#                   to infer the backend or flag a mismatch. The claude backend
+#                   is identified solely by its `CLAUDE.md` prompt file.
+#                   `.github/copilot-instructions.md` is generic GitHub Copilot
+#                   editor/IDE config — any repo may have it regardless of the
+#                   declared agent backend, so it must not trigger a mismatch.
+backends:
+  claude:  { prompt: CLAUDE.md, steering: [] }
+  codex:   { prompt: AGENTS.md, steering: [".codex"] }
+  acp:     { prompt: AGENTS.md, steering: [".kiro"] }
+  copilot: { prompt: AGENTS.md, steering: [] }
+  gemini:  { prompt: GEMINI.md, steering: [".gemini"] }
+shared_steering: [".agents", ".claude/settings.json", ".claude/settings.local.json", ".github/copilot-instructions.md"]
+prompt_fallback: AGENTS.md

--- a/.claude/skills/agent-config/data/backend-fingerprints.yaml
+++ b/.claude/skills/agent-config/data/backend-fingerprints.yaml
@@ -1,9 +1,9 @@
-# Canonical backend fingerprint registry. Vendored from steward's agent-config
-# skill (cite-don't-import); guildmaster owns this copy. Read by the agent-config
-# show.sh (bash), which `guild show` shells out to. Upstream steward also reads
-# it from a Python detector; guildmaster has no parallel detector, so only the
-# `backends:` prompt mapping below is load-bearing here. Keep that mapping in
-# sync with upstream when re-syncing.
+# Canonical backend fingerprint registry. Vendored from guildmaster's
+# agent-config skill (cite-don't-import; guildmaster forked it from steward).
+# Read by the agent-config show.sh (bash), which `guild show` shells out to.
+# Steward also reads it from a Python detector; guildmaster has no parallel
+# detector, so only the `backends:` prompt mapping below is load-bearing here.
+# Keep that mapping in sync with upstream when re-syncing.
 #
 # `prompt`        — the backend's system-prompt filename at the repo root.
 # `steering`      — files/dirs distinctive enough to attribute to this backend.

--- a/.claude/skills/agent-config/scripts/show.sh
+++ b/.claude/skills/agent-config/scripts/show.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Show a Culture agent's full configuration in one view:
+# the detected system-prompt file (CLAUDE.md / AGENTS.md / GEMINI.md), the
+# parallel culture.yaml, and the .claude/skills/ index.
+#
+# Usage: show.sh <path-or-agent-suffix>
+#
+# Path mode:   show.sh ../culture
+# Suffix mode: show.sh daria   (resolved via culture_server_yaml in skills.local.yaml)
+#
+# Exit codes:
+#   0   success
+#   1   environment error (missing manifest, missing PyYAML for suffix mode)
+#   2   user error (no target given, unknown suffix, target path doesn't exist)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML scalar from CFG. Schema is intentionally tiny:
+#   key: value     (with optional surrounding quotes / trailing comment)
+# No PyYAML dependency.
+read_cfg() {
+    awk -v key="$1" '
+        $0 ~ ("^" key ":[[:space:]]*") {
+            sub("^" key ":[[:space:]]*", "")
+            sub(/[[:space:]]*#.*$/, "")
+            sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, "")
+            sub(/^["\047]/, ""); sub(/["\047]$/, "")
+            print
+            exit
+        }
+    ' "$CFG"
+}
+
+target="${1:-}"
+if [ -z "$target" ]; then
+    echo "Usage: $(basename "$0") <path-or-agent-suffix>" >&2
+    exit 2
+fi
+
+if [ -d "$target" ]; then
+    DIR="$target"
+else
+    SERVER_YAML_RAW="$(read_cfg culture_server_yaml)"
+    SERVER_YAML="${SERVER_YAML_RAW/#\~/$HOME}"
+    if [ ! -f "$SERVER_YAML" ]; then
+        echo "no server manifest at $SERVER_YAML — set culture_server_yaml in $CFG" >&2
+        echo "or pass an explicit path instead of suffix '$target'" >&2
+        exit 1
+    fi
+    # Suffix mode parses Culture's server manifest, whose schema is dictated by
+    # Culture (not by us) and includes nested mappings — too rich for awk.
+    # We use python+PyYAML here, with a friendly install hint if it's missing.
+    if ! python3 -c 'import yaml' 2>/dev/null; then
+        echo "suffix mode needs Python + PyYAML to parse $SERVER_YAML" >&2
+        echo "  install: pip install --user pyyaml   (or: uv pip install pyyaml)" >&2
+        echo "  or pass an explicit path instead of suffix '$target'" >&2
+        exit 1
+    fi
+    # Use a dedicated exit code (2) for "unknown suffix" so the steward CLI
+    # wrapper can distinguish user errors (typo'd suffix) from env errors
+    # (missing manifest / PyYAML).
+    if ! DIR=$(python3 - "$SERVER_YAML" "$target" <<'PY'
+import sys, yaml, pathlib
+manifest_path, suffix = sys.argv[1], sys.argv[2]
+m = yaml.safe_load(pathlib.Path(manifest_path).read_text()) or {}
+agents = m.get('agents', {})
+entry = agents.get(suffix)
+if entry is None:
+    print(f"no agent registered with suffix {suffix!r} in {manifest_path}", file=sys.stderr)
+    sys.exit(2)
+print(entry['directory'] if isinstance(entry, dict) else entry)
+PY
+); then
+        exit 2
+    fi
+fi
+
+DIR="${DIR/#\~/$HOME}"
+
+# Recognized prompt filenames come from the shared registry (single source
+# of truth with the Python detector). Fall back to the built-in list if the
+# registry isn't present (e.g. skill vendored without the data file).
+REGISTRY="$SKILL_DIR/data/backend-fingerprints.yaml"
+prompt_files=()
+if [ -f "$REGISTRY" ]; then
+    while IFS= read -r pf; do
+        [ -n "$pf" ] && prompt_files+=("$pf")
+    done < <(grep -oE 'prompt:[[:space:]]*[^,}[:space:]]+' "$REGISTRY" | awk '{print $NF}' | sort -u)
+fi
+[ ${#prompt_files[@]} -eq 0 ] && prompt_files=(CLAUDE.md AGENTS.md GEMINI.md)
+
+shown=0
+for pf in "${prompt_files[@]}"; do
+    if [ -f "$DIR/$pf" ]; then
+        echo "=== $DIR/$pf ==="
+        cat "$DIR/$pf"
+        echo
+        shown=1
+    fi
+done
+if [ "$shown" -eq 0 ]; then
+    echo "=== $DIR (system prompt) ==="
+    echo "(no recognized prompt file: ${prompt_files[*]})"
+    echo
+fi
+echo "=== $DIR/culture.yaml ==="
+if [ -f "$DIR/culture.yaml" ]; then cat "$DIR/culture.yaml"; else echo "(missing)"; fi
+echo
+echo "=== $DIR/.claude/skills/ ==="
+found=0
+for s in "$DIR"/.claude/skills/*/SKILL.md; do
+    [ -f "$s" ] || continue
+    found=1
+    name=$(awk '/^name:/{print $2; exit}' "$s")
+    desc=$(awk '
+        /^description:/ {
+            sub(/^description:[[:space:]]*/, "")
+            buf = $0
+            flag = 1
+            next
+        }
+        flag && /^[a-z_-]+:/ { flag = 0 }
+        flag { buf = buf " " $0 }
+        END { gsub(/^[[:space:]]+|[[:space:]]+$/, "", buf); print buf }
+    ' "$s")
+    printf "  %-30s %s\n" "$name" "${desc:0:120}"
+done
+if [ "$found" -eq 0 ]; then
+    echo "  (no skills)"
+fi

--- a/.claude/skills/agent-config/scripts/show.sh
+++ b/.claude/skills/agent-config/scripts/show.sh
@@ -62,10 +62,16 @@ else
         echo "  or pass an explicit path instead of suffix '$target'" >&2
         exit 1
     fi
-    # Use a dedicated exit code (2) for "unknown suffix" so the steward CLI
-    # wrapper can distinguish user errors (typo'd suffix) from env errors
-    # (missing manifest / PyYAML).
-    if ! DIR=$(python3 - "$SERVER_YAML" "$target" <<'PY'
+    # Use a dedicated exit code (2) for "unknown suffix" so the guildmaster
+    # `guild show` wrapper can distinguish user errors (typo'd suffix) from
+    # env errors (missing manifest / PyYAML / malformed entry).
+    #
+    # culture-divergence: propagate the Python exit code instead of forcing
+    # exit 2 for *every* failure. Only the explicit `sys.exit(2)` (unknown
+    # suffix) maps to 2; a malformed manifest or missing `directory` key keeps
+    # Python's rc (1) so callers can tell a typo'd suffix from a broken
+    # manifest. Offered upstream to guildmaster (canonical script forces 2).
+    if DIR=$(python3 - "$SERVER_YAML" "$target" <<'PY'
 import sys, yaml, pathlib
 manifest_path, suffix = sys.argv[1], sys.argv[2]
 m = yaml.safe_load(pathlib.Path(manifest_path).read_text()) or {}
@@ -76,8 +82,10 @@ if entry is None:
     sys.exit(2)
 print(entry['directory'] if isinstance(entry, dict) else entry)
 PY
-); then
-        exit 2
+    ); then
+        :
+    else
+        exit "$?"
     fi
 fi
 

--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -11,8 +11,8 @@ description: >
   performs the fan-out. Use when the user says "assign to workforce",
   "fan out the plan", "parallel subagents", or after /spec-to-plan exports a
   plan. Authored and maintained in agentculture/devague (origin = devague);
-  steward pulls this skill from here and broadcasts it to the AgentCulture
-  mesh — it is NOT vendored from steward like the other skills here.
+  guildmaster re-broadcasts it to the AgentCulture mesh — it originates in
+  devague, not guildmaster (the supplier post steward→guildmaster cutover).
 ---
 
 # assign-to-workforce — fan out a converged plan's waves to parallel agents
@@ -236,7 +236,7 @@ This is a **first-party** skill — its origin is `agentculture/devague`, where
 the devague agent maintains it alongside the tools it operates (dogfooding),
 next to its siblings `/think` and `/spec-to-plan`. It is the *third* skill in
 that outbound family, covering the implementation leg after a plan converges.
-The flow runs the *opposite* direction of the vendored steward skills: steward
-pulls this **from** devague and broadcasts it to the rest of the AgentCulture
-mesh. The `cite, don't import` policy still holds: downstream repos copy it,
+The flow runs the *opposite* direction of the vendored guildmaster skills:
+guildmaster pulls this **from** devague and re-broadcasts it to the rest of the
+AgentCulture mesh. The `cite, don't import` policy still holds: downstream repos copy it,
 they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: assign-to-workforce
+type: command
+description: >
+  Fan out a converged devague plan's dependency waves to parallel agents in
+  isolated git worktrees, one agent per task per wave, with TDD-gated merges
+  by the main agent. Human gates: the exported spec, the implementation split
+  plan (task map + per-task agent/model proposal + go/no-go), and the final PR.
+  The devague CLI stays deterministic and non-orchestrating (#20) — it only
+  *describes* the graph via `devague plan waves`; the operator (main agent)
+  performs the fan-out. Use when the user says "assign to workforce",
+  "fan out the plan", "parallel subagents", or after /spec-to-plan exports a
+  plan. Authored and maintained in agentculture/devague (origin = devague);
+  steward pulls this skill from here and broadcasts it to the AgentCulture
+  mesh — it is NOT vendored from steward like the other skills here.
+---
+
+# assign-to-workforce — fan out a converged plan's waves to parallel agents
+
+The skill is named **`assign-to-workforce`**; the product/CLI it reads is the
+**`devague plan waves`** command. (The prior leg — turning a spec into a plan —
+is the sibling **`/spec-to-plan`** skill.)
+
+`assign-to-workforce` takes a **converged devague plan** and fans out its
+dependency waves to parallel agents (subagents, teammate agents, or generalist
+agents) — one agent per task per wave — each working in an **isolated git
+worktree**. The main agent merges each completed worktree gated by TDD. The
+human owns exactly three gates: the exported spec, the implementation split
+plan, and the final PR.
+
+The devague CLI is **never orchestrated by devague itself** — `devague plan
+waves` describes the dependency graph (#20); it does not spawn agents, manage
+worktrees, mark tasks done, or pick a backend. The fan-out is the *operator's*
+job — this skill and the main agent perform it.
+
+## How to run
+
+The entry point is `scripts/assign-to-workforce.sh`. Invoke it from the
+repository whose plan you are implementing (plans persist under `.devague/`
+in the current directory):
+
+```bash
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan [--plan <slug>]
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh waves    [--plan <slug>] [--json]
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh help
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` when you are inside the devague
+checkout, else an install hint. The `split-plan` subcommand reads
+`devague plan waves --json` and renders the human-facing implementation split
+plan: task map, proposed per-task agent + model assignment, and the go/no-go
+question. The `waves` subcommand forwards to `devague plan waves` verbatim.
+
+### Usage
+
+| Subcommand | What it does |
+|------------|--------------|
+| `split-plan [--plan S]` | Read `devague plan waves` and print the implementation split plan — task map with per-task agent + model proposal — ready for human go/no-go review. |
+| `waves [--plan S] [--json]` | Forward to `devague plan waves [--json]`. Read-only; lists wave batches. On a converged plan exits 0 listing the waves. |
+| `help` | Print usage. |
+
+## The full flow
+
+The flow has three human gates and one automated TDD merge loop.
+
+### Human gate 1 — the exported spec
+
+The plan is seeded from a converged frame (`devague plan new --frame <slug>`).
+The human reviewed and approved the spec when it was exported by the `/think`
+skill. No re-approval needed here — the spec gate is already closed.
+
+### Human gate 2 — the implementation split plan
+
+Before any task is assigned, the main agent presents the **implementation split
+plan** for human go/no-go. This is the only gate the human owns at the
+implementation stage (per task, the TDD gate is the main agent's).
+
+The split plan contains:
+
+1. **Task map** — every task id, its one-line summary, acceptance criteria, and
+   the wave it belongs to (from `devague plan waves`).
+2. **Per-task agent + model proposal** — for each task: the proposed agent type
+   (subagent / teammate / generalist), the proposed model (e.g. a cheaper/faster
+   model for a well-scoped task), and the scope justification (why this task is
+   safe to delegate).
+3. **Go/no-go question** — explicit human decision: "Approve this split and
+   assign the plan to the workforce, or edit it first?"
+
+The human may edit any row (agent type, model, scope) before approving. The
+plan is model-agnostic — devague does not pick a backend (#20).
+
+Run `split-plan` to print the proposed table:
+
+```bash
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan
+```
+
+Do not proceed to fan-out until the human approves the split plan.
+
+### Fan-out — one agent per task per wave in isolated worktrees
+
+Once the human approves, the main agent fans out each wave in order:
+
+1. **Create an isolated git worktree** for each task in the current wave:
+
+   ```bash
+   git worktree add ../worktrees/agent-<task-id> -b agent/<task-id>
+   ```
+
+2. **Spawn a task agent** inside that worktree (using the approved model from
+   the split plan), with:
+   - The task id, summary, and acceptance criteria as its brief.
+   - Instruction to work **test-first** (TDD): write the failing test(s) that
+     match the acceptance criteria before implementing.
+   - Instruction to commit its work to the worktree branch.
+
+3. **Same-wave tasks run in parallel** (within-wave tasks have no
+   inter-task dependency; the dependency graph guarantees this). Same-file
+   overlap surfaces as a merge conflict at reconcile time, not a live race —
+   isolated worktrees prevent clobbering.
+
+4. **Wait for all tasks in the wave to complete** before starting the next wave.
+
+### TDD-gated merge — main agent, no human per task
+
+For each completed task worktree, the main agent:
+
+1. **Runs the task's tests before merge** (on the main branch): baseline must
+   pass (or the relevant tests must be absent — the task adds them).
+2. **Merges the worktree branch** into the main branch:
+
+   ```bash
+   git merge --no-ff agent/<task-id>
+   ```
+
+3. **Runs the task's tests after merge**: they must pass. If they do not, the
+   merge is reverted and the task agent is given the failure output to fix.
+4. **Removes the worktree** once the merge is accepted:
+
+   ```bash
+   git worktree remove ../worktrees/agent-<task-id>
+   ```
+
+The human does **not** review individual task merges. Per-task acceptance is
+the main agent's responsibility — the TDD gate (tests pass before AND after
+merge) plus the task's acceptance criteria. This mirrors the non-authoritative
+working state pattern of the Human Review Loop (#17): per-task merge records
+are uncommitted working state; the authoritative human gate is the final PR.
+
+Advance to the next wave only after all tasks in the current wave are merged
+and their tests pass.
+
+### Human gate 3 — the final PR
+
+Once all waves are merged and the full test suite passes, the main agent opens
+a PR via the `cicd` skill (`agex pr open`). The human reviews and merges. This
+is the last and only remaining human gate.
+
+## Hard rules (do not violate)
+
+These protect the human-gate contract and the TDD guarantee.
+
+- **Present the split plan before any fan-out.** Never spawn a task agent
+  without prior human approval of the implementation split plan (gate 2). The
+  split plan is the human's only implementation-stage decision.
+- **One worktree per task.** Never run two tasks in the same worktree — file
+  contention is managed by isolation, not by trust in the dependency graph.
+  The dependency graph guarantees *logical* independence within a wave, not
+  *file* disjointness. Conflicts surface at merge time.
+- **Tests before AND after merge — no exceptions.** The TDD gate must pass on
+  both sides. A merge that makes tests pass only after (not before) means the
+  baseline was already broken — fix the baseline first.
+- **Human does not gate per-task merges.** The TDD contract replaces the
+  human here. Do not pause for human approval between wave tasks.
+- **devague CLI is not orchestrated.** `devague plan waves` is read-only
+  scheduling metadata (#20). Never run `devague plan` commands inside a task
+  worktree to "mark a task done" or modify plan state from a subagent.
+- **Three gates only.** The human's gates are: (1) the exported spec, (2) the
+  implementation split plan, (3) the final PR. No silent fourth gate.
+- **No LLM calls in the devague CLI.** The CLI is deterministic. This skill
+  adds orchestration convention, not CLI behavior.
+
+## Output contract
+
+The `split-plan` subcommand prints to **stdout** and exits 0 when a converged
+plan is found. On error (no plan, cyclic graph) it exits non-zero with a
+`hint:` line on stderr. The `waves` subcommand forwards the CLI's own output
+contract (stdout, `--json` for structured output, exit 0 on success).
+
+## Worked example
+
+Picking up after `/spec-to-plan` exported a plan for the frame `my-feature`:
+
+```bash
+a() { bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh "$@"; }
+
+# 1. Inspect the waves
+a waves
+
+# 2. Present the implementation split plan for human review
+a split-plan
+
+# --- HUMAN: review the table, edit agent/model assignments if needed,
+#     then say "approved" to proceed ---
+
+# 3. Fan out wave 1 (t1, t2, t3 are independent — run in parallel)
+git worktree add ../worktrees/agent-t1 -b agent/t1
+git worktree add ../worktrees/agent-t2 -b agent/t2
+git worktree add ../worktrees/agent-t3 -b agent/t3
+# ... spawn task agents in each worktree, await completion ...
+
+# 4. TDD-gated merge for each wave-1 task (no human per task)
+git merge --no-ff agent/t1   # tests pass before + after
+git worktree remove ../worktrees/agent-t1
+git merge --no-ff agent/t2
+git worktree remove ../worktrees/agent-t2
+git merge --no-ff agent/t3
+git worktree remove ../worktrees/agent-t3
+
+# 5. Advance to wave 2 (t4 depends on t1–t3 being merged)
+git worktree add ../worktrees/agent-t4 -b agent/t4
+# ... spawn, await, merge with TDD gate, remove worktree ...
+
+# 6. Open the final PR (human gate 3)
+bash .claude/skills/cicd/scripts/workflow.sh open
+```
+
+The exported plan-md from `devague plan export` is the standing brief for
+each task agent — its task id, summary, acceptance criteria, and the targets
+it covers are already in that file.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where
+the devague agent maintains it alongside the tools it operates (dogfooding),
+next to its siblings `/think` and `/spec-to-plan`. It is the *third* skill in
+that outbound family, covering the implementation leg after a plan converges.
+The flow runs the *opposite* direction of the vendored steward skills: steward
+pulls this **from** devague and broadcasts it to the rest of the AgentCulture
+mesh. The `cite, don't import` policy still holds: downstream repos copy it,
+they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# assign-to-workforce.sh — fan out devague plan waves to parallel agents.
+#
+# The skill is named `assign-to-workforce`; it reads `devague plan waves`
+# (scheduling metadata produced by the /spec-to-plan skill) and renders the
+# implementation split plan: task map + per-task agent/model proposal + a
+# go/no-go prompt for the human. The actual fan-out (worktree creation,
+# spawning, TDD-gated merges) is performed by the operator/main agent once
+# the human approves the split plan.
+#
+# The devague CLI is non-orchestrating (#20): `devague plan waves` describes
+# the dependency graph; it does not spawn agents, manage worktrees, or pick
+# a backend. This wrapper is the operator-facing helper.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so
+# it is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory, so run from the repo
+# you are implementing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+assign-to-workforce.sh — fan out devague plan waves to parallel agents.
+
+Usage:
+  assign-to-workforce.sh split-plan [--plan <slug>]   print the implementation split plan
+  assign-to-workforce.sh waves      [--plan <slug>] [--json]   list dependency waves
+  assign-to-workforce.sh help                         this help
+
+Commands:
+  split-plan   Read `devague plan waves --json` and render the human-facing
+               implementation split plan: task map + per-task agent/model
+               proposal + go/no-go. Present this to the human before any
+               fan-out; do not proceed without approval.
+  waves        Forward `devague plan waves` (and any extra flags) verbatim.
+               On a converged plan exits 0 and lists the dependency waves.
+
+Plans persist under .devague/ in the current directory — run from the repo
+you are implementing. Results go to stdout, diagnostics to stderr.
+
+Human gates (three only):
+  1. The exported spec (already closed by the /think leg).
+  2. This implementation split plan (go/no-go to assign to workforce).
+  3. The final PR (opened by the main agent via `cicd` / `agex pr open`).
+
+The devague CLI is non-orchestrating (#20): `devague plan waves` describes
+the graph; the operator performs the fan-out. One worktree per task; TDD
+gates every merge (tests pass before AND after merge); no human per task.
+EOF
+}
+
+# ── split-plan: render the implementation split plan for human review ────────
+cmd_split_plan() {
+    local extra_args=()
+    # Forward any --plan flag so waves targets the right plan.
+    while [ $# -gt 0 ]; do
+        extra_args+=("$1")
+        shift
+    done
+
+    local waves_json tmp_err waves_rc old_exit_trap
+    # Clean up the temp file on any exit path — including a signal after its
+    # creation — WITHOUT permanently changing the script's process-global EXIT
+    # handling. Capture any prior EXIT trap BEFORE mktemp (that capture forks a
+    # subshell, so doing it first keeps it out of the untracked-file window),
+    # then install our cleanup trap on the line immediately after mktemp, and
+    # restore the prior trap once the file is safely gone (#30; PR #31 review;
+    # devague#32).
+    old_exit_trap="$(trap -p EXIT)"
+    tmp_err="$(mktemp)"
+    trap 'rm -f "$tmp_err"' EXIT
+    set +e
+    waves_json="$("${DEVAGUE[@]}" plan waves --json "${extra_args[@]}" 2>"$tmp_err")"
+    waves_rc=$?
+    set -e
+    local waves_err
+    waves_err="$(cat "$tmp_err")"
+    rm -f "$tmp_err"
+    trap - EXIT
+    eval "${old_exit_trap}"  # empty string is a no-op; re-installs a prior trap if any
+
+    if [ "$waves_rc" -ne 0 ]; then
+        printf '%s\n' "$waves_err" >&2
+        return "$waves_rc"
+    fi
+
+    DEVAGUE_WAVES_JSON="$waves_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+raw = os.environ.get("DEVAGUE_WAVES_JSON", "").strip()
+if not raw:
+    print("error: no waves output from devague plan waves", file=sys.stderr)
+    print("hint: ensure a converged plan exists (devague plan converge)", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError as exc:
+    print(f"error: could not parse waves JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+plan_slug = data.get("plan", "(unknown)")
+waves = data.get("waves") or []
+
+print(f"Implementation split plan — plan: {plan_slug}")
+print()
+print("Dependency waves (from `devague plan waves`):")
+for i, wave in enumerate(waves, 1):
+    tasks = ", ".join(wave)
+    print(f"  Wave {i}: [{tasks}]")
+
+print()
+print("Task assignments (proposed — edit before approving):")
+print()
+
+headers = ("Task", "Wave", "Summary", "Agent type", "Model", "Scope note")
+rows = []
+for i, wave in enumerate(waves, 1):
+    for task_id in wave:
+        rows.append((
+            task_id,
+            str(i),
+            "(see plan export for summary + acceptance criteria)",
+            "subagent",
+            "cheaper/faster",
+            "TDD-scoped task; isolated worktree; tests gate merge",
+        ))
+
+col_widths = [max(len(h), max((len(r[j]) for r in rows), default=0))
+              for j, h in enumerate(headers)]
+
+def row_str(cells):
+    return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, col_widths)) + " |"
+
+sep = "| " + " | ".join("-" * w for w in col_widths) + " |"
+print(row_str(headers))
+print(sep)
+for row in rows:
+    print(row_str(row))
+
+print()
+print("Go/no-go: review the table above, edit agent type / model / scope as needed,")
+print("then confirm: \"Approved — assign to workforce\" or \"Edit first\".")
+print()
+print("Once approved, fan out wave by wave:")
+print("  1. Create one git worktree per task in the wave.")
+print("  2. Spawn a task agent per worktree (brief = task summary + acceptance criteria).")
+print("  3. Await all tasks in the wave; then TDD-gate each merge (tests before + after).")
+print("  4. Advance to the next wave.")
+print("  5. Open the final PR (human gate 3) after all waves merge and tests pass.")
+PY
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        split-plan)
+            shift
+            resolve_devague
+            cmd_split_plan "$@"
+            ;;
+        waves)
+            shift
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan waves "$@"
+            ;;
+        *)
+            printf 'error: unknown subcommand: %s\n' "$1" >&2
+            printf 'hint: run `assign-to-workforce.sh help` for usage\n' >&2
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -12,9 +12,10 @@
 # the dependency graph; it does not spawn agents, manage worktrees, or pick
 # a backend. This wrapper is the operator-facing helper.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
-# skill from here and broadcasts it to the rest of the AgentCulture mesh, so
-# it is written to run anywhere — portable bash, no devague-checkout assumptions.
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls
+# this skill from devague and re-broadcasts it to the rest of the AgentCulture
+# mesh, so it is written to run anywhere — portable bash, no devague-checkout
+# assumptions.
 #
 # Plans persist under .devague/ in the current directory, so run from the repo
 # you are implementing.

--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -322,9 +322,10 @@ CULTURE_NICK="<agent-nick>" culture channel message "#general" "PR #<N> — all 
 | `portability-lint.sh [--all]` | `.claude/skills/cicd/scripts/` | Catch absolute `/home/<user>/` paths and per-user dotfile references in committed docs/configs. Default mode lints the current diff (staged + unstaged); `--all` lints every tracked file. Run via `workflow.sh lint` (which forwards to `agex pr lint --exit-on-violation`). |
 
 All scripts auto-detect `owner/repo` from the current git remote. The
-full script set is vendored from steward (the AgentCulture alignment
-hub) — re-cite from there if you need updates. Scripts that have
-intentionally diverged from steward's upstream copy carry a
+full script set is vendored from **guildmaster** (the AgentCulture skills
+hub, post steward→guildmaster cutover; lineage: steward 0.12.0) — re-cite
+from `../guildmaster/.claude/skills/cicd/` if you need updates. Scripts
+that have intentionally diverged from the upstream copy carry a
 `# culture-divergence:` header documenting what was changed and why;
 preserve those when re-citing.
 

--- a/.claude/skills/cicd/scripts/workflow.sh
+++ b/.claude/skills/cicd/scripts/workflow.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 # culture-divergence: env var prefix renamed STEWARD_* → CULTURE_*; header
-# prose rebranded "steward" → "culture". Vendored from steward 0.12.0 — see
-# https://github.com/agentculture/steward/blob/main/.claude/skills/cicd/scripts/workflow.sh
+# prose rebranded "steward" → "culture". Supplier is guildmaster (the
+# AgentCulture skills hub, post steward→guildmaster cutover); lineage:
+# steward 0.12.0. Re-cite from
+# https://github.com/agentculture/guildmaster/blob/main/.claude/skills/cicd/scripts/workflow.sh
 #
 # Culture cicd workflow — thin layer over `agex pr` plus two culture
 # extensions (`status`, `await`) for SonarCloud gating and triage flow.

--- a/.claude/skills/communicate/SKILL.md
+++ b/.claude/skills/communicate/SKILL.md
@@ -223,7 +223,8 @@ with the next one.
 | `scripts/post-comment.sh` | Comment on an existing issue. Wraps `agtag issue reply`; auto-signs from `culture.yaml`. |
 | `scripts/fetch-issues.sh` | Fetch one or more issues (single / range / list) with body + comments. Wraps `agtag issue fetch`. |
 | `scripts/mesh-message.sh` | Send a message to a Culture mesh channel. Unsigned (IRC nick is the speaker). |
-| `scripts/templates/skill-update-brief.md` | The Markdown template the steward broadcast verb consumes. Vendored alongside the scripts for reference; culture itself does not run a broadcast verb (that lives in `steward-cli`). |
+| `scripts/templates/skill-update-brief.md` | Markdown template the upstream broadcast verb (guildmaster's `guild teach`) renders for a **resync** of an already-vendored skill. Vendored alongside the scripts for reference; culture itself does not run a broadcast verb. |
+| `scripts/templates/skill-new-brief.md` | Companion template for a **new** skill (no older copy to replace), rendered with `--new`. Same reference-only role. |
 
 More scripts can land here as the communication footprint grows —
 `mesh-ask.sh` for question-shaped pings via `culture channel ask`,
@@ -253,8 +254,9 @@ hypotheticals.
 
 ## Provenance
 
-Vendored from agentculture/steward
-([`.claude/skills/communicate/`](https://github.com/agentculture/steward/tree/main/.claude/skills/communicate)).
-Re-cite from there when steward bumps the skill. Scripts intentionally
-diverged from steward's upstream copy carry a `# culture-divergence:`
-header; preserve those when re-citing.
+Vendored from **agentculture/guildmaster** (the AgentCulture skills hub,
+post steward→guildmaster cutover; lineage: steward through 0.11.x)
+([`.claude/skills/communicate/`](https://github.com/agentculture/guildmaster/tree/main/.claude/skills/communicate)).
+Re-cite from there when guildmaster bumps the skill. Scripts intentionally
+diverged from the upstream copy carry a `# culture-divergence:` header
+(e.g. `fetch-issues.sh`'s strict range guard); preserve those when re-citing.

--- a/.claude/skills/communicate/scripts/templates/skill-new-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-new-brief.md
@@ -1,0 +1,85 @@
+<!-- markdownlint-disable MD041 -->
+<!-- This file is the NEW-SKILL template rendered by announce-skill-update -->
+<!-- when --new is passed. It posts as an issue body where GitHub supplies -->
+<!-- the title, so there's no H1 here on purpose. Placeholders use the -->
+<!-- `{{NAME}}` syntax; {{ORIGIN_BLOCK}} is empty unless --origin is given. -->
+
+## A new skill is available to vendor
+
+`{{SKILL}}` is a **new** skill in the AgentCulture mesh. Your repo does
+not have it yet — this brief tells you how to **add it fresh** (there is no
+older vendored copy to replace). If you maintain a `docs/skill-sources.md`
+provenance ledger, add a row for it; if not, just drop it into
+`.claude/skills/`.
+
+{{ORIGIN_BLOCK}}
+
+Relevant guildmaster CHANGELOG entries (where guildmaster picked the skill up):
+
+{{CHANGELOG_BLOCK}}
+
+## Cite locations (source of truth)
+
+- Local sibling checkout (preferred when available):
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
+
+guildmaster re-broadcasts this skill to the mesh, so its copy is the citation
+point even when the skill originates in another sibling (see origin note
+above, if present). The directory ships a `SKILL.md` and a `scripts/`
+directory per the AgentCulture skills-portability rule (each skill is
+self-contained; nothing reaches across skill boundaries at runtime).
+
+## What's in the upstream now
+
+`{{SKILL}}/scripts/` ({{UPSTREAM_SCRIPT_COUNT}} files):
+
+{{UPSTREAM_SCRIPT_LIST}}
+
+{{DELTA_BLOCK}}
+
+{{NOTE_BLOCK}}
+
+## What to do
+
+```bash
+# 0. Branch.
+git checkout -b skill/{{SKILL}}-add
+
+# 1. Add the skill fresh from upstream (no existing copy to remove).
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
+chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
+
+# 2. If you keep docs/skill-sources.md, add a row pointing at
+#    ../guildmaster/.claude/skills/{{SKILL}}/ (record any local divergence).
+
+# 3. Bump version per project convention (CI version-check enforces in
+#    AgentCulture siblings); add a CHANGELOG entry.
+```
+
+## Acceptance criteria
+
+- `.claude/skills/{{SKILL}}/SKILL.md` is present with frontmatter
+  `name: {{SKILL}}`. **On the culture/agex backend, also add
+  `type: command`** — `core.skill_loader` requires all of `name`,
+  `description`, and `type:`, and a SKILL.md lacking `type:` is silently
+  skipped by `backends/claude_code/probe.py`.
+- `.claude/skills/{{SKILL}}/scripts/` contains the
+  {{UPSTREAM_SCRIPT_COUNT}} files listed above (and only those, unless your
+  repo intentionally adds extras — record divergence in the SKILL.md
+  frontmatter `description` per the AgentCulture vendoring policy).
+- All scripts are executable (`chmod +x`).
+- If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with the
+  upstream `../guildmaster/.claude/skills/{{SKILL}}/`.
+- `CHANGELOG.md` has a new version entry describing the addition; the
+  version is bumped per project convention; CI's `version-check` job is green.
+
+## References
+
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
+- `{{SKILL}}` SKILL.md:
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+- AgentCulture skills-portability rule (each vendor owns and may adapt its
+  copy): the `communicate` SKILL.md "Conventions in use" section.

--- a/.claude/skills/communicate/scripts/templates/skill-update-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-update-brief.md
@@ -7,17 +7,17 @@
 
 Your repo's `.claude/skills/{{SKILL}}/` (or its older vendored
 name — see your `docs/skill-sources.md` if you keep a provenance
-ledger) is a vendored copy of the steward skill that has since
-moved on. Relevant CHANGELOG entries from steward:
+ledger) is a vendored copy of the guildmaster skill that has since
+moved on. Relevant CHANGELOG entries from guildmaster:
 
 {{CHANGELOG_BLOCK}}
 
 ## Cite locations (source of truth)
 
 - Local sibling checkout (preferred when available):
-  `../steward/.claude/skills/{{SKILL}}/`
-- Remote, if the workspace doesn't include a local steward checkout:
-  <https://github.com/agentculture/steward/tree/main/.claude/skills/{{SKILL}}>
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
 
 The directory ships with a `SKILL.md` and a `scripts/` directory
 per the AgentCulture skills-portability rule (each skill is
@@ -44,14 +44,14 @@ git checkout -b skill/{{SKILL}}-resync
 #    If your old vendored name differs (e.g. pr-review → cicd),
 #    `git rm` the old dir first.
 git rm -r .claude/skills/<old-name-if-different>   # skip if name is already {{SKILL}}
-cp -R ../steward/.claude/skills/{{SKILL}} .claude/skills/
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
 chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
 
 # 2. Adapt identifiers per the existing "identifier-only adapted"
 #    pattern in your docs/skill-sources.md (if you keep one):
-#    - SKILL.md prose framing: replace "steward" with your repo
+#    - SKILL.md prose framing: replace "guildmaster" with your repo
 #      name where it identifies the consumer (NOT where it cites
-#      steward as the upstream).
+#      guildmaster as the upstream).
 #    - For any script that hard-codes a signature literal, change it
 #      to `- <your-repo> (Claude)`. (The communicate skill no longer
 #      hard-codes one — agtag resolves the nick from your local
@@ -80,9 +80,9 @@ grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
   AgentCulture vendoring policy).
 - All scripts are executable (`chmod +x`).
 - If the skill hard-codes a signature literal anywhere, your
-  vendored copy uses your repo's signature, not `- steward (Claude)`.
+  vendored copy uses your repo's signature, not `- guildmaster (Claude)`.
 - If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with
-  the upstream `../steward/.claude/skills/{{SKILL}}/`; no row
+  the upstream `../guildmaster/.claude/skills/{{SKILL}}/`; no row
   remains for the old vendored name.
 - `grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md`
   returns zero hits, or only historical mentions in CHANGELOG.
@@ -92,10 +92,10 @@ grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
 
 ## References
 
-- Steward CHANGELOG (release-by-release deltas):
-  <https://github.com/agentculture/steward/blob/main/CHANGELOG.md>
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
 - `{{SKILL}}` SKILL.md:
-  <https://github.com/agentculture/steward/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
 - AgentCulture skills-portability rule (why each vendor adapts
   signature literals locally): the `communicate` SKILL.md
   "Per-channel signature rules" + "Conventions in use" sections.

--- a/.claude/skills/doc-test-alignment/SKILL.md
+++ b/.claude/skills/doc-test-alignment/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: doc-test-alignment
+description: >
+  Verify that committed docs (README.md, CLAUDE.md, SKILL.md descriptions) still
+  describe what the code and tests actually do. Use at the end of a plan, before
+  PR creation, or when the user says "check doc-test alignment", "verify docs",
+  or "do the docs still match the code". STUB — `scripts/check.sh` exits with a
+  not-yet-implemented error today; the contract for what it will do lives in
+  this file.
+---
+
+# doc-test-alignment (stub)
+
+This skill is a stub. The real workflow is intentionally not yet implemented —
+the file exists so that `steward verify` can find it and so contributors who
+land here know it is on the roadmap, not forgotten.
+
+## How to run
+
+`scripts/check.sh` is the entry point. Today it prints a not-yet-implemented
+notice and exits non-zero. When the workflow lands, the script will gate
+PR-readiness on the alignment contract below; until then, treat any green
+exit code from this script as a bug.
+
+## What it will check
+
+The skill is the contract for four narrow alignments. README.md command
+examples must still execute against the current checkout and produce output
+that matches the surrounding prose. The "build/test/publish" command lines in
+CLAUDE.md must do the same. For each `.claude/skills/<name>/`, the SKILL.md
+`description` frontmatter must agree with what the scripts under
+`scripts/` actually do — surfacing disagreements (e.g. SKILL.md claims the
+skill bumps versions but `scripts/` has no bump script). And for each test,
+the test name should still describe the assertions the test makes — flagging
+drift where the name advertises a feature the assertions no longer touch.
+
+## Why it ships as a stub
+
+Each of those four checks is independently non-trivial. Shipping a partial
+implementation would either silently pass when it shouldn't, or false-positive
+on intentional doc-vs-code differences. The right path is to land the checks
+one at a time, with their own tests, behind a
+`steward verify --check doc-test-alignment` flag. The parent verbs (`verify`,
+`doctor`) are named in the "Roadmap" section of `CLAUDE.md`; the broader
+sibling-pattern contract lives in `docs/sibling-pattern.md`.
+
+## What this stub guarantees today
+
+- The skill directory exists, so `steward verify`'s skills-convention check
+  finds the standard layout (SKILL.md + `scripts/` with an entry-point).
+- `scripts/check.sh` is the entry-point script, satisfying the steward skills
+  convention requirement that every skill ships an executable script.
+- This `SKILL.md` is the contract for what the skill will do — when the
+  implementation lands, it must satisfy this description or the description
+  must move first.

--- a/.claude/skills/doc-test-alignment/SKILL.md
+++ b/.claude/skills/doc-test-alignment/SKILL.md
@@ -48,8 +48,8 @@ sibling-pattern contract lives in `docs/sibling-pattern.md`.
 
 - The skill directory exists, so `steward verify`'s skills-convention check
   finds the standard layout (SKILL.md + `scripts/` with an entry-point).
-- `scripts/check.sh` is the entry-point script, satisfying the steward skills
-  convention requirement that every skill ships an executable script.
+- `scripts/check.sh` is the entry-point script, satisfying the AgentCulture
+  skills convention requirement that every skill ships an executable script.
 - This `SKILL.md` is the contract for what the skill will do — when the
   implementation lands, it must satisfy this description or the description
   must move first.

--- a/.claude/skills/doc-test-alignment/scripts/check.sh
+++ b/.claude/skills/doc-test-alignment/scripts/check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# doc-test-alignment skill — entry point.
+#
+# STUB: the real workflow is not implemented yet. This script exists so the
+# steward skills convention is satisfied (every skill ships an executable
+# entry-point script); when the real implementation lands here, it must
+# satisfy the contract documented in ../SKILL.md.
+#
+# Exits 2 (EXIT_USER_ERROR-ish for "you asked for something that isn't
+# wired up yet") so callers can tell the difference between "checks passed"
+# (would be 0) and "stub".
+
+set -euo pipefail
+
+cat >&2 <<'EOF'
+doc-test-alignment: not yet implemented.
+
+This skill is a stub; the contract for what `check.sh` will assert lives in
+.claude/skills/doc-test-alignment/SKILL.md. Until the implementation lands,
+treat any green exit code from this script as a bug.
+
+Roadmap: see CLAUDE.md ("Roadmap (CLI surface)") and docs/sibling-pattern.md.
+EOF
+exit 2

--- a/.claude/skills/doc-test-alignment/scripts/check.sh
+++ b/.claude/skills/doc-test-alignment/scripts/check.sh
@@ -2,7 +2,7 @@
 # doc-test-alignment skill — entry point.
 #
 # STUB: the real workflow is not implemented yet. This script exists so the
-# steward skills convention is satisfied (every skill ships an executable
+# AgentCulture skills convention is satisfied (every skill ships an executable
 # entry-point script); when the real implementation lands here, it must
 # satisfy the contract documented in ../SKILL.md.
 #

--- a/.claude/skills/pypi-maintainer/SKILL.md
+++ b/.claude/skills/pypi-maintainer/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pypi-maintainer
+description: >
+  Switch a PyPI package install between the production index, TestPyPI
+  pre-release builds, and a local editable checkout. Use when an agent
+  maintains a package and needs to verify a TestPyPI dev build before
+  promoting to production, or when the user says "install from
+  test-pypi", "switch to local", "change package source", or
+  "install from pypi".
+---
+
+# PyPI Maintainer
+
+Switch the install source for a package the agent maintains. Three sources
+are supported: production PyPI, TestPyPI (pre-release / dev builds), and a
+local editable checkout. The same script works for any package an
+AgentCulture sibling publishes — pass the package name as the first
+argument.
+
+## When to use
+
+- Verifying a PR's TestPyPI dev build before merging.
+- Reproducing a user-reported bug against the published version.
+- Hot-patching against a local checkout while a fix is in flight.
+- Restoring the production install after local-mode debugging.
+
+## Usage
+
+```bash
+# Production PyPI
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> pypi
+
+# TestPyPI (pre-release dev builds)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi
+
+# TestPyPI, pinned to a specific dev version
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi --version 0.4.0.dev42
+
+# Local editable checkout (defaults to current directory)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local
+
+# Local editable from an explicit path
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local --path ../<package>
+```
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `uv` — the script delegates to `uv tool install` and `uv tool list`
+  (or `uv pip install` for `local`).
+
+## Why TestPyPI needs special flags
+
+When a package is published to **both** PyPI and TestPyPI, `uv tool install`
+finds the production version on PyPI first and never looks at TestPyPI.
+The script passes `--index-strategy unsafe-best-match` so uv compares the
+two index sets and picks the highest version, plus `--prerelease=allow`
+because TestPyPI builds carry dev suffixes (e.g. `0.4.0.dev42`).
+
+## After running
+
+The script prints the resolved version once install completes — cross-check
+that against the expected version (PR run number, local `pyproject.toml`)
+before continuing.
+
+## Arguments
+
+| Position / flag | Meaning |
+|-----------------|---------|
+| `<package>` (required) | The PyPI distribution name, e.g. `steward-cli`, `culture`, `daria-cli`. |
+| `<source>` (required)  | One of `pypi`, `test-pypi`, `local`. |
+| `--version VERSION`    | Pin to a specific version (TestPyPI builds typically need this). |
+| `--path PATH`          | Local-source-only: path to the editable checkout (default: cwd). |

--- a/.claude/skills/pypi-maintainer/scripts/switch-source.sh
+++ b/.claude/skills/pypi-maintainer/scripts/switch-source.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# switch-source.sh — Switch a PyPI package install between pypi / test-pypi / local.
+#
+# Usage:
+#   switch-source.sh <package> pypi
+#   switch-source.sh <package> test-pypi [--version VERSION]
+#   switch-source.sh <package> local [--path PATH]
+#
+# Generalised from the original culture-specific change-package skill so any
+# AgentCulture sibling that publishes a PyPI package can vendor and use it.
+
+set -euo pipefail
+
+PACKAGE=""
+SOURCE=""
+VERSION=""
+LOCAL_PATH=""
+
+usage() {
+  cat <<EOF >&2
+Usage: switch-source.sh <package> <pypi|test-pypi|local> [options]
+
+Options:
+  --version VERSION   Pin to a specific version (most useful for test-pypi
+                      dev builds, e.g. --version 0.4.0.dev42).
+  --path PATH         Local source only: path to editable checkout
+                      (default: current directory).
+  -h, --help          Show this help.
+EOF
+}
+
+# --- Parse args ---
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    usage
+    exit 1
+  fi
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) require_value "$1" "$#"; VERSION="$2"; shift 2 ;;
+    --path)    require_value "$1" "$#"; LOCAL_PATH="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --*)       echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    *)         POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+PACKAGE="${POSITIONAL[0]}"
+SOURCE="${POSITIONAL[1]}"
+
+# --- Resolve install spec for pinned versions ---
+SPEC="$PACKAGE"
+if [[ -n "$VERSION" ]]; then
+  SPEC="${PACKAGE}==${VERSION}"
+fi
+
+case "$SOURCE" in
+  pypi)
+    echo "Installing $SPEC from production PyPI..."
+    uv tool install "$SPEC" --force
+    ;;
+  test-pypi)
+    echo "Installing $SPEC from TestPyPI..."
+    uv tool install "$SPEC" \
+      --index-url https://test.pypi.org/simple/ \
+      --extra-index-url https://pypi.org/simple/ \
+      --index-strategy unsafe-best-match \
+      --prerelease=allow \
+      --force
+    ;;
+  local)
+    if [[ -z "$LOCAL_PATH" ]]; then
+      LOCAL_PATH="$(pwd)"
+    fi
+    if [[ ! -f "$LOCAL_PATH/pyproject.toml" ]]; then
+      echo "Error: $LOCAL_PATH does not contain a pyproject.toml" >&2
+      exit 1
+    fi
+    echo "Installing $PACKAGE in editable mode from $LOCAL_PATH..."
+    uv tool install --from "$LOCAL_PATH" --editable "$PACKAGE" --force
+    ;;
+  *)
+    echo "Unknown source: $SOURCE (expected pypi, test-pypi, or local)" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+# --- Report what is now active ---
+echo
+echo "Installed tools matching '$PACKAGE':"
+uv tool list 2>/dev/null | awk -v pkg="$PACKAGE" 'tolower($1) == tolower(pkg) {print "  " $0}'

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -46,3 +46,12 @@ Extra arguments are passed through to pytest (e.g., `-x` for stop-on-first-failu
 - **Quick sanity check:** `bash .claude/skills/run-tests/scripts/test.sh -p -q` — minimal output
 - **Before PR / release:** `bash .claude/skills/run-tests/scripts/test.sh --ci` — matches CI exactly
 - **Debugging flaky test:** `bash .claude/skills/run-tests/scripts/test.sh tests/test_flaky.py` — sequential, single file
+
+## Provenance
+
+Canonical supplier is **agentculture/guildmaster** (post steward→guildmaster
+cutover). Culture's `scripts/test.sh` is intentionally **ahead** of guildmaster's
+copy: it adds xdist shard-combine, stale-shard wipe, coverage-floor (exit 2)
+surfacing, and combine/report/xml failure propagation that guildmaster's
+simpler `exec pytest --cov` lacks. Do not overwrite from upstream on resync;
+the improvements are offered back to guildmaster.

--- a/.claude/skills/run-tests/scripts/test.sh
+++ b/.claude/skills/run-tests/scripts/test.sh
@@ -19,6 +19,14 @@
 # Stale `.coverage` / `.coverage.*` shards from a previous run are removed
 # before pytest so `coverage combine` can never silently merge old data into
 # the new report.
+#
+# culture-divergence: this script is intentionally AHEAD of guildmaster's
+# canonical run-tests (which `exec`s `pytest --cov` and relies on
+# pytest-cov's own report). Culture keeps the xdist shard-combine, stale-shard
+# wipe, coverage-floor (exit 2) surfacing, and combine/report/xml failure
+# propagation below. Do NOT overwrite from upstream on resync — these
+# improvements are offered back to guildmaster (see issue filed against
+# agentculture/guildmaster).
 
 set -uo pipefail
 

--- a/.claude/skills/sonarclaude/SKILL.md
+++ b/.claude/skills/sonarclaude/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: sonarclaude
+description: >
+  Query SonarCloud API for code quality data. Use when: checking quality gate status,
+  fetching code issues or security hotspots, reviewing metrics (coverage, bugs, code smells),
+  or the user says "sonar", "quality gate", "code quality", "sonarclaude".
+---
+
+# SonarClaude
+
+Query SonarCloud projects for quality gate status, issues, metrics, and security hotspots.
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `curl` — talks to the SonarCloud REST API
+- `jq` — parses responses and URL-encodes accept comments
+
+## Environment
+
+Requires `SONAR_TOKEN` environment variable. Set the project key per-repo via
+the `SONAR_PROJECT` environment variable (or pass `--project KEY` on each
+invocation).
+
+## Usage
+
+```bash
+# Quality gate status (pass/fail)
+bash .claude/skills/sonarclaude/scripts/sonar.sh status
+
+# List issues (bugs, vulnerabilities, code smells)
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues
+
+# Filter issues by severity and type
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --severity CRITICAL --type BUG
+
+# Key metrics (coverage, bugs, code smells, duplication, LOC)
+bash .claude/skills/sonarclaude/scripts/sonar.sh metrics
+
+# Security hotspots
+bash .claude/skills/sonarclaude/scripts/sonar.sh hotspots
+
+# Accept (won't-fix) an OPEN issue with a rationale comment
+bash .claude/skills/sonarclaude/scripts/sonar.sh accept \
+  --issue AZ3Ep83i4ywi8V_l99p0 \
+  --comment "Pushback: rule premise doesn't fit our test fixture pattern."
+
+# Different project
+bash .claude/skills/sonarclaude/scripts/sonar.sh status --project OtherOrg_OtherProject
+
+# Raw JSON output
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --raw
+
+# Limit results
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --limit 10
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | `$SONAR_PROJECT` | SonarCloud project key |
+| `--severity` | all | Filter: `BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO` |
+| `--type` | all | Filter: `BUG`, `VULNERABILITY`, `CODE_SMELL` |
+| `--limit` | `25` | Max results returned |
+| `--raw` | off | Output raw JSON instead of formatted summary |
+| `--issue` | — | Issue key (required for `accept`) |
+| `--comment` | — | Rationale comment (required for `accept`) |
+
+## When to use `accept`
+
+Sonar rules occasionally flag patterns where the rule's premise does not fit the
+code (e.g. test fixtures with intentional bad-password literals, contradictory
+rule pairs like S7494 vs S7500). After deciding pushback in PR review, run
+`sonar.sh accept` with a rationale comment instead of leaving the issue OPEN —
+this moves it to ACCEPTED/WONTFIX in SonarCloud history (visible to future
+maintainers) while clearing the quality-gate signal. Always include a `--comment`
+explaining why; silent dismissals are not acceptable curation.
+
+Do not call SonarCloud's HTTP API directly from other skills or one-off
+scripts — `sonar.sh accept` is the supported entry point so the rationale
+flow stays consistent.

--- a/.claude/skills/sonarclaude/scripts/sonar.sh
+++ b/.claude/skills/sonarclaude/scripts/sonar.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SonarCloud API client for Claude Code.
+# Requires SONAR_TOKEN environment variable.
+# Project key resolves from --project flag, then $SONAR_PROJECT.
+
+BASE_URL="https://sonarcloud.io"
+
+# --- Defaults ---
+PROJECT="${SONAR_PROJECT:-}"
+SEVERITY=""
+TYPE=""
+LIMIT=25
+RAW=false
+COMMAND=""
+ISSUE_KEY=""
+ACCEPT_COMMENT=""
+
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    echo "Run sonar.sh --help for usage." >&2
+    exit 1
+  fi
+}
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    status|issues|metrics|hotspots|accept)
+      COMMAND="$1"; shift ;;
+    --project|-p)   require_value "$1" "$#"; PROJECT="$2";        shift 2 ;;
+    --severity|-s)  require_value "$1" "$#"; SEVERITY="$2";       shift 2 ;;
+    --type|-t)      require_value "$1" "$#"; TYPE="$2";           shift 2 ;;
+    --limit|-l)     require_value "$1" "$#"; LIMIT="$2";          shift 2 ;;
+    --raw|-r)       RAW=true;                                     shift ;;
+    --issue|-i)     require_value "$1" "$#"; ISSUE_KEY="$2";      shift 2 ;;
+    --comment|-c)   require_value "$1" "$#"; ACCEPT_COMMENT="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: sonar.sh <command> [options]"
+      echo ""
+      echo "Commands:"
+      echo "  status    Quality gate status (pass/fail)"
+      echo "  issues    List code issues (bugs, vulnerabilities, code smells)"
+      echo "  metrics   Key code metrics (coverage, bugs, duplication, LOC)"
+      echo "  hotspots  Security hotspots"
+      echo "  accept    Mark an OPEN issue as ACCEPTED with a rationale comment"
+      echo ""
+      echo "Options:"
+      echo "  --project, -p KEY       Project key (default: \$SONAR_PROJECT)"
+      echo "  --severity, -s LEVEL    Filter: BLOCKER, CRITICAL, MAJOR, MINOR, INFO"
+      echo "  --type, -t TYPE         Filter: BUG, VULNERABILITY, CODE_SMELL"
+      echo "  --limit, -l N           Max results (default: 25)"
+      echo "  --raw, -r               Output raw JSON"
+      echo "  --issue, -i KEY         Issue key (required for 'accept')"
+      echo "  --comment, -c TEXT      Rationale comment (required for 'accept')"
+      echo "  --help, -h              Show this help"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- Validate ---
+if [[ -z "${SONAR_TOKEN:-}" ]]; then
+  echo "Error: SONAR_TOKEN environment variable is not set." >&2
+  exit 1
+fi
+
+if [[ -z "$COMMAND" ]]; then
+  echo "Error: No command provided." >&2
+  echo "Usage: sonar.sh <status|issues|metrics|hotspots|accept> [options]" >&2
+  exit 1
+fi
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: No project key. Set \$SONAR_PROJECT or pass --project KEY." >&2
+  exit 1
+fi
+
+# --- API helper ---
+api_get() {
+  local endpoint="$1"
+  curl -s -f -H "Authorization: Bearer $SONAR_TOKEN" "${BASE_URL}${endpoint}"
+}
+
+# --- Commands ---
+
+cmd_status() {
+  local response
+  response=$(api_get "/api/qualitygates/project_status?projectKey=${PROJECT}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local status conditions
+  status=$(echo "$response" | jq -r '.projectStatus.status')
+  conditions=$(echo "$response" | jq -r '.projectStatus.conditions[]? | "  \(.metricKey): \(.actualValue) (threshold: \(.errorThreshold), status: \(.status))"')
+
+  if [[ "$status" == "OK" ]]; then
+    echo "Quality Gate: PASSED"
+  elif [[ "$status" == "ERROR" ]]; then
+    echo "Quality Gate: FAILED"
+  else
+    echo "Quality Gate: $status"
+  fi
+
+  if [[ -n "$conditions" ]]; then
+    echo ""
+    echo "Conditions:"
+    echo "$conditions"
+  fi
+}
+
+cmd_issues() {
+  local params="componentKeys=${PROJECT}&ps=${LIMIT}"
+  [[ -n "$SEVERITY" ]] && params="${params}&severities=${SEVERITY}"
+  [[ -n "$TYPE" ]] && params="${params}&types=${TYPE}"
+
+  local response
+  response=$(api_get "/api/issues/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.total')
+  echo "Issues: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.issues[]? | "[\(.severity)] \(.type) — \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Rule: \(.rule)\n"'
+}
+
+# Convert SonarCloud numeric rating to letter grade
+rating_letter() {
+  case "$1" in
+    1|1.0) echo "A" ;;
+    2|2.0) echo "B" ;;
+    3|3.0) echo "C" ;;
+    4|4.0) echo "D" ;;
+    5|5.0) echo "E" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+cmd_metrics() {
+  local metric_keys="bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,ncloc,sqale_rating,reliability_rating,security_rating,alert_status"
+
+  local response
+  response=$(api_get "/api/measures/component?component=${PROJECT}&metricKeys=${metric_keys}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  echo "Metrics for: $PROJECT"
+  echo ""
+
+  echo "$response" | jq -r '.component.measures[]? | "\(.metric): \(.value)"' | while IFS=: read -r key val; do
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+    case "$key" in
+      alert_status)
+        echo "  Quality Gate:     $val" ;;
+      bugs)
+        echo "  Bugs:             $val" ;;
+      vulnerabilities)
+        echo "  Vulnerabilities:  $val" ;;
+      code_smells)
+        echo "  Code Smells:      $val" ;;
+      coverage)
+        echo "  Coverage:         ${val}%" ;;
+      duplicated_lines_density)
+        echo "  Duplication:      ${val}%" ;;
+      ncloc)
+        echo "  Lines of Code:    $val" ;;
+      sqale_rating)
+        echo "  Maintainability:  $(rating_letter "$val")" ;;
+      reliability_rating)
+        echo "  Reliability:      $(rating_letter "$val")" ;;
+      security_rating)
+        echo "  Security:         $(rating_letter "$val")" ;;
+      *)
+        echo "  $key: $val" ;;
+    esac
+  done
+}
+
+cmd_hotspots() {
+  local params="projectKey=${PROJECT}&ps=${LIMIT}"
+
+  local response
+  response=$(api_get "/api/hotspots/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.paging.total')
+  echo "Security Hotspots: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.hotspots[]? | "[\(.vulnerabilityProbability)] \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Status: \(.status)\n"'
+}
+
+cmd_accept() {
+  if [[ -z "$ISSUE_KEY" ]]; then
+    echo "Error: 'accept' requires --issue KEY" >&2
+    exit 1
+  fi
+  if [[ -z "$ACCEPT_COMMENT" ]]; then
+    echo "Error: 'accept' requires --comment 'rationale text'" >&2
+    exit 1
+  fi
+
+  # 1. Transition issue to ACCEPTED.
+  local transition_resp
+  transition_resp=$(curl -s -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/do_transition" \
+    -d "issue=${ISSUE_KEY}&transition=accept")
+
+  local status
+  status=$(echo "$transition_resp" | jq -r '.issue.issueStatus // "UNKNOWN"')
+
+  # 2. Attach rationale comment (URL-encode via jq).
+  local encoded comment_resp comment_status
+  encoded=$(jq -rn --arg s "$ACCEPT_COMMENT" '$s|@uri')
+  comment_resp=$(curl -sS -w $'\n%{http_code}' -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/add_comment" \
+    -d "issue=${ISSUE_KEY}&text=${encoded}")
+  comment_status=$(printf '%s\n' "$comment_resp" | tail -n 1)
+  if [[ "$comment_status" -lt 200 || "$comment_status" -ge 300 ]]; then
+    echo "Error: failed to attach rationale comment (HTTP $comment_status)" >&2
+    echo "Response body:" >&2
+    printf '%s\n' "$comment_resp" | sed '$d' >&2
+    exit 1
+  fi
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$transition_resp" | jq .
+  else
+    echo "Issue $ISSUE_KEY -> $status"
+  fi
+}
+
+# --- Dispatch ---
+case "$COMMAND" in
+  status)   cmd_status   ;;
+  issues)   cmd_issues   ;;
+  metrics)  cmd_metrics  ;;
+  hotspots) cmd_hotspots ;;
+  accept)   cmd_accept   ;;
+  *)        echo "Unknown command: $COMMAND" >&2; exit 1 ;;
+esac

--- a/.claude/skills/sonarclaude/scripts/sonar.sh
+++ b/.claude/skills/sonarclaude/scripts/sonar.sh
@@ -223,10 +223,24 @@ cmd_accept() {
   fi
 
   # 1. Transition issue to ACCEPTED.
-  local transition_resp
-  transition_resp=$(curl -s -H "Authorization: Bearer $SONAR_TOKEN" \
+  #
+  # culture-divergence: validate the transition HTTP status (mirroring the
+  # add_comment step below). The canonical script POSTs with `-s` and never
+  # checks the response, so a failed transition (bad token, wrong state) is
+  # silently reported as success with status "UNKNOWN". Offered upstream to
+  # guildmaster.
+  local transition_resp transition_status
+  transition_resp=$(curl -sS -w $'\n%{http_code}' -H "Authorization: Bearer $SONAR_TOKEN" \
     -X POST "${BASE_URL}/api/issues/do_transition" \
     -d "issue=${ISSUE_KEY}&transition=accept")
+  transition_status=$(printf '%s\n' "$transition_resp" | tail -n 1)
+  transition_resp=$(printf '%s\n' "$transition_resp" | sed '$d')
+  if [[ "$transition_status" -lt 200 || "$transition_status" -ge 300 ]]; then
+    echo "Error: failed to transition issue $ISSUE_KEY to ACCEPTED (HTTP $transition_status)" >&2
+    echo "Response body:" >&2
+    printf '%s\n' "$transition_resp" >&2
+    exit 1
+  fi
 
   local status
   status=$(echo "$transition_resp" | jq -r '.issue.issueStatus // "UNKNOWN"')

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -10,9 +10,9 @@ description: >
   risks, and export a plan only once it *converges*. Use when the user says
   "spec to plan", "stp", "turn this spec into a plan", "plan this spec", "make a
   build plan", or after the /think skill exports a spec. Authored and maintained
-  in agentculture/devague (origin = devague); steward pulls this skill from here
-  and broadcasts it to the AgentCulture mesh — it is NOT vendored from steward
-  like the other skills here.
+  in agentculture/devague (origin = devague); guildmaster re-broadcasts it to the
+  AgentCulture mesh — it originates in devague, not guildmaster (the supplier
+  post steward→guildmaster cutover).
 ---
 
 # spec-to-plan — work a converged spec forwards into a buildable plan
@@ -224,7 +224,8 @@ implementation (or `superpowers:writing-plans`).
 This is a **first-party** skill — its origin is `agentculture/devague`, where the
 devague agent maintains it alongside the tool it operates (dogfooding), next to
 its sibling `/think`. It is the *inverse* of the other skills under
-`.claude/skills/`, which devague vendors **from** steward. When ready, steward
-pulls it **from** devague and broadcasts it to the rest of the AgentCulture mesh.
+`.claude/skills/`, which devague vendors **from** guildmaster. When ready,
+guildmaster pulls it **from** devague and re-broadcasts it to the rest of the
+AgentCulture mesh.
 The `cite, don't import` policy still holds: downstream repos copy it, they don't
 symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: spec-to-plan
+type: command
+description: >
+  Turn a converged devague spec into a buildable plan by working forwards (the
+  spec→plan leg; drives the `devague plan` CLI group). Seed a plan from a
+  converged frame, add tasks that collectively cover every coverage target (the
+  frame's confirmed claims + honesty conditions), give each task acceptance
+  criteria and an honest dependency order, park genuine unknowns as first-class
+  risks, and export a plan only once it *converges*. Use when the user says
+  "spec to plan", "stp", "turn this spec into a plan", "plan this spec", "make a
+  build plan", or after the /think skill exports a spec. Authored and maintained
+  in agentculture/devague (origin = devague); steward pulls this skill from here
+  and broadcasts it to the AgentCulture mesh — it is NOT vendored from steward
+  like the other skills here.
+---
+
+# spec-to-plan — work a converged spec forwards into a buildable plan
+
+The skill is named **`spec-to-plan`**; the product/CLI it drives is the
+**`devague plan`** command group. (The prior leg — turning a vague idea into a
+spec — is the sibling **`/think`** skill.) It is the **forward** peer of the
+working-backwards spec engine: where `/think` converges on *what* to build,
+`/spec-to-plan` converges on *how* to build it.
+
+A plan is seeded from a **converged frame** and tracks **tasks** against the
+spec's **coverage targets**. The CLI is **deterministic and move-driven** — you
+(the agent) choose the next move; the CLI tracks state and tells you what's still
+missing. Run `devague plan learn` for the method and `devague plan explain
+<move>` for any single move.
+
+## How to run
+
+The entry point is `scripts/spec-to-plan.sh`. Invoke it from the repository you
+are speccing (plans persist under `.devague/` in the current directory, alongside
+the frames they derive from):
+
+```bash
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh <move> [args...]
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` inside the devague checkout, else an
+install hint. Every move — including `status` — is forwarded verbatim as
+`devague plan <move>`, so you can equally call the CLI directly
+(`devague plan <move> …`).
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new --frame <slug>` | Seed a plan from a **converged** frame. Derives the coverage targets (`c*`/`h*`) the plan must satisfy. Refuses an unconverged frame. |
+| `task "<summary>"` | Add a task. `--accept "<crit>"`, `--dep <tN>`, `--covers <c*/h*>` (each repeatable); `--origin llm` lands it `proposed`. |
+| `accept <tN> "<crit>"` | Add an acceptance criterion to a task. |
+| `depend <tN> --on <tM>` | Record that task `tN` depends on `tM`. |
+| `cover <tN> --target <c*/h*>` | Mark a task as covering a coverage target. |
+| `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** |
+| `risk "<text>" --kind <kind>` | Record a first-class plan risk (`--task <tN>` to attach). |
+| `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
+| `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
+| `waves` | Emit deterministic dependency waves (`{plan, waves}`) — scheduling metadata only, *not* orchestration. Read-only, works on an in-progress plan; refuses a cyclic/dangling graph. Devague describes the graph; an operator decides how to run it (#20). |
+| `status` | Read-only: where the plan stands + the recommended next move, re-checked against the live frame (`--json` too). |
+| `show` / `list` | Render a plan / list plans (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Risk kinds (shared with the frame engine): `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+### `status` — the next-move verb
+
+`status` is a first-class, **read-only** CLI verb (`devague plan status`,
+internalised from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`devague plan list` + `devague plan converge` and prints where the current plan
+stands, the remaining gaps, and the recommended next move derived from the first
+gap. Like `converge`/`export` it re-checks the **live** source frame (so frame
+drift surfaces as an error), but it never mutates state. Pass `--json` for the
+structured payload (`{plan, total, ready_for_plan, blockers, warnings,
+parked_items, required_next_moves}`).
+
+```text
+plan: my-feature    (1 plan total)
+convergence: NOT passed — 2 gap(s):
+  - coverage target c5 (boundary) has no confirmed task
+  - task t2 has no acceptance criteria
+
+recommended next move (first gap):
+  cover c5: devague plan task "<summary>" --covers c5 --accept "<...>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **Seed from a converged spec only.** `plan new` refuses a frame that hasn't
+  converged. The plan's coverage targets *are* the spec's confirmed claims and
+  honesty conditions — there is nothing honest to plan against until the spec
+  converges.
+- **LLM proposals stay proposed.** A task captured with `--origin llm` lands as
+  `proposed`. **Never `confirm` your own proposal.** Confirmation is a user-only
+  decision — surface the proposed task and let the user confirm or reject it.
+- **Cover every target; criteria on every task.** The gate requires every
+  coverage target to be covered by a confirmed task, and every confirmed task to
+  carry at least one acceptance criterion. Don't hand-wave a task as "done-ish."
+- **Keep the graph honest.** Dependencies must reference real tasks and form an
+  acyclic graph; the gate rejects dangling deps and cycles.
+- **Park real unknowns as risks; don't paper over them.** A genuinely unknown
+  decision is an `unknown_blocking` risk — it holds back convergence, by design.
+- **Converge against the live frame.** `converge`/`export` re-load the source
+  frame every time. If the frame was deleted or has regressed below convergence,
+  they refuse — re-converge the spec (in `/think`) first.
+
+## Coaching toward small, file-disjoint, TDD-gated tasks
+
+When authoring a plan that will be built via parallel execution (fanned out to
+multiple agents via the downstream `/assign-to-workforce` skill), prefer the
+following discipline to maximize parallelism and minimize merge friction:
+
+### Small and crisply scoped
+
+Each task should be **small enough for a simpler or cheaper model to build
+test-first** without re-deriving the full design. If a task spans multiple files
+or architectural layers, split it — narrow scope forces you to write sharp
+acceptance criteria and keeps waves wide.
+
+### File disjoint
+
+**Prefer tasks that touch non-overlapping files.** When two same-wave tasks
+modify the same file, merge collision becomes inevitable. The dependency graph
+alone *does not* guarantee file disjointness — it only sequences task *content*
+dependencies; same-wave tasks with overlapping file-writes must be split across
+waves or given explicit dependencies.
+
+Check `devague plan waves` output: if a wave is wide but all tasks touch
+`src/core.py`, the wave is *formally* parallel but *operationally* serialized at
+merge. Reorder task boundaries so wide waves operate on disjoint file sets.
+
+### TDD acceptance criteria on every task
+
+Every confirmed task must carry **at least one acceptance criterion**, phrased as
+a testable condition (not a vague outcome). For example:
+
+- Bad: "Implement the parser"
+- Better: "Parser accepts a valid spec file and rejects malformed YAML without
+  data loss"
+
+Acceptance criteria are **the contract** between the main agent (who merges) and
+the subagent (who builds). A test suite derived from these criteria validates
+each task's output *before* merge, independent of model capability. This is not
+optional: `devague plan converge` warns (non-blocking) when a confirmed task
+lacks criteria.
+
+### The key invariant: parallel = serial
+
+**A plan built in parallel must yield identical results to building it serially.**
+This is guaranteed only if:
+
+1. Same-wave tasks have no inter-task dependencies (checked by `waves`).
+2. Same-wave tasks touch disjoint files (you must verify; the CLI does not).
+3. Each task's acceptance criteria are sharp enough that a subagent's output
+   passes them independent of whether it was built in isolation or alongside
+   other tasks.
+
+The TDD gate — tests pass before *and* after the merge — is the main agent's
+proof that parallelism didn't break correctness.
+
+### How to route tasks to the workforce
+
+Once your plan converges, `devague plan waves` emits the dependency-graph as
+**scheduling metadata** (ordered batches of task IDs). This feeds directly into
+the `/assign-to-workforce` skill, which:
+
+1. Displays the plan, waves, and suggested per-task subagent/model pairing.
+2. Waits for the human to approve the implementation split plan (or edit
+   assignments).
+3. Fans out approved waves to isolated subagent worktrees (one per task per
+   wave).
+4. Returns control to the main agent, which TDD-gates each merge before moving
+   to the next wave.
+
+Plan for workforce execution early: narrow task scope, write crisp acceptance
+criteria, and strive for wide waves with disjoint files.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload.
+Exit code `0` on success, non-zero on user error (with a `hint:` line). Plans
+live under `.devague/plans/` in the current directory; the exported plan-md lands
+in `docs/plans/`.
+
+## Worked example
+
+Picking up after `/think` exported a spec for the frame `my-feature`:
+
+```bash
+p() { bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh "$@"; }
+
+p new --frame my-feature        # seeds the plan + its coverage targets
+p show                          # see the c*/h* targets you must cover
+
+p task "Build the core engine" --accept "engine has a convergence gate" \
+    --covers c1 --covers c3
+p task "Pressure-test honesty conditions" --dep t1 --covers h1 --covers h2 \
+    --accept "every honesty condition maps to a test"
+
+# Park a genuine unknown instead of guessing:
+p risk "exact rollout sequencing" --kind unknown_nonblocking
+
+p status        # what's left + the next move
+p converge      # gate; resolve any listed gaps
+p export        # writes docs/plans/my-feature.md once converged
+```
+
+The exported plan-md is a buildable artifact: topologically ordered tasks, each
+with acceptance criteria and the spec targets it covers. It feeds directly into
+implementation (or `superpowers:writing-plans`).
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding), next to
+its sibling `/think`. It is the *inverse* of the other skills under
+`.claude/skills/`, which devague vendors **from** steward. When ready, steward
+pulls it **from** devague and broadcasts it to the rest of the AgentCulture mesh.
+The `cite, don't import` policy still holds: downstream repos copy it, they don't
+symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+#
+# The skill is named `spec-to-plan`; the product/CLI it drives is `devague` (the
+# idea→spec half lives in the sibling /think skill). This wrapper forwards every
+# move to `devague plan <move>` verbatim — including the `status` verb the CLI
+# internalised in 0.11.0 (devague#30/#31), which reads the plan convergence gate
+# and names the recommended next move. It is the forward leg: seed a plan from a
+# *converged* frame, then work it into a buildable plan.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory (alongside frames), so
+# run from the repo you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+
+Usage:
+  spec-to-plan.sh <move> [args...]   forward a `devague plan` move
+  spec-to-plan.sh status [--plan S]  where the plan stands + the next move
+  spec-to-plan.sh help               this help
+
+Moves (forwarded to `devague plan`; run `devague plan learn` for the method):
+  new          start a plan from a CONVERGED frame (--frame <slug>)
+  task         add a task (--accept / --dep / --covers, --origin user|llm)
+  accept       add an acceptance criterion to a task
+  depend       record that a task depends on another (--on)
+  cover        mark a task as covering a coverage target (c*/h*)
+  confirm      confirm a task                          (USER-only decision)
+  reject       reject a task
+  risk         record a first-class plan risk
+  converge     check whether the plan can export
+  export       write the buildable plan (only after converge passes)
+  waves        emit deterministic dependency waves (scheduling metadata, not orchestration)
+  status       where the plan stands + the recommended next move
+  show / list  render a plan / list plans
+  learn        teach the method   |   explain <move>  explain one move
+
+Plans persist under .devague/ in the current directory — run from the repo you
+are speccing. Results go to stdout, diagnostics to stderr; pass --json to any
+move for structured output.
+
+Note: every move — including `status` — is forwarded verbatim as `devague plan
+<move>`, so new plan moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
+
+Prior leg: a plan is seeded from a converged frame produced by the /think skill.
+EOF
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        *)
+            # Forward every move to `devague plan <move>` verbatim — including the
+            # internalised `status` verb (`devague plan status`) — so the CLI's own
+            # parser owns the plan surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -8,9 +8,10 @@
 # and names the recommended next move. It is the forward leg: seed a plan from a
 # *converged* frame, then work it into a buildable plan.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
-# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
-# is written to run anywhere — portable bash, no devague-checkout assumptions.
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls
+# this skill from devague and re-broadcasts it to the rest of the AgentCulture
+# mesh, so it is written to run anywhere — portable bash, no devague-checkout
+# assumptions.
 #
 # Plans persist under .devague/ in the current directory (alongside frames), so
 # run from the repo you are speccing.

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: think
+type: command
+description: >
+  Think a vague feature idea into a buildable spec by working backwards (the
+  idea→spec leg; drives the `devague` CLI). Start from the announcement
+  ("pretend it shipped"), capture and classify claims, interrogate them with
+  honesty conditions and hard questions, park open vagueness as a first-class
+  object, and export a spec only once the frame *converges*. Use when the user
+  says "think this through", "spec this", "work backwards", "turn this idea into
+  a spec", "announcement frame", or "devague", or when a feature request is too
+  vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
+  skill to turn it into a plan. Authored and maintained in agentculture/devague
+  (origin = devague); steward pulls this skill from here and broadcasts it to the
+  AgentCulture mesh — it is NOT vendored from steward like the other skills here.
+---
+
+# think — work an idea backwards into a buildable spec
+
+The skill is named **`think`**; the product/CLI it drives is **`devague`**. (The
+forward leg — turning a converged spec into a plan — is the sibling
+**`/spec-to-plan`** skill, which drives `devague plan`.)
+
+`think` turns a vague feature idea into a buildable spec by **working
+backwards**: you start from the announcement you'd make if it had already
+shipped, then build an **Announcement Frame** by capturing claims, pressure
+-testing them, parking what's still genuinely unknown, and only exporting once
+the frame converges.
+
+The CLI is **deterministic and move-driven** — it is *not* a wizard. There is no
+fixed sequence of prompts. **You (the agent) choose the next move; the CLI just
+tracks state and tells you what's still missing.** Run `devague learn` for the
+canonical ten-stage arc and `devague explain <move>` for any single move.
+
+This skill is the operator: a portable wrapper that resolves the CLI and
+forwards every move verbatim — including `status`, the read-only verb that reads
+the convergence gate and tells you the recommended next move.
+
+## How to run
+
+The entry point is `scripts/think.sh`. Invoke it from the repository you are
+speccing (frames persist under `.devague/` in the current directory):
+
+```bash
+bash .claude/skills/think/scripts/think.sh <move> [args...]
+bash .claude/skills/think/scripts/think.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` when you are inside the devague checkout.
+If neither resolves it prints an install hint (`uv tool install devague`). Every
+move — including `status` — is forwarded verbatim, so you can equally call the
+CLI directly (`devague <move> …`) when it is installed; the wrapper exists only
+for portable resolution.
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new "<announcement>"` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. |
+| `capture --kind <kind> "<text>"` | Record + classify a claim. `--origin llm` lands it as `proposed`. |
+| `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. |
+| `confirm <id> [<id>…]` / `reject <id> [<id>…]` | Resolve one or more claims (`c*`) / honesty conditions (`h*`) in one **transactional** call. **User-only decision.** Also `confirm --from-review <file>` to apply an edited review artifact. |
+| `review` | List every **proposed** (unconfirmed) claim + honesty condition with ids (`--json` too); writes a non-authoritative artifact to `.devague/reviews/<slug>.md`. Un-gated; never mutates. |
+| `question "<text>"` | Record / list / `--resolve` a pending user decision as durable working state in `.devague/questions/<slug>.md`. |
+| `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
+| `converge` | Evaluate the gate; list remaining gaps. |
+| `export` | Write the buildable spec to `docs/specs/` — only after `converge` passes. |
+| `status` | Read-only: where the frame stands + the recommended next move (`--json` too). |
+| `show` / `list` | Render a frame / list frames (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Claim kinds: `announcement`, `audience`, `after_state`, `before_state`,
+`why_it_matters`, `boundary`, `success_signal`, `open_question`, `non_goal`,
+`requirement`, `assumption`, `decision`. Vagueness kinds: `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+These are exactly the kinds the **shipped CLI enforces** (`CLAIM_KINDS` /
+`VAGUENESS_KINDS` in `devague/frame.py`) — the skill documents the surface as
+built, so every command here passes the CLI's `choices=` validation. `requirement`
+is spec-affecting (needs a confirmed honesty condition); `non_goal` / `decision`
+are descriptive; an unconfirmed `assumption` is a convergence *warning*, not a
+blocker. The formal entity model, the `(state × origin)` vocabulary, and the
+per-move input/output/transition/error contract are documented in
+[`docs/spec-contract.md`](../../../docs/spec-contract.md) (issue
+[#5](https://github.com/agentculture/devague/issues/5)); for the authoritative
+live shape of any move, run it with `--json` (or `devague learn --json` /
+`devague explain <move>`).
+
+### `status` — the next-move verb
+
+`status` is a first-class, **read-only** CLI verb (`devague status`, internalised
+from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`list` + `converge` and prints where the current frame stands, the remaining
+gaps, and the recommended next move; it never mutates state (the
+`drafting`↔`converged` transition stays in `converge`). It reports
+`ready_for_spec`, lists the `blockers` and `warnings`, and shows
+`required_next_moves[0]` as the recommended move. Pass `--json` for the same
+fields as a structured payload (`{frame, total, ready_for_spec, blockers,
+warnings, parked_items, required_next_moves}`).
+
+```text
+frame: my-feature    (1 frame total)
+convergence: NOT passed — 2 gap(s):
+  - missing a 'boundary' / non-goal claim
+  - claim c2 has no confirmed honesty condition
+
+recommended next move (first gap):
+  devague capture --kind boundary "<text>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **LLM proposals stay proposed.** A claim captured with `--origin llm`, and any
+  honesty condition you (the agent) propose, lands as `proposed`. **Never
+  `confirm` your own proposal.** Confirmation is a user-only decision — surface
+  the proposal and let the user confirm or reject it. Proposed content must not
+  silently become an authoritative requirement.
+- **Honesty conditions route through the user.** Propose them freely with
+  `interrogate --honesty`; the user owns whether they hold.
+- **Converge, don't vibe.** `export` is gated on `converge` passing. Never claim
+  the frame is ready on a hunch — run `converge` (or `status`) and resolve every
+  listed gap. The gate requires confirmed `announcement` / `audience` /
+  `after_state`, a `before_state` or `why_it_matters`, a `boundary`, a
+  `success_signal`, a confirmed honesty condition on every spec-affecting claim,
+  and no unresolved blocking vagueness or hard question.
+- **Park real unknowns; don't paper over them.** If something is genuinely
+  unknown, `park` it (blocking or non-blocking) rather than fabricating an
+  answer. Blocking vagueness holds back convergence — by design.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload
+on the same stream. Exit code `0` on success, non-zero on user error (with a
+`hint:` line). Frames live under `.devague/` in the current directory.
+
+## Worked example
+
+A short end-to-end session (the kind you'd run to spec a feature like
+[devague#5](https://github.com/agentculture/devague/issues/5)):
+
+```bash
+d() { bash .claude/skills/think/scripts/think.sh "$@"; }
+
+d new "Devague ships a documented spec contract"
+d capture --kind audience "devague + the assisting LLM"
+d capture --kind after_state "a vague idea becomes a buildable, pressure-tested spec"
+d capture --kind why_it_matters "specs converge on evidence, not vibes"
+d capture --kind boundary "not a full PRD generator; no fixed wizard"
+d capture --kind success_signal "a frame exports only after the gate passes"
+
+# Pressure-test a claim, then let the USER confirm the condition:
+d interrogate c1 --honesty "the contract round-trips: save -> load -> identical frame"
+# ...user reviews and runs: d confirm h1
+
+# Park a genuine unknown instead of guessing:
+d park "exact JSON schema versioning policy" --kind unknown_nonblocking
+
+d status        # what's left + the next move
+d converge      # gate; resolve any listed gaps
+d export        # writes docs/specs/<slug>.md once converged
+```
+
+The exported spec-md is a buildable artifact.
+
+## After export — commit, then hand off
+
+Once `export` writes the spec **and the user has reviewed it**, close the
+idea→spec leg cleanly before moving on:
+
+1. **Commit the spec.** Commit the exported `docs/specs/<slug>.md` (along with
+   the `.devague/<slug>.json` frame state and any review artifact under
+   `docs/reviews/`) so the converged frame is durable in history, not just on
+   disk. Use a focused message, e.g. `git commit -m "spec: <slug> (devague
+   /think)"`. The frame and the spec are the evidence trail for every confirmed
+   claim — keep them together. (Per the repo's standing convention this normally
+   becomes a branch + PR via the `cicd` skill; commit-only is fine when the user
+   asks for it.)
+2. **Hand off to `/spec-to-plan`.** The forward leg is the sibling skill:
+   `devague plan new --frame <slug>` seeds a plan from the converged frame and
+   works it forward into a buildable plan (it can equally feed
+   `superpowers:writing-plans` or a normal implementation PR).
+
+Don't pause for a "what next?" menu after a reviewed export — the standing flow
+is **commit, then `/spec-to-plan`**.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding). It is the
+*inverse* of the other skills under `.claude/skills/`, which devague vendors
+**from** steward. When this skill is ready, steward pulls it **from** devague and
+broadcasts it to the rest of the AgentCulture mesh. The `cite, don't import`
+policy still holds: downstream repos copy it, they don't symlink or depend on it.
+See `docs/skill-sources.md`.

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -11,8 +11,8 @@ description: >
   a spec", "announcement frame", or "devague", or when a feature request is too
   vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
   skill to turn it into a plan. Authored and maintained in agentculture/devague
-  (origin = devague); steward pulls this skill from here and broadcasts it to the
-  AgentCulture mesh — it is NOT vendored from steward like the other skills here.
+  (origin = devague); guildmaster re-broadcasts it to the AgentCulture mesh — it
+  originates in devague, not guildmaster (the supplier post steward→guildmaster cutover).
 ---
 
 # think — work an idea backwards into a buildable spec
@@ -195,7 +195,7 @@ is **commit, then `/spec-to-plan`**.
 This is a **first-party** skill — its origin is `agentculture/devague`, where the
 devague agent maintains it alongside the tool it operates (dogfooding). It is the
 *inverse* of the other skills under `.claude/skills/`, which devague vendors
-**from** steward. When this skill is ready, steward pulls it **from** devague and
-broadcasts it to the rest of the AgentCulture mesh. The `cite, don't import`
+**from** guildmaster. When this skill is ready, guildmaster pulls it **from** devague and
+re-broadcasts it to the rest of the AgentCulture mesh. The `cite, don't import`
 policy still holds: downstream repos copy it, they don't symlink or depend on it.
 See `docs/skill-sources.md`.

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
+#
+# The skill is named `think`; the product/CLI it drives is `devague` (the spec→plan
+# half lives in the sibling /spec-to-plan skill, which drives `devague plan`).
+# devague turns a vague feature idea into a buildable spec by working backwards.
+# This wrapper is the agent-facing operator for the deterministic devague CLI:
+# it resolves the CLI portably and forwards every move verbatim — including the
+# `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
+# convergence gate and names the recommended next move.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Frames persist under .devague/ in the current directory, so run from the repo
+# you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
+
+Usage:
+  think.sh <move> [args...]    forward a devague move
+  think.sh status [--frame S]  where the frame stands + the next move
+  think.sh help                this help
+
+Moves (forwarded to the devague CLI; run `devague learn` for the full method):
+  new          start a frame from the announcement ("pretend it shipped")
+  capture      record + classify a claim (--kind audience|after_state|...)
+  interrogate  pressure-test a claim (--honesty / --hard-question / --risk)
+  confirm      confirm a claim or honesty condition  (USER-only decision)
+  reject       reject a claim or honesty condition
+  park         record open vagueness instead of forcing an answer
+  converge     check whether the frame can export a spec
+  export       write the buildable spec (only after converge passes)
+  status       where the frame stands + the recommended next move
+  show / list  render a frame / list frames
+  learn        teach the method   |   explain <move>  explain one move
+
+Frames persist under .devague/ in the current directory — run from the repo
+you are speccing. Results go to stdout, diagnostics to stderr; pass --json to
+any move for structured output.
+
+Note: every move — including `status` — is forwarded verbatim to the devague
+CLI, so new devague moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
+
+Next leg: once a frame exports a spec, hand off to the /spec-to-plan skill
+(`devague plan ...`) to turn that spec into a buildable plan.
+EOF
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        *)
+            # Forward every move to the CLI verbatim (including --version, the
+            # internalised `status` verb, and any future devague move), so its
+            # own parser owns the surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -9,9 +9,10 @@
 # `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
 # convergence gate and names the recommended next move.
 #
-# Origin: authored and maintained in agentculture/devague. steward pulls this
-# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
-# is written to run anywhere — portable bash, no devague-checkout assumptions.
+# Origin: authored and maintained in agentculture/devague. guildmaster pulls
+# this skill from devague and re-broadcasts it to the rest of the AgentCulture
+# mesh, so it is written to run anywhere — portable bash, no devague-checkout
+# assumptions.
 #
 # Frames persist under .devague/ in the current directory, so run from the repo
 # you are speccing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - **steward → guildmaster skills-supplier cutover** ([#409](https://github.com/agentculture/culture/issues/409)): re-pointed vendor/provenance attribution in the `cicd` and `communicate` `SKILL.md` and the `cicd/workflow.sh` header from steward to guildmaster (steward lineage preserved), and rewrote the `CLAUDE.md` "Sibling alignment" section to the post-cutover split — guildmaster owns the canonical skill set + broadcast verbs (`guild teach` / `guild onboard`); steward retains agent alignment (the `steward-cli` dep is unchanged).
 - Kept culture's `run-tests` and `version-bump` copies, which are intentionally **ahead** of guildmaster's (xdist shard-combine + coverage-floor surfacing + combine/report/xml failure propagation; `idx >= 0` changelog insertion). Added `# culture-divergence:` notes; the improvements are offered back upstream to guildmaster rather than overwritten on resync.
+- Re-pointed the *new* skills' provenance/broadcast attribution to guildmaster too (PR #410 review): `agent-config` cites guildmaster (forked from steward, which keeps the alignment-judgment variant); the devague trio names guildmaster as the re-broadcaster (origin stays devague). Steward's retained agent-alignment references (`steward overview` / `steward doctor`) are left intact.
+
+### Fixed
+
+- `agent-config/scripts/show.sh` suffix mode no longer forces exit 2 for *every* Python failure — only the explicit "unknown suffix" case maps to 2; malformed-manifest / runtime errors keep their own rc so callers can distinguish a typo'd suffix from a broken manifest (PR #410 review; `# culture-divergence:`, offered upstream in [guildmaster#22](https://github.com/agentculture/guildmaster/issues/22)).
+- `sonarclaude/scripts/sonar.sh` `accept` now validates the SonarCloud transition HTTP status (mirroring the add-comment step) instead of silently reporting a failed transition as success (PR #410 review; `# culture-divergence:`, offered upstream in guildmaster#22).
 
 ## [13.1.0] - 2026-05-21
 
@@ -667,7 +673,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **`culture agent message` no longer treats local config as the source of truth** (#333 item 11). The previous behavior refused to send when the target nick was missing from local `server.yaml`, which broke DMs to agents reachable via federation. The local-config gate is removed; the send is delegated to the IRC server, and `401 NOSUCHNICK` propagates if the nick truly isn't on the mesh.
 - **`culture agent sleep`/`wake` usage errors now use argparse formatting** (#333 item 12). Missing-arg, conflicting-arg, and unknown-nick errors previously went to stdout via `print()` + `sys.exit(1)`, inconsistent with every other CLI verb. They now write `culture agent sleep: error: ...` to stderr with rc 2, matching argparse's standard usage-error path.
 - **`culture agent migrate --help` text now signals it's a one-time op** (#333 item 7). Help reads `Migrate legacy agents.yaml to server.yaml + culture.yaml (one-time, usually a no-op)` instead of advertising it as routine. The verb stays in the CLI surface for completeness — most repos have already migrated.
-- **Channel-existence guard now uses the server-wide `LIST` query** (#341 review). Earlier draft of the #331 guard read the daemon's `irc_channels` IPC, which only returns the daemon's _joined_ channels — false-rejecting valid channels the daemon hadn't joined. The guard now always uses the observer's `list_channels()` (a fresh peek `LIST`) regardless of IPC availability.
+- **Channel-existence guard now uses the server-wide `LIST` query** (#341 review). Earlier draft of the #331 guard read the daemon's `irc_channels` IPC, which only returns the daemon's *joined* channels — false-rejecting valid channels the daemon hadn't joined. The guard now always uses the observer's `list_channels()` (a fresh peek `LIST`) regardless of IPC availability.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [13.2.0] - 2026-05-25
+
+### Added
+
+- Vendored 7 new skills from guildmaster (cite-don't-import) into `.claude/skills/` for [issue #409](https://github.com/agentculture/culture/issues/409): `agent-config`, `pypi-maintainer`, `sonarclaude`, `doc-test-alignment`, and the devague-origin workflow trio `think` / `spec-to-plan` / `assign-to-workforce` (re-broadcast through guildmaster; the trio shells out to the `devague` CLI, installed separately).
+- `communicate` `skill-new-brief.md` template (new-skill broadcast brief) alongside the existing `skill-update-brief.md`, in both the repo-dev (`.claude/skills/`) and wheel-bundled (`culture/skills/`) copies; wired into `pyproject.toml` `force-include` and the `culture skills install` template list (`_COMMUNICATE_TEMPLATES`).
+
+### Changed
+
+- **steward → guildmaster skills-supplier cutover** ([#409](https://github.com/agentculture/culture/issues/409)): re-pointed vendor/provenance attribution in the `cicd` and `communicate` `SKILL.md` and the `cicd/workflow.sh` header from steward to guildmaster (steward lineage preserved), and rewrote the `CLAUDE.md` "Sibling alignment" section to the post-cutover split — guildmaster owns the canonical skill set + broadcast verbs (`guild teach` / `guild onboard`); steward retains agent alignment (the `steward-cli` dep is unchanged).
+- Kept culture's `run-tests` and `version-bump` copies, which are intentionally **ahead** of guildmaster's (xdist shard-combine + coverage-floor surfacing + combine/report/xml failure propagation; `idx >= 0` changelog insertion). Added `# culture-divergence:` notes; the improvements are offered back upstream to guildmaster rather than overwritten on resync.
+
 ## [13.1.0] - 2026-05-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,12 @@ Design spec: `docs/superpowers/specs/2026-03-19-agentirc-design.md`
 
 ## Sibling alignment
 
-[Steward](https://github.com/agentculture/steward) is the alignment hub for AgentCulture skills. When a skill stabilizes here that other repos benefit from (`communicate`, `cicd`, `version-bump`, `agent-config`), the expectation is that steward picks it up and propagates it to the rest of the mesh. When steward stabilizes a convention culture should adopt (naming, signature format, script layout), that lands here as a follow-up PR — see `communicate` skill briefs from `- steward (Claude)`.
+As of the **steward → guildmaster cutover** (2026-05-24), the mesh's skills role split in two:
+
+- **[guildmaster](https://github.com/agentculture/guildmaster) is the skills supplier/hub.** It owns the canonical skill set (`communicate`, `cicd`, `version-bump`, `run-tests`, `agent-config`, `pypi-maintainer`, `sonarclaude`, `doc-test-alignment`), the upstream/downstream provenance ledger, and the broadcast verbs (`guild teach` / `guild onboard`). Skills land in culture **from guildmaster** — re-cite vendored skills from `../guildmaster/.claude/skills/<skill>/`. The devague workflow trio (`think`, `spec-to-plan`, `assign-to-workforce`) originates in [devague](https://github.com/agentculture/devague) and is re-broadcast through guildmaster. When a skill stabilizes in culture that the mesh benefits from, guildmaster picks it up and propagates it.
+- **[steward](https://github.com/agentculture/steward) retains agent alignment.** The `steward doctor` / `steward overview` / `steward show` verbs (which culture forwards via the `steward-cli>=0.16` dep — unchanged by the cutover) stay with steward.
+
+When guildmaster stabilizes a convention culture should adopt (naming, signature format, script layout), that lands here as a follow-up PR — see skill-update briefs from `- guildmaster (Claude)`. Some vendored scripts are intentionally **ahead** of guildmaster's copy (e.g. `run-tests`); those carry a `# culture-divergence:` header and are offered back upstream rather than overwritten on resync.
 
 ## Package Management
 

--- a/culture/cli/skills.py
+++ b/culture/cli/skills.py
@@ -21,7 +21,7 @@ _COMMUNICATE_SCRIPTS = (
     "post-comment.sh",
     "post-issue.sh",
 )
-_COMMUNICATE_TEMPLATES = ("skill-update-brief.md",)
+_COMMUNICATE_TEMPLATES = ("skill-update-brief.md", "skill-new-brief.md")
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:

--- a/culture/skills/communicate/SKILL.md
+++ b/culture/skills/communicate/SKILL.md
@@ -13,7 +13,9 @@ description: >
 ---
 
 <!--
-Vendored from agentculture/steward → .claude/skills/communicate/. The
+Vendored from agentculture/guildmaster → .claude/skills/communicate/
+(the AgentCulture skills hub, post steward→guildmaster cutover; lineage:
+steward through 0.11.x). The
 three GitHub verbs (post-issue.sh, post-comment.sh, fetch-issues.sh)
 are thin wrappers around `agtag issue post|reply|fetch`. agtag resolves
 the signing nick from the local `culture.yaml`'s first agent suffix
@@ -247,6 +249,8 @@ Output is one JSON object per issue (separated by header bars) with
 
 ---
 
-Source: agentculture/steward → `.claude/skills/communicate/`. Re-cite
-from there when steward bumps the skill. Scripts intentionally diverged
-from steward's upstream copy carry a `# culture-divergence:` header.
+Source: agentculture/guildmaster → `.claude/skills/communicate/` (the
+AgentCulture skills hub, post steward→guildmaster cutover; lineage:
+steward through 0.11.x). Re-cite from there when guildmaster bumps the
+skill. Scripts intentionally diverged from the upstream copy carry a
+`# culture-divergence:` header.

--- a/culture/skills/communicate/scripts/templates/skill-new-brief.md
+++ b/culture/skills/communicate/scripts/templates/skill-new-brief.md
@@ -1,0 +1,85 @@
+<!-- markdownlint-disable MD041 -->
+<!-- This file is the NEW-SKILL template rendered by announce-skill-update -->
+<!-- when --new is passed. It posts as an issue body where GitHub supplies -->
+<!-- the title, so there's no H1 here on purpose. Placeholders use the -->
+<!-- `{{NAME}}` syntax; {{ORIGIN_BLOCK}} is empty unless --origin is given. -->
+
+## A new skill is available to vendor
+
+`{{SKILL}}` is a **new** skill in the AgentCulture mesh. Your repo does
+not have it yet — this brief tells you how to **add it fresh** (there is no
+older vendored copy to replace). If you maintain a `docs/skill-sources.md`
+provenance ledger, add a row for it; if not, just drop it into
+`.claude/skills/`.
+
+{{ORIGIN_BLOCK}}
+
+Relevant guildmaster CHANGELOG entries (where guildmaster picked the skill up):
+
+{{CHANGELOG_BLOCK}}
+
+## Cite locations (source of truth)
+
+- Local sibling checkout (preferred when available):
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
+
+guildmaster re-broadcasts this skill to the mesh, so its copy is the citation
+point even when the skill originates in another sibling (see origin note
+above, if present). The directory ships a `SKILL.md` and a `scripts/`
+directory per the AgentCulture skills-portability rule (each skill is
+self-contained; nothing reaches across skill boundaries at runtime).
+
+## What's in the upstream now
+
+`{{SKILL}}/scripts/` ({{UPSTREAM_SCRIPT_COUNT}} files):
+
+{{UPSTREAM_SCRIPT_LIST}}
+
+{{DELTA_BLOCK}}
+
+{{NOTE_BLOCK}}
+
+## What to do
+
+```bash
+# 0. Branch.
+git checkout -b skill/{{SKILL}}-add
+
+# 1. Add the skill fresh from upstream (no existing copy to remove).
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
+chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
+
+# 2. If you keep docs/skill-sources.md, add a row pointing at
+#    ../guildmaster/.claude/skills/{{SKILL}}/ (record any local divergence).
+
+# 3. Bump version per project convention (CI version-check enforces in
+#    AgentCulture siblings); add a CHANGELOG entry.
+```
+
+## Acceptance criteria
+
+- `.claude/skills/{{SKILL}}/SKILL.md` is present with frontmatter
+  `name: {{SKILL}}`. **On the culture/agex backend, also add
+  `type: command`** — `core.skill_loader` requires all of `name`,
+  `description`, and `type:`, and a SKILL.md lacking `type:` is silently
+  skipped by `backends/claude_code/probe.py`.
+- `.claude/skills/{{SKILL}}/scripts/` contains the
+  {{UPSTREAM_SCRIPT_COUNT}} files listed above (and only those, unless your
+  repo intentionally adds extras — record divergence in the SKILL.md
+  frontmatter `description` per the AgentCulture vendoring policy).
+- All scripts are executable (`chmod +x`).
+- If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with the
+  upstream `../guildmaster/.claude/skills/{{SKILL}}/`.
+- `CHANGELOG.md` has a new version entry describing the addition; the
+  version is bumped per project convention; CI's `version-check` job is green.
+
+## References
+
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
+- `{{SKILL}}` SKILL.md:
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+- AgentCulture skills-portability rule (each vendor owns and may adapt its
+  copy): the `communicate` SKILL.md "Conventions in use" section.

--- a/culture/skills/communicate/scripts/templates/skill-update-brief.md
+++ b/culture/skills/communicate/scripts/templates/skill-update-brief.md
@@ -7,17 +7,17 @@
 
 Your repo's `.claude/skills/{{SKILL}}/` (or its older vendored
 name — see your `docs/skill-sources.md` if you keep a provenance
-ledger) is a vendored copy of the steward skill that has since
-moved on. Relevant CHANGELOG entries from steward:
+ledger) is a vendored copy of the guildmaster skill that has since
+moved on. Relevant CHANGELOG entries from guildmaster:
 
 {{CHANGELOG_BLOCK}}
 
 ## Cite locations (source of truth)
 
 - Local sibling checkout (preferred when available):
-  `../steward/.claude/skills/{{SKILL}}/`
-- Remote, if the workspace doesn't include a local steward checkout:
-  <https://github.com/agentculture/steward/tree/main/.claude/skills/{{SKILL}}>
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
 
 The directory ships with a `SKILL.md` and a `scripts/` directory
 per the AgentCulture skills-portability rule (each skill is
@@ -44,14 +44,14 @@ git checkout -b skill/{{SKILL}}-resync
 #    If your old vendored name differs (e.g. pr-review → cicd),
 #    `git rm` the old dir first.
 git rm -r .claude/skills/<old-name-if-different>   # skip if name is already {{SKILL}}
-cp -R ../steward/.claude/skills/{{SKILL}} .claude/skills/
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
 chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
 
 # 2. Adapt identifiers per the existing "identifier-only adapted"
 #    pattern in your docs/skill-sources.md (if you keep one):
-#    - SKILL.md prose framing: replace "steward" with your repo
+#    - SKILL.md prose framing: replace "guildmaster" with your repo
 #      name where it identifies the consumer (NOT where it cites
-#      steward as the upstream).
+#      guildmaster as the upstream).
 #    - For any script that hard-codes a signature literal, change it
 #      to `- <your-repo> (Claude)`. (The communicate skill no longer
 #      hard-codes one — agtag resolves the nick from your local
@@ -80,9 +80,9 @@ grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
   AgentCulture vendoring policy).
 - All scripts are executable (`chmod +x`).
 - If the skill hard-codes a signature literal anywhere, your
-  vendored copy uses your repo's signature, not `- steward (Claude)`.
+  vendored copy uses your repo's signature, not `- guildmaster (Claude)`.
 - If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with
-  the upstream `../steward/.claude/skills/{{SKILL}}/`; no row
+  the upstream `../guildmaster/.claude/skills/{{SKILL}}/`; no row
   remains for the old vendored name.
 - `grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md`
   returns zero hits, or only historical mentions in CHANGELOG.
@@ -92,10 +92,10 @@ grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
 
 ## References
 
-- Steward CHANGELOG (release-by-release deltas):
-  <https://github.com/agentculture/steward/blob/main/CHANGELOG.md>
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
 - `{{SKILL}}` SKILL.md:
-  <https://github.com/agentculture/steward/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
 - AgentCulture skills-portability rule (why each vendor adapts
   signature literals locally): the `communicate` SKILL.md
   "Per-channel signature rules" + "Conventions in use" sections.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "13.1.0"
+version = "13.2.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"
@@ -54,6 +54,7 @@ packages = ["culture"]
 "culture/skills/communicate/scripts/fetch-issues.sh" = "culture/skills/communicate/scripts/fetch-issues.sh"
 "culture/skills/communicate/scripts/mesh-message.sh" = "culture/skills/communicate/scripts/mesh-message.sh"
 "culture/skills/communicate/scripts/templates/skill-update-brief.md" = "culture/skills/communicate/scripts/templates/skill-update-brief.md"
+"culture/skills/communicate/scripts/templates/skill-new-brief.md" = "culture/skills/communicate/scripts/templates/skill-new-brief.md"
 "culture/overview/web/style.css" = "culture/overview/web/style.css"
 "culture/bots/system/welcome/bot.yaml" = "culture/bots/system/welcome/bot.yaml"
 

--- a/tests/test_communicate_skill_install.py
+++ b/tests/test_communicate_skill_install.py
@@ -31,7 +31,7 @@ EXPECTED_SCRIPTS = (
     "post-comment.sh",
     "post-issue.sh",
 )
-EXPECTED_TEMPLATES = ("skill-update-brief.md",)
+EXPECTED_TEMPLATES = ("skill-update-brief.md", "skill-new-brief.md")
 
 
 @pytest.mark.parametrize(("target", "root"), BACKENDS)
@@ -79,13 +79,17 @@ def test_install_drops_communicate_skill_for_backend(
 
 
 def test_install_skill_md_carries_provenance_header(tmp_path, monkeypatch) -> None:
-    """The vendored SKILL.md must declare it was sourced from steward."""
+    """The vendored SKILL.md must declare its guildmaster provenance.
+
+    Post steward→guildmaster cutover (issue #409) the skills hub is
+    guildmaster; the provenance header records that supplier.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
     skills.dispatch(Namespace(skills_command="install", target="claude"))
 
     skill_md = os.path.expanduser("~/.claude/skills/communicate/SKILL.md")
     text = open(skill_md, encoding="utf-8").read()
-    assert "Vendored from agentculture/steward" in text
+    assert "Vendored from agentculture/guildmaster" in text
 
 
 def test_install_all_backends_includes_communicate(tmp_path, monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "13.1.0"
+version = "13.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## What

Handles [#409](https://github.com/agentculture/culture/issues/409) — the `guild teach` skills broadcast from **guildmaster**, the skills-supplier role that split out of steward (the steward → guildmaster cutover).

### New skills (vendored verbatim, cite-don't-import → `.claude/skills/`)

`agent-config`, `pypi-maintainer`, `sonarclaude`, `doc-test-alignment`, and the devague-origin workflow trio `think` / `spec-to-plan` / `assign-to-workforce` (re-broadcast through guildmaster; the trio shells out to the `devague` CLI, installed separately — not a culture runtime dep).

### Resync / supplier re-point

The four "resync" skills (`cicd`, `communicate`, `run-tests`, `version-bump`) carry **no new code** — guildmaster carried steward's copies verbatim, and culture is current or ahead. So the resync is a **supplier re-point**, not a code pull:

- `cicd` + `communicate`: provenance attribution steward → guildmaster in `SKILL.md` + `cicd/workflow.sh` header (steward lineage preserved); all `# culture-divergence:` blocks kept intact.
- `communicate`: added the new `skill-new-brief.md` template in both the repo-dev (`.claude/skills/`) and wheel-bundled (`culture/skills/`) copies; wired into `pyproject.toml` `force-include`, `culture skills install` (`_COMMUNICATE_TEMPLATES`), and the install test.
- `run-tests` + `version-bump`: **kept culture's copies** — they are intentionally *ahead* of guildmaster's (culture's `run-tests` has xdist shard-combine, stale-shard wipe, coverage-floor surfacing, and combine/report/xml failure propagation that guildmaster's `exec pytest --cov` lacks; `version-bump`'s `idx >= 0` changelog insertion is more robust than guildmaster's `idx > 0`). Added `# culture-divergence:` notes.
- `CLAUDE.md` "Sibling alignment" rewritten to the post-cutover split: **guildmaster = skills supplier + broadcast verbs**, **steward = agent alignment** (`steward-cli` dep unchanged).

### Follow-up (separate, cross-repo)

A consolidated issue will be filed to `agentculture/guildmaster` offering culture's ahead implementations upstream (run-tests coverage pipeline, the working `doc-test-alignment` subagent vs guildmaster's stub, and the `fetch-issues.sh` range guard).

## Testing

- `/run-tests` full suite: **1402 passed, 1 skipped**.
- `doc-test-alignment` subagent audit: clean (no new API/protocol surface).
- markdownlint + portability-lint + black/isort/flake8/pylint/bandit (pre-commit): clean.

## Version

`/version-bump minor` → **13.2.0** (pyproject.toml + CHANGELOG.md + uv.lock).

- culture (Claude)
