### PR TITLE
feat(harness): boss-supervised helpers — permission broker, context handoff, daemon log (8.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.7.0] - 2026-05-28
+
+### Added
+
+- **Helper boss permission broker** — a boss Claude Code session is the human-in-the-loop for helper agents it spawns. `culture/clients/_perm_broker.py` wires the Claude Agent SDK `can_use_tool` callback to a file-backed request/decision queue under `~/.culture/`; helpers block on boss approval for any non-safe-read tool call. Safe reads (Read/Glob/Grep, read-only Bash) auto-approve via a per-helper `perm-policy/<nick>.yaml`.
+- **Helper tool inheritance** — Claude agents now load `setting_sources=["user","project","local"]`, so helpers inherit the boss's `~/.claude/` skills, MCP servers, and plugins.
+- **Context-watermark handoff (Claude)** — `culture/clients/_context_watch.py`; the daemon self-monitors per-turn `input_tokens` and at 90% of the model's context window asks the agent to write a handoff to `~/.culture/handoff/<nick>.md`, compacts, then reminds it to read the handoff after the compact. Configurable via a `context_watch` block in `culture.yaml`.
+- **Daemon action log (all backends)** — `culture/clients/_daemon_log.py`; structured JSONL control-plane log at `~/.culture/daemon-log/<nick>.jsonl` (start/stop/exit/crash/compact/handoff/…).
+- **Agent-message audit log (all backends)** — `culture/clients/_audit.py`; one JSONL line per AssistantMessage at `~/.culture/audit/<nick>.jsonl`.
+- `docs/agentirc/helper-permissions.md`, `helper-tool-inheritance.md`, `helper-context-handoff.md`, `helper-daemon-log.md`, and the design spec `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`.
+
+### Changed
+
+- `culture/clients/claude/agent_runner.py` — widened `setting_sources`; conditional `can_use_tool` (only when a `perm-policy/<nick>.yaml` exists, preserving today's behavior for standalone agents); streaming-prompt wrapper required by the SDK when the callback is set; new `on_usage` callback.
+- `culture/clients/claude/config.py` — new `ContextWatchConfig` on `AgentConfig`.
+- `culture/clients/{claude,codex,copilot,acp}/daemon.py` — instantiate the audit + daemon-action logs and record actions; Claude daemon also drives the context-watch handoff cycle.
+- `packages/agent-harness/culture.yaml` + `culture/clients/claude/culture.yaml` — commented `context_watch` block.
+
 ## [8.6.0] - 2026-04-26
 
 ### Added

--- a/culture/clients/_audit.py
+++ b/culture/clients/_audit.py
@@ -1,0 +1,166 @@
+"""Per-helper JSONL audit log of agent activity.
+
+Captures one line per ``AssistantMessage`` emitted by an agent runner. Used by
+the boss session for after-the-fact visibility into helper behavior — and as
+the primary observability surface for backends (Codex, ACP) where the broker
+cannot synchronously gate tool calls.
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from culture.clients._perm_broker import culture_home
+
+logger = logging.getLogger(__name__)
+
+# Cap previews so a single oversized tool result cannot bloat the log.
+_PREVIEW_CHARS = 200
+
+
+def _audit_dir() -> str:
+    return os.path.join(culture_home(), "audit")
+
+
+def audit_path_for(nick: str) -> str:
+    return os.path.join(_audit_dir(), f"{nick}.jsonl")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _digest(value: Any) -> str:
+    try:
+        encoded = json.dumps(value, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    except TypeError:
+        encoded = repr(value).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()[:16]}"
+
+
+def _preview(value: Any) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False)
+        except TypeError:
+            text = repr(value)
+    return text[:_PREVIEW_CHARS]
+
+
+def _summarise_assistant_message(msg: dict[str, Any]) -> dict[str, Any]:
+    text_chunks: list[str] = []
+    tool_uses: list[dict[str, Any]] = []
+    tool_results: list[dict[str, Any]] = []
+    for block in msg.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_value = block.get("text")
+            if isinstance(text_value, str):
+                text_chunks.append(text_value)
+        elif block_type == "tool_use":
+            tool_uses.append(
+                {
+                    "name": block.get("name", ""),
+                    "input_digest": _digest(block.get("input")),
+                }
+            )
+        elif block_type == "tool_result":
+            content = block.get("content")
+            tool_results.append(
+                {
+                    "name": block.get("name", ""),
+                    "content_digest": _digest(content),
+                    "preview": _preview(content),
+                }
+            )
+    return {
+        "text": "\n".join(text_chunks),
+        "tool_uses": tool_uses,
+        "tool_results": tool_results,
+    }
+
+
+class AuditWriter:
+    """Append-only JSONL writer for a single helper's activity.
+
+    Thread/task-safe via an internal asyncio.Lock — multiple ``write()`` calls
+    on the same instance serialise to preserve line atomicity. Writes are
+    fsync'd at the end of each line so a kernel crash does not lose the
+    most-recent line's prefix.
+    """
+
+    def __init__(self, nick: str) -> None:
+        if not nick:
+            raise ValueError("AuditWriter requires a non-empty nick")
+        self._nick = nick
+        self._path = audit_path_for(nick)
+        self._lock = asyncio.Lock()
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    async def write(self, msg: dict[str, Any]) -> None:
+        """Append one JSONL line summarising an agent message.
+
+        ``msg`` follows the dict shape produced by each backend's runner: a
+        top-level ``{"type": "assistant", "model": ..., "content": [...]}``.
+        Non-assistant messages are skipped to keep the log focused on agent
+        actions.
+        """
+        if msg.get("type") != "assistant":
+            return
+        line = self._build_line(msg)
+        async with self._lock:
+            await asyncio.to_thread(self._append_line_sync, line)
+
+    def _build_line(self, msg: dict[str, Any]) -> str:
+        record = {
+            "ts": _now_iso(),
+            "nick": self._nick,
+            "type": "assistant",
+            "model": msg.get("model", ""),
+            **_summarise_assistant_message(msg),
+        }
+        return json.dumps(record, ensure_ascii=False)
+
+    def _append_line_sync(self, line: str) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        except OSError:
+            logger.debug("Failed to ensure audit dir for %s", self._nick, exc_info=True)
+            return
+        try:
+            fd = os.open(
+                self._path,
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                0o600,
+            )
+        except OSError:
+            logger.warning("Failed to open audit log %s", self._path, exc_info=True)
+            return
+        try:
+            handle = os.fdopen(fd, "a", encoding="utf-8")
+        except OSError:
+            os.close(fd)
+            logger.warning("Failed to wrap audit log fd %s", self._path, exc_info=True)
+            return
+        try:
+            with handle:
+                handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError:
+            logger.warning("Failed to append to audit log %s", self._path, exc_info=True)

--- a/culture/clients/_context_watch.py
+++ b/culture/clients/_context_watch.py
@@ -1,0 +1,127 @@
+"""Context-watermark handoff logic.
+
+A long-running agent fills its context window. Before it does, the daemon asks
+the agent to write a handoff for its post-compact self, triggers a compact, then
+reminds it to read the handoff on next activation. This module holds the pure
+decision logic; the daemon owns the I/O (sending prompts, triggering compact).
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Context window sizes by model family. Unknown models default to the
+# conservative 200K. Extend this map as new models ship.
+_CONTEXT_WINDOWS: list[tuple[re.Pattern[str], int]] = [
+    (re.compile(r"claude-opus-4.*1m", re.IGNORECASE), 1_000_000),
+    (re.compile(r"claude-opus-4", re.IGNORECASE), 200_000),
+    (re.compile(r"claude-sonnet-4", re.IGNORECASE), 200_000),
+    (re.compile(r"claude-haiku-4", re.IGNORECASE), 200_000),
+]
+_DEFAULT_CONTEXT_WINDOW = 200_000
+
+# 1M-context model IDs carry a separate marker; the SDK model id for the
+# 1M beta is exposed as e.g. "claude-opus-4-7[1m]". Match that explicitly.
+_ONE_M_MARKER = re.compile(r"\[1m\]|1m|1000k|one[-_]?m", re.IGNORECASE)
+
+
+def context_window_for(model: str) -> int:
+    """Resolve the context window (in tokens) for a model id."""
+    if not model:
+        return _DEFAULT_CONTEXT_WINDOW
+    if "opus-4" in model.lower() and _ONE_M_MARKER.search(model):
+        return 1_000_000
+    for pattern, size in _CONTEXT_WINDOWS:
+        if pattern.search(model):
+            return size
+    logger.warning(
+        "Unknown model %r for context-watch; defaulting to %d tokens",
+        model,
+        _DEFAULT_CONTEXT_WINDOW,
+    )
+    return _DEFAULT_CONTEXT_WINDOW
+
+
+class WatchAction(enum.Enum):
+    """What the daemon should do after evaluating a turn's usage."""
+
+    NONE = "none"
+    WRITE_HANDOFF = "write_handoff"
+    REMINDER_DUE = "reminder_due"
+
+
+@dataclass
+class ContextWatchState:
+    """Mutable per-agent watch state.
+
+    ``high_water`` / ``low_water`` are fractions of the context window.
+    ``handoff_latched`` prevents re-firing the handoff every turn while still
+    above threshold. ``reminder_pending`` signals that a post-compact reminder
+    is owed on the next activation.
+    """
+
+    high_water: float = 0.90
+    low_water: float = 0.50
+    enabled: bool = True
+    handoff_latched: bool = False
+    reminder_pending: bool = False
+
+
+def evaluate(state: ContextWatchState, input_tokens: int | None, model: str) -> WatchAction:
+    """Decide the next watch action from a turn's input-token count.
+
+    Called by the daemon after each ``ResultMessage``. Mutates ``state``.
+
+    - At/above ``high_water`` and not latched: return WRITE_HANDOFF, set latch.
+    - Below ``low_water`` while latched: a compact has actually dropped usage —
+      reset the latch and return REMINDER_DUE so the daemon arms the
+      post-compact reminder *now* (not when the compact was merely queued, which
+      would let an interleaving activation consume the reminder too early).
+    - Otherwise: NONE.
+    """
+    if not state.enabled or input_tokens is None or input_tokens <= 0:
+        return WatchAction.NONE
+
+    window = context_window_for(model)
+    pct = input_tokens / window
+
+    if pct < state.low_water:
+        if state.handoff_latched:
+            # Context dropped after a handoff+compact — re-arm and signal that
+            # the reminder is now due.
+            state.handoff_latched = False
+            return WatchAction.REMINDER_DUE
+        return WatchAction.NONE
+
+    if pct >= state.high_water and not state.handoff_latched:
+        state.handoff_latched = True
+        return WatchAction.WRITE_HANDOFF
+
+    return WatchAction.NONE
+
+
+def fraction(input_tokens: int | None, model: str) -> float | None:
+    """Return the context-fill fraction for a turn, or None if unknown."""
+    if input_tokens is None or input_tokens <= 0:
+        return None
+    return input_tokens / context_window_for(model)
+
+
+def mark_reminder_pending(state: ContextWatchState) -> None:
+    """Record that a post-compact reminder is owed."""
+    state.reminder_pending = True
+
+
+def take_reminder(state: ContextWatchState) -> bool:
+    """Consume the reminder flag. Returns True if a reminder was pending."""
+    if state.reminder_pending:
+        state.reminder_pending = False
+        return True
+    return False

--- a/culture/clients/_daemon_log.py
+++ b/culture/clients/_daemon_log.py
@@ -1,0 +1,86 @@
+"""Per-agent control-plane action log.
+
+Distinct from the agent-message audit log (``_audit.py``): this records what the
+*daemon* does to manage the agent — start/stop/exit/crash/compact/handoff/etc.
+One JSONL line per action at ``~/.culture/daemon-log/<nick>.jsonl``. Universal
+across all backends.
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from culture.clients._perm_broker import culture_home
+
+logger = logging.getLogger(__name__)
+
+
+def _daemon_log_dir() -> str:
+    return os.path.join(culture_home(), "daemon-log")
+
+
+def daemon_log_path_for(nick: str) -> str:
+    return os.path.join(_daemon_log_dir(), f"{nick}.jsonl")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+class DaemonLog:
+    """Append-only JSONL writer for a single agent's daemon actions."""
+
+    def __init__(self, nick: str) -> None:
+        if not nick:
+            raise ValueError("DaemonLog requires a non-empty nick")
+        self._nick = nick
+        self._path = daemon_log_path_for(nick)
+        self._lock = asyncio.Lock()
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    async def record(self, action: str, **detail: Any) -> None:
+        """Append one action line. ``detail`` becomes the record's detail dict."""
+        record = {
+            "ts": _now_iso(),
+            "nick": self._nick,
+            "action": action,
+            "detail": detail,
+        }
+        line = json.dumps(record, ensure_ascii=False, default=str)
+        async with self._lock:
+            await asyncio.to_thread(self._append_line_sync, line)
+
+    def _append_line_sync(self, line: str) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        except OSError:
+            logger.debug("Failed to ensure daemon-log dir for %s", self._nick, exc_info=True)
+            return
+        try:
+            fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        except OSError:
+            logger.warning("Failed to open daemon log %s", self._path, exc_info=True)
+            return
+        try:
+            handle = os.fdopen(fd, "a", encoding="utf-8")
+        except OSError:
+            os.close(fd)
+            logger.warning("Failed to wrap daemon log fd %s", self._path, exc_info=True)
+            return
+        try:
+            with handle:
+                handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError:
+            logger.warning("Failed to append to daemon log %s", self._path, exc_info=True)

--- a/culture/clients/_perm_broker.py
+++ b/culture/clients/_perm_broker.py
@@ -1,0 +1,486 @@
+"""File-backed permission broker for boss-supervised helper agents.
+
+The broker bridges the Claude Agent SDK's ``can_use_tool`` callback to a
+file-backed request/decision queue under ``~/.culture/``. A regular Claude
+Code session ("boss") acts as the human-in-the-loop authority for tool calls
+made by helper agent daemons it has spawned.
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import secrets
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import yaml
+from claude_agent_sdk import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+
+logger = logging.getLogger(__name__)
+
+# Poll cadence while awaiting a decision file.
+_POLL_INTERVAL_SECONDS = 0.25
+
+# Default permission policy seeded by spawn-helper.sh when a helper has no
+# existing perm-policy/<nick>.yaml.  Mirrors the spec's "pre-seeded safe-read
+# defaults".  Note: ``require_approval`` is informational; anything that does
+# not match ``auto_allow`` or ``auto_deny`` falls through to the boss anyway.
+_BASH_SAFE_READ_REGEX = (
+    r"^(ls|cat|head|tail|wc|file|stat|pwd|which|rg|grep|find|tree|"
+    r"git (status|log|diff|blame|show)|gh (.* )?(list|view))(\s|$)"
+)
+DEFAULT_POLICY: dict[str, Any] = {
+    "auto_allow": [
+        {"tool": "Read"},
+        {"tool": "Glob"},
+        {"tool": "Grep"},
+        {"tool": "Bash", "input_regex": _BASH_SAFE_READ_REGEX},
+    ],
+    "auto_deny": [],
+    "require_approval": [
+        {"tool": "Edit"},
+        {"tool": "Write"},
+        {"tool": "mcp__.*"},
+        {"tool": "Bash"},
+    ],
+}
+
+
+def culture_home() -> str:
+    """Resolve the broker's root directory.
+
+    Honors ``CULTURE_HOME`` for test isolation; falls back to ``~/.culture``.
+    """
+    return os.environ.get("CULTURE_HOME", os.path.expanduser("~/.culture"))
+
+
+def _queue_dir() -> str:
+    return os.path.join(culture_home(), "perm-queue")
+
+
+def _decisions_dir() -> str:
+    return os.path.join(culture_home(), "perm-decisions")
+
+
+def _policy_dir() -> str:
+    return os.path.join(culture_home(), "perm-policy")
+
+
+def policy_path_for(nick: str) -> str:
+    """Return the policy file path for a given agent nick."""
+    return os.path.join(_policy_dir(), f"{nick}.yaml")
+
+
+def has_policy_file(nick: str) -> bool:
+    """True iff the helper has a policy file (i.e. is boss-supervised)."""
+    return bool(nick) and os.path.exists(policy_path_for(nick))
+
+
+def _mkdir_secure(path: str) -> None:
+    """Create a directory with 0700 perms if missing."""
+    os.makedirs(path, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        logger.debug("Could not chmod %s; continuing", path, exc_info=True)
+
+
+def _atomic_write_json(dest: str, payload: dict[str, Any]) -> None:
+    """Write JSON to ``dest`` atomically with 0600 perms.
+
+    Writes via ``tempfile`` in the same directory, fsyncs, then ``os.replace``.
+    """
+    _mkdir_secure(os.path.dirname(dest))
+    fd, tmp = tempfile.mkstemp(
+        prefix=".tmp-",
+        suffix=".json",
+        dir=os.path.dirname(dest),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, dest)
+    except BaseException:
+        # Clean up the temp file on any failure (incl. cancellation).
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_yaml(dest: str, payload: dict[str, Any]) -> None:
+    """Write YAML to ``dest`` atomically with 0600 perms."""
+    _mkdir_secure(os.path.dirname(dest))
+    fd, tmp = tempfile.mkstemp(
+        prefix=".tmp-",
+        suffix=".yaml",
+        dir=os.path.dirname(dest),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False, default_flow_style=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def write_default_policy(nick: str) -> str:
+    """Seed the default policy file for a helper if missing.
+
+    Returns the path. Idempotent — if the file exists, it is not overwritten.
+    """
+    dest = policy_path_for(nick)
+    if os.path.exists(dest):
+        return dest
+    _atomic_write_yaml(dest, DEFAULT_POLICY)
+    return dest
+
+
+def handoff_path_for(nick: str) -> str:
+    """Return the context-handoff file path for a given agent nick."""
+    return os.path.join(culture_home(), "handoff", f"{nick}.md")
+
+
+def _handoff_auto_allow_rule(nick: str) -> dict[str, Any]:
+    """Auto-allow rule letting a helper write its own context-handoff file.
+
+    A context-crisis handoff must never stall on boss approval, so the helper's
+    Write to handoff/<nick>.md is pre-approved. All other Writes still route to
+    the boss.
+    """
+    return {
+        "tool": "Write",
+        "input_regex": rf"/handoff/{re.escape(nick)}\.md$",
+    }
+
+
+def seed_helper_policy(nick: str) -> str:
+    """Seed a boss-supervised helper's policy file.
+
+    Writes the default safe-read policy (if missing) and ensures the
+    context-handoff write auto-allow rule is present. Idempotent.
+    """
+    dest = write_default_policy(nick)
+    rule = _handoff_auto_allow_rule(nick)
+    try:
+        with open(dest, encoding="utf-8") as handle:
+            policy = yaml.safe_load(handle) or {}
+    except OSError:
+        policy = {}
+    if not isinstance(policy, dict):
+        policy = {}
+    auto_allow = policy.setdefault("auto_allow", []) or []
+    if not isinstance(auto_allow, list):
+        auto_allow = []
+    if rule not in auto_allow:
+        auto_allow.append(rule)
+        policy["auto_allow"] = auto_allow
+        _atomic_write_yaml(dest, policy)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Policy matcher
+# ---------------------------------------------------------------------------
+
+_REGEX_METACHARS = re.compile(r"[.*+?\[\]^$|()\\]")
+
+
+def _tool_matches(tool_name: str, pattern: str) -> bool:
+    if _REGEX_METACHARS.search(pattern):
+        try:
+            return re.fullmatch(pattern, tool_name) is not None
+        except re.error:
+            logger.warning("Invalid tool pattern %r in policy", pattern)
+            return False
+    return tool_name == pattern
+
+
+def _project_input(tool_name: str, input_dict: dict[str, Any]) -> str | None:
+    """Project a tool's input to a single string for regex matching."""
+    if tool_name == "Bash":
+        value = input_dict.get("command")
+        return value if isinstance(value, str) else None
+    if tool_name in ("Edit", "Write"):
+        value = input_dict.get("file_path")
+        return value if isinstance(value, str) else None
+    if tool_name.startswith("mcp__"):
+        try:
+            return json.dumps(input_dict, sort_keys=True)
+        except TypeError:
+            return repr(input_dict)
+    return None
+
+
+def _rule_matches(tool_name: str, input_dict: dict[str, Any], rule: dict[str, Any]) -> bool:
+    pattern = rule.get("tool")
+    if not isinstance(pattern, str) or not _tool_matches(tool_name, pattern):
+        return False
+    input_regex = rule.get("input_regex")
+    if input_regex is None:
+        return True
+    projected = _project_input(tool_name, input_dict) if isinstance(input_regex, str) else None
+    if projected is None:
+        return False
+    try:
+        return re.search(input_regex, projected) is not None
+    except re.error:
+        logger.warning("Invalid input_regex %r in policy", input_regex)
+        return False
+
+
+def match_policy(
+    tool_name: str,
+    input_dict: dict[str, Any],
+    policy: dict[str, Any],
+) -> str | None:
+    """Apply policy rules to a tool invocation.
+
+    Returns ``"allow"``, ``"deny"``, or ``None`` (route to boss). ``auto_deny``
+    is checked before ``auto_allow``; first match wins within each section.
+    """
+    for section, verdict in (("auto_deny", "deny"), ("auto_allow", "allow")):
+        for rule in policy.get(section, []) or []:
+            if isinstance(rule, dict) and _rule_matches(tool_name, input_dict, rule):
+                return verdict
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Broker
+# ---------------------------------------------------------------------------
+
+
+def _new_request_id() -> str:
+    """Mint a sortable, unique request ID."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S-%f")
+    return f"req-{ts}-{secrets.token_hex(3)}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass
+class _PolicyCache:
+    path: str
+    mtime: float
+    policy: dict[str, Any]
+
+
+class PermissionBroker:
+    """Per-helper permission broker.
+
+    One instance is created per ``AgentRunner`` and reused across SDK turns.
+    The broker's ``gate`` method is the ``can_use_tool`` callback.
+    """
+
+    def __init__(self, nick: str) -> None:
+        if not nick:
+            raise ValueError("PermissionBroker requires a non-empty nick")
+        self._nick = nick
+        self._cache: _PolicyCache | None = None
+
+    @property
+    def nick(self) -> str:
+        return self._nick
+
+    def _load_policy(self) -> dict[str, Any]:
+        """Load (or refresh) the policy file for this helper."""
+        path = policy_path_for(self._nick)
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            # No file → no auto-rules. Everything falls through to boss.
+            return {"auto_allow": [], "auto_deny": []}
+        if self._cache and self._cache.path == path and self._cache.mtime == mtime:
+            return self._cache.policy
+        try:
+            with open(path, encoding="utf-8") as handle:
+                policy = yaml.safe_load(handle) or {}
+        except (OSError, yaml.YAMLError):
+            logger.warning("Failed to read policy %s; treating as empty", path, exc_info=True)
+            policy = {}
+        if not isinstance(policy, dict):
+            logger.warning("Policy %s is not a mapping; treating as empty", path)
+            policy = {}
+        self._cache = _PolicyCache(path=path, mtime=mtime, policy=policy)
+        return policy
+
+    async def gate(
+        self,
+        tool_name: str,
+        input_dict: dict[str, Any],
+        context: ToolPermissionContext,  # noqa: ARG002 — SDK API requires this slot
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        """SDK ``can_use_tool`` callback.
+
+        Fast path: policy match returns immediately. Slow path: write request
+        to ``perm-queue/<id>.json``, await ``perm-decisions/<id>.json``,
+        return SDK verdict.
+        """
+        policy = self._load_policy()
+        verdict = match_policy(tool_name, input_dict, policy)
+        if verdict == "allow":
+            return PermissionResultAllow(updated_input=None)
+        if verdict == "deny":
+            return PermissionResultDeny(
+                message=f"Policy auto-deny for {tool_name}",
+                interrupt=False,
+            )
+        return await self._request_from_boss(tool_name, input_dict)
+
+    async def _request_from_boss(
+        self,
+        tool_name: str,
+        input_dict: dict[str, Any],
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        request_id = _new_request_id()
+        queue_path = os.path.join(_queue_dir(), f"{request_id}.json")
+        decision_path = os.path.join(_decisions_dir(), f"{request_id}.json")
+        _mkdir_secure(_queue_dir())
+        _mkdir_secure(_decisions_dir())
+
+        payload = {
+            "id": request_id,
+            "helper_nick": self._nick,
+            "tool_name": tool_name,
+            "input": _safe_jsonable(input_dict),
+            "created_at": _now_iso(),
+        }
+        _atomic_write_json(queue_path, payload)
+
+        try:
+            decision = await self._await_decision(decision_path)
+        except asyncio.CancelledError:
+            # Helper task cancelled mid-wait; clean up our request file so it
+            # does not linger in the queue.  Re-raise so the SDK sees the
+            # cancellation.  Mirrors the discipline from commit d0902f9
+            # ("fix: re-raise CancelledError and save create_task results").
+            self._best_effort_unlink(queue_path)
+            raise
+
+        # Clean up both files; they are single-use.
+        self._best_effort_unlink(queue_path)
+        self._best_effort_unlink(decision_path)
+
+        scope = decision.get("scope", "once")
+        verdict = decision.get("verdict")
+        reason = decision.get("reason", "")
+
+        if scope == "always" and verdict in ("allow", "deny"):
+            self._append_sticky_rule(verdict, tool_name, decision)
+
+        # Drop the policy cache so the freshly-appended rule is visible to
+        # the next call.
+        self._cache = None
+
+        if verdict == "allow":
+            return PermissionResultAllow(updated_input=None)
+        if verdict == "deny":
+            return PermissionResultDeny(
+                message=reason or f"Boss denied {tool_name}",
+                interrupt=False,
+            )
+        # Unknown verdict — fail closed.
+        return PermissionResultDeny(
+            message=f"Broker received unknown verdict {verdict!r}",
+            interrupt=False,
+        )
+
+    async def _await_decision(self, decision_path: str) -> dict[str, Any]:
+        """Poll until the decision file exists and parses, then return it.
+
+        Reads are best-effort each tick: a transient ``OSError`` (the file was
+        removed between the existence check and the open) or ``JSONDecodeError``
+        (a non-atomic writer mid-write) is swallowed and the loop retries on the
+        next tick. The boss scripts write atomically via ``os.replace`` so a
+        complete, valid file is the steady state; this loop simply never lets a
+        read error escape and orphan the in-flight request.
+        """
+        while True:
+            decision = self._try_read_decision(decision_path)
+            if decision is not None:
+                return decision
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+    @staticmethod
+    def _try_read_decision(decision_path: str) -> dict[str, Any] | None:
+        """Read+parse a decision file, or None if not yet readable/valid."""
+        try:
+            with open(decision_path, encoding="utf-8") as handle:
+                return json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def _append_sticky_rule(
+        self,
+        verdict: str,
+        tool_name: str,
+        decision: dict[str, Any],
+    ) -> None:
+        """Append a sticky rule to this helper's policy file."""
+        policy_path = policy_path_for(self._nick)
+        try:
+            with open(policy_path, encoding="utf-8") as handle:
+                policy = yaml.safe_load(handle) or {}
+        except OSError:
+            policy = {}
+        if not isinstance(policy, dict):
+            policy = {}
+
+        section = "auto_allow" if verdict == "allow" else "auto_deny"
+        rules = policy.setdefault(section, []) or []
+        if not isinstance(rules, list):
+            rules = []
+        # Decision may carry an override pattern in ``decision["pattern"]``;
+        # otherwise the rule is an exact-tool-name match.
+        rule: dict[str, Any] = {"tool": decision.get("pattern") or tool_name}
+        # Avoid duplicating an identical rule.
+        if rule not in rules:
+            rules.append(rule)
+        policy[section] = rules
+        _atomic_write_yaml(policy_path, policy)
+
+    @staticmethod
+    def _best_effort_unlink(path: str) -> None:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _safe_jsonable(value: Any) -> Any:
+    """Convert arbitrary tool input into a JSON-serialisable shape."""
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        if isinstance(value, dict):
+            return {str(k): _safe_jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_safe_jsonable(v) for v in value]
+        return repr(value)

--- a/culture/clients/acp/daemon.py
+++ b/culture/clients/acp/daemon.py
@@ -18,6 +18,8 @@ import time
 from collections import deque
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._daemon_log import DaemonLog
 from culture.clients.acp.agent_runner import ACPAgentRunner
 from culture.clients.acp.config import AgentConfig, DaemonConfig
 from culture.clients.acp.ipc import make_response
@@ -74,6 +76,8 @@ class ACPDaemon:
         self._supervisor: Supervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -231,6 +235,7 @@ class ACPDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -409,6 +414,9 @@ class ACPDaemon:
             self.agent.nick,
             " ".join(self.agent.acp_command),
         )
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -538,6 +546,8 @@ class ACPDaemon:
         self._consecutive_turn_failures = 0
         await self._relay_response_to_irc(msg)
 
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
@@ -598,6 +608,7 @@ class ACPDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -940,6 +951,7 @@ class ACPDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, AsyncIterable, Awaitable, Callable
 
 from claude_agent_sdk import (
     AssistantMessage,
@@ -17,12 +17,25 @@ from claude_agent_sdk import (
 )
 from opentelemetry import trace as _otel_trace
 
+from culture.clients._perm_broker import PermissionBroker, has_policy_file
 from culture.clients.claude.telemetry import _HARNESS_TRACER_NAME, record_llm_call
 
 if TYPE_CHECKING:
     from culture.clients.claude.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
+
+
+async def _single_user_message_stream(text: str) -> AsyncIterable[dict[str, Any]]:
+    """Yield one user message in the SDK's streaming-mode shape.
+
+    Required by the Claude Agent SDK whenever ``can_use_tool`` is set
+    (client.py raises ``ValueError`` if ``prompt`` is a plain string).
+    """
+    yield {
+        "type": "user",
+        "message": {"role": "user", "content": text},
+    }
 
 
 def _content_block_to_dict(block: Any) -> dict[str, Any]:
@@ -68,6 +81,7 @@ class AgentRunner:
         system_prompt: str = "",
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        on_usage: Callable[[int | None], Awaitable[None]] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
     ) -> None:
@@ -76,6 +90,7 @@ class AgentRunner:
         self.system_prompt = system_prompt
         self.on_exit = on_exit
         self.on_message = on_message
+        self.on_usage = on_usage
         self._metrics = metrics
         self._nick = nick
 
@@ -83,6 +98,16 @@ class AgentRunner:
         self._task: asyncio.Task | None = None
         self._stopping = False
         self._prompt_queue: asyncio.Queue[str] = asyncio.Queue()
+
+        # Permission broker — wired only when a perm-policy/<nick>.yaml exists.
+        # Standalone mesh agents (no policy file) keep today's bypassPermissions
+        # semantics: can_use_tool=None and string-prompt path preserved.
+        if nick and has_policy_file(nick):
+            self._broker: PermissionBroker | None = PermissionBroker(nick=nick)
+            self._can_use_tool = self._broker.gate
+        else:
+            self._broker = None
+            self._can_use_tool = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -134,7 +159,14 @@ class AgentRunner:
             model=self.model,
             cwd=self.directory,
             permission_mode="bypassPermissions",
-            setting_sources=["project"],
+            # Inherit user-level skills, MCP servers, plugins from
+            # ~/.claude/ when present.  Project + local still apply.
+            setting_sources=["user", "project", "local"],
+            # Conditional: only set when this helper has a perm-policy file.
+            # Setting it unconditionally would hang non-supervised agents
+            # (no boss watching the queue) forever on first non-auto-allow
+            # tool call.
+            can_use_tool=self._can_use_tool,
         )
         if self.system_prompt:
             opts.system_prompt = self.system_prompt
@@ -161,6 +193,15 @@ class AgentRunner:
         outcome = "success"
         usage_dict: dict | None = None
         failed = False
+        # The SDK requires AsyncIterable prompts whenever can_use_tool is
+        # set (client.py:54-60 enforces this).  Wrap the queued string into
+        # a one-shot async iterable in that branch; otherwise preserve the
+        # legacy string-prompt path for standalone agents.
+        prompt_arg: str | AsyncIterable[dict[str, Any]]
+        if self._can_use_tool is None:
+            prompt_arg = prompt
+        else:
+            prompt_arg = _single_user_message_stream(prompt)
         with tracer.start_as_current_span(
             "harness.llm.call",
             attributes={
@@ -171,7 +212,7 @@ class AgentRunner:
         ):
             try:
                 async for message in query(
-                    prompt=prompt,
+                    prompt=prompt_arg,
                     options=self._make_options(),
                 ):
                     if isinstance(message, ResultMessage):
@@ -199,6 +240,10 @@ class AgentRunner:
                 duration_ms=duration_ms,
                 outcome=outcome,
             )
+        # Feed per-turn input-token usage to the context watcher (daemon-side).
+        if not failed and self.on_usage is not None:
+            tokens_input = usage_dict.get("tokens_input") if usage_dict else None
+            await self.on_usage(tokens_input)
         if failed:
             return False
         return True

--- a/culture/clients/claude/config.py
+++ b/culture/clients/claude/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 
 import yaml
@@ -51,6 +51,21 @@ class WebhookConfig:
 
 
 @dataclass
+class ContextWatchConfig:
+    """Context-watermark handoff settings.
+
+    When enabled, the daemon monitors per-turn input-token usage; at
+    ``high_water`` it asks the agent to write a handoff for its post-compact
+    self, compacts, then reminds it to read the handoff. ``low_water`` is the
+    fraction below which the handoff latch resets for the next fill cycle.
+    """
+
+    enabled: bool = True
+    high_water: float = 0.90
+    low_water: float = 0.50
+
+
+@dataclass
 class AgentConfig:
     """Per-agent settings."""
 
@@ -66,6 +81,7 @@ class AgentConfig:
     archived: bool = False
     archived_at: str = ""
     archived_reason: str = ""
+    context_watch: ContextWatchConfig = field(default_factory=ContextWatchConfig)
 
 
 @dataclass
@@ -122,11 +138,18 @@ def load_config(path: str | Path) -> DaemonConfig:
     telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
-    known_agent_fields = {f.name for f in AgentConfig.__dataclass_fields__.values()}
+    known_agent_fields = {f.name for f in fields(AgentConfig)}
     for agent_raw in raw.get("agents", []):
         # Strip unknown fields (e.g. acp_command from ACP backend configs)
         # so multi-backend configs don't crash on load.
         filtered = {k: v for k, v in agent_raw.items() if k in known_agent_fields}
+        # Coerce the nested context_watch mapping into its dataclass.
+        cw = filtered.get("context_watch")
+        if isinstance(cw, dict):
+            known_cw = {f.name for f in fields(ContextWatchConfig)}
+            filtered["context_watch"] = ContextWatchConfig(
+                **{k: v for k, v in cw.items() if k in known_cw}
+            )
         agents.append(AgentConfig(**filtered))
 
     return DaemonConfig(

--- a/culture/clients/claude/culture.yaml
+++ b/culture/clients/claude/culture.yaml
@@ -13,6 +13,15 @@ tags:
   - harness
   - claude
 
+# Context-watermark handoff (Claude backend only).
+# When the daemon detects the agent is approaching its context window, it asks
+# the agent to write a handoff for its post-compact self, compacts, then reminds
+# it to read the handoff. See docs/agentirc/helper-context-handoff.md.
+context_watch:
+  enabled: true       # master switch
+  high_water: 0.90    # fraction of the context window that triggers a handoff
+  low_water: 0.50     # fraction below which the handoff latch resets
+
 # OpenTelemetry configuration for the agent harness.
 # Set enabled: true once your OTLP collector is running.
 # See docs/agentirc/harness-telemetry.md for a setup guide.

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -8,6 +8,19 @@ import re
 import time
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._context_watch import (
+    ContextWatchState,
+    WatchAction,
+)
+from culture.clients._context_watch import evaluate as context_evaluate
+from culture.clients._context_watch import fraction as context_fraction
+from culture.clients._context_watch import (
+    mark_reminder_pending,
+    take_reminder,
+)
+from culture.clients._daemon_log import DaemonLog
+from culture.clients._perm_broker import handoff_path_for
 from culture.clients.claude.agent_runner import AgentRunner
 from culture.clients.claude.config import AgentConfig, DaemonConfig
 from culture.clients.claude.ipc import make_response
@@ -63,6 +76,16 @@ class AgentDaemon:
         self._supervisor: Supervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
+
+        # Context-watermark handoff state (Claude exposes per-turn input_tokens).
+        cw = agent.context_watch
+        self._context_watch = ContextWatchState(
+            high_water=cw.high_water,
+            low_water=cw.low_water,
+            enabled=cw.enabled,
+        )
 
         # Crash-recovery state
         self._crash_times: list[float] = []
@@ -195,6 +218,7 @@ class AgentDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -301,6 +325,7 @@ class AgentDaemon:
             f"{lines}\n\n"
             "Respond naturally if any messages need your attention."
         )
+        prompt = self._maybe_prepend_reminder(prompt)
         task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
@@ -329,11 +354,15 @@ class AgentDaemon:
             system_prompt=self._build_system_prompt(),
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
+            on_usage=self._on_agent_usage,
             metrics=self._metrics,
             nick=self.agent.nick,
         )
         await self._agent_runner.start()
         logger.info("AgentRunner started via SDK for %s", self.agent.nick)
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -349,6 +378,7 @@ class AgentDaemon:
             prompt = self._build_channel_prompt(target, sender, text)
         else:
             prompt = self._build_dm_prompt(sender, text)
+        prompt = self._maybe_prepend_reminder(prompt)
         task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
@@ -425,10 +455,58 @@ class AgentDaemon:
 
     async def _on_agent_message(self, msg: dict) -> None:
         """Feed agent activity to the supervisor for observation."""
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
         self._capture_agent_status(msg)
+
+    async def _on_agent_usage(self, input_tokens: int | None) -> None:
+        """Evaluate context utilization after a turn; drive the handoff cycle."""
+        action = context_evaluate(self._context_watch, input_tokens, self.agent.model)
+        if action is WatchAction.REMINDER_DUE:
+            # Context actually dropped after the compact — arm the reminder now,
+            # so an activation that interleaved with the handoff/compact turns
+            # can't consume it early.
+            mark_reminder_pending(self._context_watch)
+            await self._daemon_log.record("handoff_reminder_armed")
+            return
+        if action is not WatchAction.WRITE_HANDOFF:
+            return
+        if self._agent_runner is None or not self._agent_runner.is_running():
+            return
+        pct = context_fraction(input_tokens, self.agent.model) or 0.0
+        handoff_path = handoff_path_for(self.agent.nick)
+        logger.info(
+            "Context watermark reached for %s (%.0f%%) — requesting handoff",
+            self.agent.nick,
+            pct * 100,
+        )
+        await self._daemon_log.record("handoff_written", pct=round(pct, 3), path=handoff_path)
+        handoff_prompt = (
+            "[context-handoff] You are approaching your context limit "
+            f"({pct * 100:.0f}% full). Before it fills, write a concise handoff "
+            f"for your post-compact self to {handoff_path}. Include: what you are "
+            "working on, key decisions made, what remains, and important file "
+            "paths. Use your Write tool (this path is pre-approved). Then stop."
+        )
+        await self._agent_runner.send_prompt(handoff_prompt)
+        # Compact runs as the next queued turn, after the handoff is written.
+        await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="context_watermark", pct=round(pct, 3))
+
+    def _maybe_prepend_reminder(self, prompt: str) -> str:
+        """Prepend a post-compact handoff reminder when one is owed."""
+        if take_reminder(self._context_watch):
+            handoff_path = handoff_path_for(self.agent.nick)
+            reminder = (
+                "[context-handoff] You recently compacted. Read your handoff at "
+                f"{handoff_path} before continuing.\n\n"
+            )
+            self._log_action_bg("handoff_reminder", path=handoff_path)
+            return reminder + prompt
+        return prompt
 
     def _build_system_prompt(self) -> str:
         if self.agent.system_prompt:
@@ -447,6 +525,7 @@ class AgentDaemon:
         logger.warning("Agent %s crashed with exit code %d", self.agent.nick, exit_code)
         self._crash_times = [t for t in self._crash_times if now - t < CRASH_WINDOW_SECONDS]
         self._crash_times.append(now)
+        await self._daemon_log.record("crash", exit_code=exit_code, count=len(self._crash_times))
         if self._webhook:
             await self._webhook.fire(
                 AlertEvent(
@@ -468,6 +547,11 @@ class AgentDaemon:
                 self.agent.nick,
                 len(self._crash_times),
                 CRASH_WINDOW_SECONDS,
+            )
+            await self._daemon_log.record(
+                "circuit_open",
+                count=len(self._crash_times),
+                window_s=CRASH_WINDOW_SECONDS,
             )
             if self._webhook:
                 await self._webhook.fire(
@@ -501,6 +585,7 @@ class AgentDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -575,16 +660,24 @@ class AgentDaemon:
     # IPC sub-handlers
     # ------------------------------------------------------------------
 
+    def _log_action_bg(self, action: str, **detail) -> None:
+        """Fire-and-forget a daemon-log record from a synchronous context."""
+        task = asyncio.create_task(self._daemon_log.record(action, **detail))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
     def _ipc_pause(self, req_id: str, msg: dict) -> dict:
         self._paused = True
         self._manually_paused = True
         logger.info("Agent %s paused (manual)", self.agent.nick)
+        self._log_action_bg("pause", manual=True)
         return make_response(req_id, ok=True)
 
     def _ipc_resume(self, req_id: str, msg: dict) -> dict:
         self._paused = False
         self._manually_paused = False
         logger.info("Agent %s resumed", self.agent.nick)
+        self._log_action_bg("resume", manual=True)
         # NOTE: Catch-up on missed messages is not yet implemented.
         # IRCTransport does not process HISTORY responses into the buffer.
         # The agent resumes and will see new messages going forward.
@@ -832,12 +925,14 @@ class AgentDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/clear")
+        await self._daemon_log.record("clear")
         return make_response(req_id, ok=True)
 
     def _ipc_shutdown(self, req_id: str, msg: dict) -> dict:

--- a/culture/clients/codex/daemon.py
+++ b/culture/clients/codex/daemon.py
@@ -15,6 +15,8 @@ import time
 from collections import deque
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._daemon_log import DaemonLog
 from culture.clients.codex.agent_runner import CodexAgentRunner
 from culture.clients.codex.config import AgentConfig, DaemonConfig
 from culture.clients.codex.ipc import make_response
@@ -78,6 +80,8 @@ class CodexDaemon:
         self._supervisor: CodexSupervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -213,6 +217,7 @@ class CodexDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -384,6 +389,9 @@ class CodexDaemon:
         )
         await self._agent_runner.start()
         logger.info("CodexAgentRunner started for %s", self.agent.nick)
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -531,6 +539,8 @@ class CodexDaemon:
         self._consecutive_turn_failures = 0
         await self._relay_response_to_irc(msg)
 
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
@@ -595,6 +605,7 @@ class CodexDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -929,6 +940,7 @@ class CodexDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:

--- a/culture/clients/copilot/daemon.py
+++ b/culture/clients/copilot/daemon.py
@@ -15,6 +15,8 @@ import time
 from collections import deque
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._daemon_log import DaemonLog
 from culture.clients.copilot.agent_runner import CopilotAgentRunner
 from culture.clients.copilot.config import AgentConfig, DaemonConfig
 from culture.clients.copilot.ipc import make_response
@@ -71,6 +73,8 @@ class CopilotDaemon:
         self._supervisor: CopilotSupervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -206,6 +210,7 @@ class CopilotDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -384,6 +389,9 @@ class CopilotDaemon:
         )
         await self._agent_runner.start()
         logger.info("CopilotAgentRunner started for %s", self.agent.nick)
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -513,6 +521,8 @@ class CopilotDaemon:
         self._consecutive_turn_failures = 0
         await self._relay_response_to_irc(msg)
 
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
@@ -573,6 +583,7 @@ class CopilotDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -907,6 +918,7 @@ class CopilotDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:

--- a/docs/agentirc/helper-context-handoff.md
+++ b/docs/agentirc/helper-context-handoff.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Helper Context Handoff
+parent: AgentIRC
+nav_order: 95
+---
+
+# Helper Context Handoff
+
+A long-running agent fills its context window. Before it does, the daemon asks the
+agent to write a handoff for its post-compact self, triggers a compact, then
+reminds it to read that handoff on its next activation — so working state
+survives the compaction.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## How it works
+
+The daemon self-monitors context utilization (it is reliable and can't miss the
+threshold the way an async boss poll could). After each turn it reads the SDK's
+`ResultMessage.usage.input_tokens`, which under session resume reflects the full
+context sent to the model — a direct proxy for context-window occupancy:
+
+```text
+pct = input_tokens / context_window_tokens
+```
+
+At `pct >= high_water` (default 0.90) the daemon, once per fill cycle:
+
+1. Records a `handoff_written` daemon action.
+2. Sends the agent a prompt asking it to write a concise handoff to
+   `CULTURE_HOME/handoff/<nick>.md` (what it's doing, key decisions, what
+   remains, important paths).
+3. Queues `/compact` as the next turn.
+4. Records a `compact` daemon action with `trigger: context_watermark`.
+5. On the next activation, prepends a reminder to read the handoff, and records a
+   `handoff_reminder` action.
+
+The handoff write is pre-approved in the helper's permission policy (an
+`auto_allow` rule for `Write` to `handoff/<nick>.md`), so a context-crisis
+handoff never stalls waiting for boss approval. All other writes still route to
+the boss.
+
+The handoff latch resets once usage drops below `low_water` (default 0.50, e.g.
+after the compact), arming the next cycle.
+
+## Context windows
+
+| Model family | Window |
+|---|---|
+| `claude-opus-4-*` with a `1m` / `[1m]` marker | 1,000,000 |
+| other `claude-opus-4-*`, `claude-sonnet-4-*`, `claude-haiku-4-*` | 200,000 |
+| unknown | 200,000 (conservative default, logged) |
+
+## Configuration
+
+Optional, per-agent in `culture.yaml`:
+
+```yaml
+context_watch:
+  enabled: true     # default true
+  high_water: 0.90  # fraction of the window that triggers a handoff
+  low_water: 0.50   # fraction below which the latch resets
+```
+
+Omit the block for defaults. This is additive — existing `culture.yaml` files
+need no change.
+
+## Visibility
+
+```bash
+context-status.sh            # last-known context % per helper
+context-status.sh <name>     # one helper
+daemon-log.sh <name>         # full action log incl. handoff_written / compact / handoff_reminder
+```
+
+## Backend support
+
+Context-watch is **Claude-only**. Codex and Copilot do not expose per-turn token
+counts on their responses (Copilot: issue #299), so the watermark cannot be
+computed there. On those backends the [daemon-action log](helper-daemon-log.md)
+still records compactions when they happen via the IPC `compact` path.

--- a/docs/agentirc/helper-daemon-log.md
+++ b/docs/agentirc/helper-daemon-log.md
@@ -1,0 +1,97 @@
+---
+layout: default
+title: Helper Daemon Action Log
+parent: AgentIRC
+nav_order: 96
+---
+
+# Helper Daemon Action Log
+
+The daemon-action log is a structured, control-plane record of what each agent
+daemon *does* to manage its agent — distinct from the agent-message audit log,
+which records what the agent *says* and which tools it calls.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## File layout
+
+One JSONL line per action at `CULTURE_HOME/daemon-log/<nick>.jsonl` (default
+`~/.culture/daemon-log/<nick>.jsonl`). Universal across all four backends. Each
+line:
+
+```json
+{"ts": "2026-05-28T14:32:17.123Z", "nick": "local-research", "action": "compact", "detail": {"trigger": "context_watermark", "pct": 0.91}}
+```
+
+## Action vocabulary
+
+| action | when | detail |
+|---|---|---|
+| `agent_start` | the daemon starts the runner | `model`, `directory` |
+| `agent_stop` | graceful stop | — |
+| `agent_exit` | runner exits (incl. crash) | `exit_code` |
+| `crash` | crash recorded in the sliding window | `exit_code`, `count` |
+| `circuit_open` | circuit breaker trips | `count`, `window_s` |
+| `pause` / `resume` | pause state changes | `manual` |
+| `compact` | compact triggered | `trigger` (`ipc` or `context_watermark`), `pct?` |
+| `clear` | context cleared | — |
+| `handoff_written` | context-watermark handoff prompt sent | `pct`, `path` |
+| `handoff_reminder` | post-compact reminder injected | `path` |
+
+> Across backends, the universal actions are `agent_start`, `agent_stop`,
+> `agent_exit`, and `compact`. The remaining actions (crash, circuit_open,
+> pause, resume, clear, handoff_*) are emitted by the Claude daemon; other
+> backends emit the universal subset.
+
+## Relationship to Python logging
+
+The daemon keeps its existing `logger.info/warning` calls for the systemd
+journal. The action log is the structured, boss-readable complement — not a
+replacement. Where both fire for one event, that's intentional: one for ops, one
+for the boss.
+
+## Boss workflow
+
+```bash
+daemon-log.sh <name> [limit]   # tail + pretty-print (default limit 30)
+```
+
+`status.sh` also prints the most recent action per supervised helper.
+
+## Writing semantics
+
+Lines are appended with `O_APPEND` and fsynced per line; concurrent writes on one
+agent serialize through an in-process lock so each line stays intact. The log
+grows without bound — rotation is out of scope and left to the operator.
+
+## Related: the agent-message audit log
+
+The daemon-action log is the *control-plane* record. Its companion is the
+*agent-message audit log* at `CULTURE_HOME/audit/<nick>.jsonl` — one line per
+`AssistantMessage` the agent emits, on every backend. Where the daemon-action
+log says "the daemon compacted the agent", the audit log says "the agent said X
+and called tool Y". Schema:
+
+```json
+{
+  "ts": "2026-05-28T14:32:17.123Z",
+  "nick": "local-research",
+  "type": "assistant",
+  "model": "claude-opus-4-7",
+  "text": "I'll search for PR #123 …",
+  "tool_uses": [{"name": "Bash", "input_digest": "sha256:…"}],
+  "tool_results": [{"name": "Bash", "content_digest": "sha256:…", "preview": "first 200 chars"}]
+}
+```
+
+Tool inputs and results are stored as 16-hex SHA-256 digests plus a 200-char
+preview to keep the log compact; the digest lets you correlate an audit entry
+with the full input captured in a `perm-queue/<id>.json` request (see
+[Helper Permission Broker](helper-permissions.md)). Read it the same way:
+
+```bash
+tail -f ~/.culture/audit/local-research.jsonl | jq .
+```
+
+This is distinct from the **server-level** audit log documented in
+[Audit](audit.md), which records IRC protocol events across the whole server.

--- a/docs/agentirc/helper-permissions.md
+++ b/docs/agentirc/helper-permissions.md
@@ -1,0 +1,139 @@
+---
+layout: default
+title: Helper Permission Broker
+parent: AgentIRC
+nav_order: 93
+---
+
+# Helper Permission Broker
+
+The permission broker lets a regular Claude Code session (the **boss**) act as the
+human-in-the-loop authority for tool calls made by helper agents it spawns on a
+local Culture mesh. Helpers run headless (no terminal), so the boss approves or
+denies their tool use over a file-backed queue instead of a terminal prompt.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## Why a broker
+
+Helper daemons run the Claude Agent SDK in `bypassPermissions` mode — the only
+mode that doesn't block on a terminal prompt nobody is reading. That mode turns
+off the *UI* prompt path, not the programmatic `can_use_tool` callback. The
+broker is that callback: it decides allow/deny per tool call, consulting a
+per-helper policy file and, when no rule matches, the boss.
+
+## File layout
+
+All under `CULTURE_HOME` (default `~/.culture`):
+
+| Path | Purpose |
+|---|---|
+| `perm-policy/<nick>.yaml` | Per-helper auto-allow / auto-deny rules. Its presence is what makes a helper *boss-supervised*. |
+| `perm-queue/<id>.json` | A pending request the helper wrote and is blocking on. |
+| `perm-decisions/<id>.json` | The boss's verdict; the helper consumes it and unblocks. |
+
+`CULTURE_HOME` is honored by both the broker (Python) and the boss scripts. Set
+it consistently if you override it.
+
+## Policy file
+
+`spawn-helper.sh` seeds a default policy with safe-read auto-allows:
+
+```yaml
+auto_allow:
+  - tool: Read
+  - tool: Glob
+  - tool: Grep
+  - tool: Bash
+    input_regex: '^(ls|cat|head|tail|wc|file|stat|pwd|which|rg|grep|find|tree|git (status|log|diff|blame|show)|gh (.* )?(list|view))(\s|$)'
+  - tool: Write
+    input_regex: '/handoff/<nick>\.md$'   # context-handoff write, see helper-context-handoff
+auto_deny: []
+require_approval:
+  - tool: Edit
+  - tool: Write
+  - tool: 'mcp__.*'
+  - tool: Bash
+```
+
+Matching: `auto_deny` is checked before `auto_allow`; first match wins. A tool
+pattern containing regex metacharacters is matched as a regex (`re.fullmatch`),
+otherwise by exact string. `input_regex` (optional) is `re.search` against a
+per-tool projection — `Bash`→command, `Edit`/`Write`→file_path, `mcp__*`→JSON
+of the input. Anything not matched falls through to the boss.
+
+The policy is re-read on every gate call (mtime-checked), so `approve.sh … always`
+takes effect immediately, including after a session resume.
+
+## Lifecycle
+
+1. The SDK fires `can_use_tool(tool, input, ctx)` before a tool runs.
+2. The broker matches the policy. `allow`/`deny` return immediately — no round trip.
+3. Otherwise it writes `perm-queue/<id>.json` and blocks on `perm-decisions/<id>.json`,
+   polling every 250 ms. **There is no timeout** — the helper waits indefinitely.
+4. When the boss writes a decision, the helper reads it, deletes both files, and
+   returns allow/deny to the SDK. `scope: always` first appends a sticky rule to
+   the policy file.
+5. If the helper task is cancelled mid-wait (e.g. `close-helper.sh`), the broker
+   deletes its in-flight request file and re-raises the cancellation.
+
+## Boss workflow
+
+```bash
+pending-perms.sh                 # list all pending requests across helpers
+pending-perms.sh --full <id>     # full request JSON for one id
+approve.sh <id>                  # one-shot allow
+approve.sh <id> always           # sticky allow for this exact tool name
+approve.sh <id> always 'Bash'    # sticky allow for a tool pattern
+deny.sh <id> [reason...]         # deny; reason returned to the model
+watch-perms.sh                   # live tail of new requests (side terminal)
+policy.sh list <name>            # inspect a helper's policy
+policy.sh allow|deny <name> <tool> [input_regex]
+policy.sh reset <name>           # reseed default policy
+cleanup-stale-perms.sh           # GC requests whose helper is gone + orphan decisions
+```
+
+`status.sh` and `read-replies.sh` surface a `[N pending perms]` count so the boss
+notices requests during its normal flow.
+
+## Atomicity and races
+
+- Decision and request files are written via tempfile + `os.replace` — readers
+  never see a partial file.
+- `approve.sh`/`deny.sh` use `O_CREAT | O_EXCL` on the destination so two
+  concurrent boss invocations can't both decide one request (first writer wins).
+- A decision written after the helper already consumed its verdict becomes an
+  orphan; `cleanup-stale-perms.sh` garbage-collects orphans and requests whose
+  helper daemon is no longer running.
+
+> **Known limitation:** `os.replace` is atomic on local POSIX filesystems
+> (macOS/Linux) but not on NFS or some FUSE mounts. Keep `CULTURE_HOME` on a
+> local disk.
+
+## Backend support
+
+| Backend | Broker |
+|---|---|
+| Claude | **Full** — native `can_use_tool`. |
+| Copilot | Audit-only in this release (the Copilot SDK `PermissionHandler` signature could not be verified at build time). |
+| Codex | Audit-only — no per-tool callback in the app-server protocol. |
+| ACP | Audit-only — no per-tool callback in the ACP surface. |
+
+Audit-only backends still record every agent message to
+`audit/<nick>.jsonl` and every daemon action to `daemon-log/<nick>.jsonl`, so the
+boss retains visibility even where synchronous approval isn't possible.
+
+## Security model
+
+Same-machine, same-UID only. The broker directories are created `0700` with
+`0600` files. Anyone able to write to `perm-decisions/` as the user already has
+shell access to the user's home directory; the broker is a *boss-as-human*
+mechanism, not a sandbox.
+
+## Standalone agents
+
+An agent **without** a `perm-policy/<nick>.yaml` runs exactly as before this
+feature: `can_use_tool` is not set, no broker is involved, no approval is
+required. Only boss-spawned helpers (which get a seeded policy file) are
+supervised. Existing mesh agents are unaffected except that they now inherit the
+boss's user-level tool surface — see [Helper Tool Inheritance](helper-tool-inheritance.md).

--- a/docs/agentirc/helper-tool-inheritance.md
+++ b/docs/agentirc/helper-tool-inheritance.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Helper Tool Inheritance
+parent: AgentIRC
+nav_order: 94
+---
+
+# Helper Tool Inheritance
+
+Helper agents spawned by a boss session inherit the boss's full tool surface —
+the user-level skills, MCP servers, and plugins configured in `~/.claude/` — so a
+helper can reach for the same tools the boss can.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## What changed
+
+The Claude agent runner previously loaded only project-level settings:
+
+```python
+ClaudeAgentOptions(setting_sources=["project"])
+```
+
+It now loads all three layers:
+
+```python
+ClaudeAgentOptions(setting_sources=["user", "project", "local"])
+```
+
+The Claude CLI reads each layer's `settings.json` (and skills/plugins), so a
+helper now sees:
+
+- **`user`** — `~/.claude/settings.json` (your MCP servers), `~/.claude/skills/`,
+  `~/.claude/plugins/`.
+- **`project`** — the helper cwd's `.claude/` (project skills, project MCP).
+- **`local`** — machine-local overrides.
+
+## Scope: every Claude agent, not just helpers
+
+This widening applies to **all** Claude agents on the mesh, including
+standalone, long-running ones started with `cu agent start` (e.g.
+`spark-culture`). Those agents now have access to the user's MCP servers and
+skills.
+
+This is intentional — any agent on the mesh should be able to use the boss's
+tool surface. The difference between a *supervised helper* and a *standalone
+agent* is **not** the tool surface; it is whether a `perm-policy/<nick>.yaml`
+exists (see [Helper Permission Broker](helper-permissions.md)):
+
+- **Helper** (policy file present): inherits tools **and** routes dangerous tool
+  calls through the boss for approval.
+- **Standalone agent** (no policy file): inherits tools and runs autonomously
+  (`bypassPermissions`, as before), with the
+  [daemon-action log](helper-daemon-log.md) providing after-the-fact visibility.
+
+## Security note
+
+A helper inheriting `~/.claude/` gains every MCP server you have configured —
+including Gmail, Drive, Calendar, Atlassian, Cloudflare, etc. For a supervised
+helper, the broker gates these (all `mcp__*` tools require boss approval by
+default). For a standalone agent, there is no gate — so only run standalone
+agents you trust with your full tool surface, or give them a policy file to bring
+them under boss supervision.
+
+## Backend support
+
+| Backend | Inheritance |
+|---|---|
+| Claude | Full — `setting_sources=["user","project","local"]`. |
+| Copilot | Deferred — the Copilot SDK `skill_directories` wiring is planned but the SDK was not verifiable at build time. |
+| Codex | Not applicable — the app-server protocol exposes no user-skills/MCP surface from the harness. |
+| ACP | Not applicable — no skill/MCP inheritance hook in the ACP surface. |

--- a/docs/agentirc/index.md
+++ b/docs/agentirc/index.md
@@ -89,6 +89,17 @@ description: The runtime and protocol that powers Culture.
   </a>
 </div>
 
+## Boss Supervision
+
+A boss Claude Code session can spawn helper agents and supervise them: gating
+their tool calls, watching their context budget, and logging their daemon
+actions.
+
+- [Helper Permission Broker](helper-permissions.md) — boss-as-human approval for helper tool calls.
+- [Helper Tool Inheritance](helper-tool-inheritance.md) — helpers inherit the boss's skills + MCP servers.
+- [Helper Context Handoff](helper-context-handoff.md) — auto-handoff + compact at 90% context.
+- [Helper Daemon Action Log](helper-daemon-log.md) — structured control-plane log per agent.
+
 <div class="callout-relationship">
   <p><strong>Want to run it, not just read about it?</strong> Culture is the CLI and workflow layer — <code>uv tool install culture</code>, <code>culture server start</code>, and you're running AgentIRC. Add harnesses and workflows for the full experience. <a href="{{ '/quickstart/' | relative_url }}">Get started with Culture →</a></p>
 </div>

--- a/docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+++ b/docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
@@ -1,0 +1,878 @@
+---
+title: "Helper Boss Permission Broker"
+parent: "Design"
+nav_order: 24
+---
+
+# Helper Boss Permission Broker
+
+**Status:** Draft
+**Date:** 2026-05-28
+**Branch:** `feat/helper-boss-permission-broker`
+
+> **Scope note (rev 2):** This PR ships three related boss-supervision pillars,
+> aligned with the user during authoring:
+>
+> 1. **Permission broker** — boss-as-human approval for helper tool calls (the
+>    bulk of this spec).
+> 2. **Context-watermark handoff** — daemon self-monitors context usage; at 90%
+>    it asks the agent to write a handoff for its post-compact self, compacts,
+>    then reminds it to read the handoff. See
+>    [Context-watermark handoff](#context-watermark-handoff).
+> 3. **Daemon action log** — structured control-plane JSONL per agent, all
+>    backends. See [Daemon action log](#daemon-action-log).
+>
+> All three share the same `~/.culture/` file conventions, `CULTURE_HOME`
+> resolution, atomic-write discipline, and JSONL shapes.
+
+## Problem
+
+The `culture-boss` skill lets a regular Claude Code session ("boss") spawn helper Claude Code sessions on a local culture IRC mesh. Today, helpers run with:
+
+```python
+# culture/clients/claude/agent_runner.py:132-143
+opts = ClaudeAgentOptions(
+    model=self.model,
+    cwd=self.directory,
+    permission_mode="bypassPermissions",
+    setting_sources=["project"],
+)
+```
+
+Two consequences:
+
+1. **Helpers don't inherit the boss's tools.** `setting_sources=["project"]` reads only the helper's `cwd` `.claude/` directory. The boss's user-level MCP servers (Gmail, Drive, Atlassian, Cloudflare, Context7, Playwright), skills (`~/.claude/skills/`), and plugins are unavailable to helpers.
+2. **Helpers are silently autonomous.** `permission_mode="bypassPermissions"` means tool calls never prompt — and there is no other gating dial. A helper with a wider toolbox could autonomously send email, edit Drive files, or run arbitrary Bash, with the boss only seeing the IRC chatter after the fact.
+
+The user wants: *boss is the human-in-the-loop*. Helpers should inherit the boss's full tool surface, but every dangerous tool call should route through the boss for approval — same UX a human gets in standard Claude Code, transposed onto IRC.
+
+## Why `bypassPermissions` stays on
+
+`permission_mode` controls the **terminal UI prompts**. Helpers are headless daemon processes with no tty; the SDK's other modes (`default`, `acceptEdits`, `plan`) all expect a human reading stdin. `bypassPermissions` is the only mode that doesn't block on a prompt that nobody is reading.
+
+The actual safety lever is independent: `ClaudeAgentOptions.can_use_tool` (verified at `claude_agent_sdk/types.py:1075`). It's a programmatic callback fired **before every tool invocation**, returning `PermissionResultAllow` or `PermissionResultDeny`. It is honored even in `bypassPermissions` mode — that mode just turns off the *UI* prompt path, not the programmatic callback.
+
+The signature (`claude_agent_sdk/types.py:159-161`):
+
+```python
+CanUseTool = Callable[
+    [str, dict[str, Any], ToolPermissionContext],
+    Awaitable[PermissionResult]
+]
+```
+
+This is the SDK hook we use to make the boss the gatekeeper.
+
+### SDK consequence: `can_use_tool` forces streaming-mode prompts
+
+`claude_agent_sdk/_internal/client.py:54-60` enforces:
+
+```python
+if options.can_use_tool:
+    if isinstance(prompt, str):
+        raise ValueError(
+            "can_use_tool callback requires streaming mode. "
+            "Please provide prompt as an AsyncIterable instead of a string."
+        )
+```
+
+The current `AgentRunner` at `culture/clients/claude/agent_runner.py:173-176` calls `query(prompt=prompt, …)` with `prompt: str` from `_prompt_queue: asyncio.Queue[str]`. **Adding `can_use_tool` without converting the prompt to an `AsyncIterable[dict]` raises immediately on first turn.**
+
+The implementation must wrap each queued prompt at the `_process_turn` call site:
+
+```python
+async def _as_stream(text: str) -> AsyncIterable[dict[str, Any]]:
+    yield {"type": "user", "message": {"role": "user", "content": text}}
+
+async for message in query(
+    prompt=_as_stream(prompt),  # was: prompt=prompt
+    options=self._make_options(),
+):
+    ...
+```
+
+This change is required in Phase 2 alongside the callback wiring. No other call sites change — `_prompt_queue` stays `asyncio.Queue[str]`; only the SDK-call surface adapts.
+
+### SDK consequence: no timeout on the callback
+
+`claude_agent_sdk/_internal/query.py:258-262` calls `await self.can_use_tool(...)` with no timeout wrapper. The CLI subprocess does not impose its own deadline either. "Queue and wait indefinitely" is structurally supported by the SDK.
+
+### SDK consequence: deny without interrupt
+
+`claude_agent_sdk/types.py:154` defines `PermissionResultDeny.interrupt: bool = False`. The broker returns `interrupt=False` so a deny scopes to the single tool call (model receives the denial in its `tool_result` and decides what to do next) rather than aborting the entire turn. Spec mandates `interrupt=False` everywhere unless future work explicitly opts into hard abort.
+
+## Architecture overview
+
+```text
+┌──────────────────────┐                ┌─────────────────────┐
+│ Boss Claude Code     │                │ Helper daemon       │
+│ session (interactive)│                │ (culture-agent-*)   │
+│                      │                │                     │
+│ - pending-perms.sh   │   reads /      │ - AgentRunner       │
+│ - approve.sh         │   writes       │ - can_use_tool=     │
+│ - deny.sh            │ ◄────────────► │     broker.gate()   │
+│ - watch-perms.sh     │                │                     │
+└──────────────────────┘                └─────────────────────┘
+              │                                    │
+              │                                    │
+              ▼                                    ▼
+   ┌──────────────────────────────────────────────────┐
+   │  ~/.culture/                                     │
+   │   ├── perm-queue/<id>.json     (requests)        │
+   │   ├── perm-decisions/<id>.json (verdicts)        │
+   │   ├── perm-policy/<nick>.yaml  (auto-rules)      │
+   │   └── audit/<nick>.jsonl       (after-the-fact)  │
+   └──────────────────────────────────────────────────┘
+```
+
+Three concerns separated:
+
+| Concern | Mechanism | Files |
+|---|---|---|
+| **Tool inheritance** | Widen `setting_sources` (Claude); populate `skill_directories` (Copilot) | `culture/clients/claude/agent_runner.py`, `culture/clients/copilot/agent_runner.py` |
+| **Synchronous boss approval** | `can_use_tool` callback (Claude) / `PermissionHandler` (Copilot) wired to a file-backed broker | New `culture/clients/_perm_broker.py` |
+| **Post-hoc visibility** | Per-helper JSONL audit log of every AssistantMessage | All four `daemon.py` files, hooked in existing `_on_agent_message` |
+
+## File layouts
+
+All paths under `~/.culture/`. Directories are created on demand by `ensure-mesh.sh` and `spawn-helper.sh`.
+
+### `perm-queue/<id>.json` — helper request
+
+```json
+{
+  "id": "req-2026-05-28T14-32-17-abc12",
+  "helper_nick": "local-research",
+  "tool_name": "Bash",
+  "input": {"command": "gh pr create --title ...", "description": "..."},
+  "context": {
+    "task_channel": "#task-research",
+    "session_id": "uuid-from-sdk"
+  },
+  "created_at": "2026-05-28T14:32:17.123Z"
+}
+```
+
+- Filename = `<id>.json`. ID format: `req-<ISO8601 with dashes>-<5 hex chars>`. Sortable by creation order, unique under timer collision.
+- Written atomically via `tempfile + os.replace`. Helpers `os.fsync` before the rename so a kernel-level crash doesn't leave a partial file.
+- Persists until the matching decision file is consumed.
+
+### `perm-decisions/<id>.json` — boss verdict
+
+```json
+{
+  "id": "req-2026-05-28T14-32-17-abc12",
+  "verdict": "allow",
+  "scope": "once",
+  "reason": "ok",
+  "decided_by": "boss",
+  "decided_at": "2026-05-28T14:32:21.456Z"
+}
+```
+
+- `verdict`: `"allow" | "deny"`.
+- `scope`: `"once" | "always"`. If `"always"`, the decision is appended to `perm-policy/<helper_nick>.yaml` before the file is written.
+- `reason`: optional free text. Returned to the SDK's `PermissionResultDeny.message` on deny. Surfaces in the model's tool_result.
+- Written atomically via `tempfile + os.replace`. The helper watches for this file's appearance.
+
+### `perm-policy/<nick>.yaml` — per-helper sticky rules
+
+Seeded by `spawn-helper.sh` with safe-read defaults; mutated by `approve.sh ... always`.
+
+```yaml
+# auto_allow: rules matched before any IRC round-trip — return allow immediately
+auto_allow:
+  - tool: Read
+  - tool: Glob
+  - tool: Grep
+  - tool: Bash
+    input_regex: '^(ls|cat|head|tail|wc|file|stat|pwd|which|rg|grep|find|tree|git (status|log|diff|blame|show)|gh (.* )?(list|view))(\s|$)'
+
+# auto_deny: rules matched before any IRC round-trip — return deny immediately
+auto_deny: []
+
+# require_approval: explicitly route to boss (default fallthrough for anything
+# not matched above is also "require approval", so this section is informational
+# unless you want to surface specific tool classes explicitly)
+require_approval:
+  - tool: Edit
+  - tool: Write
+  - tool: 'mcp__.*'
+  - tool: Bash  # matches everything not in auto_allow's regex
+```
+
+Matching order: `auto_deny` → `auto_allow` → require approval (fallthrough). First match wins. `input_regex` is Python `re.search`-style; absence of `input_regex` means "any input matches".
+
+For MCP tools, `tool` is matched as a regex when it contains regex metacharacters; otherwise an exact string match.
+
+### Path resolution — `CULTURE_HOME`
+
+All four directories (`perm-queue/`, `perm-decisions/`, `perm-policy/`, `audit/`) are rooted under a single `CULTURE_HOME`. Every Python module that touches these paths uses a single helper:
+
+```python
+# culture/clients/_perm_broker.py
+def _culture_home() -> str:
+    return os.environ.get("CULTURE_HOME", os.path.expanduser("~/.culture"))
+```
+
+Every bash script uses the parallel:
+
+```bash
+CULTURE_HOME="${CULTURE_HOME:-$HOME/.culture}"
+```
+
+Tests override via `monkeypatch.setenv("CULTURE_HOME", str(tmp_path))`; the broker, scripts, and `spawn-helper.sh` all see the same root.
+
+**Caveat:** systemd/launchd-spawned agent daemons do not inherit the user's shell `CULTURE_HOME` unless the service file sets it. For v1, this is documented in `docs/agentirc/helper-permissions.md` as a known gotcha — agents started via the standard `cu agent start` flow inherit the shell environment, which is the common path.
+
+### `audit/<nick>.jsonl` — post-hoc activity log
+
+One line per AssistantMessage. Grows forever (rotation is non-goal; see "Non-goals"). Schema:
+
+```json
+{
+  "ts": "2026-05-28T14:32:17.123Z",
+  "nick": "local-research",
+  "type": "assistant",
+  "model": "claude-opus-4-7",
+  "text": "I'll search for PR #123 …",
+  "tool_uses": [
+    {"name": "Bash", "input_digest": "sha256:abc..."}
+  ],
+  "tool_results": [
+    {"name": "Bash", "content_digest": "sha256:def...", "preview": "first 200 chars"}
+  ]
+}
+```
+
+`input_digest`/`content_digest` lets the audit log stay compact while still letting the boss correlate to the in-flight `perm-queue/<id>.json` (which contains the full input).
+
+### `daemon-log/<nick>.jsonl` — control-plane action log
+
+One line per daemon action (see [Daemon action log](#daemon-action-log) for the vocabulary). Grows forever. Schema:
+
+```json
+{"ts": "2026-05-28T14:32:17.123Z", "nick": "local-research", "action": "compact", "detail": {"trigger": "context_watermark", "pct": 0.91}}
+```
+
+### `handoff/<nick>.md` — context-handoff document
+
+Plain markdown, overwritten each context-fill cycle. Written by the agent (via its `Write` tool, auto-allowed for this path) when the daemon detects the 90% watermark. Read by the agent after compact (daemon injects a reminder) and by the boss for visibility. See [Context-watermark handoff](#context-watermark-handoff).
+
+## Permission lifecycle
+
+```text
+┌─────────┐     ┌─────────────┐    ┌──────────────┐    ┌────────┐
+│ SDK     │ ──► │ broker.gate │──► │ policy match │──► │ allow  │
+│ tool    │     │ (callback)  │    │              │    │ (fast) │
+│ wants to│     └─────────────┘    └──────────────┘    └────────┘
+│ run     │                                │
+└─────────┘                                │ no match
+                                           ▼
+                              ┌──────────────────────┐
+                              │ write perm-queue/    │
+                              │ <id>.json            │
+                              │ (atomic rename)      │
+                              └──────────────────────┘
+                                           │
+                                           ▼
+                              ┌──────────────────────┐
+                              │ await decision file  │
+                              │ (poll + asyncio.sleep│
+                              │  or watchdog/inotify)│
+                              │ NO TIMEOUT           │
+                              └──────────────────────┘
+                                           │
+                                           ▼
+                              ┌──────────────────────┐
+                              │ read decision; if    │
+                              │ scope=always, append │
+                              │ to perm-policy yaml  │
+                              └──────────────────────┘
+                                           │
+                              ┌────────────┴────────────┐
+                              ▼                         ▼
+                  ┌──────────────────┐      ┌──────────────────┐
+                  │ PermissionResult │      │ PermissionResult │
+                  │ Allow            │      │ Deny(message=    │
+                  │                  │      │   reason)        │
+                  └──────────────────┘      └──────────────────┘
+```
+
+**Steps in detail:**
+
+1. SDK fires `can_use_tool(tool_name, input, context)`.
+2. Broker reads `perm-policy/<nick>.yaml` (cached, mtime-checked).
+3. If a rule matches: return `PermissionResultAllow` or `PermissionResultDeny` immediately. **No round-trip.**
+4. Otherwise: mint `id`, write request to `perm-queue/<id>.json` atomically.
+5. `await` decision file. Poll every 250ms with `os.path.exists`, then re-stat on appearance to handle the atomic-rename race. Indefinite — no timeout. (IRC summary post to `#perm-<name>` is **deferred to v1.1**: the broker module sits below the daemon's IRC transport and has no clean plumbing to it today; threading an `on_perm_request` callback from daemon → runner → broker is a follow-up. v1 boss UX is `pending-perms.sh`/`watch-perms.sh`.)
+6. Read decision JSON. If `scope == "always"`, append to policy YAML *before* returning, so subsequent matching calls auto-resolve.
+7. Delete `perm-queue/<id>.json` and `perm-decisions/<id>.json` after consuming (both files are single-use).
+8. Return `PermissionResultAllow(updated_input=None)` or `PermissionResultDeny(message=reason, interrupt=False)`.
+
+## Race conditions and atomicity
+
+| Scenario | Mitigation |
+|---|---|
+| Boss writes two decisions for one ID | `approve.sh`/`deny.sh` refuse to write if `perm-decisions/<id>.json` exists. Race-window: two concurrent boss invocations. Mitigated by `os.O_CREAT \| os.O_EXCL` open before the rename target. First-writer-wins; second exits non-zero. |
+| Helper dies waiting | Request file stays in `perm-queue/`. On next `spawn-helper.sh`, `--reattach` is non-goal; the orphan is shown by `pending-perms.sh` but cannot be resolved (no helper to unblock). `cleanup-stale-perms.sh` (new) garbage-collects requests whose helper is not running. |
+| Helper task cancelled by SDK / `close-helper.sh` mid-`await` | The broker's `gate()` wraps its poll loop in `try/finally` — on `asyncio.CancelledError` it deletes its in-flight `perm-queue/<id>.json` and re-raises the cancellation. Past asyncio incidents in this codebase (commit `d0902f9`, "fix: re-raise CancelledError and save create_task results") mandate explicit re-raise discipline; broker code follows the same rule. |
+| Boss decides but file write is partial | Atomic `tempfile + os.replace`. Readers only see the post-rename inode. Partial writes never become visible. |
+| Helper reads policy mid-update by `approve.sh always` | Policy YAML is also written via atomic `tempfile + os.replace`. Broker checks mtime before each request; stale cache is benign (one extra round-trip until next read). |
+| Multiple helpers on the same boss | Each helper has its own policy file (`<nick>.yaml`), audit log, and request IDs. No shared state besides directory layout. |
+| `perm-queue/` directory missing | Broker creates it (and `perm-decisions/`, `perm-policy/`, `audit/`) on first request with `os.makedirs(..., exist_ok=True)`. `ensure-mesh.sh` also pre-creates them. |
+
+**Concurrent file-watcher latency:** poll cadence of 250ms is an explicit trade-off — fast enough that human-typed approvals feel instant (boss-to-helper unblock under 500ms typical), slow enough that 4 helpers waiting don't burn measurable CPU. inotify (Linux) and FSEvents (macOS) are available via `watchdog` but add a dependency; deferred to follow-up if poll cadence proves too slow.
+
+## Policy matcher semantics
+
+Implemented in `culture/clients/_perm_broker.py` as a pure-Python matcher (no third-party dep beyond PyYAML, already in `pyproject.toml` for culture.yaml parsing).
+
+```python
+def match(tool_name: str, input_dict: dict, policy: dict) -> Literal["allow", "deny", None]:
+    for section, verdict in (("auto_deny", "deny"), ("auto_allow", "allow")):
+        for rule in policy.get(section, []) or []:
+            if _rule_matches(tool_name, input_dict, rule):
+                return verdict
+    return None  # caller routes to boss
+```
+
+`_rule_matches`:
+
+- `rule["tool"]` is a string. If it contains any of `.*+?[]^$|`, treat as `re.fullmatch`; else exact equality.
+- `rule["input_regex"]` (optional) is `re.search`-style against a tool-specific projection of `input_dict`:
+  - `Bash` → `input_dict["command"]` (string).
+  - `Edit` / `Write` → `input_dict["file_path"]` (string).
+  - `mcp__*` → `json.dumps(input_dict, sort_keys=True)` (string).
+  - Other tools → no input projection; rule with `input_regex` against them is a no-match.
+- All rule keys other than `tool` and `input_regex` are reserved (silently ignored to allow forward-compatible additions).
+
+Policy file is parsed once at broker init and re-loaded on `os.path.getmtime` change (checked at the start of every `gate()` call). Stale policy cache → one extra round-trip; not a correctness issue.
+
+## Backend matrix
+
+| Backend | Tool inheritance | Permission broker | Context-watch | Audit log | Daemon-action log |
+|---|---|---|---|---|---|
+| **Claude** | `setting_sources=["user","project","local"]` (`agent_runner.py`) | **Full** — native `can_use_tool` (SDK `types.py:1075`) | **Full** — `ResultMessage.usage.input_tokens` | Yes | Yes |
+| **Copilot** | `skill_directories` (deferred — SDK not verifiable in venv) | **Deferred → audit-only** this PR (Copilot SDK `PermissionHandler` signature not verifiable in the current venv; see Unverified Assumptions) | No — no token counts on responses (issue #299) | Yes | Yes |
+| **Codex** | No setting_sources surface in app-server JSON-RPC | **Audit-only** — no per-tool callback in protocol | No — no token counts | Yes | Yes |
+| **ACP** | No skill/MCP inheritance hook in ACP surface | **Audit-only** — no per-tool callback | No — no token counts | Yes | Yes |
+
+**All-backends rule honored via documentation**, per CLAUDE.md ("a feature that only exists in one backend is a bug" — addressed by the **audit log** and **daemon-action log** providing parity-of-visibility on every backend, even where parity-of-control or context-watch is technically impossible). The two universal pillars (audit log, daemon-action log) ship on all four backends; the two Claude-only pillars (synchronous broker approval, context-watermark) are gated by SDK capability and documented as such.
+
+`spawn-helper.sh` does **not** restrict backend choice. A boss spawning a non-Claude backend gets a warning printed to stderr ("audit-only mode: this helper will not request boss approval before tool calls and has no context-watch") but is allowed to proceed.
+
+## Boss-side script surface
+
+All under `~/.claude/skills/culture-boss/scripts/`. Existing scripts that grow new behavior are noted.
+
+| Script | Argv | Behavior |
+|---|---|---|
+| `pending-perms.sh` | (none) | Lists every `perm-queue/*.json`. Columns: `id`, `nick`, `tool`, `input-preview`, `age`. Empty list → exit 0 with no output. Exit 1 if `perm-queue/` is missing (mesh not bootstrapped). |
+| `approve.sh` | `<id> [always [<tool-pattern>]]` | Writes `perm-decisions/<id>.json` with `verdict=allow`, `scope` per argv. `always` without a pattern uses `tool: <tool_name>` (exact match); `always <pattern>` uses pattern as `tool` field. Fails if decision file already exists. **Atomic-write discipline:** the script writes to a temp path via `python3 -c "import os, json, tempfile; …"` using `O_CREAT \| O_EXCL` on the temp file, then `os.replace(tmp, dest)` for atomic install. The `O_CREAT \| O_EXCL` on the *destination* path is the first-writer-wins guard. |
+| `deny.sh` | `<id> [reason...]` | Writes `perm-decisions/<id>.json` with `verdict=deny`. Reason joined into `reason` field. Fails if decision file already exists. **Atomic-write discipline:** identical to `approve.sh` — temp file + `os.replace` + `O_CREAT \| O_EXCL` first-writer-wins. |
+| `watch-perms.sh` | (none) | `tail -F` style live view. Combines `inotifywait` (Linux) / `fswatch` (macOS) when available, else polls every 1s. Prints new requests with timestamp + helper nick + tool. |
+| `policy.sh` | `list <nick>` / `add <nick> <yaml-snippet>` / `remove <nick> <rule-index>` | Inspect/edit `perm-policy/<nick>.yaml`. Adds run through a YAML re-emit so formatting stays consistent. |
+| `cleanup-stale-perms.sh` | (none) | Walk `perm-queue/`; for each request whose `helper_nick` has no running daemon (check via `cu agent status`), delete the file. Idempotent. |
+| `daemon-log.sh` | `<name> [limit]` | Tail + pretty-print `daemon-log/local-<name>.jsonl`. Default limit 30. |
+| `context-status.sh` | `[name]` | Read-only context-watch visibility. Reports last-known context `pct` per helper (from the daemon-action log's most recent `compact`/`handoff_written` entries, or a dedicated `context` action emitted each turn). With a name, shows just that helper. |
+| `spawn-helper.sh` | `<name> [cwd]` (unchanged argv) | **Now also** seeds `perm-policy/<name>.yaml` with safe-read defaults + the handoff-write auto-allow rule. Creates `audit/`, `perm-queue/`, `perm-decisions/`, `perm-policy/`, `daemon-log/`, `handoff/` if missing. |
+| `status.sh` | (unchanged) | **Now also** prints `[N pending perms]` and the most recent daemon-action per helper. |
+| `read-replies.sh` | `<name> [limit]` (unchanged) | **Now also** prepends `[N pending perms]` summary line if any exist for that helper. |
+
+Per-script bash files target POSIX `bash`, follow the existing `_common.sh` sourcing pattern, and use `python -c` for atomic file writes (avoiding the need to add a write-fence dependency).
+
+## Helper-side wiring
+
+### Claude backend
+
+`culture/clients/claude/agent_runner.py:_make_options` becomes:
+
+```python
+def _make_options(self) -> ClaudeAgentOptions:
+    opts = ClaudeAgentOptions(
+        model=self.model,
+        cwd=self.directory,
+        permission_mode="bypassPermissions",
+        setting_sources=["user", "project", "local"],   # widen
+        can_use_tool=self._can_use_tool,                # conditional — see below
+    )
+    if self.system_prompt:
+        opts.system_prompt = self.system_prompt
+    if self._session_id:
+        opts.resume = self._session_id
+    return opts
+```
+
+**Critical: `_can_use_tool` is conditionally set.** Setting it unconditionally would route every Claude agent's tool calls through the broker, including standalone mesh agents (e.g. `spark-culture`, future agents started directly via `cu agent start`) where no boss is watching the queue — those agents would hang indefinitely on the first non-auto-allow tool call.
+
+`AgentRunner.__init__` decides at construction time whether to attach the callback:
+
+```python
+def __init__(self, ..., nick: str = "", ...) -> None:
+    ...
+    policy_path = os.path.expanduser(f"~/.culture/perm-policy/{nick}.yaml")
+    if nick and os.path.exists(policy_path):
+        self._broker = PermissionBroker(nick=nick)
+        self._can_use_tool = self._broker.gate  # bound method
+    else:
+        self._broker = None
+        self._can_use_tool = None  # SDK skips the streaming-mode check too
+```
+
+`spawn-helper.sh` seeds the policy file before starting the helper daemon, so helpers always get supervision. Standalone agents (no policy file) get `can_use_tool=None`, preserving pre-broker behavior identically.
+
+Also: the `query()` call at `_process_turn` is modified to use the streaming-prompt wrapper described in [SDK consequence: `can_use_tool` forces streaming-mode prompts](#sdk-consequence-can_use_tool-forces-streaming-mode-prompts) **only when** `_can_use_tool is not None`. When it's `None`, the existing string-prompt path is preserved (no SDK error, no unnecessary refactor of non-supervised agents).
+
+### Copilot backend
+
+`culture/clients/copilot/agent_runner.py:start` builds `session_kwargs` (line 87). Today:
+
+```python
+session_kwargs = {
+    "on_permission_request": PermissionHandler.approve_all,
+    "model": self.model,
+}
+```
+
+Becomes:
+
+```python
+policy_path = os.path.expanduser(f"~/.culture/perm-policy/{self._nick}.yaml")
+if self._nick and os.path.exists(policy_path):
+    broker = PermissionBroker(nick=self._nick)
+    handler = broker.copilot_handler()  # adapter
+else:
+    broker = None
+    handler = PermissionHandler.approve_all  # preserve current behavior
+
+session_kwargs = {
+    "on_permission_request": handler,
+    "model": self.model,
+}
+if user_skill_dirs := _discover_user_skill_dirs():
+    session_kwargs["skill_directories"] = user_skill_dirs + self.skill_directories
+```
+
+Same gate as Claude: standalone Copilot agents without a policy file keep `PermissionHandler.approve_all` and are unaffected. Boss-spawned helpers get the broker.
+
+`_discover_user_skill_dirs()` returns `[~/.claude/skills/]` if the directory exists, plus any subdirectory matching `*/skills/` under `~/.claude/plugins/` (mirrors the SDK's plugin layout).
+
+`broker.copilot_handler()` is an adapter that closes over the same `gate()` function but adapts the argv/return shape to the Copilot SDK's expected `PermissionHandler` callable.
+
+> **Unverified assumption (Copilot SDK):** the actual `PermissionHandler` callable signature is not visible in this venv (lazy import — `from copilot import CopilotClient, PermissionHandler, SubprocessConfig`). The exact adapter shape must be confirmed at implementation time against the `github-copilot-sdk` package version pinned in `pyproject.toml`. Fallback: if the SDK exposes only `approve_all`/`deny_all` static methods (no callable interface), Copilot reverts to **audit-only** mode (same as Codex/ACP) and the matrix entry is downgraded with a note in the docs page.
+
+### Codex + ACP backends
+
+No agent_runner changes. Daemon-level audit log only.
+
+### Audit log (all four backends)
+
+Each backend's `daemon._on_agent_message` grows one new call. Reference implementation lives in a new `culture/clients/_audit.py`:
+
+```python
+# culture/clients/_audit.py
+class AuditWriter:
+    def __init__(self, nick: str, *, root: str | None = None) -> None: ...
+    async def write(self, msg: dict) -> None: ...  # JSONL append, fsync at end
+```
+
+Per-backend `daemon.__init__` instantiates `self._audit = AuditWriter(self.agent.nick)`. Each `_on_agent_message` adds one line:
+
+```python
+async def _on_agent_message(self, msg: dict) -> None:
+    await self._audit.write(msg)              # new
+    # ... existing supervisor/relay/status code unchanged
+```
+
+Hook points already exist verbatim:
+
+- `culture/clients/claude/daemon.py:426`
+- `culture/clients/codex/daemon.py:529`
+- `culture/clients/copilot/daemon.py:511`
+- `culture/clients/acp/daemon.py:536`
+
+All four files get the same one-line addition. Per the "cite, don't import" rule for `packages/`, `_audit.py` is in `culture/clients/` (not `packages/`) because it's runtime-internal to the harnesses, not a backend template.
+
+## Migration and backward compatibility
+
+- **Helpers spawned before this change**: have no `perm-policy/<nick>.yaml`. **By design, the absence of a policy file means `can_use_tool=None` is set on the SDK call — the agent behaves exactly as it does today (`bypassPermissions` semantics, no broker involvement, no hang).** To bring an existing helper under boss supervision, re-run `spawn-helper.sh <name>` (idempotent — seeds the policy file if missing and restarts the daemon).
+- **Boss sessions running an older culture-boss skill**: the new scripts coexist with the old ones (no script is removed; only new scripts added and three existing scripts gain extra output lines). `status.sh`'s extra `[N pending perms]` line is additive and downstream `awk`/`grep` consumers in any other scripts would need to skip the new prefix — but no such consumers exist within this repo.
+- **Existing `bypassPermissions` agents that are not helpers** (e.g. long-running mesh agents started directly via `cu agent start`, such as `spark-culture`): no `can_use_tool` callback because there's no policy file. The change to `setting_sources=["user","project","local"]` *does* affect them — they now inherit the user's MCP servers and skills. This is intentional: any agent on the mesh can use the boss's tool surface. They run autonomously as before (no broker gate), with the new audit log providing post-hoc visibility. **Documented as an upgrade note in `docs/agentirc/helper-tool-inheritance.md`.**
+- **Config schema**: no breaking changes to `culture.yaml`. The broker reads only `perm-policy/<nick>.yaml`, a separate file written by tooling, not by the user.
+
+## Security threat model
+
+Same-machine, same-UID only. The broker's authority surface (`~/.culture/perm-decisions/`) is filesystem-protected by standard POSIX permissions (`0700` on the directory, `0600` on files — set explicitly by `ensure-mesh.sh` and the broker on creation). Anyone who can write to this directory as the user already has shell access to the user's home dir; the broker offers no protection against that case.
+
+Out of scope: multi-user systems, attacker-controlled supply chain on the helper itself (a malicious skill installed under `~/.claude/skills/` is trusted by the user's normal Claude Code session anyway). The broker is a *boss-as-human* mechanism, not a sandbox.
+
+In scope: race conditions between concurrent boss script invocations (covered by `O_CREAT|O_EXCL` first-writer-wins above), partial-write recovery (atomic rename), and orphaned requests from dead helpers (covered by `cleanup-stale-perms.sh`).
+
+## Context-watermark handoff
+
+**Problem.** A long-running helper accumulates context until the model's window is full. The SDK auto-compacts, but a naive compact loses the working state the agent built up — what it was doing, what it learned, what's left. The fix: just before the window fills, have the agent write a durable handoff for its post-compact self, then remind it to read that handoff after the compact.
+
+**Who monitors.** The **daemon** self-monitors (decided during authoring — reliable, can't blow past the limit between async boss polls). The boss gets read-only visibility via `context-status.sh`.
+
+**Signal.** The Claude SDK's `ResultMessage.usage` exposes per-turn `input_tokens`. Under session resume, each turn's `input_tokens` reflects the *full* context sent to the model (history + new prompt), so it is a direct proxy for current context-window occupancy. The daemon computes:
+
+```
+pct = last_input_tokens / context_window_tokens
+```
+
+`context_window_tokens` is resolved per-model (see table). At `pct >= 0.90` (configurable; default 0.90) the daemon enters the handoff flow **once** per fill cycle (a latch prevents re-firing every turn while still above threshold; it resets after a compact drops usage below a low-water mark of 0.5).
+
+| Model family | Context window |
+|---|---|
+| `claude-opus-4-*` (1M beta) | 1_000_000 |
+| `claude-opus-4-*`, `claude-sonnet-4-*` | 200_000 |
+| `claude-haiku-4-*` | 200_000 |
+| unknown | 200_000 (conservative default) |
+
+The window map lives in `culture/clients/_context_watch.py`; unknown models default to 200K and log a warning so the map can be extended.
+
+**Flow (daemon-side, after each turn's ResultMessage):**
+
+```text
+turn completes → ResultMessage.usage.input_tokens
+       │
+       ▼
+pct >= 0.90 AND not already latched?
+       │ yes
+       ▼
+1. send handoff prompt to the agent:
+   "You are approaching your context limit. Write a concise handoff to
+    <CULTURE_HOME>/handoff/<nick>.md for your post-compact self: what you're
+    doing, key decisions, what's left, important file paths. Then stop."
+       │  (wait for the turn to complete — agent writes the file via its
+       │   normal Write tool, which the broker auto-allows for the handoff
+       │   path; see policy note below)
+       ▼
+2. trigger compact (existing _ipc_compact path / runner.send_prompt("/compact"))
+       │
+       ▼
+3. set "reminder pending" latch
+       │
+       ▼
+next activation (mention/poll) → prepend to the prompt:
+   "[context-handoff] You recently compacted. Read your handoff at
+    <CULTURE_HOME>/handoff/<nick>.md before continuing."
+       │
+       ▼
+clear reminder latch
+```
+
+**Handoff file.** `~/.culture/handoff/<nick>.md` — plain markdown, overwritten each cycle (the latest handoff is the only relevant one). Not JSONL; it is meant to be read by the agent (and the boss) as prose.
+
+**Policy interaction.** For a *supervised* helper, the handoff `Write` must not block on boss approval (the agent is mid-context-crisis; a stalled approval defeats the purpose). The daemon seeds an `auto_allow` rule for `Write` to the handoff path into the helper's policy at spawn time:
+
+```yaml
+auto_allow:
+  - tool: Write
+    input_regex: '/handoff/<nick>\.md$'
+```
+
+(Added by `spawn-helper.sh` policy seed and by `_context_watch` defensively if absent.) All *other* `Write` calls still route to the boss.
+
+**Config.** New optional fields on the agent `culture.yaml`:
+
+```yaml
+context_watch:
+  enabled: true          # default true
+  high_water: 0.90       # fraction of context window that triggers handoff
+  low_water: 0.50        # fraction below which the latch resets
+```
+
+Absent config → defaults (`enabled: true`, `0.90`, `0.50`). This is additive; no breaking change to existing `culture.yaml` files.
+
+**Module.** `culture/clients/_context_watch.py` holds the pure logic:
+
+```python
+@dataclass
+class ContextWatchState:
+    high_water: float = 0.90
+    low_water: float = 0.50
+    handoff_latched: bool = False
+    reminder_pending: bool = False
+
+def context_window_for(model: str) -> int: ...
+def evaluate(state, input_tokens, model) -> WatchAction: ...
+#   WatchAction ∈ {NONE, WRITE_HANDOFF, REMINDER_DUE}
+```
+
+The daemon owns an instance per agent, feeds it each `ResultMessage`, and acts on the returned `WatchAction`. Pure-function `evaluate` is unit-tested without a live SDK.
+
+**Backend coverage.** Claude exposes per-turn `input_tokens` (`ResultMessage.usage`) — full support. Codex/Copilot do **not** expose token counts on their responses today (Copilot: documented at `copilot/agent_runner.py:210`, issue #299; Codex: same gap). For those backends the watermark cannot be computed, so context-watch is **Claude-only** in this PR; documented in the backend matrix. The daemon-action log still records compaction events on all backends when they occur via the existing `_ipc_compact` path.
+
+## Daemon action log
+
+**Problem.** The agent-message audit log captures what the *agent* says and which tools it calls. It does not capture what the *daemon* does to manage the agent — starts, stops, compactions, crashes, pause/resume, watermark-triggered handoffs. The boss wants a control-plane record.
+
+**Shape.** One JSONL line per daemon action at `~/.culture/daemon-log/<nick>.jsonl`. Universal across all four backends. Schema:
+
+```json
+{
+  "ts": "2026-05-28T14:32:17.123Z",
+  "nick": "local-research",
+  "action": "compact",
+  "detail": {"trigger": "context_watermark", "pct": 0.91}
+}
+```
+
+**Action vocabulary** (string `action` + free-form `detail` dict):
+
+| action | when | detail |
+|---|---|---|
+| `agent_start` | daemon starts the runner | `{model, directory}` |
+| `agent_stop` | graceful stop | `{}` |
+| `agent_exit` | runner exits (incl. crash) | `{exit_code}` |
+| `crash` | crash recorded in sliding window | `{exit_code, count}` |
+| `circuit_open` | circuit breaker trips | `{count, window_s}` |
+| `pause` / `resume` | pause state changes | `{manual: bool}` |
+| `compact` | compact triggered | `{trigger: "ipc"\|"context_watermark", pct?}` |
+| `clear` | context cleared | `{}` |
+| `handoff_written` | watermark handoff prompt sent | `{pct, path}` |
+| `handoff_reminder` | post-compact reminder injected | `{path}` |
+
+**Module.** `culture/clients/_daemon_log.py` with a `DaemonLog` writer mirroring `AuditWriter`'s atomic-append discipline:
+
+```python
+class DaemonLog:
+    def __init__(self, nick: str) -> None: ...
+    async def record(self, action: str, **detail: Any) -> None: ...
+```
+
+Each backend's `daemon.__init__` instantiates `self._daemon_log = DaemonLog(nick=agent.nick)`. Existing lifecycle methods gain one `await self._daemon_log.record(...)` line each at the points in the vocabulary table. These are surgical additions; no control-flow changes.
+
+**Relationship to Python logging.** The daemon keeps its existing `logger.info/warning` calls (human-readable, systemd journal). The action log is the *structured, boss-readable* complement — not a replacement. Where both fire for the same event, that's intentional (one for ops, one for the boss).
+
+**Boss-side.** `daemon-log.sh <name> [limit]` tails `~/.culture/daemon-log/<nick>.jsonl` and pretty-prints. `status.sh` additionally prints the most recent action per helper.
+
+## Testing strategy
+
+Per project convention (CLAUDE.md): no mocks for the server; real I/O. Pytest + pytest-asyncio + pytest-xdist (already in use). `/run-tests` for execution.
+
+| Test | Location | What it verifies |
+|---|---|---|
+| `test_perm_broker_policy.py` | `tests/clients/` | Policy matcher: exact tool match, regex tool match, `input_regex` against Bash command, MCP wildcards, fallthrough to None, malformed YAML graceful degrade. Pure-function tests; no filesystem. |
+| `test_perm_broker_fs.py` | `tests/clients/` | End-to-end with a real tmp dir as `~/.culture`. Spin a broker, fire `gate()` in a task, verify request file appears, write decision file, verify task completes with correct verdict. Cover allow/deny/timeout-via-cancel/scope-always-mutates-policy/missing-policy-file. |
+| `test_perm_broker_atomic.py` | `tests/clients/` | Concurrent `approve.sh`-equivalent calls for the same ID — verify exactly one wins. Verify partial-write recovery (write to tmpfile, kill before rename, broker doesn't see it). |
+| `test_audit_writer.py` | `tests/clients/` | Append-only JSONL semantics across re-opens. Verify each line is valid JSON. Verify timestamps are monotonic ISO8601. |
+| `test_spawn_helper_seeds_policy.py` | `tests/integration/` | Pytest. Runs `spawn-helper.sh foo` via subprocess against an isolated `CULTURE_HOME` temp dir, then asserts `<CULTURE_HOME>/perm-policy/local-foo.yaml` exists and matches the default-content fixture. (Repo convention is pytest, not shell — even for shell-driven flows.) |
+| `test_claude_agent_runner_inheritance.py` | `tests/clients/` (or `tests/harness/` alongside existing `test_agent_runner_claude.py`) | Construct an `AgentRunner` two ways: (a) without a policy file → assert `_make_options().setting_sources == ["user","project","local"]` and `can_use_tool is None`; (b) with a fixture-written policy file → assert `can_use_tool is not None` and is a callable bound to a `PermissionBroker`. |
+| `test_claude_runner_streaming_mode.py` | `tests/harness/` | Verify the conditional prompt-wrapping branch in `_process_turn`. With no policy file: `_can_use_tool is None`, and the `query()` call site receives `prompt` as a `str` (today's behavior). With a policy file: `_can_use_tool` is set, and the call site receives `prompt` as an `AsyncIterable[dict]` whose first yielded item is `{"type": "user", "message": {"role": "user", "content": <text>}}`. Use a Transport stub injected via `ClaudeAgentOptions(...)` to capture what `query()` was called with — no live Claude CLI required. |
+| `test_context_watch.py` | `tests/` | Pure-function `evaluate()`: below high-water → NONE; at/above high-water and not latched → WRITE_HANDOFF + latch set; still above while latched → NONE; after drop below low-water → latch reset; reminder_pending → REMINDER_DUE then cleared. `context_window_for()` maps known models and defaults unknown to 200K. |
+| `test_daemon_log.py` | `tests/` | `DaemonLog.record()` appends one valid-JSON line per call; action + detail round-trip; concurrent records serialize; timestamps ISO8601-UTC. Real tmp `CULTURE_HOME`. |
+
+xdist-safe via `tmp_path` fixture for the `~/.culture`-root isolation; environment variable `CULTURE_HOME` (new, defaults to `~/.culture`) lets tests override.
+
+**AgentRunner constructor change — callsite enumeration.** Adding the policy-file gate at `AgentRunner.__init__` does not change the constructor *signature* (no new required kwargs — `nick` already exists), so existing callsites continue to compile. However, runtime behavior changes: any test that constructs an `AgentRunner` with a `nick` value that happens to match an existing policy file path will see `can_use_tool` set. Phase 2 must verify the seven existing callsites (`culture/clients/claude/daemon.py:326`; `tests/test_agent_runner.py:64, 90, 120, 143, 175, 204`; `tests/harness/test_agent_runner_claude.py:180`) and confirm:
+
+1. Production callsite — gets supervised iff its policy file exists (correct by design).
+2. Test callsites use either a sentinel nick (`"test-..."`) that has no policy file, OR an explicit `CULTURE_HOME` env override pointing at an empty tmp dir.
+
+Existing tests using `nick="spark-claude"` (`test_agent_runner_claude.py:178`) are safe as long as no `~/.culture/perm-policy/spark-claude.yaml` exists on the developer's machine. CI is clean by definition. Local-dev test runs that *happen* to have a real `spark-claude` agent registered will see different behavior — flagged as a known dev-environment caveat in the testing docs.
+
+## Project conventions applied
+
+From `culture/CLAUDE.md`:
+
+- **All-backends rule** — addressed via documentation parity (audit log universal) + matrix table calling out where control parity is impossible.
+- **Citation pattern** — `_perm_broker.py`, `_audit.py`, `_context_watch.py`, `_daemon_log.py` live in `culture/clients/` (runtime-internal). They are **not** added to `packages/agent-harness/`. Backend daemons import them directly. (Rationale: these are cross-backend infrastructure; the "cite, don't import" rule applies to per-backend templates that are reflected into each backend, not to genuinely shared runtime code.)
+- **Documentation** — four new pages: `docs/agentirc/helper-permissions.md` (broker), `docs/agentirc/helper-tool-inheritance.md` (setting_sources widening + skill_directories), `docs/agentirc/helper-context-handoff.md` (context-watermark), `docs/agentirc/helper-daemon-log.md` (daemon-action log). Linked from `docs/agentirc/index.md`.
+- **Idempotent migrations** — N/A; no DDL.
+- **Pre-push review** — touches transport-adjacent daemon code in all four backends. Invoke `Agent(subagent_type="feature-dev:code-reviewer", ...)` on staged diff before first push.
+- **Doc-test-alignment** — new boss-side scripts, new config file paths (`perm-policy/<nick>.yaml`), new `CULTURE_HOME` env var convention. (No new IRC verbs or channel patterns in v1 — those land in v1.1 with the IRC-summary follow-up.) Invoke `Agent(subagent_type="doc-test-alignment", ...)` before first push.
+- **Version bump** — minor (new feature). Per CLAUDE.md, run `/version-bump minor` before opening PR.
+- **Format before commit** — run `uv run black <files>` and `uv run isort <files>` on staged Python files before `git commit`.
+
+## Unverified assumptions
+
+| Assumption | Required check | When |
+|---|---|---|
+| Copilot SDK's `PermissionHandler` exposes a callable interface that can be substituted for `PermissionHandler.approve_all` | Read `github-copilot-sdk` source at the version pinned in `pyproject.toml`; confirm `on_permission_request` accepts a custom callable matching `Callable[[PermissionRequest], Awaitable[PermissionDecision]]` (or similar) | Before wiring Copilot — if it doesn't, Copilot drops to audit-only and the matrix is downgraded |
+| `~/.claude/skills/` exists for the user running the boss | At broker init in Copilot wiring, log a warning if absent; do not fail | Implementation time |
+| `os.replace` is atomic on the user's filesystem | True on POSIX local filesystems including macOS/Linux; non-atomic on NFS or some FUSE mounts | Documented limitation; flag in `docs/agentirc/helper-permissions.md` |
+| `CULTURE_HOME` env var doesn't collide with an existing convention | `grep -rn "CULTURE_HOME" culture/` | Implementation time |
+
+## Open questions
+
+1. **Should `auto_allow` rules be re-evaluated after a session-resume?** A helper that crashes and resumes via SDK `resume` could face a different policy if `approve.sh always` was used during the prior session. Decision: re-read on each `gate()` call (already in design), so resume picks up the latest policy automatically. Documented behavior, not a question — listed here as confirmation.
+2. **Watchdog/inotify vs polling**: poll-only for v1. If approval latency feedback is bad, add `watchdog` as a dep and switch in v1.1. Tracked as a follow-up issue, not in scope.
+
+## Non-goals
+
+- **Multi-boss arbitration on a single helper.** One helper, one boss. If two boss sessions share a helper name (against the documented convention), behavior is undefined — first-writer-wins on decisions.
+- **Web UI.** Boss UX is shell + IRC only.
+- **RBAC / per-channel policy.** All policy is per-helper-nick. No "this user can approve Bash but not Edit."
+- **Audit log rotation.** Grows forever. Operator concern, not feature scope.
+- **Reversing the gate** (allow by default, ask for deny). Default is "ask boss"; safe-read auto-allow is the only fast-path concession.
+- **Boss notifications outside the boss session** (push to phone, etc). Boss is responsible for noticing pending requests in its own conversation flow.
+- **IRC `#perm-<name>` channel posts.** Deferred to v1.1. The broker module sits below the daemon's IRC transport with no clean plumbing today. v1 boss UX is the file-backed queue surfaced via `pending-perms.sh` and `watch-perms.sh`.
+
+## Phases
+
+| Phase | Work | Acceptance gate |
+|---|---|---|
+| **P0** | Spec authored and reviewed. | `/review-plan` reports no critical findings. |
+| **P1** | `culture/clients/_perm_broker.py` + `culture/clients/_audit.py`. Pure modules, no backend wiring. Unit tests pass. | `test_perm_broker.py`, `test_audit_writer.py` all green. |
+| **P2** | Claude backend wiring. `agent_runner.py` widens settings + adds callback + streaming-prompt branch. `daemon.py` adds audit writer. | `test_claude_runner_inheritance.py` green. Existing claude tests still pass. |
+| **P3** | Codex/ACP audit-only wiring. Just the audit writer in each daemon. | Existing codex/acp tests still pass. |
+| **P4** | Copilot wiring (subject to PermissionHandler verification). If verification fails, demote Copilot to audit-only and update the matrix. | Manual inspection + existing copilot tests still pass. |
+| **P5** | Boss-side scripts: `pending-perms.sh`, `approve.sh`, `deny.sh`, `watch-perms.sh`, `policy.sh`, `cleanup-stale-perms.sh`, `daemon-log.sh`, `context-status.sh`. Modify `spawn-helper.sh`, `ensure-mesh.sh`, `status.sh`, `read-replies.sh`, `_common.sh`. | `test_spawn_helper_seeds_policy.py` green; manual smoke test (spawn helper, see policy seeded). |
+| **P6 (context-watch)** | `culture/clients/_context_watch.py` (pure). Wire into Claude `daemon.py`: feed `ResultMessage.usage` per turn, act on `WatchAction` (write-handoff prompt → compact → reminder). Add `context_watch` config to `culture/clients/claude/config.py`. | `test_context_watch.py` green. |
+| **P7 (daemon-log)** | `culture/clients/_daemon_log.py` (atomic JSONL). Instantiate `DaemonLog` in all four `daemon.__init__`; add `record(...)` calls at lifecycle points (start/stop/exit/crash/circuit/pause/resume/compact/clear/handoff). | `test_daemon_log.py` green. Existing daemon tests still pass. |
+| **P8** | Docs: `docs/agentirc/helper-permissions.md`, `docs/agentirc/helper-tool-inheritance.md`, `docs/agentirc/helper-context-handoff.md`, `docs/agentirc/helper-daemon-log.md`. Update `docs/agentirc/index.md`. Update culture-boss `SKILL.md`. | `doc-test-alignment` subagent reports no missing coverage. |
+| **P9** | Format, `/run-tests`, code-reviewer subagent on staged diff. | All green + reviewer findings addressed or explicitly accepted. |
+| **P10** | `/version-bump minor` + CHANGELOG entry. Commit, push, open PR. | PR exists, CI green. |
+
+## Out of scope
+
+- Any change to the IRC server (`culture/agentirc/`).
+- Any change to `packages/agent-harness/` template files (broker is runtime-internal; not reflected).
+- Web UI, dashboards, metrics dashboards. (Audit JSONL feeds whatever the operator wants.)
+- Permission rule import/export (e.g. share a policy file between machines). Operator concern.
+- Long-term audit log archival, redaction, or compliance features.
+
+## Acceptance summary
+
+The feature ships when:
+
+1. A boss can run `spawn-helper.sh foo`, brief the helper, and see all of the boss's MCP servers + skills available to the helper.
+2. When the helper tries to invoke Edit/Write/Bash-with-side-effects/any MCP, the boss receives a pending request via `pending-perms.sh`.
+3. `approve.sh <id>` unblocks the helper within ~500ms; `deny.sh <id> <reason>` causes the model to receive a denial in its tool result.
+4. `approve.sh <id> always` makes subsequent identical requests auto-approve with no round-trip.
+5. `~/.culture/audit/<nick>.jsonl` contains a line per AssistantMessage for every helper in every backend.
+6. Helpers in Codex/ACP backends do not block on `can_use_tool` (no broker hook) and have audit logs.
+7. A Claude helper approaching 90% context writes `~/.culture/handoff/<nick>.md`, compacts, and is reminded to read it on next activation (verifiable via `daemon-log/<nick>.jsonl` `handoff_written` + `compact` + `handoff_reminder` entries).
+8. `~/.culture/daemon-log/<nick>.jsonl` records control-plane actions (start/stop/compact/crash/handoff) for every helper in every backend; `daemon-log.sh <name>` tails it.
+9. `/run-tests` green. `doc-test-alignment` reports no gaps. `feature-dev:code-reviewer` finds no high-confidence issues unaddressed.
+
+---
+
+## Evidence Log
+
+### Cited source — SDK supports `can_use_tool`
+
+`claude_agent_sdk/types.py:159-161`:
+
+```python
+CanUseTool = Callable[
+    [str, dict[str, Any], ToolPermissionContext], Awaitable[PermissionResult]
+]
+```
+
+`claude_agent_sdk/types.py:1075`:
+
+```python
+# Tool permission callback
+can_use_tool: CanUseTool | None = None
+```
+
+`claude_agent_sdk/types.py:139-157` defines `PermissionResultAllow(behavior="allow", updated_input, updated_permissions)` and `PermissionResultDeny(behavior="deny", message, interrupt)`.
+
+### Cited source — SDK supports `setting_sources` with `user|project|local`
+
+`claude_agent_sdk/types.py:1090`:
+
+```python
+# Setting sources to load (user, project, local)
+setting_sources: list[SettingSource] | None = None
+```
+
+### Cited source — current Claude wiring uses project-only
+
+`culture/clients/claude/agent_runner.py:132-143` (verbatim, current main):
+
+```python
+def _make_options(self) -> ClaudeAgentOptions:
+    opts = ClaudeAgentOptions(
+        model=self.model,
+        cwd=self.directory,
+        permission_mode="bypassPermissions",
+        setting_sources=["project"],
+    )
+    if self.system_prompt:
+        opts.system_prompt = self.system_prompt
+    if self._session_id:
+        opts.resume = self._session_id
+    return opts
+```
+
+### Cited source — Copilot's existing PermissionHandler swap point
+
+`culture/clients/copilot/agent_runner.py:85-96`:
+
+```python
+session_kwargs: dict[str, Any] = {
+    "on_permission_request": PermissionHandler.approve_all,
+    "model": self.model,
+}
+if self.system_prompt:
+    session_kwargs["system_message"] = {"content": self.system_prompt}
+if self.skill_directories:
+    session_kwargs["skill_directories"] = self.skill_directories
+
+self._session = await self._client.create_session(**session_kwargs)
+```
+
+### Cited source — `_on_agent_message` hook points across all four backends
+
+- `culture/clients/claude/daemon.py:426-431`:
+
+  ```python
+  async def _on_agent_message(self, msg: dict) -> None:
+      """Feed agent activity to the supervisor for observation."""
+      if self._supervisor:
+          await self._supervisor.observe(msg)
+
+      self._capture_agent_status(msg)
+  ```
+
+- `culture/clients/codex/daemon.py:529-537`:
+
+  ```python
+  async def _on_agent_message(self, msg: dict) -> None:
+      """Relay agent text to IRC and feed to supervisor."""
+      self._consecutive_turn_failures = 0
+      await self._relay_response_to_irc(msg)
+
+      if self._supervisor:
+          await self._supervisor.observe(msg)
+
+      self._capture_agent_status(msg)
+  ```
+
+- `culture/clients/copilot/daemon.py:511-519`: same shape as codex (verified by grep + 20-line read).
+- `culture/clients/acp/daemon.py:536-544`: same shape as codex (verified by grep + 20-line read).
+
+### Cited source — spawn-helper.sh script (insertion point for policy seeding)
+
+`~/.claude/skills/culture-boss/scripts/spawn-helper.sh:1-45` (verbatim, current):
+
+```bash
+#!/usr/bin/env bash
+# Spawn a helper agent into its own private task channel.
+# Usage: spawn-helper <name> [cwd]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+
+NAME="${1:?usage: spawn-helper <name> [cwd]}"
+CWD="${2:-}"
+if [ -z "$CWD" ]; then
+  CWD="${HOME}/.culture/helpers/${NAME}"
+  mkdir -p "$CWD"
+fi
+NICK="local-${NAME}"
+TASK_CHAN="#task-${NAME}"
+# ... agent registration ...
+echo "[boss] spawned $NICK; private channel $TASK_CHAN; cwd $CWD."
+```
+
+Policy seed insertion lands after the `mkdir -p "$CWD"` block and before agent registration.
+
+---
+
+*End of spec.*

--- a/packages/agent-harness/culture.yaml
+++ b/packages/agent-harness/culture.yaml
@@ -12,6 +12,15 @@ tags:
   - harness
   - template
 
+# Context-watermark handoff (Claude backend only).
+# When the daemon detects the agent is approaching its context window, it asks
+# the agent to write a handoff for its post-compact self, compacts, then reminds
+# it to read the handoff. See docs/agentirc/helper-context-handoff.md.
+context_watch:
+  enabled: true       # master switch
+  high_water: 0.90    # fraction of the context window that triggers a handoff
+  low_water: 0.50     # fraction below which the handoff latch resets
+
 # OpenTelemetry configuration for the agent harness.
 # Set enabled: true once your OTLP collector is running.
 # See docs/agentirc/harness-telemetry.md for a setup guide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.6.0"
+version = "8.7.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/_sdk_stub.py
+++ b/tests/_sdk_stub.py
@@ -1,0 +1,121 @@
+"""Shared claude_agent_sdk stub for tests that need it.
+
+Calling :func:`install_claude_sdk_stub` is idempotent — it only installs the
+stub if ``claude_agent_sdk`` is not already in ``sys.modules``. Test files
+that need a deterministic stub should call this at module top *before*
+importing any culture module that imports the SDK (notably
+``culture.clients._perm_broker`` and ``culture.clients.claude.agent_runner``).
+
+The stub mirrors the subset of the SDK surface that culture's harnesses
+touch. New SDK surface that culture starts importing should be added here.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+
+class _StubAsyncIter:
+    def __init__(self, messages: list[Any]) -> None:
+        self._iter = iter(messages)
+
+    def __aiter__(self):  # type: ignore[no-untyped-def]
+        return self
+
+    async def __anext__(self):  # type: ignore[no-untyped-def]
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def install_claude_sdk_stub() -> None:
+    """Install a minimal stub for claude_agent_sdk if not already loaded."""
+    if "claude_agent_sdk" in sys.modules:
+        return
+
+    mod = types.ModuleType("claude_agent_sdk")
+
+    class _Base:
+        pass
+
+    class AssistantMessage(_Base):
+        def __init__(self, model: str = "stub-model", content: list[Any] | None = None) -> None:
+            self.model = model
+            self.content = content or []
+
+    class ResultMessage(_Base):
+        def __init__(
+            self,
+            session_id: str = "sid-1",
+            is_error: bool = False,
+            result: str = "",
+            usage: Any = None,
+        ) -> None:
+            self.session_id = session_id
+            self.is_error = is_error
+            self.result = result
+            self.usage = usage
+
+    class ClaudeAgentOptions(_Base):
+        def __init__(self, **kwargs: Any) -> None:
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class TextBlock(_Base):
+        pass
+
+    class ThinkingBlock(_Base):
+        pass
+
+    class ToolUseBlock(_Base):
+        pass
+
+    class ToolResultBlock(_Base):
+        pass
+
+    class PermissionResultAllow(_Base):
+        def __init__(
+            self,
+            behavior: str = "allow",
+            updated_input: Any = None,
+            updated_permissions: Any = None,
+        ) -> None:
+            self.behavior = behavior
+            self.updated_input = updated_input
+            self.updated_permissions = updated_permissions
+
+    class PermissionResultDeny(_Base):
+        def __init__(
+            self,
+            behavior: str = "deny",
+            message: str = "",
+            interrupt: bool = False,
+        ) -> None:
+            self.behavior = behavior
+            self.message = message
+            self.interrupt = interrupt
+
+    class ToolPermissionContext(_Base):
+        def __init__(self, signal: Any = None, suggestions: list[Any] | None = None) -> None:
+            self.signal = signal
+            self.suggestions = suggestions or []
+
+    def query(**kwargs: Any) -> _StubAsyncIter:  # noqa: ARG001
+        return _StubAsyncIter([])
+
+    mod.AssistantMessage = AssistantMessage
+    mod.ResultMessage = ResultMessage
+    mod.ClaudeAgentOptions = ClaudeAgentOptions
+    mod.TextBlock = TextBlock
+    mod.ThinkingBlock = ThinkingBlock
+    mod.ToolUseBlock = ToolUseBlock
+    mod.ToolResultBlock = ToolResultBlock
+    mod.PermissionResultAllow = PermissionResultAllow
+    mod.PermissionResultDeny = PermissionResultDeny
+    mod.ToolPermissionContext = ToolPermissionContext
+    mod.query = query
+
+    sys.modules["claude_agent_sdk"] = mod

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -101,6 +101,23 @@ def _stub_claude_sdk():
     class ToolResultBlock(_Base):
         pass
 
+    class PermissionResultAllow(_Base):
+        def __init__(self, behavior="allow", updated_input=None, updated_permissions=None):
+            self.behavior = behavior
+            self.updated_input = updated_input
+            self.updated_permissions = updated_permissions
+
+    class PermissionResultDeny(_Base):
+        def __init__(self, behavior="deny", message="", interrupt=False):
+            self.behavior = behavior
+            self.message = message
+            self.interrupt = interrupt
+
+    class ToolPermissionContext(_Base):
+        def __init__(self, signal=None, suggestions=None):
+            self.signal = signal
+            self.suggestions = suggestions or []
+
     def query(**kwargs):
         return _StubAsyncIter([])
 
@@ -111,6 +128,9 @@ def _stub_claude_sdk():
     mod.ThinkingBlock = ThinkingBlock
     mod.ToolUseBlock = ToolUseBlock
     mod.ToolResultBlock = ToolResultBlock
+    mod.PermissionResultAllow = PermissionResultAllow
+    mod.PermissionResultDeny = PermissionResultDeny
+    mod.ToolPermissionContext = ToolPermissionContext
     mod.query = query
 
     sys.modules["claude_agent_sdk"] = mod

--- a/tests/test_audit_writer.py
+++ b/tests/test_audit_writer.py
@@ -1,0 +1,119 @@
+"""Tests for the per-helper JSONL audit log."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients._audit import AuditWriter, audit_path_for  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestAuditWriter:
+    def test_path_under_culture_home(self, culture_root):
+        assert audit_path_for("local-foo").startswith(str(culture_root))
+
+    @pytest.mark.asyncio
+    async def test_write_assistant_message_appends_line(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        msg = {
+            "type": "assistant",
+            "model": "claude-opus-4-7",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            ],
+        }
+        await writer.write(msg)
+
+        with open(writer.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["type"] == "assistant"
+        assert record["nick"] == "local-foo"
+        assert record["model"] == "claude-opus-4-7"
+        assert record["text"] == "Hello"
+        assert record["tool_uses"][0]["name"] == "Bash"
+        assert record["tool_uses"][0]["input_digest"].startswith("sha256:")
+        assert record["ts"].endswith("Z")  # ISO8601 UTC
+
+    @pytest.mark.asyncio
+    async def test_non_assistant_messages_are_skipped(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        await writer.write({"type": "user", "content": [{"type": "text", "text": "hi"}]})
+        await writer.write({"type": "result", "session_id": "x"})
+        assert not os.path.exists(writer.path)
+
+    @pytest.mark.asyncio
+    async def test_multiple_writes_preserve_order(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        for i in range(5):
+            await writer.write(
+                {
+                    "type": "assistant",
+                    "model": "m",
+                    "content": [{"type": "text", "text": f"line-{i}"}],
+                }
+            )
+        with open(writer.path) as f:
+            lines = [json.loads(line) for line in f.readlines()]
+        assert [record["text"] for record in lines] == [f"line-{i}" for i in range(5)]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_serialize(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+
+        async def write_one(i: int) -> None:
+            await writer.write(
+                {
+                    "type": "assistant",
+                    "model": "m",
+                    "content": [{"type": "text", "text": f"line-{i:02d}"}],
+                }
+            )
+
+        await asyncio.gather(*(write_one(i) for i in range(20)))
+
+        with open(writer.path) as f:
+            lines = f.readlines()
+        # All 20 lines must be present and individually valid JSON.
+        assert len(lines) == 20
+        for line in lines:
+            json.loads(line)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_preview_truncated(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        big = "x" * 1000
+        await writer.write(
+            {
+                "type": "assistant",
+                "model": "m",
+                "content": [
+                    {"type": "tool_result", "name": "Bash", "content": big},
+                ],
+            }
+        )
+        with open(writer.path) as f:
+            record = json.loads(f.readlines()[0])
+        preview = record["tool_results"][0]["preview"]
+        assert len(preview) <= 200
+        assert preview.startswith("x")
+
+    @pytest.mark.asyncio
+    async def test_empty_nick_rejected(self, culture_root):
+        with pytest.raises(ValueError):
+            AuditWriter(nick="")

--- a/tests/test_claude_runner_inheritance.py
+++ b/tests/test_claude_runner_inheritance.py
@@ -1,0 +1,76 @@
+"""Tests for the Claude AgentRunner's setting_sources widening and the
+conditional can_use_tool wiring tied to perm-policy file existence."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import tempfile  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients._perm_broker import write_default_policy  # noqa: E402
+from culture.clients.claude.agent_runner import AgentRunner  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _runner(nick: str) -> AgentRunner:
+    return AgentRunner(
+        model="claude-opus-4-7",
+        directory=tempfile.mkdtemp(prefix="culture-test-claude-"),
+        nick=nick,
+    )
+
+
+class TestSettingSources:
+    def test_setting_sources_widened(self, culture_root):
+        runner = _runner(nick="local-foo")
+        opts = runner._make_options()
+        assert opts.setting_sources == ["user", "project", "local"]
+
+    def test_permission_mode_still_bypass(self, culture_root):
+        runner = _runner(nick="local-foo")
+        opts = runner._make_options()
+        assert opts.permission_mode == "bypassPermissions"
+
+
+class TestConditionalCanUseTool:
+    def test_no_policy_file_no_callback(self, culture_root):
+        runner = _runner(nick="local-no-policy")
+        opts = runner._make_options()
+        assert opts.can_use_tool is None
+        assert runner._broker is None
+
+    def test_policy_file_present_wires_callback(self, culture_root):
+        write_default_policy("local-with-policy")
+        runner = _runner(nick="local-with-policy")
+        opts = runner._make_options()
+        assert opts.can_use_tool is not None
+        assert callable(opts.can_use_tool)
+        assert runner._broker is not None
+        assert runner._broker.nick == "local-with-policy"
+
+    def test_empty_nick_no_callback(self, culture_root):
+        # Even with a policy file present, empty nick means no broker.
+        runner = _runner(nick="")
+        opts = runner._make_options()
+        assert opts.can_use_tool is None
+        assert runner._broker is None
+
+
+class TestStreamingPromptWrapper:
+    @pytest.mark.asyncio
+    async def test_single_user_message_stream_shape(self):
+        from culture.clients.claude.agent_runner import _single_user_message_stream
+
+        items = [item async for item in _single_user_message_stream("hello world")]
+        assert items == [
+            {"type": "user", "message": {"role": "user", "content": "hello world"}}
+        ]

--- a/tests/test_context_watch.py
+++ b/tests/test_context_watch.py
@@ -1,0 +1,109 @@
+"""Tests for the pure context-watermark logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.clients._context_watch import (
+    ContextWatchState,
+    WatchAction,
+    context_window_for,
+    evaluate,
+    fraction,
+    mark_reminder_pending,
+    take_reminder,
+)
+
+
+class TestContextWindowFor:
+    def test_opus_default_200k(self):
+        assert context_window_for("claude-opus-4-6") == 200_000
+
+    def test_opus_1m_marker(self):
+        assert context_window_for("claude-opus-4-7[1m]") == 1_000_000
+
+    def test_sonnet_200k(self):
+        assert context_window_for("claude-sonnet-4-6") == 200_000
+
+    def test_haiku_200k(self):
+        assert context_window_for("claude-haiku-4-5-20251001") == 200_000
+
+    def test_unknown_defaults_200k(self):
+        assert context_window_for("some-future-model") == 200_000
+
+    def test_empty_defaults_200k(self):
+        assert context_window_for("") == 200_000
+
+
+class TestEvaluate:
+    def test_below_high_water_none(self):
+        st = ContextWatchState()
+        # 100K of 200K = 50% — at low_water boundary, not high.
+        assert evaluate(st, 100_000, "claude-opus-4-6") is WatchAction.NONE
+        assert st.handoff_latched is False
+
+    def test_at_high_water_triggers_handoff(self):
+        st = ContextWatchState()
+        # 185K of 200K = 92.5% >= 90%.
+        assert evaluate(st, 185_000, "claude-opus-4-6") is WatchAction.WRITE_HANDOFF
+        assert st.handoff_latched is True
+
+    def test_latched_does_not_refire(self):
+        st = ContextWatchState()
+        assert evaluate(st, 190_000, "claude-opus-4-6") is WatchAction.WRITE_HANDOFF
+        # Still above threshold, latched → no re-fire.
+        assert evaluate(st, 192_000, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_latch_resets_below_low_water_signals_reminder(self):
+        st = ContextWatchState()
+        evaluate(st, 190_000, "claude-opus-4-6")  # latched (handoff written)
+        # Drop below 50% (e.g. after compact) → reminder is now due.
+        assert evaluate(st, 50_000, "claude-opus-4-6") is WatchAction.REMINDER_DUE
+        assert st.handoff_latched is False
+        # Re-fills → fires handoff again.
+        assert evaluate(st, 190_000, "claude-opus-4-6") is WatchAction.WRITE_HANDOFF
+
+    def test_low_usage_without_prior_latch_is_none(self):
+        st = ContextWatchState()
+        # Never latched — a low reading is just NONE (no spurious reminder).
+        assert evaluate(st, 50_000, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_disabled_never_fires(self):
+        st = ContextWatchState(enabled=False)
+        assert evaluate(st, 199_000, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_none_tokens_no_fire(self):
+        st = ContextWatchState()
+        assert evaluate(st, None, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_zero_tokens_no_fire(self):
+        st = ContextWatchState()
+        assert evaluate(st, 0, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_1m_model_threshold(self):
+        st = ContextWatchState()
+        # 185K of 1M = 18.5% — well below high-water for a 1M model.
+        assert evaluate(st, 185_000, "claude-opus-4-7[1m]") is WatchAction.NONE
+        # 920K of 1M = 92%.
+        assert evaluate(st, 920_000, "claude-opus-4-7[1m]") is WatchAction.WRITE_HANDOFF
+
+
+class TestFraction:
+    def test_fraction_basic(self):
+        assert fraction(100_000, "claude-opus-4-6") == pytest.approx(0.5)
+
+    def test_fraction_none(self):
+        assert fraction(None, "claude-opus-4-6") is None
+
+    def test_fraction_zero(self):
+        assert fraction(0, "claude-opus-4-6") is None
+
+
+class TestReminder:
+    def test_reminder_roundtrip(self):
+        st = ContextWatchState()
+        assert take_reminder(st) is False
+        mark_reminder_pending(st)
+        assert take_reminder(st) is True
+        # Consumed — second take returns False.
+        assert take_reminder(st) is False

--- a/tests/test_daemon_log.py
+++ b/tests/test_daemon_log.py
@@ -1,0 +1,70 @@
+"""Tests for the per-agent daemon-action log."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients._daemon_log import DaemonLog, daemon_log_path_for  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestDaemonLog:
+    def test_path_under_culture_home(self, culture_root):
+        assert daemon_log_path_for("local-foo").startswith(str(culture_root))
+
+    @pytest.mark.asyncio
+    async def test_record_appends_line(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        await log.record("agent_start", model="claude-opus-4-7", directory="/tmp/x")
+        with open(log.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["action"] == "agent_start"
+        assert rec["nick"] == "local-foo"
+        assert rec["detail"]["model"] == "claude-opus-4-7"
+        assert rec["ts"].endswith("Z")
+
+    @pytest.mark.asyncio
+    async def test_detail_roundtrip(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        await log.record("compact", trigger="context_watermark", pct=0.91)
+        with open(log.path) as f:
+            rec = json.loads(f.readlines()[0])
+        assert rec["detail"] == {"trigger": "context_watermark", "pct": 0.91}
+
+    @pytest.mark.asyncio
+    async def test_multiple_records_ordered(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        for action in ("agent_start", "compact", "agent_stop"):
+            await log.record(action)
+        with open(log.path) as f:
+            recs = [json.loads(line) for line in f.readlines()]
+        assert [r["action"] for r in recs] == ["agent_start", "compact", "agent_stop"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_records_serialize(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        await asyncio.gather(*(log.record("tick", i=i) for i in range(20)))
+        with open(log.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 20
+        for line in lines:
+            json.loads(line)
+
+    @pytest.mark.asyncio
+    async def test_empty_nick_rejected(self, culture_root):
+        with pytest.raises(ValueError):
+            DaemonLog(nick="")

--- a/tests/test_perm_broker.py
+++ b/tests/test_perm_broker.py
@@ -1,0 +1,351 @@
+"""Tests for the file-backed permission broker.
+
+Per project convention: real I/O against an isolated tmp dir.  No mocks of
+the broker's filesystem layer.  Tests honor ``CULTURE_HOME`` via monkeypatch
+so they are xdist-safe.
+"""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+from typing import Any  # noqa: E402
+
+import pytest  # noqa: E402
+import yaml  # noqa: E402
+from claude_agent_sdk import (  # noqa: E402
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+
+from culture.clients._perm_broker import (  # noqa: E402
+    DEFAULT_POLICY,
+    PermissionBroker,
+    culture_home,
+    has_policy_file,
+    match_policy,
+    policy_path_for,
+    write_default_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    """Isolate ``CULTURE_HOME`` per test."""
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _empty_context() -> ToolPermissionContext:
+    return ToolPermissionContext(signal=None, suggestions=[])
+
+
+# ---------------------------------------------------------------------------
+# Pure policy matcher
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyMatcher:
+    def test_exact_tool_match_allows(self):
+        policy = {"auto_allow": [{"tool": "Read"}]}
+        assert match_policy("Read", {}, policy) == "allow"
+
+    def test_exact_tool_match_misses(self):
+        policy = {"auto_allow": [{"tool": "Read"}]}
+        assert match_policy("Write", {}, policy) is None
+
+    def test_regex_tool_pattern(self):
+        policy = {"auto_allow": [{"tool": "mcp__.*"}]}
+        assert match_policy("mcp__gmail__send", {}, policy) == "allow"
+        assert match_policy("Bash", {}, policy) is None
+
+    def test_auto_deny_takes_priority_over_auto_allow(self):
+        policy = {
+            "auto_deny": [{"tool": "Bash"}],
+            "auto_allow": [{"tool": "Bash"}],
+        }
+        assert match_policy("Bash", {"command": "ls"}, policy) == "deny"
+
+    def test_bash_input_regex_match(self):
+        policy = {"auto_allow": [{"tool": "Bash", "input_regex": r"^ls\b"}]}
+        assert match_policy("Bash", {"command": "ls -la"}, policy) == "allow"
+        assert match_policy("Bash", {"command": "rm -rf /"}, policy) is None
+
+    def test_bash_default_safe_read_regex(self):
+        policy = DEFAULT_POLICY
+        for cmd in ("ls", "ls -la", "git status", "git diff HEAD", "rg foo src/"):
+            assert match_policy("Bash", {"command": cmd}, policy) == "allow", cmd
+        for cmd in ("rm -rf /", "curl https://evil.tld", "git push"):
+            assert match_policy("Bash", {"command": cmd}, policy) is None, cmd
+
+    def test_empty_policy_falls_through(self):
+        assert match_policy("Read", {}, {}) is None
+        assert match_policy("Read", {}, {"auto_allow": []}) is None
+
+    def test_malformed_rule_is_skipped(self):
+        policy = {"auto_allow": [{"not_a_tool_field": 1}, {"tool": "Read"}]}
+        assert match_policy("Read", {}, policy) == "allow"
+
+    def test_input_regex_against_non_projectable_tool_does_not_match(self):
+        # ``Read`` has no input projection; a rule with input_regex against
+        # Read should never match.
+        policy = {"auto_allow": [{"tool": "Read", "input_regex": ".*"}]}
+        assert match_policy("Read", {"file_path": "x"}, policy) is None
+
+
+# ---------------------------------------------------------------------------
+# Policy file seed / load
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyFile:
+    def test_write_default_policy_creates_file(self, culture_root):
+        path = write_default_policy("local-foo")
+        assert os.path.exists(path)
+        with open(path) as f:
+            policy = yaml.safe_load(f)
+        assert policy == DEFAULT_POLICY
+
+    def test_write_default_policy_is_idempotent(self, culture_root):
+        path = write_default_policy("local-foo")
+        # Mutate the file then re-seed; existing file must not be overwritten.
+        with open(path, "w") as f:
+            yaml.safe_dump({"auto_allow": [{"tool": "Custom"}]}, f)
+        write_default_policy("local-foo")
+        with open(path) as f:
+            policy = yaml.safe_load(f)
+        assert policy == {"auto_allow": [{"tool": "Custom"}]}
+
+    def test_has_policy_file_reflects_filesystem(self, culture_root):
+        assert has_policy_file("local-foo") is False
+        write_default_policy("local-foo")
+        assert has_policy_file("local-foo") is True
+
+    def test_has_policy_file_empty_nick(self, culture_root):
+        write_default_policy("local-foo")
+        assert has_policy_file("") is False
+        assert has_policy_file(None) is False  # type: ignore[arg-type]
+
+    def test_policy_path_uses_culture_home(self, culture_root):
+        assert policy_path_for("x").startswith(str(culture_root))
+        assert culture_home() == str(culture_root)
+
+
+# ---------------------------------------------------------------------------
+# Broker end-to-end (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerEndToEnd:
+    @pytest.mark.asyncio
+    async def test_policy_match_returns_immediately_allow(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+        result = await asyncio.wait_for(
+            broker.gate("Read", {"file_path": "/x"}, _empty_context()),
+            timeout=1.0,
+        )
+        assert isinstance(result, PermissionResultAllow)
+
+    @pytest.mark.asyncio
+    async def test_policy_match_returns_immediately_deny(self, culture_root):
+        # Write a custom policy that hard-denies Bash.
+        path = policy_path_for("local-helper")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            yaml.safe_dump({"auto_deny": [{"tool": "Bash"}], "auto_allow": []}, f)
+        broker = PermissionBroker(nick="local-helper")
+        result = await asyncio.wait_for(
+            broker.gate("Bash", {"command": "rm -rf /"}, _empty_context()),
+            timeout=1.0,
+        )
+        assert isinstance(result, PermissionResultDeny)
+        assert result.interrupt is False
+
+    @pytest.mark.asyncio
+    async def test_unmatched_tool_routes_to_boss_and_allows_on_decision(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        # Boss-side: poll for the request, write a decision.
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "allow",
+                "scope": "once",
+                "reason": "",
+                "decided_by": "test",
+            },
+        )
+
+        result = await asyncio.wait_for(gate_task, timeout=2.0)
+        assert isinstance(result, PermissionResultAllow)
+
+        # Queue and decision files are consumed on success.
+        assert not os.path.exists(os.path.join(queue_dir, f"{request_id}.json"))
+        assert not os.path.exists(os.path.join(decisions_dir, f"{request_id}.json"))
+
+    @pytest.mark.asyncio
+    async def test_boss_deny_propagates_reason(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "deny",
+                "scope": "once",
+                "reason": "not approved",
+            },
+        )
+        result = await asyncio.wait_for(gate_task, timeout=2.0)
+        assert isinstance(result, PermissionResultDeny)
+        assert "not approved" in result.message
+        assert result.interrupt is False
+
+    @pytest.mark.asyncio
+    async def test_scope_always_appends_to_policy(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "allow",
+                "scope": "always",
+            },
+        )
+        await asyncio.wait_for(gate_task, timeout=2.0)
+
+        with open(policy_path_for("local-helper")) as f:
+            policy = yaml.safe_load(f)
+        tools_allowed = [rule.get("tool") for rule in policy.get("auto_allow", [])]
+        assert "Edit" in tools_allowed
+
+    @pytest.mark.asyncio
+    async def test_scope_always_with_pattern_uses_pattern(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        # Use Edit — guaranteed to fall through to boss (no auto-allow for it).
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "allow",
+                "scope": "always",
+                "pattern": "Custom.*",  # pattern field overrides tool match
+            },
+        )
+        await asyncio.wait_for(gate_task, timeout=2.0)
+
+        with open(policy_path_for("local-helper")) as f:
+            policy = yaml.safe_load(f)
+        tools_allowed = [rule.get("tool") for rule in policy.get("auto_allow", [])]
+        # The pattern is stored verbatim as the tool field.
+        assert "Custom.*" in tools_allowed
+
+    @pytest.mark.asyncio
+    async def test_cancellation_cleans_up_queue_file(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        await _wait_for_request(queue_dir)
+
+        gate_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await gate_task
+
+        # Queue dir should be empty — the in-flight request was cleaned up.
+        entries = [e for e in os.listdir(queue_dir) if not e.startswith(".")]
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_missing_policy_file_routes_everything_to_boss(self, culture_root):
+        # No policy file written; broker treats as empty → boss-routed.
+        broker = PermissionBroker(nick="local-orphan")
+
+        gate_task = asyncio.create_task(broker.gate("Read", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {"id": request_id, "verdict": "allow", "scope": "once"},
+        )
+        result = await asyncio.wait_for(gate_task, timeout=2.0)
+        assert isinstance(result, PermissionResultAllow)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — boss-side simulation
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_request(queue_dir: str, timeout: float = 2.0) -> str:
+    """Poll until one request file appears in ``queue_dir``; return its ID."""
+
+    async def _poll() -> str:
+        while True:
+            try:
+                entries = [
+                    e
+                    for e in os.listdir(queue_dir)
+                    if e.endswith(".json") and not e.startswith(".")
+                ]
+            except FileNotFoundError:
+                entries = []
+            if entries:
+                return entries[0][: -len(".json")]
+            await asyncio.sleep(0.05)
+
+    return await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def _write_decision_atomic(path: str, payload: dict[str, Any]) -> None:
+    """Mirror the boss-script atomic-write contract for tests."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.6.0"
+version = "8.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Lets a regular Claude Code session (the **boss**) spawn helper agents on a local Culture mesh and supervise them as a team lead. Three pillars, all sharing one `~/.culture/` file convention (`CULTURE_HOME`-rooted, atomic writes, JSONL):

1. **Permission broker** (Claude) — `culture/clients/_perm_broker.py` wires the Claude Agent SDK `can_use_tool` callback to a file-backed request/decision queue. Helpers block on boss approval for any non-safe-read tool call; safe reads (Read/Glob/Grep, read-only Bash) auto-approve via a per-helper `perm-policy/<nick>.yaml`. The callback is set **only** when a policy file exists, so standalone mesh agents keep today's `bypassPermissions` behavior untouched.
2. **Tool inheritance** (Claude) — `setting_sources` widened to `["user","project","local"]`, so helpers inherit the boss's `~/.claude/` skills, MCP servers, and plugins.
3. **Context-watermark handoff** (Claude) — `culture/clients/_context_watch.py`; the daemon self-monitors per-turn `input_tokens` and at 90% of the model's context window asks the agent to write a handoff to `~/.culture/handoff/<nick>.md`, compacts, then reminds it to read the handoff once context actually drops post-compact.
4. **Audit log + daemon-action log** (all four backends) — `_audit.py` (one line per AssistantMessage) and `_daemon_log.py` (control-plane actions: start/stop/exit/crash/compact/handoff). These provide visibility parity even where synchronous control isn't possible.

### Backend matrix

| Backend | Broker | Context-watch | Audit log | Daemon log |
|---|---|---|---|---|
| Claude | Full | Full | ✅ | ✅ |
| Copilot | Audit-only¹ | — | ✅ | ✅ |
| Codex | Audit-only | — | ✅ | ✅ |
| ACP | Audit-only | — | ✅ | ✅ |

¹ Copilot SDK `PermissionHandler` signature could not be verified in the build environment; deferred per the spec's documented fallback. Codex/ACP have no per-tool callback in their protocols. The all-backends rule is satisfied by the two universal pillars (audit + daemon log).

### Boss-side tooling

The boss scripts (`pending-perms.sh`, `approve.sh`, `deny.sh`, `watch-perms.sh`, `policy.sh`, `cleanup-stale-perms.sh`, `daemon-log.sh`, `context-status.sh`) live in the user-global `culture-boss` skill (`~/.claude/skills/culture-boss/`), not this repo — this PR is the engine half.

### Design + docs

- Spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md` (authored via dev-plan, looped through review-plan to clean).
- Docs: `docs/agentirc/helper-{permissions,tool-inheritance,context-handoff,daemon-log}.md` + index.

## Test plan

- [x] `tests/test_perm_broker.py` — policy matcher, end-to-end allow/deny/scope-always/cancellation/missing-policy (real FS, isolated `CULTURE_HOME`)
- [x] `tests/test_audit_writer.py`, `tests/test_daemon_log.py` — JSONL append/ordering/concurrency
- [x] `tests/test_context_watch.py` — watermark thresholds, latch, reminder timing, model windows
- [x] `tests/test_claude_runner_inheritance.py` — conditional `can_use_tool` + `setting_sources` + streaming-prompt wrapper
- [x] Full suite via `-n auto`: 1167 passed; 13 pre-existing env/socket failures unchanged (no new regressions)
- [x] black / isort / flake8 / pylint (≥9.0) / bandit / markdownlint clean
- [x] doc-test-alignment + code-reviewer subagents run; findings addressed (broker poll-loop robustness, fd-leak guards, handoff-reminder timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)