### PR TITLE
feat: Mission Control dashboard — watch + control the mesh (8.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.9.0] - 2026-05-29
+
+### Added
+
+- **Mission Control dashboard** — a localhost web app (`culture dashboard`) to watch every agent live and intervene. Three-pane UI: agent grid (state, pending count, last action, BOSS tag), per-agent session/daemon-log SSE streams, and a pending-approvals panel. Full control surface: approve/deny (human is top authority — not ceiling-bounded), pause/resume, close, emergency stop-all (pause or kill), and grant-policy edit. `aiohttp` backend (existing dep) + vanilla-JS frontend (no build step); binds `127.0.0.1` only (refuses non-loopback without `--unsafe-bind`). Spec: `docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md`; guide: `docs/agentirc/dashboard.md`.
+- `culture/dashboard/` (server + static SPA), `culture/cli/dashboard.py` (`culture dashboard` command).
+
+### Changed
+
+- `_perm_broker.list_pending()` now excludes requests that already have a decision (awaiting their worker to consume it), so approvers (dashboard and `culture boss pending`) don't re-act on decided requests. Surfaced by live in-browser verification of the dashboard.
+
 ## [8.8.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 - `_perm_broker.list_pending()` now excludes requests that already have a decision (awaiting their worker to consume it), so approvers (dashboard and `culture boss pending`) don't re-act on decided requests. Surfaced by live in-browser verification of the dashboard.
 
+### Fixed
+
+- **Critical (regression from 8.7.0/8.8.0):** the Claude daemon read `agent.context_watch` / `agent.boss` directly, but at runtime it receives `culture.config.AgentConfig` (manifest config) where those live in `extras`, not as typed fields — so **every Claude agent daemon crashed on startup** (`'AgentConfig' object has no attribute 'context_watch'`). Unit tests missed it because they construct the backend-specific config. Fixed: `culture.config.AgentConfig` exposes `boss` + `context_watch` properties (reading `extras`, mirroring `acp_command`); the daemon normalizes either config flavor. Caught by the first live boss+worker bring-up.
+- The dashboard's `list_agents` used the backend-specific config loader, which rejects a real `server.yaml` (`telemetry.audit_enabled`); switched to the canonical `culture.config` loader.
+
 ## [8.8.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.7.0] - 2026-05-28
+
+### Added
+
+- **Helper boss permission broker** — a boss Claude Code session is the human-in-the-loop for helper agents it spawns. `culture/clients/_perm_broker.py` wires the Claude Agent SDK `can_use_tool` callback to a file-backed request/decision queue under `~/.culture/`; helpers block on boss approval for any non-safe-read tool call. Safe reads (Read/Glob/Grep, read-only Bash) auto-approve via a per-helper `perm-policy/<nick>.yaml`.
+- **Helper tool inheritance** — Claude agents now load `setting_sources=["user","project","local"]`, so helpers inherit the boss's `~/.claude/` skills, MCP servers, and plugins.
+- **Context-watermark handoff (Claude)** — `culture/clients/_context_watch.py`; the daemon self-monitors per-turn `input_tokens` and at 90% of the model's context window asks the agent to write a handoff to `~/.culture/handoff/<nick>.md`, compacts, then reminds it to read the handoff after the compact. Configurable via a `context_watch` block in `culture.yaml`.
+- **Daemon action log (all backends)** — `culture/clients/_daemon_log.py`; structured JSONL control-plane log at `~/.culture/daemon-log/<nick>.jsonl` (start/stop/exit/crash/compact/handoff/…).
+- **Agent-message audit log (all backends)** — `culture/clients/_audit.py`; one JSONL line per AssistantMessage at `~/.culture/audit/<nick>.jsonl`.
+- `docs/agentirc/helper-permissions.md`, `helper-tool-inheritance.md`, `helper-context-handoff.md`, `helper-daemon-log.md`, and the design spec `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`.
+
+### Changed
+
+- `culture/clients/claude/agent_runner.py` — widened `setting_sources`; conditional `can_use_tool` (only when a `perm-policy/<nick>.yaml` exists, preserving today's behavior for standalone agents); streaming-prompt wrapper required by the SDK when the callback is set; new `on_usage` callback.
+- `culture/clients/claude/config.py` — new `ContextWatchConfig` on `AgentConfig`.
+- `culture/clients/{claude,codex,copilot,acp}/daemon.py` — instantiate the audit + daemon-action logs and record actions; Claude daemon also drives the context-watch handoff cycle.
+- `packages/agent-harness/culture.yaml` + `culture/clients/claude/culture.yaml` — commented `context_watch` block.
+
 ## [8.6.0] - 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [8.8.0] - 2026-05-28
+
+### Added
+
+- **Boss agent orchestration** — an autonomous boss agent (a culture daemon) that manages worker agents in the human's place: spawns them, drives them over IRC like a Claude Code session, challenges their plans/implementations/claims, and approves/denies their tool requests. Spec: `docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md`.
+- `culture boss` CLI (`culture/cli/boss.py`): `init/spawn/brief/read/pending/approve/deny/audit/log/status/close`. Reuses `_perm_broker` for queue/decision/ceiling ops. Approver flips from human → boss agent.
+- **Grant ceiling (human-over-boss gate)** — `boss-policy/<boss-nick>.yaml`; high-risk tools (MCP sends, destructive Bash) are above the boss's ceiling and escalate to the human (`approve.sh`) rather than being auto-granted. `culture boss approve` refuses them (exit 2). Reuses `match_policy`.
+- **Worker→boss permission notice** — `PermissionBroker` gains a best-effort `on_request` callback; the worker daemon DMs its owning boss (`AgentConfig.boss`) so the boss's activation handler fires (finishes #411's deferred v1.1).
+- `CULTURE_NICK` is now set in every agent's SDK subprocess env (all four backends) so an autonomous daemon agent can address its own IRC / boss sockets.
+- `culture boss init` writes the boss identity: manager `system_prompt` (with context re-grounding), seeded ceiling, copied boss skill, and the no-perm-policy deadlock guard (a boss must never be permission-supervised).
+- `docs/agentirc/boss-agent.md`; `culture/clients/claude/skill/boss/SKILL.md`.
+
+### Changed
+
+- `culture/clients/_perm_broker.py` — `on_request` callback; grant-ceiling helpers (`is_above_ceiling`, `write_default_boss_ceiling`); approver-side helpers (`list_pending`, `read_request`, `write_decision` with `O_CREAT\|O_EXCL` first-writer-wins).
+- `culture/clients/claude/{agent_runner,daemon,config}.py` — `on_perm_request` plumbing, worker→boss DM (`_on_perm_request`), `AgentConfig.boss`.
+- `culture/clients/{claude,codex,copilot,acp}/agent_runner.py` — `CULTURE_NICK` in subprocess env.
+
 ## [8.7.0] - 2026-05-28
 
 ### Added

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -23,9 +23,9 @@ import logging
 import sys
 
 from culture import __version__
-from culture.cli import afi, agent, bot, channel, devex, introspect, mesh, server, skills
+from culture.cli import afi, agent, boss, bot, channel, devex, introspect, mesh, server, skills
 
-GROUPS = [agent, server, mesh, channel, bot, skills, devex, afi, introspect]
+GROUPS = [agent, server, mesh, channel, bot, boss, skills, devex, afi, introspect]
 
 
 def _names_of(group) -> set[str]:

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -23,9 +23,21 @@ import logging
 import sys
 
 from culture import __version__
-from culture.cli import afi, agent, boss, bot, channel, devex, introspect, mesh, server, skills
+from culture.cli import (
+    afi,
+    agent,
+    boss,
+    bot,
+    channel,
+    dashboard,
+    devex,
+    introspect,
+    mesh,
+    server,
+    skills,
+)
 
-GROUPS = [agent, server, mesh, channel, bot, boss, skills, devex, afi, introspect]
+GROUPS = [agent, server, mesh, channel, bot, boss, dashboard, skills, devex, afi, introspect]
 
 
 def _names_of(group) -> set[str]:

--- a/culture/cli/boss.py
+++ b/culture/cli/boss.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -317,6 +318,16 @@ def _cmd_spawn(args: argparse.Namespace) -> None:
     boss = _boss_nick()
     server = args.server or _server_of(boss)
     name = args.name
+    # Validate the worker suffix before it touches any path — `name` flows into
+    # os.path.join(...helpers, name); an unsanitized value like "../x" would
+    # escape the helpers dir and let a (mis-briefed) boss write outside it.
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", name):
+        print(
+            f"Error: invalid worker name {name!r} "
+            "(use lowercase letters, digits, hyphens; must start alphanumeric)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     worker_nick = f"{server}-{name}"
     if worker_nick == boss:
         print("Error: a boss cannot spawn a worker with its own nick", file=sys.stderr)

--- a/culture/cli/boss.py
+++ b/culture/cli/boss.py
@@ -1,0 +1,440 @@
+"""Boss subcommands: ``culture boss {init,spawn,brief,read,pending,approve,deny,audit,log,status,close}``.
+
+The orchestration surface for a *boss agent* — an autonomous culture daemon that
+manages worker agents (spawns them, drives them over IRC, and approves/denies
+their tool requests bounded by a grant ceiling). Mirrors the IRC skill's
+``culture channel`` shape; reuses ``culture.clients._perm_broker`` for all
+queue/decision/ceiling operations so there is one implementation.
+
+The boss's own nick comes from ``CULTURE_NICK`` (set by the agent runner).
+
+Design spec: docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+
+from culture.clients._audit import audit_path_for
+from culture.clients._daemon_log import daemon_log_path_for
+from culture.clients._perm_broker import (
+    DecisionExistsError,
+    culture_home,
+    has_policy_file,
+    is_above_ceiling,
+    list_pending,
+    read_request,
+    seed_helper_policy,
+    write_decision,
+    write_default_boss_ceiling,
+)
+
+from .shared.constants import DEFAULT_CONFIG
+from .shared.ipc import agent_socket_path, ipc_request
+
+NAME = "boss"
+
+_ALL_CMDS = "init|spawn|brief|read|pending|approve|deny|audit|log|status|close"
+
+_MANAGER_PROMPT = """\
+You are {nick}, a manager agent on the culture mesh. A human briefs you in your
+IRC channel ({channel}); that brief is your mission. You do NOT do the
+implementation work yourself — you drive worker agents that do.
+
+On a mission:
+1. Read CLAUDE.md and any referenced plan/spec to ground yourself in the
+   project's purpose and conventions. Ask clarifying questions in {channel} if
+   the brief is ambiguous.
+2. Spawn workers (`culture boss spawn <name>`) and drive each like a Claude Code
+   session: ask what's open, scope what fits together, tell them to plan, then
+   CHALLENGE their plan before they implement, then their implementation, then
+   their claims — verify against `culture boss audit <name>`; never take "done"
+   on faith.
+3. Approve worker tool requests as they arrive (`culture boss approve|deny`).
+   Grant `--always` for tools you trust a worker with. Some high-risk tools are
+   above your grant ceiling — when `culture boss approve` refuses, do NOT retry;
+   post the request to your human in {channel} and let them grant it.
+4. Report progress and blockers to your human in {channel}. Escalate genuine
+   judgment calls and above-ceiling requests; handle the rest yourself.
+
+When you approach your context limit you'll be asked to write a handoff and
+reminded to re-read it — re-ground on the mission, CLAUDE.md, and the plan, not
+just the last few messages.
+"""
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser("boss", help="Boss-agent orchestration of worker agents")
+    sub = p.add_subparsers(dest="boss_command")
+
+    init_p = sub.add_parser("init", help="Create/refresh this boss agent's identity")
+    init_p.add_argument("--nick", default="boss", help="Boss suffix (default: boss)")
+    init_p.add_argument("--server", default=None, help="Server name (default: from config)")
+    init_p.add_argument("--channel", default="#boss", help="Boss channel (default: #boss)")
+    init_p.add_argument("--cwd", default=None, help="Boss working directory")
+    init_p.add_argument("--config", default=DEFAULT_CONFIG)
+
+    spawn_p = sub.add_parser("spawn", help="Create + start a worker under this boss")
+    spawn_p.add_argument("name", help="Worker suffix (becomes <server>-<name>)")
+    spawn_p.add_argument("--cwd", default=None, help="Worker working directory")
+    spawn_p.add_argument("--server", default=None)
+    spawn_p.add_argument("--config", default=DEFAULT_CONFIG)
+
+    brief_p = sub.add_parser("brief", help="Send a task to a worker's channel")
+    brief_p.add_argument("name", help="Worker suffix")
+    brief_p.add_argument("task", help="Task text")
+
+    read_p = sub.add_parser("read", help="Read recent worker channel messages")
+    read_p.add_argument("name", help="Worker suffix")
+    read_p.add_argument("--limit", "-n", type=int, default=30)
+
+    sub.add_parser("pending", help="List pending worker permission requests")
+
+    approve_p = sub.add_parser("approve", help="Grant a worker permission request")
+    approve_p.add_argument("id", help="Request id")
+    approve_p.add_argument("--always", action="store_true", help="Save a sticky allow rule")
+    approve_p.add_argument("--pattern", default="", help="Tool pattern for the sticky rule")
+
+    deny_p = sub.add_parser("deny", help="Deny a worker permission request")
+    deny_p.add_argument("id", help="Request id")
+    deny_p.add_argument("reason", nargs="*", help="Reason (shown to the worker)")
+
+    audit_p = sub.add_parser("audit", help="Read a worker's agent-message audit log")
+    audit_p.add_argument("name", help="Worker suffix")
+    audit_p.add_argument("--limit", "-n", type=int, default=30)
+
+    log_p = sub.add_parser("log", help="Read a worker's daemon-action log")
+    log_p.add_argument("name", help="Worker suffix")
+    log_p.add_argument("--limit", "-n", type=int, default=30)
+
+    sub.add_parser("status", help="Summarize workers + pending perms")
+
+    close_p = sub.add_parser("close", help="Stop a worker daemon")
+    close_p.add_argument("name", help="Worker suffix")
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    if not getattr(args, "boss_command", None):
+        print(f"Usage: culture boss {{{_ALL_CMDS}}}", file=sys.stderr)
+        sys.exit(1)
+    handlers = {
+        "init": _cmd_init,
+        "spawn": _cmd_spawn,
+        "brief": _cmd_brief,
+        "read": _cmd_read,
+        "pending": _cmd_pending,
+        "approve": _cmd_approve,
+        "deny": _cmd_deny,
+        "audit": _cmd_audit,
+        "log": _cmd_log,
+        "status": _cmd_status,
+        "close": _cmd_close,
+    }
+    handler = handlers.get(args.boss_command)
+    if not handler:
+        print(f"Unknown boss command: {args.boss_command}", file=sys.stderr)
+        sys.exit(1)
+    handler(args)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _boss_nick() -> str:
+    nick = os.environ.get("CULTURE_NICK", "")
+    if not nick:
+        print(
+            "Error: CULTURE_NICK is not set. `culture boss` must run as the boss "
+            "agent (the daemon sets CULTURE_NICK) or you must export it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return nick
+
+
+def _server_of(nick: str) -> str:
+    return nick.split("-", 1)[0] if "-" in nick else "local"
+
+
+def _task_channel(name: str) -> str:
+    return f"#task-{name}"
+
+
+def _boss_irc(msg_type: str, **kwargs) -> dict | None:
+    """Route an IRC op through the boss daemon's own socket."""
+    sock = agent_socket_path(_boss_nick())
+    return asyncio.run(ipc_request(sock, msg_type, **kwargs))
+
+
+def _tail_jsonl(path: str, limit: int) -> list[dict]:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return []
+    out = []
+    for line in lines[-limit:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def _input_preview(tool: str, input_dict: dict) -> str:
+    if tool == "Bash":
+        value = input_dict.get("command", "")
+    elif tool in ("Edit", "Write"):
+        value = input_dict.get("file_path", "")
+    else:
+        try:
+            value = json.dumps(input_dict)
+        except (TypeError, ValueError):
+            value = repr(input_dict)
+    return str(value)[:70]
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _cmd_pending(args: argparse.Namespace) -> None:
+    reqs = list_pending()
+    if not reqs:
+        return
+    print(f"{'ID':<34}  {'WORKER':<16}  {'TOOL':<10}  INPUT")
+    for r in reqs:
+        print(
+            f"{r.get('id', '?'):<34}  {r.get('helper_nick', '?'):<16}  "
+            f"{r.get('tool_name', '?'):<10}  {_input_preview(r.get('tool_name', ''), r.get('input', {}))}"
+        )
+
+
+def _cmd_approve(args: argparse.Namespace) -> None:
+    boss = _boss_nick()
+    req = read_request(args.id)
+    if req is None:
+        print(f"Error: no pending request {args.id}", file=sys.stderr)
+        sys.exit(1)
+    tool = req.get("tool_name", "")
+    if is_above_ceiling(tool, req.get("input", {}), boss):
+        print(
+            f"REFUSED: {tool} is above your grant ceiling. Do not retry — escalate "
+            f"to your human in your boss channel and let them run "
+            f"`approve.sh {args.id}` (or `culture boss` with a widened ceiling).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    scope = "always" if args.always else "once"
+    try:
+        write_decision(args.id, verdict="allow", scope=scope, pattern=args.pattern, decided_by=boss)
+    except DecisionExistsError:
+        print(f"Error: a decision already exists for {args.id}", file=sys.stderr)
+        sys.exit(1)
+    print(f"approved {args.id} (scope={scope})")
+
+
+def _cmd_deny(args: argparse.Namespace) -> None:
+    boss = _boss_nick()
+    reason = " ".join(args.reason) if args.reason else ""
+    try:
+        write_decision(args.id, verdict="deny", scope="once", reason=reason, decided_by=boss)
+    except DecisionExistsError:
+        print(f"Error: a decision already exists for {args.id}", file=sys.stderr)
+        sys.exit(1)
+    print(f"denied {args.id}" + (f": {reason}" if reason else ""))
+
+
+def _cmd_audit(args: argparse.Namespace) -> None:
+    nick = f"{_server_of(_boss_nick())}-{args.name}"
+    rows = _tail_jsonl(audit_path_for(nick), args.limit)
+    if not rows:
+        print(f"No audit entries for {nick}")
+        return
+    for r in rows:
+        text = (r.get("text") or "").replace("\n", " ")[:120]
+        tools = ",".join(t.get("name", "") for t in r.get("tool_uses", []))
+        suffix = f"  [tools: {tools}]" if tools else ""
+        print(f"{r.get('ts', '')}  {text}{suffix}")
+
+
+def _cmd_log(args: argparse.Namespace) -> None:
+    nick = f"{_server_of(_boss_nick())}-{args.name}"
+    rows = _tail_jsonl(daemon_log_path_for(nick), args.limit)
+    if not rows:
+        print(f"No daemon-log entries for {nick}")
+        return
+    for r in rows:
+        detail = r.get("detail", {})
+        detail_str = " ".join(f"{k}={v}" for k, v in detail.items()) if detail else ""
+        print(f"{r.get('ts', '')}  {r.get('action', '?'):<18}  {detail_str}")
+
+
+def _cmd_brief(args: argparse.Namespace) -> None:
+    nick = f"{_server_of(_boss_nick())}-{args.name}"
+    channel = _task_channel(args.name)
+    # Prefix the worker nick so its mention detector fires.
+    text = f"@{nick} {args.task}"
+    resp = _boss_irc("irc_send", channel=channel, message=text)
+    if resp and resp.get("ok"):
+        print(f"briefed {nick} in {channel}")
+    else:
+        print(f"Error: could not brief {nick} (is the boss daemon running?)", file=sys.stderr)
+        sys.exit(1)
+
+
+def _cmd_read(args: argparse.Namespace) -> None:
+    channel = _task_channel(args.name)
+    resp = _boss_irc("irc_read", channel=channel, limit=args.limit)
+    if not resp or not resp.get("ok"):
+        print(f"Error: could not read {channel}", file=sys.stderr)
+        sys.exit(1)
+    for msg in resp.get("data", {}).get("messages", []):
+        print(f"<{msg.get('nick', '???')}> {msg.get('text', '')}")
+
+
+def _cmd_status(args: argparse.Namespace) -> None:
+    # Worker/agent states come from `culture agent status`; pending perms from
+    # the queue.
+    subprocess.run([sys.executable, "-m", "culture", "agent", "status"], check=False)
+    reqs = list_pending()
+    if reqs:
+        print(f"\n{len(reqs)} pending permission request(s) — run: culture boss pending")
+
+
+def _cmd_spawn(args: argparse.Namespace) -> None:
+    boss = _boss_nick()
+    server = args.server or _server_of(boss)
+    name = args.name
+    worker_nick = f"{server}-{name}"
+    if worker_nick == boss:
+        print("Error: a boss cannot spawn a worker with its own nick", file=sys.stderr)
+        sys.exit(1)
+    cwd = args.cwd or os.path.join(culture_home(), "helpers", name)
+    os.makedirs(cwd, exist_ok=True)
+
+    # Create + start the worker via the agent CLI (same operations as
+    # spawn-helper.sh), then seed its policy and record its boss.
+    create = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "culture",
+            "agent",
+            "create",
+            "--server",
+            server,
+            "--nick",
+            name,
+            "--agent",
+            "claude",
+        ],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if create.returncode != 0 and "already exists" not in (create.stderr + create.stdout):
+        print(f"Error creating worker: {create.stderr or create.stdout}", file=sys.stderr)
+        sys.exit(1)
+    seed_helper_policy(worker_nick)
+    _record_worker_boss(cwd, name, boss)
+    subprocess.run([sys.executable, "-m", "culture", "agent", "register", cwd], check=False)
+    subprocess.run([sys.executable, "-m", "culture", "agent", "start", worker_nick], check=False)
+    # Boss joins the worker's task channel so it sees replies + perm DMs.
+    _boss_irc("irc_join", channel=_task_channel(name))
+    print(f"spawned {worker_nick} (boss={boss}, cwd={cwd}); channel {_task_channel(name)}")
+
+
+def _record_worker_boss(cwd: str, suffix: str, boss: str) -> None:
+    """Write boss/suffix/channels into the worker's culture.yaml."""
+    import yaml
+
+    path = os.path.join(cwd, "culture.yaml")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except OSError:
+        data = {}
+    if not isinstance(data, dict):
+        data = {}
+    data.setdefault("suffix", suffix)
+    data.setdefault("backend", "claude")
+    data["boss"] = boss
+    data["channels"] = ["#team", _task_channel(suffix)]
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False)
+
+
+def _cmd_close(args: argparse.Namespace) -> None:
+    worker_nick = f"{_server_of(_boss_nick())}-{args.name}"
+    subprocess.run([sys.executable, "-m", "culture", "agent", "stop", worker_nick], check=False)
+    print(f"closed {worker_nick}")
+
+
+def _cmd_init(args: argparse.Namespace) -> None:
+    server = args.server or "local"
+    nick = f"{server}-{args.nick}"
+    cwd = args.cwd or os.path.join(culture_home(), "boss")
+    os.makedirs(cwd, exist_ok=True)
+
+    # Deadlock guard: a boss must NOT be permission-supervised, or its own
+    # `culture boss approve` calls would themselves require approval.
+    if has_policy_file(nick):
+        os.remove(_perm_policy_path(nick))
+        print(f"warning: removed stray perm-policy for boss {nick}", file=sys.stderr)
+
+    write_default_boss_ceiling(nick)
+    _write_boss_yaml(cwd, args.nick, nick, args.channel)
+    _copy_boss_skill(cwd)
+    subprocess.run([sys.executable, "-m", "culture", "agent", "register", cwd], check=False)
+    print(
+        f"boss {nick} initialized (cwd={cwd}, channel={args.channel}). "
+        f"Start it: culture agent start {nick}, then brief it in {args.channel}."
+    )
+
+
+def _perm_policy_path(nick: str) -> str:
+    from culture.clients._perm_broker import policy_path_for
+
+    return policy_path_for(nick)
+
+
+def _write_boss_yaml(cwd: str, suffix: str, nick: str, channel: str) -> None:
+    import yaml
+
+    path = os.path.join(cwd, "culture.yaml")
+    data = {
+        "suffix": suffix,
+        "backend": "claude",
+        "channels": ["#team", channel],
+        "system_prompt": _MANAGER_PROMPT.format(nick=nick, channel=channel),
+        "tags": ["boss"],
+    }
+    with open(path, "w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False)
+
+
+def _copy_boss_skill(cwd: str) -> None:
+    """Copy the in-repo boss SKILL.md into the boss cwd's .claude/skills/boss/."""
+    import shutil
+
+    src = os.path.join(os.path.dirname(__file__), "..", "clients", "claude", "skill", "boss")
+    src = os.path.abspath(src)
+    if not os.path.isdir(src):
+        return
+    dest = os.path.join(cwd, ".claude", "skills", "boss")
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    shutil.rmtree(dest, ignore_errors=True)
+    shutil.copytree(src, dest)

--- a/culture/cli/dashboard.py
+++ b/culture/cli/dashboard.py
@@ -1,0 +1,49 @@
+"""Dashboard subcommand: ``culture dashboard`` — the Mission Control web app.
+
+Localhost-only web UI to watch every agent live and intervene (approve/deny,
+pause/resume, close, emergency stop-all, policy edit).
+
+Design spec: docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .shared.constants import DEFAULT_CONFIG
+
+NAME = "dashboard"
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "dashboard", help="Mission Control web app (watch + control the mesh)"
+    )
+    p.add_argument(
+        "--host", default="127.0.0.1", help="Bind host (loopback only unless --unsafe-bind)"
+    )
+    p.add_argument("--port", type=int, default=8787, help="Bind port (default: 8787)")
+    p.add_argument("--config", default=DEFAULT_CONFIG, help="Server config path")
+    p.add_argument(
+        "--unsafe-bind",
+        action="store_true",
+        help="DANGEROUS: allow binding a non-loopback host (the dashboard can kill agents and approve tool calls)",
+    )
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    from culture.dashboard.server import serve_dashboard
+
+    try:
+        serve_dashboard(
+            host=args.host,
+            port=args.port,
+            config_path=args.config,
+            unsafe_bind=args.unsafe_bind,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        pass

--- a/culture/clients/_audit.py
+++ b/culture/clients/_audit.py
@@ -1,0 +1,166 @@
+"""Per-helper JSONL audit log of agent activity.
+
+Captures one line per ``AssistantMessage`` emitted by an agent runner. Used by
+the boss session for after-the-fact visibility into helper behavior — and as
+the primary observability surface for backends (Codex, ACP) where the broker
+cannot synchronously gate tool calls.
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from culture.clients._perm_broker import culture_home
+
+logger = logging.getLogger(__name__)
+
+# Cap previews so a single oversized tool result cannot bloat the log.
+_PREVIEW_CHARS = 200
+
+
+def _audit_dir() -> str:
+    return os.path.join(culture_home(), "audit")
+
+
+def audit_path_for(nick: str) -> str:
+    return os.path.join(_audit_dir(), f"{nick}.jsonl")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _digest(value: Any) -> str:
+    try:
+        encoded = json.dumps(value, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    except TypeError:
+        encoded = repr(value).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()[:16]}"
+
+
+def _preview(value: Any) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False)
+        except TypeError:
+            text = repr(value)
+    return text[:_PREVIEW_CHARS]
+
+
+def _summarise_assistant_message(msg: dict[str, Any]) -> dict[str, Any]:
+    text_chunks: list[str] = []
+    tool_uses: list[dict[str, Any]] = []
+    tool_results: list[dict[str, Any]] = []
+    for block in msg.get("content", []) or []:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text_value = block.get("text")
+            if isinstance(text_value, str):
+                text_chunks.append(text_value)
+        elif block_type == "tool_use":
+            tool_uses.append(
+                {
+                    "name": block.get("name", ""),
+                    "input_digest": _digest(block.get("input")),
+                }
+            )
+        elif block_type == "tool_result":
+            content = block.get("content")
+            tool_results.append(
+                {
+                    "name": block.get("name", ""),
+                    "content_digest": _digest(content),
+                    "preview": _preview(content),
+                }
+            )
+    return {
+        "text": "\n".join(text_chunks),
+        "tool_uses": tool_uses,
+        "tool_results": tool_results,
+    }
+
+
+class AuditWriter:
+    """Append-only JSONL writer for a single helper's activity.
+
+    Thread/task-safe via an internal asyncio.Lock — multiple ``write()`` calls
+    on the same instance serialise to preserve line atomicity. Writes are
+    fsync'd at the end of each line so a kernel crash does not lose the
+    most-recent line's prefix.
+    """
+
+    def __init__(self, nick: str) -> None:
+        if not nick:
+            raise ValueError("AuditWriter requires a non-empty nick")
+        self._nick = nick
+        self._path = audit_path_for(nick)
+        self._lock = asyncio.Lock()
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    async def write(self, msg: dict[str, Any]) -> None:
+        """Append one JSONL line summarising an agent message.
+
+        ``msg`` follows the dict shape produced by each backend's runner: a
+        top-level ``{"type": "assistant", "model": ..., "content": [...]}``.
+        Non-assistant messages are skipped to keep the log focused on agent
+        actions.
+        """
+        if msg.get("type") != "assistant":
+            return
+        line = self._build_line(msg)
+        async with self._lock:
+            await asyncio.to_thread(self._append_line_sync, line)
+
+    def _build_line(self, msg: dict[str, Any]) -> str:
+        record = {
+            "ts": _now_iso(),
+            "nick": self._nick,
+            "type": "assistant",
+            "model": msg.get("model", ""),
+            **_summarise_assistant_message(msg),
+        }
+        return json.dumps(record, ensure_ascii=False)
+
+    def _append_line_sync(self, line: str) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        except OSError:
+            logger.debug("Failed to ensure audit dir for %s", self._nick, exc_info=True)
+            return
+        try:
+            fd = os.open(
+                self._path,
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                0o600,
+            )
+        except OSError:
+            logger.warning("Failed to open audit log %s", self._path, exc_info=True)
+            return
+        try:
+            handle = os.fdopen(fd, "a", encoding="utf-8")
+        except OSError:
+            os.close(fd)
+            logger.warning("Failed to wrap audit log fd %s", self._path, exc_info=True)
+            return
+        try:
+            with handle:
+                handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError:
+            logger.warning("Failed to append to audit log %s", self._path, exc_info=True)

--- a/culture/clients/_context_watch.py
+++ b/culture/clients/_context_watch.py
@@ -1,0 +1,127 @@
+"""Context-watermark handoff logic.
+
+A long-running agent fills its context window. Before it does, the daemon asks
+the agent to write a handoff for its post-compact self, triggers a compact, then
+reminds it to read the handoff on next activation. This module holds the pure
+decision logic; the daemon owns the I/O (sending prompts, triggering compact).
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Context window sizes by model family. Unknown models default to the
+# conservative 200K. Extend this map as new models ship.
+_CONTEXT_WINDOWS: list[tuple[re.Pattern[str], int]] = [
+    (re.compile(r"claude-opus-4.*1m", re.IGNORECASE), 1_000_000),
+    (re.compile(r"claude-opus-4", re.IGNORECASE), 200_000),
+    (re.compile(r"claude-sonnet-4", re.IGNORECASE), 200_000),
+    (re.compile(r"claude-haiku-4", re.IGNORECASE), 200_000),
+]
+_DEFAULT_CONTEXT_WINDOW = 200_000
+
+# 1M-context model IDs carry a separate marker; the SDK model id for the
+# 1M beta is exposed as e.g. "claude-opus-4-7[1m]". Match that explicitly.
+_ONE_M_MARKER = re.compile(r"\[1m\]|1m|1000k|one[-_]?m", re.IGNORECASE)
+
+
+def context_window_for(model: str) -> int:
+    """Resolve the context window (in tokens) for a model id."""
+    if not model:
+        return _DEFAULT_CONTEXT_WINDOW
+    if "opus-4" in model.lower() and _ONE_M_MARKER.search(model):
+        return 1_000_000
+    for pattern, size in _CONTEXT_WINDOWS:
+        if pattern.search(model):
+            return size
+    logger.warning(
+        "Unknown model %r for context-watch; defaulting to %d tokens",
+        model,
+        _DEFAULT_CONTEXT_WINDOW,
+    )
+    return _DEFAULT_CONTEXT_WINDOW
+
+
+class WatchAction(enum.Enum):
+    """What the daemon should do after evaluating a turn's usage."""
+
+    NONE = "none"
+    WRITE_HANDOFF = "write_handoff"
+    REMINDER_DUE = "reminder_due"
+
+
+@dataclass
+class ContextWatchState:
+    """Mutable per-agent watch state.
+
+    ``high_water`` / ``low_water`` are fractions of the context window.
+    ``handoff_latched`` prevents re-firing the handoff every turn while still
+    above threshold. ``reminder_pending`` signals that a post-compact reminder
+    is owed on the next activation.
+    """
+
+    high_water: float = 0.90
+    low_water: float = 0.50
+    enabled: bool = True
+    handoff_latched: bool = False
+    reminder_pending: bool = False
+
+
+def evaluate(state: ContextWatchState, input_tokens: int | None, model: str) -> WatchAction:
+    """Decide the next watch action from a turn's input-token count.
+
+    Called by the daemon after each ``ResultMessage``. Mutates ``state``.
+
+    - At/above ``high_water`` and not latched: return WRITE_HANDOFF, set latch.
+    - Below ``low_water`` while latched: a compact has actually dropped usage —
+      reset the latch and return REMINDER_DUE so the daemon arms the
+      post-compact reminder *now* (not when the compact was merely queued, which
+      would let an interleaving activation consume the reminder too early).
+    - Otherwise: NONE.
+    """
+    if not state.enabled or input_tokens is None or input_tokens <= 0:
+        return WatchAction.NONE
+
+    window = context_window_for(model)
+    pct = input_tokens / window
+
+    if pct < state.low_water:
+        if state.handoff_latched:
+            # Context dropped after a handoff+compact — re-arm and signal that
+            # the reminder is now due.
+            state.handoff_latched = False
+            return WatchAction.REMINDER_DUE
+        return WatchAction.NONE
+
+    if pct >= state.high_water and not state.handoff_latched:
+        state.handoff_latched = True
+        return WatchAction.WRITE_HANDOFF
+
+    return WatchAction.NONE
+
+
+def fraction(input_tokens: int | None, model: str) -> float | None:
+    """Return the context-fill fraction for a turn, or None if unknown."""
+    if input_tokens is None or input_tokens <= 0:
+        return None
+    return input_tokens / context_window_for(model)
+
+
+def mark_reminder_pending(state: ContextWatchState) -> None:
+    """Record that a post-compact reminder is owed."""
+    state.reminder_pending = True
+
+
+def take_reminder(state: ContextWatchState) -> bool:
+    """Consume the reminder flag. Returns True if a reminder was pending."""
+    if state.reminder_pending:
+        state.reminder_pending = False
+        return True
+    return False

--- a/culture/clients/_daemon_log.py
+++ b/culture/clients/_daemon_log.py
@@ -1,0 +1,86 @@
+"""Per-agent control-plane action log.
+
+Distinct from the agent-message audit log (``_audit.py``): this records what the
+*daemon* does to manage the agent — start/stop/exit/crash/compact/handoff/etc.
+One JSONL line per action at ``~/.culture/daemon-log/<nick>.jsonl``. Universal
+across all backends.
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from culture.clients._perm_broker import culture_home
+
+logger = logging.getLogger(__name__)
+
+
+def _daemon_log_dir() -> str:
+    return os.path.join(culture_home(), "daemon-log")
+
+
+def daemon_log_path_for(nick: str) -> str:
+    return os.path.join(_daemon_log_dir(), f"{nick}.jsonl")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+class DaemonLog:
+    """Append-only JSONL writer for a single agent's daemon actions."""
+
+    def __init__(self, nick: str) -> None:
+        if not nick:
+            raise ValueError("DaemonLog requires a non-empty nick")
+        self._nick = nick
+        self._path = daemon_log_path_for(nick)
+        self._lock = asyncio.Lock()
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    async def record(self, action: str, **detail: Any) -> None:
+        """Append one action line. ``detail`` becomes the record's detail dict."""
+        record = {
+            "ts": _now_iso(),
+            "nick": self._nick,
+            "action": action,
+            "detail": detail,
+        }
+        line = json.dumps(record, ensure_ascii=False, default=str)
+        async with self._lock:
+            await asyncio.to_thread(self._append_line_sync, line)
+
+    def _append_line_sync(self, line: str) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        except OSError:
+            logger.debug("Failed to ensure daemon-log dir for %s", self._nick, exc_info=True)
+            return
+        try:
+            fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        except OSError:
+            logger.warning("Failed to open daemon log %s", self._path, exc_info=True)
+            return
+        try:
+            handle = os.fdopen(fd, "a", encoding="utf-8")
+        except OSError:
+            os.close(fd)
+            logger.warning("Failed to wrap daemon log fd %s", self._path, exc_info=True)
+            return
+        try:
+            with handle:
+                handle.write(line + "\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError:
+            logger.warning("Failed to append to daemon log %s", self._path, exc_info=True)

--- a/culture/clients/_perm_broker.py
+++ b/culture/clients/_perm_broker.py
@@ -352,14 +352,24 @@ def _now_iso() -> str:
 
 
 def list_pending() -> list[dict[str, Any]]:
-    """Return all pending permission requests (parsed queue files), oldest first."""
+    """Return permission requests still awaiting a decision, oldest first.
+
+    A request whose ``perm-decisions/<id>.json`` already exists is *decided* —
+    it is only waiting for its worker to consume the verdict — so it is excluded.
+    Otherwise an approver (boss CLI or dashboard) would see already-decided
+    requests and re-act on them (hitting :class:`DecisionExistsError`), which is
+    visible whenever a worker is slow or gone.
+    """
     queue_dir = _queue_dir()
+    decisions_dir = _decisions_dir()
     out: list[dict[str, Any]] = []
     try:
         names = sorted(n for n in os.listdir(queue_dir) if n.endswith(".json"))
     except OSError:
         return out
     for name in names:
+        if os.path.exists(os.path.join(decisions_dir, name)):
+            continue  # already decided, awaiting worker consumption
         try:
             with open(os.path.join(queue_dir, name), encoding="utf-8") as handle:
                 out.append(json.load(handle))

--- a/culture/clients/_perm_broker.py
+++ b/culture/clients/_perm_broker.py
@@ -1,0 +1,486 @@
+"""File-backed permission broker for boss-supervised helper agents.
+
+The broker bridges the Claude Agent SDK's ``can_use_tool`` callback to a
+file-backed request/decision queue under ``~/.culture/``. A regular Claude
+Code session ("boss") acts as the human-in-the-loop authority for tool calls
+made by helper agent daemons it has spawned.
+
+Design spec: docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import secrets
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import yaml
+from claude_agent_sdk import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+
+logger = logging.getLogger(__name__)
+
+# Poll cadence while awaiting a decision file.
+_POLL_INTERVAL_SECONDS = 0.25
+
+# Default permission policy seeded by spawn-helper.sh when a helper has no
+# existing perm-policy/<nick>.yaml.  Mirrors the spec's "pre-seeded safe-read
+# defaults".  Note: ``require_approval`` is informational; anything that does
+# not match ``auto_allow`` or ``auto_deny`` falls through to the boss anyway.
+_BASH_SAFE_READ_REGEX = (
+    r"^(ls|cat|head|tail|wc|file|stat|pwd|which|rg|grep|find|tree|"
+    r"git (status|log|diff|blame|show)|gh (.* )?(list|view))(\s|$)"
+)
+DEFAULT_POLICY: dict[str, Any] = {
+    "auto_allow": [
+        {"tool": "Read"},
+        {"tool": "Glob"},
+        {"tool": "Grep"},
+        {"tool": "Bash", "input_regex": _BASH_SAFE_READ_REGEX},
+    ],
+    "auto_deny": [],
+    "require_approval": [
+        {"tool": "Edit"},
+        {"tool": "Write"},
+        {"tool": "mcp__.*"},
+        {"tool": "Bash"},
+    ],
+}
+
+
+def culture_home() -> str:
+    """Resolve the broker's root directory.
+
+    Honors ``CULTURE_HOME`` for test isolation; falls back to ``~/.culture``.
+    """
+    return os.environ.get("CULTURE_HOME", os.path.expanduser("~/.culture"))
+
+
+def _queue_dir() -> str:
+    return os.path.join(culture_home(), "perm-queue")
+
+
+def _decisions_dir() -> str:
+    return os.path.join(culture_home(), "perm-decisions")
+
+
+def _policy_dir() -> str:
+    return os.path.join(culture_home(), "perm-policy")
+
+
+def policy_path_for(nick: str) -> str:
+    """Return the policy file path for a given agent nick."""
+    return os.path.join(_policy_dir(), f"{nick}.yaml")
+
+
+def has_policy_file(nick: str) -> bool:
+    """True iff the helper has a policy file (i.e. is boss-supervised)."""
+    return bool(nick) and os.path.exists(policy_path_for(nick))
+
+
+def _mkdir_secure(path: str) -> None:
+    """Create a directory with 0700 perms if missing."""
+    os.makedirs(path, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        logger.debug("Could not chmod %s; continuing", path, exc_info=True)
+
+
+def _atomic_write_json(dest: str, payload: dict[str, Any]) -> None:
+    """Write JSON to ``dest`` atomically with 0600 perms.
+
+    Writes via ``tempfile`` in the same directory, fsyncs, then ``os.replace``.
+    """
+    _mkdir_secure(os.path.dirname(dest))
+    fd, tmp = tempfile.mkstemp(
+        prefix=".tmp-",
+        suffix=".json",
+        dir=os.path.dirname(dest),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, dest)
+    except BaseException:
+        # Clean up the temp file on any failure (incl. cancellation).
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_yaml(dest: str, payload: dict[str, Any]) -> None:
+    """Write YAML to ``dest`` atomically with 0600 perms."""
+    _mkdir_secure(os.path.dirname(dest))
+    fd, tmp = tempfile.mkstemp(
+        prefix=".tmp-",
+        suffix=".yaml",
+        dir=os.path.dirname(dest),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False, default_flow_style=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def write_default_policy(nick: str) -> str:
+    """Seed the default policy file for a helper if missing.
+
+    Returns the path. Idempotent — if the file exists, it is not overwritten.
+    """
+    dest = policy_path_for(nick)
+    if os.path.exists(dest):
+        return dest
+    _atomic_write_yaml(dest, DEFAULT_POLICY)
+    return dest
+
+
+def handoff_path_for(nick: str) -> str:
+    """Return the context-handoff file path for a given agent nick."""
+    return os.path.join(culture_home(), "handoff", f"{nick}.md")
+
+
+def _handoff_auto_allow_rule(nick: str) -> dict[str, Any]:
+    """Auto-allow rule letting a helper write its own context-handoff file.
+
+    A context-crisis handoff must never stall on boss approval, so the helper's
+    Write to handoff/<nick>.md is pre-approved. All other Writes still route to
+    the boss.
+    """
+    return {
+        "tool": "Write",
+        "input_regex": rf"/handoff/{re.escape(nick)}\.md$",
+    }
+
+
+def seed_helper_policy(nick: str) -> str:
+    """Seed a boss-supervised helper's policy file.
+
+    Writes the default safe-read policy (if missing) and ensures the
+    context-handoff write auto-allow rule is present. Idempotent.
+    """
+    dest = write_default_policy(nick)
+    rule = _handoff_auto_allow_rule(nick)
+    try:
+        with open(dest, encoding="utf-8") as handle:
+            policy = yaml.safe_load(handle) or {}
+    except OSError:
+        policy = {}
+    if not isinstance(policy, dict):
+        policy = {}
+    auto_allow = policy.setdefault("auto_allow", []) or []
+    if not isinstance(auto_allow, list):
+        auto_allow = []
+    if rule not in auto_allow:
+        auto_allow.append(rule)
+        policy["auto_allow"] = auto_allow
+        _atomic_write_yaml(dest, policy)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Policy matcher
+# ---------------------------------------------------------------------------
+
+_REGEX_METACHARS = re.compile(r"[.*+?\[\]^$|()\\]")
+
+
+def _tool_matches(tool_name: str, pattern: str) -> bool:
+    if _REGEX_METACHARS.search(pattern):
+        try:
+            return re.fullmatch(pattern, tool_name) is not None
+        except re.error:
+            logger.warning("Invalid tool pattern %r in policy", pattern)
+            return False
+    return tool_name == pattern
+
+
+def _project_input(tool_name: str, input_dict: dict[str, Any]) -> str | None:
+    """Project a tool's input to a single string for regex matching."""
+    if tool_name == "Bash":
+        value = input_dict.get("command")
+        return value if isinstance(value, str) else None
+    if tool_name in ("Edit", "Write"):
+        value = input_dict.get("file_path")
+        return value if isinstance(value, str) else None
+    if tool_name.startswith("mcp__"):
+        try:
+            return json.dumps(input_dict, sort_keys=True)
+        except TypeError:
+            return repr(input_dict)
+    return None
+
+
+def _rule_matches(tool_name: str, input_dict: dict[str, Any], rule: dict[str, Any]) -> bool:
+    pattern = rule.get("tool")
+    if not isinstance(pattern, str) or not _tool_matches(tool_name, pattern):
+        return False
+    input_regex = rule.get("input_regex")
+    if input_regex is None:
+        return True
+    projected = _project_input(tool_name, input_dict) if isinstance(input_regex, str) else None
+    if projected is None:
+        return False
+    try:
+        return re.search(input_regex, projected) is not None
+    except re.error:
+        logger.warning("Invalid input_regex %r in policy", input_regex)
+        return False
+
+
+def match_policy(
+    tool_name: str,
+    input_dict: dict[str, Any],
+    policy: dict[str, Any],
+) -> str | None:
+    """Apply policy rules to a tool invocation.
+
+    Returns ``"allow"``, ``"deny"``, or ``None`` (route to boss). ``auto_deny``
+    is checked before ``auto_allow``; first match wins within each section.
+    """
+    for section, verdict in (("auto_deny", "deny"), ("auto_allow", "allow")):
+        for rule in policy.get(section, []) or []:
+            if isinstance(rule, dict) and _rule_matches(tool_name, input_dict, rule):
+                return verdict
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Broker
+# ---------------------------------------------------------------------------
+
+
+def _new_request_id() -> str:
+    """Mint a sortable, unique request ID."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S-%f")
+    return f"req-{ts}-{secrets.token_hex(3)}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass
+class _PolicyCache:
+    path: str
+    mtime: float
+    policy: dict[str, Any]
+
+
+class PermissionBroker:
+    """Per-helper permission broker.
+
+    One instance is created per ``AgentRunner`` and reused across SDK turns.
+    The broker's ``gate`` method is the ``can_use_tool`` callback.
+    """
+
+    def __init__(self, nick: str) -> None:
+        if not nick:
+            raise ValueError("PermissionBroker requires a non-empty nick")
+        self._nick = nick
+        self._cache: _PolicyCache | None = None
+
+    @property
+    def nick(self) -> str:
+        return self._nick
+
+    def _load_policy(self) -> dict[str, Any]:
+        """Load (or refresh) the policy file for this helper."""
+        path = policy_path_for(self._nick)
+        try:
+            mtime = os.path.getmtime(path)
+        except OSError:
+            # No file → no auto-rules. Everything falls through to boss.
+            return {"auto_allow": [], "auto_deny": []}
+        if self._cache and self._cache.path == path and self._cache.mtime == mtime:
+            return self._cache.policy
+        try:
+            with open(path, encoding="utf-8") as handle:
+                policy = yaml.safe_load(handle) or {}
+        except (OSError, yaml.YAMLError):
+            logger.warning("Failed to read policy %s; treating as empty", path, exc_info=True)
+            policy = {}
+        if not isinstance(policy, dict):
+            logger.warning("Policy %s is not a mapping; treating as empty", path)
+            policy = {}
+        self._cache = _PolicyCache(path=path, mtime=mtime, policy=policy)
+        return policy
+
+    async def gate(
+        self,
+        tool_name: str,
+        input_dict: dict[str, Any],
+        context: ToolPermissionContext,  # noqa: ARG002 — SDK API requires this slot
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        """SDK ``can_use_tool`` callback.
+
+        Fast path: policy match returns immediately. Slow path: write request
+        to ``perm-queue/<id>.json``, await ``perm-decisions/<id>.json``,
+        return SDK verdict.
+        """
+        policy = self._load_policy()
+        verdict = match_policy(tool_name, input_dict, policy)
+        if verdict == "allow":
+            return PermissionResultAllow(updated_input=None)
+        if verdict == "deny":
+            return PermissionResultDeny(
+                message=f"Policy auto-deny for {tool_name}",
+                interrupt=False,
+            )
+        return await self._request_from_boss(tool_name, input_dict)
+
+    async def _request_from_boss(
+        self,
+        tool_name: str,
+        input_dict: dict[str, Any],
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        request_id = _new_request_id()
+        queue_path = os.path.join(_queue_dir(), f"{request_id}.json")
+        decision_path = os.path.join(_decisions_dir(), f"{request_id}.json")
+        _mkdir_secure(_queue_dir())
+        _mkdir_secure(_decisions_dir())
+
+        payload = {
+            "id": request_id,
+            "helper_nick": self._nick,
+            "tool_name": tool_name,
+            "input": _safe_jsonable(input_dict),
+            "created_at": _now_iso(),
+        }
+        _atomic_write_json(queue_path, payload)
+
+        try:
+            decision = await self._await_decision(decision_path)
+        except asyncio.CancelledError:
+            # Helper task cancelled mid-wait; clean up our request file so it
+            # does not linger in the queue.  Re-raise so the SDK sees the
+            # cancellation.  Mirrors the discipline from commit d0902f9
+            # ("fix: re-raise CancelledError and save create_task results").
+            self._best_effort_unlink(queue_path)
+            raise
+
+        # Clean up both files; they are single-use.
+        self._best_effort_unlink(queue_path)
+        self._best_effort_unlink(decision_path)
+
+        scope = decision.get("scope", "once")
+        verdict = decision.get("verdict")
+        reason = decision.get("reason", "")
+
+        if scope == "always" and verdict in ("allow", "deny"):
+            self._append_sticky_rule(verdict, tool_name, decision)
+
+        # Drop the policy cache so the freshly-appended rule is visible to
+        # the next call.
+        self._cache = None
+
+        if verdict == "allow":
+            return PermissionResultAllow(updated_input=None)
+        if verdict == "deny":
+            return PermissionResultDeny(
+                message=reason or f"Boss denied {tool_name}",
+                interrupt=False,
+            )
+        # Unknown verdict — fail closed.
+        return PermissionResultDeny(
+            message=f"Broker received unknown verdict {verdict!r}",
+            interrupt=False,
+        )
+
+    async def _await_decision(self, decision_path: str) -> dict[str, Any]:
+        """Poll until the decision file exists and parses, then return it.
+
+        Reads are best-effort each tick: a transient ``OSError`` (the file was
+        removed between the existence check and the open) or ``JSONDecodeError``
+        (a non-atomic writer mid-write) is swallowed and the loop retries on the
+        next tick. The boss scripts write atomically via ``os.replace`` so a
+        complete, valid file is the steady state; this loop simply never lets a
+        read error escape and orphan the in-flight request.
+        """
+        while True:
+            decision = self._try_read_decision(decision_path)
+            if decision is not None:
+                return decision
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+    @staticmethod
+    def _try_read_decision(decision_path: str) -> dict[str, Any] | None:
+        """Read+parse a decision file, or None if not yet readable/valid."""
+        try:
+            with open(decision_path, encoding="utf-8") as handle:
+                return json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def _append_sticky_rule(
+        self,
+        verdict: str,
+        tool_name: str,
+        decision: dict[str, Any],
+    ) -> None:
+        """Append a sticky rule to this helper's policy file."""
+        policy_path = policy_path_for(self._nick)
+        try:
+            with open(policy_path, encoding="utf-8") as handle:
+                policy = yaml.safe_load(handle) or {}
+        except OSError:
+            policy = {}
+        if not isinstance(policy, dict):
+            policy = {}
+
+        section = "auto_allow" if verdict == "allow" else "auto_deny"
+        rules = policy.setdefault(section, []) or []
+        if not isinstance(rules, list):
+            rules = []
+        # Decision may carry an override pattern in ``decision["pattern"]``;
+        # otherwise the rule is an exact-tool-name match.
+        rule: dict[str, Any] = {"tool": decision.get("pattern") or tool_name}
+        # Avoid duplicating an identical rule.
+        if rule not in rules:
+            rules.append(rule)
+        policy[section] = rules
+        _atomic_write_yaml(policy_path, policy)
+
+    @staticmethod
+    def _best_effort_unlink(path: str) -> None:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _safe_jsonable(value: Any) -> Any:
+    """Convert arbitrary tool input into a JSON-serialisable shape."""
+    try:
+        json.dumps(value)
+        return value
+    except TypeError:
+        if isinstance(value, dict):
+            return {str(k): _safe_jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [_safe_jsonable(v) for v in value]
+        return repr(value)

--- a/culture/clients/_perm_broker.py
+++ b/culture/clients/_perm_broker.py
@@ -415,7 +415,18 @@ def write_decision(
         payload["reason"] = reason
     if pattern:
         payload["pattern"] = pattern
-    _atomic_write_json(dest, payload)
+    try:
+        _atomic_write_json(dest, payload)
+    except BaseException:
+        # On any failure after we created the O_EXCL placeholder, remove it.
+        # Otherwise a zero-byte sentinel lingers at dest: the waiting worker
+        # parses it forever (silent deadlock) and a retry is permanently
+        # blocked by DecisionExistsError.
+        try:
+            os.unlink(dest)
+        except OSError:
+            pass
+        raise
     return dest
 
 

--- a/culture/clients/_perm_broker.py
+++ b/culture/clients/_perm_broker.py
@@ -346,6 +346,79 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
+# ---------------------------------------------------------------------------
+# Approver-side helpers (shared by the boss CLI and the human approve scripts)
+# ---------------------------------------------------------------------------
+
+
+def list_pending() -> list[dict[str, Any]]:
+    """Return all pending permission requests (parsed queue files), oldest first."""
+    queue_dir = _queue_dir()
+    out: list[dict[str, Any]] = []
+    try:
+        names = sorted(n for n in os.listdir(queue_dir) if n.endswith(".json"))
+    except OSError:
+        return out
+    for name in names:
+        try:
+            with open(os.path.join(queue_dir, name), encoding="utf-8") as handle:
+                out.append(json.load(handle))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def read_request(request_id: str) -> dict[str, Any] | None:
+    """Read a single pending request by id, or None if absent/unreadable."""
+    path = os.path.join(_queue_dir(), f"{request_id}.json")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+class DecisionExistsError(RuntimeError):
+    """Raised when a decision already exists for a request (first-writer-wins)."""
+
+
+def write_decision(
+    request_id: str,
+    *,
+    verdict: str,
+    scope: str = "once",
+    reason: str = "",
+    pattern: str = "",
+    decided_by: str = "boss",
+) -> str:
+    """Write a decision file (first-writer-wins via O_CREAT|O_EXCL + atomic rename).
+
+    Raises :class:`DecisionExistsError` if a decision already exists for the id.
+    Returns the decision path. Used by the boss CLI; the human scripts mirror it.
+    """
+    dest = os.path.join(_decisions_dir(), f"{request_id}.json")
+    _mkdir_secure(_decisions_dir())
+    # First-writer-wins guard on the destination path.
+    try:
+        fd = os.open(dest, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise DecisionExistsError(request_id) from exc
+    os.close(fd)
+    payload: dict[str, Any] = {
+        "id": request_id,
+        "verdict": verdict,
+        "scope": scope,
+        "decided_by": decided_by,
+        "decided_at": _now_iso(),
+    }
+    if reason:
+        payload["reason"] = reason
+    if pattern:
+        payload["pattern"] = pattern
+    _atomic_write_json(dest, payload)
+    return dest
+
+
 @dataclass
 class _PolicyCache:
     path: str

--- a/culture/clients/_perm_broker.py
+++ b/culture/clients/_perm_broker.py
@@ -17,6 +17,7 @@ import os
 import re
 import secrets
 import tempfile
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -270,6 +271,67 @@ def match_policy(
 
 
 # ---------------------------------------------------------------------------
+# Boss grant ceiling (human-over-boss gate)
+# ---------------------------------------------------------------------------
+
+# Tools a boss agent MAY NOT auto-grant to a worker; these escalate to the human.
+# Structurally a denylist, matched by reusing ``match_policy`` (as auto_deny).
+DEFAULT_BOSS_CEILING: list[dict[str, Any]] = [
+    {"tool": "mcp__.*"},  # any MCP server — external side effects
+    {
+        "tool": "Bash",
+        "input_regex": (
+            r"(^|\s|;|&&|\|\|)(rm\s+-rf|git\s+push|gh\s+(pr|release)\s+(create|merge)|"
+            r"kubectl|terraform|drop\s+table|truncate)"
+        ),
+    },
+]
+
+
+def _boss_policy_dir() -> str:
+    return os.path.join(culture_home(), "boss-policy")
+
+
+def boss_policy_path_for(nick: str) -> str:
+    """Path to a boss agent's grant-ceiling file."""
+    return os.path.join(_boss_policy_dir(), f"{nick}.yaml")
+
+
+def write_default_boss_ceiling(nick: str) -> str:
+    """Seed a boss agent's grant-ceiling file if missing. Idempotent."""
+    dest = boss_policy_path_for(nick)
+    if os.path.exists(dest):
+        return dest
+    _atomic_write_yaml(dest, {"grant_ceiling": DEFAULT_BOSS_CEILING})
+    return dest
+
+
+def load_boss_ceiling(nick: str) -> list[dict[str, Any]]:
+    """Load a boss agent's ceiling rules (empty list if no file)."""
+    path = boss_policy_path_for(nick)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    rules = data.get("grant_ceiling", []) or []
+    return [r for r in rules if isinstance(r, dict)]
+
+
+def is_above_ceiling(tool_name: str, input_dict: dict[str, Any], boss_nick: str) -> bool:
+    """True iff a tool call is above the boss's grant ceiling (→ escalate to human).
+
+    Reuses ``match_policy`` by treating the ceiling as an ``auto_deny`` denylist.
+    """
+    ceiling = load_boss_ceiling(boss_nick)
+    if not ceiling:
+        return False
+    return match_policy(tool_name, input_dict, {"auto_deny": ceiling}) == "deny"
+
+
+# ---------------------------------------------------------------------------
 # Broker
 # ---------------------------------------------------------------------------
 
@@ -298,11 +360,18 @@ class PermissionBroker:
     The broker's ``gate`` method is the ``can_use_tool`` callback.
     """
 
-    def __init__(self, nick: str) -> None:
+    def __init__(
+        self,
+        nick: str,
+        on_request: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    ) -> None:
         if not nick:
             raise ValueError("PermissionBroker requires a non-empty nick")
         self._nick = nick
         self._cache: _PolicyCache | None = None
+        # Optional best-effort notification fired when a request is routed to the
+        # boss (e.g. the worker daemon posts an IRC notice). Never blocks gating.
+        self._on_request = on_request
 
     @property
     def nick(self) -> str:
@@ -372,6 +441,22 @@ class PermissionBroker:
             "created_at": _now_iso(),
         }
         _atomic_write_json(queue_path, payload)
+
+        # Best-effort notify the boss (e.g. an IRC post). A failure here must
+        # never block or fail the gate — the file queue is the source of truth
+        # and the boss can still find the request by polling.
+        if self._on_request is not None:
+            try:
+                await self._on_request(dict(payload))
+            except asyncio.CancelledError:
+                self._best_effort_unlink(queue_path)
+                raise
+            except Exception:  # noqa: BLE001 — notification is advisory
+                logger.warning(
+                    "on_request notification failed for %s; boss must poll",
+                    request_id,
+                    exc_info=True,
+                )
 
         try:
             decision = await self._await_decision(decision_path)

--- a/culture/clients/acp/agent_runner.py
+++ b/culture/clients/acp/agent_runner.py
@@ -138,6 +138,10 @@ class ACPAgentRunner:
         isolated_env = dict(os.environ)
         isolated_env["XDG_DATA_HOME"] = os.path.join(self._isolated_home, ".local", "share")
         isolated_env["XDG_STATE_HOME"] = os.path.join(self._isolated_home, ".local", "state")
+        # Expose the agent's own nick so its IRC / boss skills can resolve this
+        # daemon's socket (autonomous agents can't `export` it themselves).
+        if self._nick:
+            isolated_env["CULTURE_NICK"] = self._nick
 
         cmd_label = " ".join(self.acp_command)
         try:

--- a/culture/clients/acp/daemon.py
+++ b/culture/clients/acp/daemon.py
@@ -18,6 +18,8 @@ import time
 from collections import deque
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._daemon_log import DaemonLog
 from culture.clients.acp.agent_runner import ACPAgentRunner
 from culture.clients.acp.config import AgentConfig, DaemonConfig
 from culture.clients.acp.ipc import make_response
@@ -74,6 +76,8 @@ class ACPDaemon:
         self._supervisor: Supervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -231,6 +235,7 @@ class ACPDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -409,6 +414,9 @@ class ACPDaemon:
             self.agent.nick,
             " ".join(self.agent.acp_command),
         )
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -538,6 +546,8 @@ class ACPDaemon:
         self._consecutive_turn_failures = 0
         await self._relay_response_to_irc(msg)
 
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
@@ -598,6 +608,7 @@ class ACPDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -940,6 +951,7 @@ class ACPDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any, AsyncIterable, Awaitable, Callable
 
@@ -171,12 +172,24 @@ class AgentRunner:
             # (no boss watching the queue) forever on first non-auto-allow
             # tool call.
             can_use_tool=self._can_use_tool,
+            # Expose the agent's own nick to its Bash tools so the IRC skill
+            # (`culture channel …`) and the boss skill (`culture boss …`) can
+            # resolve this daemon's socket. Without it an autonomous daemon
+            # agent cannot address its own IRC connection.
+            env=self._subprocess_env(),
         )
         if self.system_prompt:
             opts.system_prompt = self.system_prompt
         if self._session_id:
             opts.resume = self._session_id
         return opts
+
+    def _subprocess_env(self) -> dict[str, str]:
+        """Env for the SDK subprocess: inherit ours + pin CULTURE_NICK."""
+        env = dict(os.environ)
+        if self._nick:
+            env["CULTURE_NICK"] = self._nick
+        return env
 
     def _handle_result_message(self, msg: ResultMessage) -> None:
         """Handle a ResultMessage — track session and log errors."""

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -82,6 +82,7 @@ class AgentRunner:
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         on_usage: Callable[[int | None], Awaitable[None]] | None = None,
+        on_perm_request: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
     ) -> None:
@@ -91,6 +92,7 @@ class AgentRunner:
         self.on_exit = on_exit
         self.on_message = on_message
         self.on_usage = on_usage
+        self.on_perm_request = on_perm_request
         self._metrics = metrics
         self._nick = nick
 
@@ -103,7 +105,9 @@ class AgentRunner:
         # Standalone mesh agents (no policy file) keep today's bypassPermissions
         # semantics: can_use_tool=None and string-prompt path preserved.
         if nick and has_policy_file(nick):
-            self._broker: PermissionBroker | None = PermissionBroker(nick=nick)
+            self._broker: PermissionBroker | None = PermissionBroker(
+                nick=nick, on_request=on_perm_request
+            )
             self._can_use_tool = self._broker.gate
         else:
             self._broker = None

--- a/culture/clients/claude/agent_runner.py
+++ b/culture/clients/claude/agent_runner.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, AsyncIterable, Awaitable, Callable
 
 from claude_agent_sdk import (
     AssistantMessage,
@@ -17,12 +17,25 @@ from claude_agent_sdk import (
 )
 from opentelemetry import trace as _otel_trace
 
+from culture.clients._perm_broker import PermissionBroker, has_policy_file
 from culture.clients.claude.telemetry import _HARNESS_TRACER_NAME, record_llm_call
 
 if TYPE_CHECKING:
     from culture.clients.claude.telemetry import HarnessMetricsRegistry
 
 logger = logging.getLogger(__name__)
+
+
+async def _single_user_message_stream(text: str) -> AsyncIterable[dict[str, Any]]:
+    """Yield one user message in the SDK's streaming-mode shape.
+
+    Required by the Claude Agent SDK whenever ``can_use_tool`` is set
+    (client.py raises ``ValueError`` if ``prompt`` is a plain string).
+    """
+    yield {
+        "type": "user",
+        "message": {"role": "user", "content": text},
+    }
 
 
 def _content_block_to_dict(block: Any) -> dict[str, Any]:
@@ -68,6 +81,7 @@ class AgentRunner:
         system_prompt: str = "",
         on_exit: Callable[[int], Awaitable[None]] | None = None,
         on_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        on_usage: Callable[[int | None], Awaitable[None]] | None = None,
         metrics: HarnessMetricsRegistry | None = None,
         nick: str = "",
     ) -> None:
@@ -76,6 +90,7 @@ class AgentRunner:
         self.system_prompt = system_prompt
         self.on_exit = on_exit
         self.on_message = on_message
+        self.on_usage = on_usage
         self._metrics = metrics
         self._nick = nick
 
@@ -83,6 +98,16 @@ class AgentRunner:
         self._task: asyncio.Task | None = None
         self._stopping = False
         self._prompt_queue: asyncio.Queue[str] = asyncio.Queue()
+
+        # Permission broker — wired only when a perm-policy/<nick>.yaml exists.
+        # Standalone mesh agents (no policy file) keep today's bypassPermissions
+        # semantics: can_use_tool=None and string-prompt path preserved.
+        if nick and has_policy_file(nick):
+            self._broker: PermissionBroker | None = PermissionBroker(nick=nick)
+            self._can_use_tool = self._broker.gate
+        else:
+            self._broker = None
+            self._can_use_tool = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -134,7 +159,14 @@ class AgentRunner:
             model=self.model,
             cwd=self.directory,
             permission_mode="bypassPermissions",
-            setting_sources=["project"],
+            # Inherit user-level skills, MCP servers, plugins from
+            # ~/.claude/ when present.  Project + local still apply.
+            setting_sources=["user", "project", "local"],
+            # Conditional: only set when this helper has a perm-policy file.
+            # Setting it unconditionally would hang non-supervised agents
+            # (no boss watching the queue) forever on first non-auto-allow
+            # tool call.
+            can_use_tool=self._can_use_tool,
         )
         if self.system_prompt:
             opts.system_prompt = self.system_prompt
@@ -161,6 +193,15 @@ class AgentRunner:
         outcome = "success"
         usage_dict: dict | None = None
         failed = False
+        # The SDK requires AsyncIterable prompts whenever can_use_tool is
+        # set (client.py:54-60 enforces this).  Wrap the queued string into
+        # a one-shot async iterable in that branch; otherwise preserve the
+        # legacy string-prompt path for standalone agents.
+        prompt_arg: str | AsyncIterable[dict[str, Any]]
+        if self._can_use_tool is None:
+            prompt_arg = prompt
+        else:
+            prompt_arg = _single_user_message_stream(prompt)
         with tracer.start_as_current_span(
             "harness.llm.call",
             attributes={
@@ -171,7 +212,7 @@ class AgentRunner:
         ):
             try:
                 async for message in query(
-                    prompt=prompt,
+                    prompt=prompt_arg,
                     options=self._make_options(),
                 ):
                     if isinstance(message, ResultMessage):
@@ -199,6 +240,10 @@ class AgentRunner:
                 duration_ms=duration_ms,
                 outcome=outcome,
             )
+        # Feed per-turn input-token usage to the context watcher (daemon-side).
+        if not failed and self.on_usage is not None:
+            tokens_input = usage_dict.get("tokens_input") if usage_dict else None
+            await self.on_usage(tokens_input)
         if failed:
             return False
         return True

--- a/culture/clients/claude/config.py
+++ b/culture/clients/claude/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 
 import yaml
@@ -51,6 +51,21 @@ class WebhookConfig:
 
 
 @dataclass
+class ContextWatchConfig:
+    """Context-watermark handoff settings.
+
+    When enabled, the daemon monitors per-turn input-token usage; at
+    ``high_water`` it asks the agent to write a handoff for its post-compact
+    self, compacts, then reminds it to read the handoff. ``low_water`` is the
+    fraction below which the handoff latch resets for the next fill cycle.
+    """
+
+    enabled: bool = True
+    high_water: float = 0.90
+    low_water: float = 0.50
+
+
+@dataclass
 class AgentConfig:
     """Per-agent settings."""
 
@@ -66,6 +81,7 @@ class AgentConfig:
     archived: bool = False
     archived_at: str = ""
     archived_reason: str = ""
+    context_watch: ContextWatchConfig = field(default_factory=ContextWatchConfig)
 
 
 @dataclass
@@ -122,11 +138,18 @@ def load_config(path: str | Path) -> DaemonConfig:
     telemetry = TelemetryConfig(**raw.get("telemetry", {}))
 
     agents = []
-    known_agent_fields = {f.name for f in AgentConfig.__dataclass_fields__.values()}
+    known_agent_fields = {f.name for f in fields(AgentConfig)}
     for agent_raw in raw.get("agents", []):
         # Strip unknown fields (e.g. acp_command from ACP backend configs)
         # so multi-backend configs don't crash on load.
         filtered = {k: v for k, v in agent_raw.items() if k in known_agent_fields}
+        # Coerce the nested context_watch mapping into its dataclass.
+        cw = filtered.get("context_watch")
+        if isinstance(cw, dict):
+            known_cw = {f.name for f in fields(ContextWatchConfig)}
+            filtered["context_watch"] = ContextWatchConfig(
+                **{k: v for k, v in cw.items() if k in known_cw}
+            )
         agents.append(AgentConfig(**filtered))
 
     return DaemonConfig(

--- a/culture/clients/claude/config.py
+++ b/culture/clients/claude/config.py
@@ -82,6 +82,9 @@ class AgentConfig:
     archived_at: str = ""
     archived_reason: str = ""
     context_watch: ContextWatchConfig = field(default_factory=ContextWatchConfig)
+    # Nick of the boss agent that owns this worker (empty for unmanaged agents).
+    # Used to @mention the boss in permission-request IRC notices.
+    boss: str = ""
 
 
 @dataclass

--- a/culture/clients/claude/culture.yaml
+++ b/culture/clients/claude/culture.yaml
@@ -13,6 +13,15 @@ tags:
   - harness
   - claude
 
+# Context-watermark handoff (Claude backend only).
+# When the daemon detects the agent is approaching its context window, it asks
+# the agent to write a handoff for its post-compact self, compacts, then reminds
+# it to read the handoff. See docs/agentirc/helper-context-handoff.md.
+context_watch:
+  enabled: true       # master switch
+  high_water: 0.90    # fraction of the context window that triggers a handoff
+  low_water: 0.50     # fraction below which the handoff latch resets
+
 # OpenTelemetry configuration for the agent harness.
 # Set enabled: true once your OTLP collector is running.
 # See docs/agentirc/harness-telemetry.md for a setup guide.

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -355,6 +355,7 @@ class AgentDaemon:
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
             on_usage=self._on_agent_usage,
+            on_perm_request=self._on_perm_request,
             metrics=self._metrics,
             nick=self.agent.nick,
         )
@@ -495,6 +496,43 @@ class AgentDaemon:
         # Compact runs as the next queued turn, after the handoff is written.
         await self._agent_runner.send_prompt("/compact")
         await self._daemon_log.record("compact", trigger="context_watermark", pct=round(pct, 3))
+
+    async def _on_perm_request(self, payload: dict) -> None:
+        """Surface a worker permission request to its boss over IRC (best-effort).
+
+        Fired by this worker's PermissionBroker when a tool call routes to the
+        boss. DMs the owning boss (``self.agent.boss``) so the boss's activation
+        handler fires and it can approve/deny. If no boss is configured (the
+        human-supervised case from PR #411) we post nothing — the human finds the
+        request via ``pending-perms.sh``.
+        """
+        boss = self.agent.boss
+        if not boss or self._transport is None:
+            return
+        tool = payload.get("tool_name", "?")
+        req_id = payload.get("id", "?")
+        preview = self._perm_input_preview(tool, payload.get("input", {}))
+        notice = (
+            f"[perm] worker {self.agent.nick} wants {tool}: {preview} "
+            f"— id {req_id} (approve/deny)"
+        )
+        await self._transport.send_privmsg(boss, notice)
+
+    @staticmethod
+    def _perm_input_preview(tool: str, input_dict: dict) -> str:
+        """Short one-line preview of a tool's input for the perm notice."""
+        if tool == "Bash":
+            value = input_dict.get("command", "")
+        elif tool in ("Edit", "Write"):
+            value = input_dict.get("file_path", "")
+        else:
+            try:
+                import json as _json
+
+                value = _json.dumps(input_dict)
+            except (TypeError, ValueError):
+                value = repr(input_dict)
+        return str(value)[:80]
 
     def _maybe_prepend_reminder(self, prompt: str) -> str:
         """Prepend a post-compact handoff reminder when one is owed."""

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -8,6 +8,19 @@ import re
 import time
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._context_watch import (
+    ContextWatchState,
+    WatchAction,
+)
+from culture.clients._context_watch import evaluate as context_evaluate
+from culture.clients._context_watch import fraction as context_fraction
+from culture.clients._context_watch import (
+    mark_reminder_pending,
+    take_reminder,
+)
+from culture.clients._daemon_log import DaemonLog
+from culture.clients._perm_broker import handoff_path_for
 from culture.clients.claude.agent_runner import AgentRunner
 from culture.clients.claude.config import AgentConfig, DaemonConfig
 from culture.clients.claude.ipc import make_response
@@ -63,6 +76,16 @@ class AgentDaemon:
         self._supervisor: Supervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
+
+        # Context-watermark handoff state (Claude exposes per-turn input_tokens).
+        cw = agent.context_watch
+        self._context_watch = ContextWatchState(
+            high_water=cw.high_water,
+            low_water=cw.low_water,
+            enabled=cw.enabled,
+        )
 
         # Crash-recovery state
         self._crash_times: list[float] = []
@@ -195,6 +218,7 @@ class AgentDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -301,6 +325,7 @@ class AgentDaemon:
             f"{lines}\n\n"
             "Respond naturally if any messages need your attention."
         )
+        prompt = self._maybe_prepend_reminder(prompt)
         task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
@@ -329,11 +354,15 @@ class AgentDaemon:
             system_prompt=self._build_system_prompt(),
             on_exit=self._on_agent_exit,
             on_message=self._on_agent_message,
+            on_usage=self._on_agent_usage,
             metrics=self._metrics,
             nick=self.agent.nick,
         )
         await self._agent_runner.start()
         logger.info("AgentRunner started via SDK for %s", self.agent.nick)
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -349,6 +378,7 @@ class AgentDaemon:
             prompt = self._build_channel_prompt(target, sender, text)
         else:
             prompt = self._build_dm_prompt(sender, text)
+        prompt = self._maybe_prepend_reminder(prompt)
         task = asyncio.create_task(self._agent_runner.send_prompt(prompt))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
@@ -425,10 +455,58 @@ class AgentDaemon:
 
     async def _on_agent_message(self, msg: dict) -> None:
         """Feed agent activity to the supervisor for observation."""
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
         self._capture_agent_status(msg)
+
+    async def _on_agent_usage(self, input_tokens: int | None) -> None:
+        """Evaluate context utilization after a turn; drive the handoff cycle."""
+        action = context_evaluate(self._context_watch, input_tokens, self.agent.model)
+        if action is WatchAction.REMINDER_DUE:
+            # Context actually dropped after the compact — arm the reminder now,
+            # so an activation that interleaved with the handoff/compact turns
+            # can't consume it early.
+            mark_reminder_pending(self._context_watch)
+            await self._daemon_log.record("handoff_reminder_armed")
+            return
+        if action is not WatchAction.WRITE_HANDOFF:
+            return
+        if self._agent_runner is None or not self._agent_runner.is_running():
+            return
+        pct = context_fraction(input_tokens, self.agent.model) or 0.0
+        handoff_path = handoff_path_for(self.agent.nick)
+        logger.info(
+            "Context watermark reached for %s (%.0f%%) — requesting handoff",
+            self.agent.nick,
+            pct * 100,
+        )
+        await self._daemon_log.record("handoff_written", pct=round(pct, 3), path=handoff_path)
+        handoff_prompt = (
+            "[context-handoff] You are approaching your context limit "
+            f"({pct * 100:.0f}% full). Before it fills, write a concise handoff "
+            f"for your post-compact self to {handoff_path}. Include: what you are "
+            "working on, key decisions made, what remains, and important file "
+            "paths. Use your Write tool (this path is pre-approved). Then stop."
+        )
+        await self._agent_runner.send_prompt(handoff_prompt)
+        # Compact runs as the next queued turn, after the handoff is written.
+        await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="context_watermark", pct=round(pct, 3))
+
+    def _maybe_prepend_reminder(self, prompt: str) -> str:
+        """Prepend a post-compact handoff reminder when one is owed."""
+        if take_reminder(self._context_watch):
+            handoff_path = handoff_path_for(self.agent.nick)
+            reminder = (
+                "[context-handoff] You recently compacted. Read your handoff at "
+                f"{handoff_path} before continuing.\n\n"
+            )
+            self._log_action_bg("handoff_reminder", path=handoff_path)
+            return reminder + prompt
+        return prompt
 
     def _build_system_prompt(self) -> str:
         if self.agent.system_prompt:
@@ -447,6 +525,7 @@ class AgentDaemon:
         logger.warning("Agent %s crashed with exit code %d", self.agent.nick, exit_code)
         self._crash_times = [t for t in self._crash_times if now - t < CRASH_WINDOW_SECONDS]
         self._crash_times.append(now)
+        await self._daemon_log.record("crash", exit_code=exit_code, count=len(self._crash_times))
         if self._webhook:
             await self._webhook.fire(
                 AlertEvent(
@@ -468,6 +547,11 @@ class AgentDaemon:
                 self.agent.nick,
                 len(self._crash_times),
                 CRASH_WINDOW_SECONDS,
+            )
+            await self._daemon_log.record(
+                "circuit_open",
+                count=len(self._crash_times),
+                window_s=CRASH_WINDOW_SECONDS,
             )
             if self._webhook:
                 await self._webhook.fire(
@@ -501,6 +585,7 @@ class AgentDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -575,16 +660,24 @@ class AgentDaemon:
     # IPC sub-handlers
     # ------------------------------------------------------------------
 
+    def _log_action_bg(self, action: str, **detail) -> None:
+        """Fire-and-forget a daemon-log record from a synchronous context."""
+        task = asyncio.create_task(self._daemon_log.record(action, **detail))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
     def _ipc_pause(self, req_id: str, msg: dict) -> dict:
         self._paused = True
         self._manually_paused = True
         logger.info("Agent %s paused (manual)", self.agent.nick)
+        self._log_action_bg("pause", manual=True)
         return make_response(req_id, ok=True)
 
     def _ipc_resume(self, req_id: str, msg: dict) -> dict:
         self._paused = False
         self._manually_paused = False
         logger.info("Agent %s resumed", self.agent.nick)
+        self._log_action_bg("resume", manual=True)
         # NOTE: Catch-up on missed messages is not yet implemented.
         # IRCTransport does not process HISTORY responses into the buffer.
         # The agent resumes and will see new messages going forward.
@@ -832,12 +925,14 @@ class AgentDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/clear")
+        await self._daemon_log.record("clear")
         return make_response(req_id, ok=True)
 
     def _ipc_shutdown(self, req_id: str, msg: dict) -> dict:

--- a/culture/clients/claude/daemon.py
+++ b/culture/clients/claude/daemon.py
@@ -48,6 +48,34 @@ _ERR_CHANNEL_PREFIX = "Channel name must start with '#'"
 _MENTION_RE = re.compile(r"@([\w-]+)")
 
 
+def _context_watch_state(agent) -> ContextWatchState:
+    """Normalize an agent's context_watch config (dict / object / None) to state.
+
+    Runtime config (``culture.config.AgentConfig``) exposes it as a dict from
+    ``culture.yaml`` extras; the backend-specific config exposes a
+    ``ContextWatchConfig`` object; either may be empty/absent → defaults.
+    """
+    cw = getattr(agent, "context_watch", None)
+    if not cw:
+        return ContextWatchState()
+    if isinstance(cw, dict):
+        return ContextWatchState(
+            enabled=cw.get("enabled", True),
+            high_water=cw.get("high_water", 0.90),
+            low_water=cw.get("low_water", 0.50),
+        )
+    return ContextWatchState(
+        enabled=getattr(cw, "enabled", True),
+        high_water=getattr(cw, "high_water", 0.90),
+        low_water=getattr(cw, "low_water", 0.50),
+    )
+
+
+def _boss_nick(agent) -> str:
+    """The owning boss nick, or '' — works for both config flavors."""
+    return getattr(agent, "boss", "") or ""
+
+
 class AgentDaemon:
     """Central orchestrator that ties together the IRC transport, socket server,
     agent runner, supervisor, and webhook client for a single agent nick."""
@@ -80,12 +108,10 @@ class AgentDaemon:
         self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # Context-watermark handoff state (Claude exposes per-turn input_tokens).
-        cw = agent.context_watch
-        self._context_watch = ContextWatchState(
-            high_water=cw.high_water,
-            low_water=cw.low_water,
-            enabled=cw.enabled,
-        )
+        # `agent.context_watch` is a dict on the runtime config (culture.config,
+        # from culture.yaml extras) or a ContextWatchConfig object on the
+        # backend-specific config (tests) — normalize both.
+        self._context_watch = _context_watch_state(agent)
 
         # Crash-recovery state
         self._crash_times: list[float] = []
@@ -506,7 +532,7 @@ class AgentDaemon:
         human-supervised case from PR #411) we post nothing — the human finds the
         request via ``pending-perms.sh``.
         """
-        boss = self.agent.boss
+        boss = _boss_nick(self.agent)
         if not boss or self._transport is None:
             return
         tool = payload.get("tool_name", "?")

--- a/culture/clients/claude/skill/boss/SKILL.md
+++ b/culture/clients/claude/skill/boss/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: boss
+description: Orchestrate worker agents as an autonomous boss — spawn workers, drive them like Claude Code sessions, challenge their work, and approve/deny their tool requests bounded by a grant ceiling. Use when you are a boss agent given a mission in your IRC channel.
+---
+
+# Boss Skill
+
+You are a **boss agent**: a human briefs you in your IRC channel with a mission,
+and you drive **worker agents** that do the implementation. You do not write the
+code yourself — you manage. You converse with workers over IRC (the `irc` skill,
+`culture channel …`) and use the `culture boss …` commands below for the
+out-of-band operations (spawn, approve, read logs).
+
+Your own nick is in `$CULTURE_NICK`. The daemon sets it.
+
+## The loop (how to manage a worker)
+
+Drive a worker exactly like a human drives a Claude Code session:
+
+1. **Spawn** a worker for a unit of work: `culture boss spawn <name>`.
+2. **Ask + scope**: brief it conversationally — "what open dev tasks do we have?",
+   "what goes well together?". Use `culture boss brief <name> "<message>"` to send,
+   `culture boss read <name>` to read replies.
+3. **Plan, then challenge**: tell it to make a plan; when it does, *challenge* it
+   before it implements — poke holes, ask for evidence, redirect.
+4. **Approve tools as they arrive**: when a worker needs a tool it can't auto-run,
+   you get a DM. Resolve it: `culture boss approve <id>` (or `--always` for tools
+   you trust it with), or `culture boss deny <id> <reason>`.
+5. **Verify claims**: never take "done" on faith. Read the worker's actual
+   activity with `culture boss audit <name>` and challenge discrepancies.
+6. **Report** progress/blockers to your human in your channel.
+
+## Commands
+
+```bash
+culture boss spawn <name> [--cwd PATH]   # create+start a worker under you
+culture boss brief <name> "<task>"       # send a task to the worker's channel
+culture boss read  <name> [--limit N]    # read the worker's recent replies
+culture boss pending                     # list pending tool-approval requests
+culture boss approve <id> [--always] [--pattern P]   # grant a request
+culture boss deny <id> [reason...]       # refuse a request (reason → worker)
+culture boss audit <name> [--limit N]    # worker's agent-message log (verify claims)
+culture boss log   <name> [--limit N]    # worker's daemon-action log
+culture boss status                      # workers + pending perms
+culture boss close <name>                # stop a worker daemon
+```
+
+## Grant ceiling (you are not the final authority on risky actions)
+
+Some high-risk tools are **above your grant ceiling** — external MCP sends
+(Gmail/Drive/etc.) and destructive Bash (`rm -rf`, `git push`, `kubectl`, …).
+When `culture boss approve` prints `REFUSED: … above your grant ceiling`, **do
+not retry**. Post the request to your human in your channel and let them approve
+it. The human is the final authority on irreversible/external actions.
+
+## Conversation, not just commands
+
+Most of managing a worker is plain IRC conversation in its `#task-<name>`
+channel — ask, direct, challenge, acknowledge. The `culture boss` commands only
+cover what conversation can't do (spawn, approve, read logs). Talk to your
+workers; don't just command them.

--- a/culture/clients/codex/agent_runner.py
+++ b/culture/clients/codex/agent_runner.py
@@ -77,6 +77,10 @@ class CodexAgentRunner:
         isolated_env = dict(os.environ)
         isolated_env["XDG_DATA_HOME"] = os.path.join(self._isolated_home, ".local", "share")
         isolated_env["XDG_STATE_HOME"] = os.path.join(self._isolated_home, ".local", "state")
+        # Expose the agent's own nick so its IRC / boss skills can resolve this
+        # daemon's socket (autonomous agents can't `export` it themselves).
+        if self._nick:
+            isolated_env["CULTURE_NICK"] = self._nick
 
         try:
             # Spawn codex app-server in stdio mode

--- a/culture/clients/codex/daemon.py
+++ b/culture/clients/codex/daemon.py
@@ -15,6 +15,8 @@ import time
 from collections import deque
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._daemon_log import DaemonLog
 from culture.clients.codex.agent_runner import CodexAgentRunner
 from culture.clients.codex.config import AgentConfig, DaemonConfig
 from culture.clients.codex.ipc import make_response
@@ -78,6 +80,8 @@ class CodexDaemon:
         self._supervisor: CodexSupervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -213,6 +217,7 @@ class CodexDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -384,6 +389,9 @@ class CodexDaemon:
         )
         await self._agent_runner.start()
         logger.info("CodexAgentRunner started for %s", self.agent.nick)
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -531,6 +539,8 @@ class CodexDaemon:
         self._consecutive_turn_failures = 0
         await self._relay_response_to_irc(msg)
 
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
@@ -595,6 +605,7 @@ class CodexDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -929,6 +940,7 @@ class CodexDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:

--- a/culture/clients/copilot/agent_runner.py
+++ b/culture/clients/copilot/agent_runner.py
@@ -75,6 +75,10 @@ class CopilotAgentRunner:
         isolated_env = dict(os.environ)
         isolated_env["XDG_DATA_HOME"] = os.path.join(self._isolated_home, ".local", "share")
         isolated_env["XDG_STATE_HOME"] = os.path.join(self._isolated_home, ".local", "state")
+        # Expose the agent's own nick so its IRC / boss skills can resolve this
+        # daemon's socket (autonomous agents can't `export` it themselves).
+        if self._nick:
+            isolated_env["CULTURE_NICK"] = self._nick
 
         try:
             # Create and start the CopilotClient (spawns copilot CLI process)

--- a/culture/clients/copilot/daemon.py
+++ b/culture/clients/copilot/daemon.py
@@ -15,6 +15,8 @@ import time
 from collections import deque
 
 from culture.aio import maybe_await
+from culture.clients._audit import AuditWriter
+from culture.clients._daemon_log import DaemonLog
 from culture.clients.copilot.agent_runner import CopilotAgentRunner
 from culture.clients.copilot.config import AgentConfig, DaemonConfig
 from culture.clients.copilot.ipc import make_response
@@ -71,6 +73,8 @@ class CopilotDaemon:
         self._supervisor: CopilotSupervisor | None = None
         self._tracer = None
         self._metrics = None
+        self._audit: AuditWriter = AuditWriter(nick=agent.nick)
+        self._daemon_log: DaemonLog = DaemonLog(nick=agent.nick)
 
         # FIFO queue of relay targets — each @mention enqueues a target,
         # each agent response dequeues one, ensuring correct routing even
@@ -206,6 +210,7 @@ class CopilotDaemon:
         if self._agent_runner is not None:
             await self._agent_runner.stop()
             self._agent_runner = None
+            await self._daemon_log.record("agent_stop")
 
         if self._socket_server is not None:
             await self._socket_server.stop()
@@ -384,6 +389,9 @@ class CopilotDaemon:
         )
         await self._agent_runner.start()
         logger.info("CopilotAgentRunner started for %s", self.agent.nick)
+        await self._daemon_log.record(
+            "agent_start", model=self.agent.model, directory=self.agent.directory
+        )
 
     def _on_mention(self, target: str, sender: str, text: str) -> None:
         """Called by IRCTransport when the agent is @mentioned or DM'd.
@@ -513,6 +521,8 @@ class CopilotDaemon:
         self._consecutive_turn_failures = 0
         await self._relay_response_to_irc(msg)
 
+        await self._audit.write(msg)
+
         if self._supervisor:
             await self._supervisor.observe(msg)
 
@@ -573,6 +583,7 @@ class CopilotDaemon:
 
     async def _on_agent_exit(self, exit_code: int) -> None:
         """Handle agent process exit with crash recovery and circuit breaker."""
+        await self._daemon_log.record("agent_exit", exit_code=exit_code)
         if exit_code == 0:
             logger.info("Agent %s exited cleanly", self.agent.nick)
             if self._webhook:
@@ -907,6 +918,7 @@ class CopilotDaemon:
         if self._agent_runner is None or not self._agent_runner.is_running():
             return make_response(req_id, ok=False, error="Agent runner is not running")
         await self._agent_runner.send_prompt("/compact")
+        await self._daemon_log.record("compact", trigger="ipc")
         return make_response(req_id, ok=True)
 
     async def _ipc_clear(self, req_id: str, msg: dict) -> dict:

--- a/culture/config.py
+++ b/culture/config.py
@@ -92,6 +92,26 @@ class AgentConfig:
         """ACP-specific: command to spawn the ACP process."""
         return self.extras.get("acp_command", ["opencode", "acp"])
 
+    @property
+    def boss(self) -> str:
+        """Nick of the boss agent that owns this worker (empty if unmanaged).
+
+        Set by ``culture boss spawn`` into the worker's culture.yaml; the Claude
+        daemon DMs this nick on permission requests. Lives in ``extras`` like
+        other backend-specific fields.
+        """
+        return self.extras.get("boss", "")
+
+    @property
+    def context_watch(self) -> dict:
+        """Context-watermark handoff settings (Claude only), or {} for defaults.
+
+        A mapping ``{enabled, high_water, low_water}`` from culture.yaml; the
+        Claude daemon normalizes it. Lives in ``extras``.
+        """
+        cw = self.extras.get("context_watch", {})
+        return cw if isinstance(cw, dict) else {}
+
 
 @dataclass
 class ServerConfig:

--- a/culture/dashboard/__init__.py
+++ b/culture/dashboard/__init__.py
@@ -1,0 +1,8 @@
+"""Mission Control dashboard — a local web app to watch and steer the mesh.
+
+Design spec: docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md
+"""
+
+from culture.dashboard.server import build_app, serve_dashboard
+
+__all__ = ["build_app", "serve_dashboard"]

--- a/culture/dashboard/server.py
+++ b/culture/dashboard/server.py
@@ -34,7 +34,7 @@ from culture.clients._perm_broker import (
     policy_path_for,
     write_decision,
 )
-from culture.clients.claude.config import load_config_or_default
+from culture.config import load_config_or_default
 from culture.pidfile import read_pid
 
 logger = logging.getLogger(__name__)

--- a/culture/dashboard/server.py
+++ b/culture/dashboard/server.py
@@ -1,0 +1,449 @@
+"""Mission Control dashboard server (aiohttp).
+
+Localhost-only web app that streams every agent's activity + pending approvals
+into one browser view and exposes the full intervention surface (approve/deny,
+pause/resume, close, emergency stop-all, policy edit). Reuses the existing data
+files (``~/.culture/{audit,daemon-log,perm-queue,perm-policy}``) and control
+levers (the permission broker, daemon IPC, the ``culture agent`` CLI).
+
+Design spec: docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+
+import yaml
+from aiohttp import web
+
+from culture.cli.shared.ipc import agent_socket_path, ipc_request
+from culture.cli.shared.process import is_process_alive
+from culture.clients._audit import audit_path_for
+from culture.clients._daemon_log import daemon_log_path_for
+from culture.clients._perm_broker import (
+    DecisionExistsError,
+    culture_home,
+    list_pending,
+    policy_path_for,
+    write_decision,
+)
+from culture.clients.claude.config import load_config_or_default
+from culture.pidfile import read_pid
+
+logger = logging.getLogger(__name__)
+
+_STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
+_SSE_POLL_SECONDS = 0.25
+_SSE_BACKLOG_LINES = 200
+_KEEPALIVE_SECONDS = 15
+
+# Typed app key for the optional server-config path.
+_CONFIG_PATH: web.AppKey[str | None] = web.AppKey("config_path", object)  # type: ignore[arg-type]
+
+# Agent nicks are <server>-<agent>: alphanumerics + hyphens only. Validating
+# every nick that reaches a path builder (audit/daemon-log/policy/socket) closes
+# the path-traversal hole — a nick like "../../etc/passwd" must be rejected.
+_NICK_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?$")
+
+# Loopback-only Origin/Host. The dashboard can approve tool calls and kill
+# agents; the localhost bind alone does NOT stop a malicious web page from
+# POSTing to 127.0.0.1 via DNS rebinding, so mutating requests are origin-gated.
+_LOOPBACK_RE = re.compile(r"^https?://(127\.0\.0\.1|localhost|\[::1\])(:\d+)?$")
+_LOOPBACK_HOST_RE = re.compile(r"^(127\.0\.0\.1|localhost|\[?::1\]?)(:\d+)?$")
+
+
+def _valid_nick(nick: str) -> bool:
+    return bool(nick) and _NICK_RE.fullmatch(nick) is not None
+
+
+def _require_nick(nick: str) -> str:
+    if not _valid_nick(nick):
+        raise web.HTTPBadRequest(text=f"invalid nick {nick!r}")
+    return nick
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def _pending_counts() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for req in list_pending():
+        nick = req.get("helper_nick", "")
+        if nick:
+            counts[nick] = counts.get(nick, 0) + 1
+    return counts
+
+
+def _last_action(nick: str) -> str:
+    """Most recent daemon-action for an agent (empty if none)."""
+    path = daemon_log_path_for(nick)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return ""
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line).get("action", "")
+        except json.JSONDecodeError:
+            continue
+    return ""
+
+
+def _agent_state(nick: str) -> str:
+    pid = read_pid(f"agent-{nick}")
+    if pid and is_process_alive(pid):
+        return "running"
+    return "stopped"
+
+
+def list_agents(config_path: str | None = None) -> list[dict]:
+    """Programmatic agent grid (no CLI-text parsing)."""
+    config = (
+        load_config_or_default(config_path)
+        if config_path
+        else load_config_or_default(os.path.join(culture_home(), "server.yaml"))
+    )
+    pending = _pending_counts()
+    rows = []
+    for agent in config.agents:
+        if getattr(agent, "archived", False):
+            continue
+        nick = agent.nick
+        rows.append(
+            {
+                "nick": nick,
+                "state": _agent_state(nick),
+                "pending": pending.get(nick, 0),
+                "last_action": _last_action(nick),
+                "is_boss": "boss" in (getattr(agent, "tags", []) or []),
+                "boss": getattr(agent, "boss", "") or "",
+            }
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# HTTP / SSE handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handle_index(request: web.Request) -> web.StreamResponse:
+    return web.FileResponse(os.path.join(_STATIC_DIR, "index.html"))
+
+
+async def _handle_agents(request: web.Request) -> web.Response:
+    return web.json_response({"agents": list_agents(request.app.get(_CONFIG_PATH))})
+
+
+async def _handle_pending(request: web.Request) -> web.Response:
+    return web.json_response({"pending": list_pending()})
+
+
+def _jsonl_path(kind: str, nick: str) -> str | None:
+    if kind == "audit":
+        return audit_path_for(nick)
+    if kind == "daemon-log":
+        return daemon_log_path_for(nick)
+    return None
+
+
+async def _sse_prologue(request: web.Request) -> web.StreamResponse:
+    resp = web.StreamResponse(
+        headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        }
+    )
+    await resp.prepare(request)
+    return resp
+
+
+async def _handle_stream_jsonl(request: web.Request) -> web.StreamResponse:
+    """Tail a per-agent JSONL file as SSE: backlog, then live appends.
+
+    All file I/O is byte-oriented: ``offset`` is a byte offset compared against
+    ``os.path.getsize`` (also bytes). Text-mode ``tell()`` returns an opaque
+    cursor that does not equal the byte size for non-ASCII content, which would
+    break the truncation/no-new-data checks — so we read in binary and decode.
+    """
+    kind = request.match_info["kind"]
+    nick = _require_nick(request.match_info["nick"])
+    path = _jsonl_path(kind, nick)
+    if path is None:
+        raise web.HTTPNotFound(text=f"unknown stream kind {kind!r}")
+
+    resp = await _sse_prologue(request)
+    try:
+        # Backlog: last N lines via a bounded deque (no full-file load).
+        offset = 0
+        backlog: collections.deque[str] = collections.deque(maxlen=_SSE_BACKLOG_LINES)
+        try:
+            with open(path, "rb") as handle:
+                for raw in handle:
+                    backlog.append(raw.decode("utf-8", "replace").rstrip("\n"))
+                offset = handle.tell()
+        except OSError:
+            offset = 0
+        for line in backlog:
+            if _client_gone(request):
+                return resp
+            if line.strip():
+                await _sse_send(resp, line)
+        # Live tail.
+        idle = 0.0
+        while not _client_gone(request):
+            new_offset, chunk = _read_appended(path, offset)
+            if chunk:
+                offset = new_offset
+                for line in chunk.splitlines():
+                    if line.strip():
+                        await _sse_send(resp, line)
+                idle = 0.0
+            else:
+                await asyncio.sleep(_SSE_POLL_SECONDS)
+                idle += _SSE_POLL_SECONDS
+                if idle >= _KEEPALIVE_SECONDS:
+                    await resp.write(b": keepalive\n\n")
+                    idle = 0.0
+    except (ConnectionResetError, asyncio.CancelledError):
+        pass  # client disconnected — stop tailing, no leak
+    return resp
+
+
+def _read_appended(path: str, offset: int) -> tuple[int, str]:
+    """Read bytes appended to ``path`` since byte ``offset``. Returns (new_offset, text)."""
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        return offset, ""
+    if size < offset:  # file truncated/rotated — restart from 0
+        offset = 0
+    if size == offset:
+        return offset, ""
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(offset)
+            data = handle.read()
+            return handle.tell(), data.decode("utf-8", "replace")
+    except OSError:
+        return offset, ""
+
+
+async def _sse_send(resp: web.StreamResponse, data: str) -> None:
+    await resp.write(f"data: {data}\n\n".encode("utf-8"))
+
+
+def _client_gone(request: web.Request) -> bool:
+    """True once the client has disconnected (transport closed)."""
+    transport = request.transport
+    return transport is None or transport.is_closing()
+
+
+# ---------------------------------------------------------------------------
+# Control handlers (the human operator is the top authority — no grant ceiling)
+# ---------------------------------------------------------------------------
+
+
+async def _json_body(request: web.Request) -> dict:
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, Exception):  # noqa: BLE001
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
+async def _handle_approve(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    req_id = body.get("id")
+    if not req_id:
+        return web.json_response({"error": "missing id"}, status=400)
+    scope = "always" if body.get("always") else "once"
+    try:
+        write_decision(
+            req_id,
+            verdict="allow",
+            scope=scope,
+            pattern=body.get("pattern", ""),
+            decided_by="dashboard",
+        )
+    except DecisionExistsError:
+        return web.json_response({"error": "decision already exists"}, status=409)
+    return web.json_response({"ok": True})
+
+
+async def _handle_deny(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    req_id = body.get("id")
+    if not req_id:
+        return web.json_response({"error": "missing id"}, status=400)
+    try:
+        write_decision(
+            req_id,
+            verdict="deny",
+            reason=str(body.get("reason", "")),
+            decided_by="dashboard",
+        )
+    except DecisionExistsError:
+        return web.json_response({"error": "decision already exists"}, status=409)
+    return web.json_response({"ok": True})
+
+
+async def _ipc_to(nick: str, msg_type: str) -> bool:
+    resp = await ipc_request(agent_socket_path(nick), msg_type)
+    return bool(resp and resp.get("ok"))
+
+
+async def _handle_pause(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    nick = body.get("nick")
+    if not nick:
+        return web.json_response({"error": "missing nick"}, status=400)
+    if not _valid_nick(nick):
+        return web.json_response({"error": "invalid nick"}, status=400)
+    ok = await _ipc_to(nick, "pause")
+    return web.json_response({"ok": ok})
+
+
+async def _handle_resume(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    nick = body.get("nick")
+    if not nick:
+        return web.json_response({"error": "missing nick"}, status=400)
+    if not _valid_nick(nick):
+        return web.json_response({"error": "invalid nick"}, status=400)
+    ok = await _ipc_to(nick, "resume")
+    return web.json_response({"ok": ok})
+
+
+def _agent_stop(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "culture", "agent", "stop", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+async def _handle_close(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    nick = body.get("nick")
+    if not nick:
+        return web.json_response({"error": "missing nick"}, status=400)
+    if not _valid_nick(nick):
+        return web.json_response({"error": "invalid nick"}, status=400)
+    res = await asyncio.to_thread(_agent_stop, nick)
+    return web.json_response({"ok": res.returncode == 0, "detail": res.stdout or res.stderr})
+
+
+async def _handle_stop_all(request: web.Request) -> web.Response:
+    body = await _json_body(request)
+    mode = body.get("mode", "pause")
+    if mode == "kill":
+        res = await asyncio.to_thread(_agent_stop, "--all")
+        return web.json_response({"ok": res.returncode == 0, "mode": "kill"})
+    # pause every running agent
+    paused = []
+    for agent in list_agents(request.app.get(_CONFIG_PATH)):
+        if agent["state"] == "running":
+            if await _ipc_to(agent["nick"], "pause"):
+                paused.append(agent["nick"])
+    return web.json_response({"ok": True, "mode": "pause", "paused": paused})
+
+
+async def _handle_policy_get(request: web.Request) -> web.Response:
+    nick = _require_nick(request.match_info["nick"])
+    try:
+        with open(policy_path_for(nick), encoding="utf-8") as handle:
+            policy = yaml.safe_load(handle) or {}
+    except (OSError, yaml.YAMLError):
+        policy = {}
+    return web.json_response({"nick": nick, "policy": policy})
+
+
+async def _handle_policy_put(request: web.Request) -> web.Response:
+    nick = _require_nick(request.match_info["nick"])
+    body = await _json_body(request)
+    policy = body.get("policy")
+    if not isinstance(policy, dict):
+        return web.json_response({"error": "policy must be an object"}, status=400)
+    # Atomic write via the broker's discipline.
+    from culture.clients._perm_broker import _atomic_write_yaml  # noqa: PLC0415
+
+    _atomic_write_yaml(policy_path_for(nick), policy)
+    return web.json_response({"ok": True})
+
+
+# ---------------------------------------------------------------------------
+# App wiring
+# ---------------------------------------------------------------------------
+
+
+@web.middleware
+async def _loopback_guard(request: web.Request, handler):
+    """Reject cross-origin / non-loopback requests (anti-DNS-rebinding).
+
+    A direct fetch/curl sends no Origin; a browser page sends its Origin. We
+    allow only loopback origins and a loopback Host header, so a malicious page
+    that rebinds DNS to 127.0.0.1 (sending ``Origin: http://evil.com``) cannot
+    drive the control plane.
+    """
+    origin = request.headers.get("Origin", "")
+    if origin and not _LOOPBACK_RE.match(origin):
+        raise web.HTTPForbidden(text="cross-origin requests are not allowed")
+    host = request.headers.get("Host", "")
+    if host and not _LOOPBACK_HOST_RE.match(host):
+        raise web.HTTPForbidden(text="non-loopback Host is not allowed")
+    return await handler(request)
+
+
+def build_app(config_path: str | None = None) -> web.Application:
+    app = web.Application(middlewares=[_loopback_guard])
+    app[_CONFIG_PATH] = config_path
+    app.router.add_get("/", _handle_index)
+    app.router.add_get("/api/agents", _handle_agents)
+    app.router.add_get("/api/pending", _handle_pending)
+    app.router.add_get("/api/stream/{kind}/{nick}", _handle_stream_jsonl)
+    app.router.add_post("/api/approve", _handle_approve)
+    app.router.add_post("/api/deny", _handle_deny)
+    app.router.add_post("/api/pause", _handle_pause)
+    app.router.add_post("/api/resume", _handle_resume)
+    app.router.add_post("/api/close", _handle_close)
+    app.router.add_post("/api/stop-all", _handle_stop_all)
+    app.router.add_get("/api/policy/{nick}", _handle_policy_get)
+    app.router.add_put("/api/policy/{nick}", _handle_policy_put)
+    if os.path.isdir(_STATIC_DIR):
+        app.router.add_static("/static/", _STATIC_DIR)
+    return app
+
+
+def serve_dashboard(
+    host: str = "127.0.0.1",
+    port: int = 8787,
+    config_path: str | None = None,
+    unsafe_bind: bool = False,
+) -> None:
+    """Run the dashboard. Refuses a non-loopback host unless unsafe_bind is set."""
+    if host not in ("127.0.0.1", "localhost", "::1") and not unsafe_bind:
+        raise ValueError(
+            f"Refusing to bind dashboard to non-loopback host {host!r}. "
+            "The dashboard can approve tool calls and kill agents — keep it on "
+            "localhost. Pass unsafe_bind=True only if you understand the risk."
+        )
+    app = build_app(config_path)
+    logger.info("Mission Control dashboard on http://%s:%d", host, port)
+    web.run_app(app, host=host, port=port, print=None)

--- a/culture/dashboard/static/app.js
+++ b/culture/dashboard/static/app.js
@@ -1,0 +1,233 @@
+"use strict";
+
+// Mission Control SPA — vanilla JS, no build step.
+const state = { selected: null, kind: "audit", es: null };
+
+const $ = (sel) => document.querySelector(sel);
+const el = (tag, cls, text) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = text;
+  return n;
+};
+
+function toast(msg, isErr) {
+  const t = $("#toast");
+  t.textContent = msg;
+  t.classList.remove("hidden", "err");
+  if (isErr) t.classList.add("err");
+  clearTimeout(toast._t);
+  toast._t = setTimeout(() => t.classList.add("hidden"), 3000);
+}
+
+async function api(path, opts) {
+  const res = await fetch(path, opts);
+  let data = {};
+  try { data = await res.json(); } catch (_) {}
+  if (!res.ok || data.error) {
+    throw new Error(data.error || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
+async function post(path, body) {
+  return api(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body || {}),
+  });
+}
+
+// ---- Agents grid -----------------------------------------------------------
+
+async function refreshAgents() {
+  let data;
+  try { data = await api("/api/agents"); } catch (e) { return; }
+  const list = $("#agent-list");
+  list.replaceChildren();
+  if (!data.agents.length) {
+    list.appendChild(el("div", "empty", "No agents registered."));
+    return;
+  }
+  for (const a of data.agents) {
+    const item = el("li", "agent-item");
+    if (a.nick === state.selected) item.classList.add("selected");
+    item.onclick = () => selectAgent(a.nick);
+
+    const row = el("div", "agent-row");
+    const nick = el("span", "agent-nick");
+    nick.appendChild(el("span", "dot " + a.state));
+    nick.appendChild(document.createTextNode(a.nick));
+    if (a.is_boss) nick.appendChild(el("span", "boss-tag", "BOSS"));
+    row.appendChild(nick);
+    if (a.pending > 0) row.appendChild(el("span", "agent-pending", a.pending + " ⏳"));
+    item.appendChild(row);
+
+    const meta = el("div", "agent-meta");
+    meta.appendChild(el("span", null, a.state));
+    meta.appendChild(el("span", null, a.last_action || ""));
+    item.appendChild(meta);
+
+    const actions = el("div", "agent-actions");
+    actions.appendChild(ctlBtn("pause", "Pause", a.nick));
+    actions.appendChild(ctlBtn("resume", "Resume", a.nick));
+    const close = el("button", "btn btn-sm btn-danger", "Close");
+    close.onclick = (e) => { e.stopPropagation(); confirmClose(a.nick); };
+    actions.appendChild(close);
+    item.appendChild(actions);
+    list.appendChild(item);
+  }
+}
+
+function ctlBtn(action, label, nick) {
+  const b = el("button", "btn btn-sm", label);
+  b.onclick = async (e) => {
+    e.stopPropagation();
+    try {
+      const r = await post("/api/" + action, { nick });
+      toast(r.ok ? `${label} ${nick}` : `${label} ${nick} failed`, !r.ok);
+      refreshAgents();
+    } catch (err) { toast(err.message, true); }
+  };
+  return b;
+}
+
+function confirmClose(nick) {
+  if (!confirm(`Close agent ${nick}? Its daemon will be stopped.`)) return;
+  post("/api/close", { nick })
+    .then((r) => { toast(r.ok ? `Closed ${nick}` : `Close failed`, !r.ok); refreshAgents(); })
+    .catch((e) => toast(e.message, true));
+}
+
+// ---- Stream (per-agent session / daemon-log) -------------------------------
+
+function selectAgent(nick) {
+  state.selected = nick;
+  $("#stream-title").textContent = nick;
+  refreshAgents();
+  openStream();
+}
+
+function openStream() {
+  if (state.es) { state.es.close(); state.es = null; }
+  const box = $("#stream");
+  box.replaceChildren();
+  if (!state.selected) return;
+  const url = `/api/stream/${state.kind}/${encodeURIComponent(state.selected)}`;
+  const es = new EventSource(url);
+  state.es = es;
+  es.onmessage = (ev) => {
+    if (!ev.data) return;
+    appendStreamLine(box, ev.data);
+  };
+  es.onerror = () => { /* EventSource auto-reconnects */ };
+}
+
+function appendStreamLine(box, raw) {
+  let rec;
+  try { rec = JSON.parse(raw); } catch (_) { rec = null; }
+  const line = el("div", "stream-line");
+  if (rec && state.kind === "audit") {
+    line.appendChild(el("span", "ts", (rec.ts || "") + "  "));
+    if (rec.text) line.appendChild(document.createTextNode(rec.text));
+    if (rec.tool_uses && rec.tool_uses.length) {
+      const tools = rec.tool_uses.map((t) => t.name).join(", ");
+      line.appendChild(el("div", "tools", "→ " + tools));
+    }
+  } else if (rec && state.kind === "daemon-log") {
+    line.appendChild(el("span", "ts", (rec.ts || "") + "  "));
+    line.appendChild(el("span", "action", rec.action || "?"));
+    const detail = rec.detail ? " " + Object.entries(rec.detail).map(([k, v]) => `${k}=${v}`).join(" ") : "";
+    if (detail) line.appendChild(document.createTextNode(detail));
+  } else {
+    line.textContent = raw;
+  }
+  box.appendChild(line);
+  box.scrollTop = box.scrollHeight;
+}
+
+// ---- Pending approvals -----------------------------------------------------
+
+async function refreshPending() {
+  let data;
+  try { data = await api("/api/pending"); } catch (_) { return; }
+  const list = $("#pending-list");
+  list.replaceChildren();
+  const badge = $("#pending-badge");
+  if (!data.pending.length) {
+    list.appendChild(el("div", "empty", "Nothing waiting."));
+    badge.classList.add("hidden");
+    return;
+  }
+  badge.textContent = data.pending.length + " pending";
+  badge.classList.remove("hidden");
+  for (const p of data.pending) {
+    const item = el("li", "pending-item");
+    item.appendChild(el("div", "ptool", p.tool_name || "?"));
+    item.appendChild(el("div", "pworker", p.helper_nick || ""));
+    item.appendChild(el("div", "pinput", inputPreview(p)));
+    const actions = el("div", "pending-actions");
+    const ok = el("button", "btn btn-sm btn-ok", "Approve");
+    ok.onclick = () => decide("approve", p.id, { id: p.id });
+    const okAlways = el("button", "btn btn-sm btn-ok", "Always");
+    okAlways.onclick = () => decide("approve", p.id, { id: p.id, always: true });
+    const no = el("button", "btn btn-sm btn-danger", "Deny");
+    no.onclick = () => {
+      const reason = prompt("Deny reason (optional):") || "";
+      decide("deny", p.id, { id: p.id, reason });
+    };
+    actions.appendChild(ok);
+    actions.appendChild(okAlways);
+    actions.appendChild(no);
+    item.appendChild(actions);
+    list.appendChild(item);
+  }
+}
+
+function inputPreview(p) {
+  const inp = p.input || {};
+  if (p.tool_name === "Bash") return inp.command || "";
+  if (p.tool_name === "Edit" || p.tool_name === "Write") return inp.file_path || "";
+  try { return JSON.stringify(inp); } catch (_) { return ""; }
+}
+
+async function decide(kind, id, body) {
+  try {
+    await post("/api/" + kind, body);
+    toast(`${kind} ${id}`);
+    refreshPending();
+    refreshAgents();
+  } catch (e) { toast(e.message, true); }
+}
+
+// ---- Emergency controls ----------------------------------------------------
+
+$("#btn-stop-pause").onclick = async () => {
+  if (!confirm("Pause EVERY running agent?")) return;
+  try { const r = await post("/api/stop-all", { mode: "pause" }); toast(`Paused ${(r.paused||[]).length} agent(s)`); refreshAgents(); }
+  catch (e) { toast(e.message, true); }
+};
+
+$("#btn-stop-kill").onclick = async () => {
+  if (!confirm("EMERGENCY STOP — kill every agent (including the boss)?")) return;
+  try { await post("/api/stop-all", { mode: "kill" }); toast("Stopped all agents"); refreshAgents(); }
+  catch (e) { toast(e.message, true); }
+};
+
+// ---- Stream tabs -----------------------------------------------------------
+
+document.querySelectorAll(".tab").forEach((tab) => {
+  tab.onclick = () => {
+    document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"));
+    tab.classList.add("active");
+    state.kind = tab.dataset.kind;
+    openStream();
+  };
+});
+
+// ---- Boot ------------------------------------------------------------------
+
+refreshAgents();
+refreshPending();
+setInterval(refreshAgents, 2500);
+setInterval(refreshPending, 2000);

--- a/culture/dashboard/static/index.html
+++ b/culture/dashboard/static/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Culture · Mission Control</title>
+  <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">culture · <span>mission control</span></div>
+    <div class="topbar-actions">
+      <span id="pending-badge" class="badge hidden">0 pending</span>
+      <button id="btn-stop-pause" class="btn btn-warn" title="Pause every running agent">Pause all</button>
+      <button id="btn-stop-kill" class="btn btn-danger" title="Kill every agent (emergency)">STOP&nbsp;ALL</button>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section class="col col-agents">
+      <h2>Agents</h2>
+      <ul id="agent-list" class="agent-list"></ul>
+    </section>
+
+    <section class="col col-stream">
+      <h2 id="stream-title">Session</h2>
+      <div class="stream-tabs">
+        <button class="tab active" data-kind="audit">Session</button>
+        <button class="tab" data-kind="daemon-log">Daemon actions</button>
+      </div>
+      <div id="stream" class="stream" aria-live="polite"></div>
+    </section>
+
+    <section class="col col-perms">
+      <h2>Pending approvals</h2>
+      <ul id="pending-list" class="pending-list"></ul>
+    </section>
+  </main>
+
+  <div id="toast" class="toast hidden"></div>
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/culture/dashboard/static/style.css
+++ b/culture/dashboard/static/style.css
@@ -1,0 +1,127 @@
+:root {
+  --bg: #0d1117;
+  --panel: #11161b;
+  --border: #1f2730;
+  --text: #c7d0d9;
+  --muted: #8a97a3;
+  --green: #41d67a;
+  --amber: #e3b341;
+  --red: #f06d6d;
+  --accent: #4aa3ff;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.brand { font-weight: 600; letter-spacing: 0.5px; }
+.brand span { color: var(--muted); }
+
+.topbar-actions { display: flex; gap: 8px; align-items: center; }
+
+.badge {
+  background: var(--amber);
+  color: #000;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 600;
+}
+.badge.hidden { display: none; }
+
+.btn {
+  background: #1a222b;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 10px;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.btn:hover { border-color: var(--accent); }
+.btn-warn { border-color: var(--amber); color: var(--amber); }
+.btn-danger { border-color: var(--red); color: var(--red); font-weight: 700; }
+.btn-danger:hover { background: var(--red); color: #000; }
+.btn-ok { border-color: var(--green); color: var(--green); }
+.btn-ok:hover { background: var(--green); color: #000; }
+.btn-sm { padding: 3px 7px; font-size: 11px; }
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr 340px;
+  gap: 1px;
+  height: calc(100vh - 49px);
+  background: var(--border);
+}
+
+.col { background: var(--bg); overflow-y: auto; padding: 12px; }
+.col h2 { font-size: 12px; text-transform: uppercase; color: var(--muted); margin: 0 0 10px; letter-spacing: 1px; }
+
+.agent-list, .pending-list { list-style: none; margin: 0; padding: 0; }
+
+.agent-item {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  background: var(--panel);
+}
+.agent-item:hover { border-color: var(--accent); }
+.agent-item.selected { border-color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent); }
+.agent-row { display: flex; align-items: center; justify-content: space-between; }
+.agent-nick { font-weight: 600; }
+.agent-nick .boss-tag { color: var(--accent); font-size: 10px; margin-left: 4px; }
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 6px; }
+.dot.running { background: var(--green); }
+.dot.stopped { background: var(--muted); }
+.agent-meta { color: var(--muted); font-size: 11px; margin-top: 4px; display: flex; justify-content: space-between; }
+.agent-pending { color: var(--amber); font-weight: 600; }
+.agent-actions { margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap; }
+
+.stream-tabs { display: flex; gap: 6px; margin-bottom: 8px; }
+.tab { background: none; border: none; color: var(--muted); cursor: pointer; padding: 4px 8px; font-family: var(--mono); border-bottom: 2px solid transparent; }
+.tab.active { color: var(--text); border-bottom-color: var(--accent); }
+
+.stream { font-size: 12px; line-height: 1.5; }
+.stream-line { padding: 6px 8px; border-bottom: 1px solid var(--border); white-space: pre-wrap; word-break: break-word; }
+.stream-line .ts { color: var(--muted); font-size: 10px; }
+.stream-line .tools { color: var(--accent); font-size: 11px; }
+.stream-line .action { color: var(--amber); font-weight: 600; }
+
+.pending-item {
+  border: 1px solid var(--amber);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  background: var(--panel);
+}
+.pending-item .ptool { font-weight: 600; color: var(--amber); }
+.pending-item .pworker { color: var(--muted); font-size: 11px; }
+.pending-item .pinput { font-size: 11px; color: var(--text); margin: 4px 0; white-space: pre-wrap; word-break: break-word; }
+.pending-actions { display: flex; gap: 6px; margin-top: 6px; }
+
+.toast {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  background: var(--panel); border: 1px solid var(--accent); color: var(--text);
+  padding: 8px 14px; border-radius: 6px; z-index: 100;
+}
+.toast.hidden { display: none; }
+.toast.err { border-color: var(--red); color: var(--red); }
+.empty { color: var(--muted); font-style: italic; padding: 8px; }

--- a/docs/agentirc/boss-agent.md
+++ b/docs/agentirc/boss-agent.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: Boss Agent Orchestration
+parent: AgentIRC
+nav_order: 97
+---
+
+# Boss Agent Orchestration
+
+A **boss agent** is an autonomous culture daemon that manages worker agents in
+your place. You brief it once in an IRC channel; it reads `CLAUDE.md` and the
+plan, spawns workers, drives them like you'd drive a Claude Code session —
+asking, scoping, telling them to plan, **challenging** their work and claims —
+and approves or denies their tool requests, bounded by a grant ceiling. One or
+many bosses, within a project or across several.
+
+Design spec: `docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md`
+Builds on the [Helper Permission Broker](helper-permissions.md).
+
+## The model
+
+The boss is a normal culture mesh agent whose tools are:
+
+- the **IRC skill** (`culture channel …`) — to converse with workers and with you;
+- the **boss skill** (`culture boss …`) — the out-of-band operations conversation
+  can't do: spawn a worker, approve/deny its tool requests, read its logs.
+
+Its manager behavior comes from a system-prompt identity, not rigid code — it
+exercises judgment about what to ask, when to challenge, and what "done" means.
+
+```text
+   you ──brief/steer (IRC #boss)──►  boss agent (daemon)
+                                       │  culture boss spawn / approve / …
+                  ┌────────────────────┼────────────────────┐
+                  ▼                     ▼                     ▼
+              worker A              worker B              worker C
+              #task-A               #task-B               #task-C
+                  └── perm request DM ──► boss (approve/deny, bounded by ceiling)
+```
+
+## Quick start
+
+```bash
+culture boss init --nick boss --channel '#boss'   # create the boss identity
+culture agent start local-boss                     # start the boss daemon
+# then, in #boss, brief it:  "@local-boss ship feature X in project Y"
+```
+
+The boss takes it from there: spawns workers, drives them, approves their routine
+tool calls, escalates the risky ones to you.
+
+## `culture boss` commands (used by the boss agent)
+
+| Command | Purpose |
+|---|---|
+| `culture boss init [--nick boss] [--channel '#boss'] [--cwd PATH]` | Create the boss identity: manager `system_prompt`, seeded grant ceiling, copied boss skill, **no perm-policy** (deadlock guard), boss channel. Idempotent. |
+| `culture boss spawn <name> [--cwd PATH]` | Create + start a worker under this boss; seed its policy; record `boss:` in its `culture.yaml`; join its task channel. Refuses a nick colliding with a boss. |
+| `culture boss brief <name> "<task>"` | Send a task to the worker's channel. |
+| `culture boss read <name> [--limit N]` | Read the worker's recent replies. |
+| `culture boss pending` | List pending worker permission requests. |
+| `culture boss approve <id> [--always] [--pattern P]` | Grant a request. Refuses (exit 2 + escalation message) if the tool is above the boss's grant ceiling. |
+| `culture boss deny <id> [reason...]` | Deny; the reason is returned to the worker's model. |
+| `culture boss audit <name> [--limit N]` | The worker's agent-message log — to verify/challenge claims. |
+| `culture boss log <name> [--limit N]` | The worker's daemon-action log. |
+| `culture boss status` | Workers + pending-perm count. |
+| `culture boss close <name>` | Stop a worker daemon. |
+
+The boss's own nick comes from `CULTURE_NICK`, which the agent runner now sets in
+every daemon agent's subprocess environment (so an autonomous agent can address
+its own IRC/boss sockets).
+
+## The grant ceiling (you stay the final authority on risk)
+
+The boss can `--always`-grant routine tools (Edit/Write/Bash) freely, but a
+denylist of high-risk actions — external MCP sends (Gmail/Drive/…), destructive
+Bash (`rm -rf`, `git push`, `kubectl`, …) — is **above its grant ceiling**.
+`culture boss approve` refuses those (exit 2) and tells the boss to escalate; you
+grant them with the human `approve.sh <id>` from the [permission broker](helper-permissions.md).
+The ceiling lives at `~/.culture/boss-policy/<boss-nick>.yaml` and is editable.
+
+> **This is a cooperative guardrail, not a hard boundary.** The boss is an LLM
+> with a Bash tool; on a single-UID machine nothing cryptographically stops it
+> from writing a decision file directly. The ceiling shapes a cooperative boss's
+> behavior (the tool refuses + the system prompt says to escalate); it does not
+> defend against an adversarial or malfunctioning boss. Don't over-trust it.
+
+## Deadlock invariant
+
+A boss must **not** be permission-supervised — it has no
+`~/.culture/perm-policy/<boss-nick>.yaml`. If it did, its own `culture boss
+approve` Bash calls would themselves require approval, and there is no higher
+boss to grant them → deadlock. `culture boss init` enforces this (and removes a
+stray policy file if found); the boss is supervised by **you over IRC**, not by
+the broker.
+
+## Re-grounding on long missions
+
+The boss is a long-lived agent, so the [context handoff](helper-context-handoff.md)
+applies: near its context limit it writes a handoff and is reminded to read it
+after compacting. Its manager system-prompt tells it to re-ground on the mission,
+`CLAUDE.md`, and the plan — not just the last few messages.
+
+## Backend support
+
+The boss agent is **Claude-only** (it depends on the broker and context-watch,
+both Claude-only). Workers may be any backend — a Claude boss can spawn and
+converse with a Codex/ACP worker over IRC — but those workers are audit-only (no
+synchronous tool gate), so the boss oversees them by reading their audit logs and
+conversing, not by approving individual tool calls.
+
+**Single mesh (v1).** The worker→boss permission DM addresses the boss by nick on
+the same `local` server; one boss and its workers live on one mesh. Cross-mesh /
+multi-machine boss coordination is out of scope for v1.

--- a/docs/agentirc/dashboard.md
+++ b/docs/agentirc/dashboard.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: Mission Control Dashboard
+parent: AgentIRC
+nav_order: 98
+---
+
+# Mission Control Dashboard
+
+A local web app to **watch the whole mesh and take the wheel**. It streams every
+agent's session, the daemon-action log, and pending tool-approvals into one
+browser view, and exposes the full intervention surface — approve/deny,
+pause/resume, close, emergency stop-all, and grant-policy edits — for when a run
+goes sideways.
+
+Design spec: `docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md`
+Builds on the [Permission Broker](helper-permissions.md), [Daemon Action Log](helper-daemon-log.md), and [Boss Agent](boss-agent.md).
+
+## Run it
+
+```bash
+culture dashboard               # http://127.0.0.1:8787
+culture dashboard --port 9000
+```
+
+Bound to `127.0.0.1` only. It can approve tool calls and kill agents, so it
+refuses a non-loopback `--host` unless you pass `--unsafe-bind` (documented as
+dangerous). No new dependency — it's an `aiohttp` server (already a dep) serving
+a vanilla-JS page (no build step).
+
+## What you see
+
+Three columns, no setup beyond a running mesh:
+
+- **Agents** — every registered agent with live state (running/stopped), pending-
+  approval count, last daemon action, and a `BOSS` tag for boss agents. Per-agent
+  **Pause / Resume / Close** buttons.
+- **Session** — click an agent to live-stream its **session** (the agent's own
+  messages + tool calls, from `audit/<nick>.jsonl`) or its **daemon actions**
+  (`daemon-log/<nick>.jsonl`). Server-sent events; backlog then live tail.
+- **Pending approvals** — every worker tool request waiting on a human, with
+  **Approve / Always / Deny**. (Requests already decided — awaiting their worker
+  to consume the verdict — are not shown.)
+
+Top bar: a pending badge, **Pause all**, and a red **STOP ALL** (emergency
+kill of every agent including the boss).
+
+## Control = the operator is the top authority
+
+Unlike the boss agent (bounded by its [grant ceiling](boss-agent.md)), the
+dashboard is **you** — its approvals are **not** ceiling-bounded. You can approve
+any tool, including the high-risk ones a boss must escalate. Control actions reuse
+the existing levers:
+
+| Action | Under the hood |
+|---|---|
+| Approve / Deny | writes `perm-decisions/<id>.json` (`decided_by: dashboard`) |
+| Pause / Resume | daemon IPC (`pause`/`resume`) |
+| Close | `culture agent stop <nick>` |
+| Stop all | `pause` every agent, or `culture agent stop --all` (kill) |
+| Edit policy | read/write `perm-policy/<nick>.yaml` |
+
+## API (for scripting / integration)
+
+`GET /api/agents`, `GET /api/pending`, `GET /api/stream/{audit|daemon-log}/<nick>`
+(SSE), `GET/PUT /api/policy/<nick>`, and `POST /api/{approve,deny,pause,resume,close,stop-all}`.
+All localhost JSON.
+
+## Security model
+
+Same-machine, same-UID, localhost-only. Anyone who can reach the port as this
+user already has shell access and the same powers via the CLI/files — the
+dashboard adds no privilege. There is no auth token in v1; if the host is shared,
+do not run it (or front it with your own auth). Never bind a non-loopback
+interface.

--- a/docs/agentirc/helper-context-handoff.md
+++ b/docs/agentirc/helper-context-handoff.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Helper Context Handoff
+parent: AgentIRC
+nav_order: 95
+---
+
+# Helper Context Handoff
+
+A long-running agent fills its context window. Before it does, the daemon asks the
+agent to write a handoff for its post-compact self, triggers a compact, then
+reminds it to read that handoff on its next activation — so working state
+survives the compaction.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## How it works
+
+The daemon self-monitors context utilization (it is reliable and can't miss the
+threshold the way an async boss poll could). After each turn it reads the SDK's
+`ResultMessage.usage.input_tokens`, which under session resume reflects the full
+context sent to the model — a direct proxy for context-window occupancy:
+
+```text
+pct = input_tokens / context_window_tokens
+```
+
+At `pct >= high_water` (default 0.90) the daemon, once per fill cycle:
+
+1. Records a `handoff_written` daemon action.
+2. Sends the agent a prompt asking it to write a concise handoff to
+   `CULTURE_HOME/handoff/<nick>.md` (what it's doing, key decisions, what
+   remains, important paths).
+3. Queues `/compact` as the next turn.
+4. Records a `compact` daemon action with `trigger: context_watermark`.
+5. On the next activation, prepends a reminder to read the handoff, and records a
+   `handoff_reminder` action.
+
+The handoff write is pre-approved in the helper's permission policy (an
+`auto_allow` rule for `Write` to `handoff/<nick>.md`), so a context-crisis
+handoff never stalls waiting for boss approval. All other writes still route to
+the boss.
+
+The handoff latch resets once usage drops below `low_water` (default 0.50, e.g.
+after the compact), arming the next cycle.
+
+## Context windows
+
+| Model family | Window |
+|---|---|
+| `claude-opus-4-*` with a `1m` / `[1m]` marker | 1,000,000 |
+| other `claude-opus-4-*`, `claude-sonnet-4-*`, `claude-haiku-4-*` | 200,000 |
+| unknown | 200,000 (conservative default, logged) |
+
+## Configuration
+
+Optional, per-agent in `culture.yaml`:
+
+```yaml
+context_watch:
+  enabled: true     # default true
+  high_water: 0.90  # fraction of the window that triggers a handoff
+  low_water: 0.50   # fraction below which the latch resets
+```
+
+Omit the block for defaults. This is additive — existing `culture.yaml` files
+need no change.
+
+## Visibility
+
+```bash
+context-status.sh            # last-known context % per helper
+context-status.sh <name>     # one helper
+daemon-log.sh <name>         # full action log incl. handoff_written / compact / handoff_reminder
+```
+
+## Backend support
+
+Context-watch is **Claude-only**. Codex and Copilot do not expose per-turn token
+counts on their responses (Copilot: issue #299), so the watermark cannot be
+computed there. On those backends the [daemon-action log](helper-daemon-log.md)
+still records compactions when they happen via the IPC `compact` path.

--- a/docs/agentirc/helper-daemon-log.md
+++ b/docs/agentirc/helper-daemon-log.md
@@ -1,0 +1,97 @@
+---
+layout: default
+title: Helper Daemon Action Log
+parent: AgentIRC
+nav_order: 96
+---
+
+# Helper Daemon Action Log
+
+The daemon-action log is a structured, control-plane record of what each agent
+daemon *does* to manage its agent — distinct from the agent-message audit log,
+which records what the agent *says* and which tools it calls.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## File layout
+
+One JSONL line per action at `CULTURE_HOME/daemon-log/<nick>.jsonl` (default
+`~/.culture/daemon-log/<nick>.jsonl`). Universal across all four backends. Each
+line:
+
+```json
+{"ts": "2026-05-28T14:32:17.123Z", "nick": "local-research", "action": "compact", "detail": {"trigger": "context_watermark", "pct": 0.91}}
+```
+
+## Action vocabulary
+
+| action | when | detail |
+|---|---|---|
+| `agent_start` | the daemon starts the runner | `model`, `directory` |
+| `agent_stop` | graceful stop | — |
+| `agent_exit` | runner exits (incl. crash) | `exit_code` |
+| `crash` | crash recorded in the sliding window | `exit_code`, `count` |
+| `circuit_open` | circuit breaker trips | `count`, `window_s` |
+| `pause` / `resume` | pause state changes | `manual` |
+| `compact` | compact triggered | `trigger` (`ipc` or `context_watermark`), `pct?` |
+| `clear` | context cleared | — |
+| `handoff_written` | context-watermark handoff prompt sent | `pct`, `path` |
+| `handoff_reminder` | post-compact reminder injected | `path` |
+
+> Across backends, the universal actions are `agent_start`, `agent_stop`,
+> `agent_exit`, and `compact`. The remaining actions (crash, circuit_open,
+> pause, resume, clear, handoff_*) are emitted by the Claude daemon; other
+> backends emit the universal subset.
+
+## Relationship to Python logging
+
+The daemon keeps its existing `logger.info/warning` calls for the systemd
+journal. The action log is the structured, boss-readable complement — not a
+replacement. Where both fire for one event, that's intentional: one for ops, one
+for the boss.
+
+## Boss workflow
+
+```bash
+daemon-log.sh <name> [limit]   # tail + pretty-print (default limit 30)
+```
+
+`status.sh` also prints the most recent action per supervised helper.
+
+## Writing semantics
+
+Lines are appended with `O_APPEND` and fsynced per line; concurrent writes on one
+agent serialize through an in-process lock so each line stays intact. The log
+grows without bound — rotation is out of scope and left to the operator.
+
+## Related: the agent-message audit log
+
+The daemon-action log is the *control-plane* record. Its companion is the
+*agent-message audit log* at `CULTURE_HOME/audit/<nick>.jsonl` — one line per
+`AssistantMessage` the agent emits, on every backend. Where the daemon-action
+log says "the daemon compacted the agent", the audit log says "the agent said X
+and called tool Y". Schema:
+
+```json
+{
+  "ts": "2026-05-28T14:32:17.123Z",
+  "nick": "local-research",
+  "type": "assistant",
+  "model": "claude-opus-4-7",
+  "text": "I'll search for PR #123 …",
+  "tool_uses": [{"name": "Bash", "input_digest": "sha256:…"}],
+  "tool_results": [{"name": "Bash", "content_digest": "sha256:…", "preview": "first 200 chars"}]
+}
+```
+
+Tool inputs and results are stored as 16-hex SHA-256 digests plus a 200-char
+preview to keep the log compact; the digest lets you correlate an audit entry
+with the full input captured in a `perm-queue/<id>.json` request (see
+[Helper Permission Broker](helper-permissions.md)). Read it the same way:
+
+```bash
+tail -f ~/.culture/audit/local-research.jsonl | jq .
+```
+
+This is distinct from the **server-level** audit log documented in
+[Audit](audit.md), which records IRC protocol events across the whole server.

--- a/docs/agentirc/helper-permissions.md
+++ b/docs/agentirc/helper-permissions.md
@@ -1,0 +1,139 @@
+---
+layout: default
+title: Helper Permission Broker
+parent: AgentIRC
+nav_order: 93
+---
+
+# Helper Permission Broker
+
+The permission broker lets a regular Claude Code session (the **boss**) act as the
+human-in-the-loop authority for tool calls made by helper agents it spawns on a
+local Culture mesh. Helpers run headless (no terminal), so the boss approves or
+denies their tool use over a file-backed queue instead of a terminal prompt.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## Why a broker
+
+Helper daemons run the Claude Agent SDK in `bypassPermissions` mode — the only
+mode that doesn't block on a terminal prompt nobody is reading. That mode turns
+off the *UI* prompt path, not the programmatic `can_use_tool` callback. The
+broker is that callback: it decides allow/deny per tool call, consulting a
+per-helper policy file and, when no rule matches, the boss.
+
+## File layout
+
+All under `CULTURE_HOME` (default `~/.culture`):
+
+| Path | Purpose |
+|---|---|
+| `perm-policy/<nick>.yaml` | Per-helper auto-allow / auto-deny rules. Its presence is what makes a helper *boss-supervised*. |
+| `perm-queue/<id>.json` | A pending request the helper wrote and is blocking on. |
+| `perm-decisions/<id>.json` | The boss's verdict; the helper consumes it and unblocks. |
+
+`CULTURE_HOME` is honored by both the broker (Python) and the boss scripts. Set
+it consistently if you override it.
+
+## Policy file
+
+`spawn-helper.sh` seeds a default policy with safe-read auto-allows:
+
+```yaml
+auto_allow:
+  - tool: Read
+  - tool: Glob
+  - tool: Grep
+  - tool: Bash
+    input_regex: '^(ls|cat|head|tail|wc|file|stat|pwd|which|rg|grep|find|tree|git (status|log|diff|blame|show)|gh (.* )?(list|view))(\s|$)'
+  - tool: Write
+    input_regex: '/handoff/<nick>\.md$'   # context-handoff write, see helper-context-handoff
+auto_deny: []
+require_approval:
+  - tool: Edit
+  - tool: Write
+  - tool: 'mcp__.*'
+  - tool: Bash
+```
+
+Matching: `auto_deny` is checked before `auto_allow`; first match wins. A tool
+pattern containing regex metacharacters is matched as a regex (`re.fullmatch`),
+otherwise by exact string. `input_regex` (optional) is `re.search` against a
+per-tool projection — `Bash`→command, `Edit`/`Write`→file_path, `mcp__*`→JSON
+of the input. Anything not matched falls through to the boss.
+
+The policy is re-read on every gate call (mtime-checked), so `approve.sh … always`
+takes effect immediately, including after a session resume.
+
+## Lifecycle
+
+1. The SDK fires `can_use_tool(tool, input, ctx)` before a tool runs.
+2. The broker matches the policy. `allow`/`deny` return immediately — no round trip.
+3. Otherwise it writes `perm-queue/<id>.json` and blocks on `perm-decisions/<id>.json`,
+   polling every 250 ms. **There is no timeout** — the helper waits indefinitely.
+4. When the boss writes a decision, the helper reads it, deletes both files, and
+   returns allow/deny to the SDK. `scope: always` first appends a sticky rule to
+   the policy file.
+5. If the helper task is cancelled mid-wait (e.g. `close-helper.sh`), the broker
+   deletes its in-flight request file and re-raises the cancellation.
+
+## Boss workflow
+
+```bash
+pending-perms.sh                 # list all pending requests across helpers
+pending-perms.sh --full <id>     # full request JSON for one id
+approve.sh <id>                  # one-shot allow
+approve.sh <id> always           # sticky allow for this exact tool name
+approve.sh <id> always 'Bash'    # sticky allow for a tool pattern
+deny.sh <id> [reason...]         # deny; reason returned to the model
+watch-perms.sh                   # live tail of new requests (side terminal)
+policy.sh list <name>            # inspect a helper's policy
+policy.sh allow|deny <name> <tool> [input_regex]
+policy.sh reset <name>           # reseed default policy
+cleanup-stale-perms.sh           # GC requests whose helper is gone + orphan decisions
+```
+
+`status.sh` and `read-replies.sh` surface a `[N pending perms]` count so the boss
+notices requests during its normal flow.
+
+## Atomicity and races
+
+- Decision and request files are written via tempfile + `os.replace` — readers
+  never see a partial file.
+- `approve.sh`/`deny.sh` use `O_CREAT | O_EXCL` on the destination so two
+  concurrent boss invocations can't both decide one request (first writer wins).
+- A decision written after the helper already consumed its verdict becomes an
+  orphan; `cleanup-stale-perms.sh` garbage-collects orphans and requests whose
+  helper daemon is no longer running.
+
+> **Known limitation:** `os.replace` is atomic on local POSIX filesystems
+> (macOS/Linux) but not on NFS or some FUSE mounts. Keep `CULTURE_HOME` on a
+> local disk.
+
+## Backend support
+
+| Backend | Broker |
+|---|---|
+| Claude | **Full** — native `can_use_tool`. |
+| Copilot | Audit-only in this release (the Copilot SDK `PermissionHandler` signature could not be verified at build time). |
+| Codex | Audit-only — no per-tool callback in the app-server protocol. |
+| ACP | Audit-only — no per-tool callback in the ACP surface. |
+
+Audit-only backends still record every agent message to
+`audit/<nick>.jsonl` and every daemon action to `daemon-log/<nick>.jsonl`, so the
+boss retains visibility even where synchronous approval isn't possible.
+
+## Security model
+
+Same-machine, same-UID only. The broker directories are created `0700` with
+`0600` files. Anyone able to write to `perm-decisions/` as the user already has
+shell access to the user's home directory; the broker is a *boss-as-human*
+mechanism, not a sandbox.
+
+## Standalone agents
+
+An agent **without** a `perm-policy/<nick>.yaml` runs exactly as before this
+feature: `can_use_tool` is not set, no broker is involved, no approval is
+required. Only boss-spawned helpers (which get a seeded policy file) are
+supervised. Existing mesh agents are unaffected except that they now inherit the
+boss's user-level tool surface — see [Helper Tool Inheritance](helper-tool-inheritance.md).

--- a/docs/agentirc/helper-tool-inheritance.md
+++ b/docs/agentirc/helper-tool-inheritance.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: Helper Tool Inheritance
+parent: AgentIRC
+nav_order: 94
+---
+
+# Helper Tool Inheritance
+
+Helper agents spawned by a boss session inherit the boss's full tool surface —
+the user-level skills, MCP servers, and plugins configured in `~/.claude/` — so a
+helper can reach for the same tools the boss can.
+
+Design spec: `docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md`
+
+## What changed
+
+The Claude agent runner previously loaded only project-level settings:
+
+```python
+ClaudeAgentOptions(setting_sources=["project"])
+```
+
+It now loads all three layers:
+
+```python
+ClaudeAgentOptions(setting_sources=["user", "project", "local"])
+```
+
+The Claude CLI reads each layer's `settings.json` (and skills/plugins), so a
+helper now sees:
+
+- **`user`** — `~/.claude/settings.json` (your MCP servers), `~/.claude/skills/`,
+  `~/.claude/plugins/`.
+- **`project`** — the helper cwd's `.claude/` (project skills, project MCP).
+- **`local`** — machine-local overrides.
+
+## Scope: every Claude agent, not just helpers
+
+This widening applies to **all** Claude agents on the mesh, including
+standalone, long-running ones started with `cu agent start` (e.g.
+`spark-culture`). Those agents now have access to the user's MCP servers and
+skills.
+
+This is intentional — any agent on the mesh should be able to use the boss's
+tool surface. The difference between a *supervised helper* and a *standalone
+agent* is **not** the tool surface; it is whether a `perm-policy/<nick>.yaml`
+exists (see [Helper Permission Broker](helper-permissions.md)):
+
+- **Helper** (policy file present): inherits tools **and** routes dangerous tool
+  calls through the boss for approval.
+- **Standalone agent** (no policy file): inherits tools and runs autonomously
+  (`bypassPermissions`, as before), with the
+  [daemon-action log](helper-daemon-log.md) providing after-the-fact visibility.
+
+## Security note
+
+A helper inheriting `~/.claude/` gains every MCP server you have configured —
+including Gmail, Drive, Calendar, Atlassian, Cloudflare, etc. For a supervised
+helper, the broker gates these (all `mcp__*` tools require boss approval by
+default). For a standalone agent, there is no gate — so only run standalone
+agents you trust with your full tool surface, or give them a policy file to bring
+them under boss supervision.
+
+## Backend support
+
+| Backend | Inheritance |
+|---|---|
+| Claude | Full — `setting_sources=["user","project","local"]`. |
+| Copilot | Deferred — the Copilot SDK `skill_directories` wiring is planned but the SDK was not verifiable at build time. |
+| Codex | Not applicable — the app-server protocol exposes no user-skills/MCP surface from the harness. |
+| ACP | Not applicable — no skill/MCP inheritance hook in the ACP surface. |

--- a/docs/agentirc/index.md
+++ b/docs/agentirc/index.md
@@ -95,6 +95,7 @@ A boss — either your Claude Code session or an autonomous **boss agent** — c
 spawn worker agents and supervise them: gating their tool calls, watching their
 context budget, and logging their daemon actions.
 
+- [Mission Control Dashboard](dashboard.md) — a local web app to watch every agent live and intervene (approve/deny, pause, kill, stop-all).
 - [Boss Agent Orchestration](boss-agent.md) — an autonomous boss agent that spawns and manages worker agents in your place.
 - [Helper Permission Broker](helper-permissions.md) — approval gate for helper tool calls (human or boss-agent as approver).
 - [Helper Tool Inheritance](helper-tool-inheritance.md) — helpers inherit the boss's skills + MCP servers.

--- a/docs/agentirc/index.md
+++ b/docs/agentirc/index.md
@@ -91,11 +91,12 @@ description: The runtime and protocol that powers Culture.
 
 ## Boss Supervision
 
-A boss Claude Code session can spawn helper agents and supervise them: gating
-their tool calls, watching their context budget, and logging their daemon
-actions.
+A boss — either your Claude Code session or an autonomous **boss agent** — can
+spawn worker agents and supervise them: gating their tool calls, watching their
+context budget, and logging their daemon actions.
 
-- [Helper Permission Broker](helper-permissions.md) — boss-as-human approval for helper tool calls.
+- [Boss Agent Orchestration](boss-agent.md) — an autonomous boss agent that spawns and manages worker agents in your place.
+- [Helper Permission Broker](helper-permissions.md) — approval gate for helper tool calls (human or boss-agent as approver).
 - [Helper Tool Inheritance](helper-tool-inheritance.md) — helpers inherit the boss's skills + MCP servers.
 - [Helper Context Handoff](helper-context-handoff.md) — auto-handoff + compact at 90% context.
 - [Helper Daemon Action Log](helper-daemon-log.md) — structured control-plane log per agent.

--- a/docs/agentirc/index.md
+++ b/docs/agentirc/index.md
@@ -89,6 +89,17 @@ description: The runtime and protocol that powers Culture.
   </a>
 </div>
 
+## Boss Supervision
+
+A boss Claude Code session can spawn helper agents and supervise them: gating
+their tool calls, watching their context budget, and logging their daemon
+actions.
+
+- [Helper Permission Broker](helper-permissions.md) — boss-as-human approval for helper tool calls.
+- [Helper Tool Inheritance](helper-tool-inheritance.md) — helpers inherit the boss's skills + MCP servers.
+- [Helper Context Handoff](helper-context-handoff.md) — auto-handoff + compact at 90% context.
+- [Helper Daemon Action Log](helper-daemon-log.md) — structured control-plane log per agent.
+
 <div class="callout-relationship">
   <p><strong>Want to run it, not just read about it?</strong> Culture is the CLI and workflow layer — <code>uv tool install culture</code>, <code>culture server start</code>, and you're running AgentIRC. Add harnesses and workflows for the full experience. <a href="{{ '/quickstart/' | relative_url }}">Get started with Culture →</a></p>
 </div>

--- a/docs/reference/architecture/agent-harness-spec.md
+++ b/docs/reference/architecture/agent-harness-spec.md
@@ -461,6 +461,8 @@ agents:
 | `thinking` | string | `"medium"` | Thinking/reasoning level (Claude only) |
 | `tags` | list | `[]` | Capability/interest tags for self-organizing rooms |
 | `acp_command` | list | `["opencode", "acp"]` | Spawn command for ACP backend (e.g. `["cline", "--acp"]`) |
+| `context_watch` | mapping | `{enabled: true, high_water: 0.90, low_water: 0.50}` | Context-watermark handoff (Claude only). See [Helper Context Handoff](../../agentirc/helper-context-handoff.md). |
+| `boss` | string | `""` | Nick of the boss agent that owns this worker; set by `culture boss spawn`. Used to DM the boss on permission requests. See [Boss Agent Orchestration](../../agentirc/boss-agent.md). |
 
 Backend-specific fields are passed through to the runner implementation.
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -417,6 +417,22 @@ culture boss close <name>                # stop a worker daemon
 (`~/.culture/boss-policy/<nick>.yaml`) — high-risk actions (MCP sends,
 destructive Bash) escalate to the human via `approve.sh`.
 
+## Dashboard
+
+Launch the [Mission Control web app]({{ '/agentirc/dashboard/' | relative_url }})
+— watch every agent live and intervene (approve/deny, pause/resume, close,
+emergency stop-all). Localhost-only.
+
+```bash
+culture dashboard                       # http://127.0.0.1:8787
+culture dashboard --port 9000
+culture dashboard --host 0.0.0.0 --unsafe-bind   # DANGEROUS: non-loopback bind
+```
+
+Binds `127.0.0.1` only and refuses a non-loopback `--host` unless `--unsafe-bind`
+is given (the dashboard can approve tool calls and kill agents). No new
+dependency — an `aiohttp` server + a vanilla-JS page.
+
 ## Configuration
 
 All commands use `~/.culture/server.yaml` by default. Override with `--config`.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -393,6 +393,30 @@ Restore an archived bot.
 culture bot unarchive spark-ori-ghci
 ```
 
+## Boss
+
+Orchestration commands used by an autonomous **boss agent** to manage worker
+agents. See [Boss Agent Orchestration]({{ '/agentirc/boss-agent/' | relative_url }}).
+The boss's own nick comes from `CULTURE_NICK` (set by the daemon).
+
+```bash
+culture boss init [--nick boss] [--channel '#boss'] [--cwd PATH]   # create the boss identity
+culture boss spawn <name> [--cwd PATH]   # create + start a worker under this boss
+culture boss brief <name> "<task>"       # send a task to a worker's channel
+culture boss read  <name> [--limit N]    # read a worker's recent replies
+culture boss pending                     # list pending worker permission requests
+culture boss approve <id> [--always] [--pattern P]   # grant (refused if above grant ceiling)
+culture boss deny <id> [reason...]       # deny, with a reason returned to the worker
+culture boss audit <name> [--limit N]    # worker's agent-message log (verify claims)
+culture boss log   <name> [--limit N]    # worker's daemon-action log
+culture boss status                      # workers + pending-perm count
+culture boss close <name>                # stop a worker daemon
+```
+
+`culture boss approve` refuses tools above the boss's **grant ceiling**
+(`~/.culture/boss-policy/<nick>.yaml`) — high-risk actions (MCP sends,
+destructive Bash) escalate to the human via `approve.sh`.
+
 ## Configuration
 
 All commands use `~/.culture/server.yaml` by default. Override with `--config`.

--- a/docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md
+++ b/docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md
@@ -115,34 +115,55 @@ Requirements for the boss agent:
      a known boss nick, so a boss can't accidentally re-spawn itself as a
      supervised worker.
 
-## The orchestration skill (`culture-boss-agent`)
+## The orchestration skill — a `culture boss` CLI subcommand (in-repo)
 
-A new skill placed in the boss agent's cwd. Mirrors the human-facing culture-boss
-scripts, but documented and shaped for an **LLM caller**. It reuses the exact
-same underlying operations (and where possible the same scripts) so there is one
-implementation, not two.
+The orchestration capability ships **in the repo** as a new `culture boss` CLI
+subcommand group (`culture/cli/boss.py`), exactly mirroring how the IRC skill is
+the `culture channel` subcommand. This is testable Python that reuses the broker
++ ceiling code directly (no shelling to bash scripts), and is versioned and
+reviewable. A `SKILL.md` at `culture/clients/claude/skill/boss/` documents it for
+an LLM caller; `culture boss init` copies that skill dir into the boss agent's
+cwd `.claude/skills/` so the boss picks it up (project setting source).
 
-| Tool (Bash entry) | Purpose | Maps to |
-|---|---|---|
-| `boss spawn <name> [cwd]` | Create + start a worker, seed its policy, join its task channel. | `spawn-helper.sh` |
-| `boss brief <name> "<task>"` | Send a task/message to a worker's channel (prefixes the worker nick so its mention detector fires). | `brief.sh` |
-| `boss read <name> [limit]` | Read recent worker replies + `[N pending perms]`. | `read-replies.sh` |
-| `boss pending` | List all pending worker permission requests. | `pending-perms.sh` |
-| `boss approve <id> [always [<pattern>]]` | Grant a worker's tool request ("yes, that tool — always"). Refuses if the tool is above the boss's grant ceiling (→ escalate to human). | `approve.sh` + ceiling check |
-| `boss deny <id> [reason]` | Refuse a worker's tool request, with a reason the worker's model sees. | `deny.sh` |
-| `boss audit <name> [limit]` | Read a worker's agent-message audit log — to challenge claims. | reads `audit/<nick>.jsonl` |
-| `boss log <name> [limit]` | Read a worker's daemon-action log. | `daemon-log.sh` |
-| `boss status` | Summarize the mesh: workers, states, pending perms, last actions. | `status.sh` |
-| `boss close <name>` | Stop a worker daemon. | `close-helper.sh` |
+The boss agent's own nick comes from the `CULTURE_NICK` env var (now set by the
+agent runner — see "CULTURE_NICK prerequisite"), so `culture boss approve`
+knows whose grant ceiling to apply and IRC ops act as the boss.
+
+| Subcommand | Purpose |
+|---|---|
+| `culture boss init [--nick boss] [--channel '#boss'] [--cwd PATH]` | Create the boss agent: write its `culture.yaml` (manager `system_prompt`, `context_watch` on), seed its grant ceiling (`boss-policy/<nick>.yaml`), copy the boss skill into its cwd, **assert no `perm-policy/<nick>.yaml`**, join the boss channel. Idempotent. |
+| `culture boss spawn <name> [--cwd PATH]` | Create + start a worker (`cu agent create/start`), seed its policy (`seed_helper_policy`), set the worker's `boss:` field to `$CULTURE_NICK`, join its task channel. Refuses a `<name>` colliding with a known boss nick. |
+| `culture boss brief <name> "<task>"` | Send a task to a worker's channel (prefixes the worker nick so its mention detector fires). |
+| `culture boss read <name> [--limit N]` | Read recent worker replies. |
+| `culture boss pending` | List all pending worker permission requests. |
+| `culture boss approve <id> [--always] [--pattern P]` | Grant a worker's tool request. **Refuses (non-zero exit + escalation message) if the tool is above `$CULTURE_NICK`'s grant ceiling** (`is_above_ceiling`); writes the decision otherwise. |
+| `culture boss deny <id> [reason...]` | Refuse a worker's tool request, with a reason the worker's model sees. |
+| `culture boss audit <name> [--limit N]` | Read a worker's agent-message audit log — to challenge claims. |
+| `culture boss log <name> [--limit N]` | Read a worker's daemon-action log. |
+| `culture boss status` | Summarize the mesh: workers, states, pending perms. |
+| `culture boss close <name>` | Stop a worker daemon. |
 
 These are thin; the boss's IRC skill handles the actual conversation
 (`culture channel message #task-<name> ...` / `culture channel read ...`). The
-orchestration skill only adds what conversation can't do.
+`culture boss` subcommand only adds what conversation can't do (spawn, approve,
+read logs). The decision/queue/ceiling operations reuse `_perm_broker.py`
+directly — one implementation, callable by both the CLI and tests.
 
-**Single implementation:** the human-facing culture-boss skill and the
-boss-agent orchestration skill call the *same* scripts. The only differences are
-(a) the SKILL.md is written for an LLM operator, and (b) `CULTURE_NICK` is the
-boss agent's nick so IRC ops act as the boss.
+## CULTURE_NICK prerequisite
+
+The harness does **not** currently set `CULTURE_NICK` in the agent's SDK
+subprocess environment (verified: the Claude runner's `_make_options` sets no
+`env`; codex/copilot build an `isolated_env` without it). An autonomous daemon
+agent therefore cannot reliably address its own IRC socket — the IRC skill and
+the `culture boss` skill both resolve the daemon socket from `CULTURE_NICK`.
+
+Fix (all four backends, per the all-backends rule): each agent runner sets
+`CULTURE_NICK=<own-nick>` in the env it passes to the SDK/CLI subprocess (merged
+over `os.environ`). For the Claude runner this is `ClaudeAgentOptions(env=...)`;
+codex/copilot already build an `isolated_env` dict — add the key there; ACP
+similarly. This is a latent enabler for *any* autonomous agent using its own
+skills, not just the boss. Test: each runner's constructed options/env contains
+`CULTURE_NICK == nick`.
 
 ## Worker permission requests surface to the boss over IRC
 
@@ -311,9 +332,13 @@ individual tool calls. Documented in the backend matrix.
 ## Files
 
 New:
-- `culture/clients/claude/skill/boss/` (or a sibling skill dir) — orchestration
-  SKILL.md + a `boss` CLI/script shim that calls the shared operations, including
-  the `boss approve` grant-ceiling check (reusing `match_policy`).
+- `culture/cli/boss.py` — the `culture boss` subcommand group (init/spawn/brief/
+  read/pending/approve/deny/audit/log/status/close), reusing `_perm_broker.py`
+  for queue/decision/ceiling ops. Registered in the CLI dispatcher.
+- `culture/clients/claude/skill/boss/SKILL.md` — documents `culture boss …` for
+  an LLM boss agent. Copied into the boss cwd by `culture boss init`.
+- Per-backend runner env: `CULTURE_NICK` set in the SDK subprocess env (see
+  "CULTURE_NICK prerequisite").
 
 Changed (`on_request` plumbing path is daemon → AgentRunner → PermissionBroker,
 because the broker is constructed inside `AgentRunner.__init__`, not the daemon):

--- a/docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md
+++ b/docs/superpowers/specs/2026-05-28-boss-agent-orchestration-design.md
@@ -1,0 +1,401 @@
+---
+title: "Boss Agent Orchestration"
+parent: "Design"
+nav_order: 25
+---
+
+# Boss Agent Orchestration
+
+**Status:** Draft
+**Date:** 2026-05-28
+**Depends on:** [Helper Boss Permission Broker](2026-05-28-helper-boss-permission-broker.md) (PR #411, v8.7.0)
+**Branch:** `feat/boss-agent-orchestration`
+
+## Problem
+
+PR #411 made a *human-driven* Claude Code session the "boss": the human runs
+`spawn-helper.sh` / `approve.sh` from their terminal and is the human-in-the-loop
+for every worker permission request. The human is still doing the managing.
+
+The actual goal is to **remove the human from the management loop**. The boss
+should be an **autonomous agent** that the human briefs once (and steers live),
+which then:
+
+- reads `CLAUDE.md` and the project/plan context, and re-grounds itself on long
+  contexts (project purpose, plan purpose);
+- spawns worker agents and drives them **exactly the way a human drives a Claude
+  Code session** — "what open dev tasks do we have?" → "what goes well
+  together?" → "ok, make a plan" → "yes, you can use that tool, always" →
+  challenges the plan/implementation/claims → ushers to completion;
+- does this for one or many workers, within a project or across projects;
+- and runs as one or many bosses.
+
+The human's job shrinks to: brief the boss in an IRC channel, steer occasionally,
+walk away.
+
+## What already exists vs. what's new
+
+PR #411 is the **substrate**; this spec is the **agent layer** on top.
+
+| Capability | #411 (substrate) | This spec (agent layer) |
+|---|---|---|
+| Worker permission gate | File-backed broker; approver = human via scripts | Approver = **boss agent** via orchestration-skill tools |
+| Worker visibility | `audit/<nick>.jsonl`, `daemon-log/<nick>.jsonl` | Boss reads these to challenge/verify worker claims |
+| Re-grounding on long context | `context_watch` handoff (any Claude daemon) | Applies to the **boss** too — re-reads brief + CLAUDE.md + plan |
+| Tool inheritance | `setting_sources=["user","project","local"]` | Boss + workers both inherit the operator's tools |
+| Spawning / briefing / approving | Bash scripts a **human** runs in a terminal | An **orchestration skill** the **boss agent** calls via Bash |
+| Boss identity | "boss daemon" exists but is a puppet of the human session | Boss daemon's **own LLM** is the orchestrator, with a manager system-prompt |
+| Worker→boss permission notification | Deferred to v1.1 (file queue only) | **Load-bearing now** — requests surface to the boss over IRC |
+
+## Mental model
+
+The boss is a **culture mesh agent** (a daemon running the Claude Agent SDK,
+exactly like a worker) whose "tools" are:
+
+1. **The IRC skill it already has** (`culture channel message|read|join|...`) — to
+   converse with workers in their task channels and with the human in the boss
+   channel. This is how the boss "talks to a Claude Code session": it sends a
+   message to the worker's channel and reads the reply, the same back-and-forth a
+   human has.
+2. **A new orchestration skill** (`culture-boss-agent`, in the boss's cwd) — the
+   out-of-band capabilities that aren't plain conversation: spawn a worker,
+   approve/deny a worker's pending permission request (including "always"),
+   list pending requests, read a worker's audit/daemon logs, close a worker,
+   summarize project state.
+
+The boss's *judgment* — what to ask, when to challenge, what "done" means —
+comes from its **system-prompt identity + the model**, not from rigid code. The
+code only provides the levers; the LLM pulls them like a human would.
+
+```text
+        ┌─────────────┐   briefs / steers (IRC)   ┌──────────────────────┐
+ Human  │  #boss-<n>  │ ────────────────────────► │  Boss agent (daemon) │
+        └─────────────┘                           │  - irc skill         │
+                                                  │  - orchestration skill│
+                                                  │  - manager prompt    │
+                                                  └──────────┬───────────┘
+                                spawn / approve / converse   │
+                          ┌──────────────────┬───────────────┼────────────────┐
+                          ▼                  ▼               ▼                 ▼
+                   ┌────────────┐     ┌────────────┐   ┌────────────┐   (perm request
+                   │ worker A   │     │ worker B   │   │ worker C   │    surfaces back
+                   │ #task-A    │     │ #task-B    │   │ #task-C    │    over IRC)
+                   └────────────┘     └────────────┘   └────────────┘
+```
+
+## Boss as a first-class agent
+
+Today `ensure-mesh.sh` creates a `local-boss` daemon, but the culture-boss skill
+drives the mesh "from outside" — the boss daemon is just an IRC identity; the
+human's session is the orchestrator (per the SKILL.md limitation note). This spec
+**inverts** that: the boss daemon's own LLM is the orchestrator.
+
+Requirements for the boss agent:
+
+1. **It is a normal culture daemon agent** — gets mentions, polls channels, has
+   the IRC skill, participates in supervisor/whisper machinery like any agent.
+2. **Its cwd contains the orchestration skill** so the LLM can call spawn/approve
+   /etc. via Bash. (Skills are loaded from the agent's cwd `.claude/skills/` via
+   `setting_sources=["project"]`/`["user",...]`, the same path the IRC skill uses.)
+3. **Its system prompt is a manager identity** (see "Boss system prompt").
+4. **It is NOT itself permission-supervised.** Critical: the boss must have **no
+   `~/.culture/perm-policy/<boss-nick>.yaml`**, so `can_use_tool` is not wired for
+   it (per #411's gate at `agent_runner.py:105`, `has_policy_file`). Otherwise the
+   boss's own `approve.sh`/`spawn-helper.sh` Bash calls would themselves require
+   approval — and there is no higher boss to grant it, so the boss would deadlock.
+   The boss is supervised by the **human over IRC**, not by the broker.
+
+   **Guarding the invariant (three guards, because `spawn-helper.sh` seeds a
+   policy file for whatever name it spawns):**
+   - The boss is created via `cu agent create` in `ensure-mesh.sh`, **never** via
+     `spawn-helper.sh` / `boss spawn` (which would seed a policy and deadlock it).
+   - `ensure-mesh.sh` asserts no `perm-policy/<boss-nick>.yaml` exists after boss
+     setup (and removes one if found, logging a warning).
+   - `boss spawn <name>` **refuses** a `<name>` whose resulting nick collides with
+     a known boss nick, so a boss can't accidentally re-spawn itself as a
+     supervised worker.
+
+## The orchestration skill (`culture-boss-agent`)
+
+A new skill placed in the boss agent's cwd. Mirrors the human-facing culture-boss
+scripts, but documented and shaped for an **LLM caller**. It reuses the exact
+same underlying operations (and where possible the same scripts) so there is one
+implementation, not two.
+
+| Tool (Bash entry) | Purpose | Maps to |
+|---|---|---|
+| `boss spawn <name> [cwd]` | Create + start a worker, seed its policy, join its task channel. | `spawn-helper.sh` |
+| `boss brief <name> "<task>"` | Send a task/message to a worker's channel (prefixes the worker nick so its mention detector fires). | `brief.sh` |
+| `boss read <name> [limit]` | Read recent worker replies + `[N pending perms]`. | `read-replies.sh` |
+| `boss pending` | List all pending worker permission requests. | `pending-perms.sh` |
+| `boss approve <id> [always [<pattern>]]` | Grant a worker's tool request ("yes, that tool — always"). Refuses if the tool is above the boss's grant ceiling (→ escalate to human). | `approve.sh` + ceiling check |
+| `boss deny <id> [reason]` | Refuse a worker's tool request, with a reason the worker's model sees. | `deny.sh` |
+| `boss audit <name> [limit]` | Read a worker's agent-message audit log — to challenge claims. | reads `audit/<nick>.jsonl` |
+| `boss log <name> [limit]` | Read a worker's daemon-action log. | `daemon-log.sh` |
+| `boss status` | Summarize the mesh: workers, states, pending perms, last actions. | `status.sh` |
+| `boss close <name>` | Stop a worker daemon. | `close-helper.sh` |
+
+These are thin; the boss's IRC skill handles the actual conversation
+(`culture channel message #task-<name> ...` / `culture channel read ...`). The
+orchestration skill only adds what conversation can't do.
+
+**Single implementation:** the human-facing culture-boss skill and the
+boss-agent orchestration skill call the *same* scripts. The only differences are
+(a) the SKILL.md is written for an LLM operator, and (b) `CULTURE_NICK` is the
+boss agent's nick so IRC ops act as the boss.
+
+## Worker permission requests surface to the boss over IRC
+
+This is the one genuinely-new Python piece (finishing #411's deferred v1.1).
+
+When a worker hits a permission gate, the broker writes `perm-queue/<id>.json`
+(as today) **and** the worker daemon posts a one-line notice to the boss so the
+boss "sees" the request inline — the agent analogue of a permission prompt
+appearing in a human's session.
+
+Design:
+
+- The worker's `PermissionBroker.gate` already runs inside the worker daemon. The
+  daemon supplies the broker an optional `on_request` async callback
+  (daemon → runner → broker plumbing, the hook #411 named but deferred).
+- On a boss-routed request, the callback **DMs the owning boss** via the worker's
+  IRC transport (`IRCTransport.send_privmsg(boss_nick, notice)`, verified to
+  exist):
+  `[perm] worker <nick> wants <tool>: <preview> — id <id> (approve/deny)`.
+- A DM to the boss nick fires the boss's activation handler
+  (`irc_transport.py:357` calls `on_mention` when `target == self.nick`), so the
+  boss wakes, reads the request (`boss pending`), decides, and calls
+  `boss approve|deny`.
+- The boss may also pre-grant (`always`) so routine tools stop round-tripping —
+  exactly "yes, you can use that tool, always".
+
+**The worker must know its boss's nick to DM it.** The worker does not inherently
+know which boss owns it. Mechanism: when the boss spawns a worker (`boss spawn`),
+it records the ownership as a `boss: <boss-nick>` field in the worker's
+`culture.yaml` (a new `AgentConfig.boss` field, read by the worker daemon). The
+daemon's `_on_perm_request` DMs `self.agent.boss`. **Fallback if the field is
+empty** (the human-supervised case from #411): post nothing — the human finds
+the request via `pending-perms.sh`. A DM is used rather than a channel
+`@`-mention because it needs no task-channel derivation and directly addresses
+the boss; the notice content is informational, not parsed, so it is not
+format-load-bearing the way an `@`-mention would be.
+
+**`on_request` is best-effort.** The broker calls it inside a `try/except` after
+writing `perm-queue/<id>.json` and before awaiting the decision. A failed IRC
+post (transport down, etc.) is logged and swallowed — it must **never** block or
+fail the gate. The file queue remains the source of truth and the unblock
+mechanism; the IRC post is only the *notification*. If it fails, the boss still
+finds the request via `boss pending` (polling fallback).
+
+## Boss grant ceiling (human-over-boss gate)
+
+The boss drives workers autonomously, but it is **not** the final authority on
+irreversible or external actions. A configurable **grant ceiling** — a denylist
+of high-risk tool patterns — bounds what the boss may grant on a worker's behalf.
+
+Default ceiling (per-boss, `~/.culture/boss-policy/<boss-nick>.yaml`, seeded by
+`ensure-mesh.sh`):
+
+```yaml
+# Tools the boss MAY NOT auto-grant to a worker; these escalate to the human.
+grant_ceiling:
+  - 'mcp__.*'        # any MCP server (Gmail/Drive/Calendar/Atlassian/…) — external side effects
+  - tool: Bash
+    input_regex: '(^|\s|;|&&|\|\|)(rm\s+-rf|git\s+push|gh\s+(pr|release)\s+(create|merge)|kubectl|terraform|drop\s+table|truncate)'
+```
+
+Enforcement is at the **boss `approve` tool** layer:
+
+1. Worker requests a tool → broker queues it → notice surfaces to the boss.
+2. Boss decides to allow and calls `boss approve <id> [always]`.
+3. `boss approve` loads the request, matches the tool/input against the boss's
+   `grant_ceiling`. **If it matches, the tool refuses to write a decision** and
+   returns: *"`<tool>` is above your grant ceiling — escalate to your human in
+   the boss channel; do not retry approve."*
+4. The boss posts the request to the human boss channel
+   (`@human [escalation] worker <name> wants <tool> <preview> — id <id>`).
+5. The **human** approves via #411's existing `approve.sh <id>` (the human path
+   is unchanged and is the escalation target). The worker unblocks.
+
+Why enforce at the boss tool, not the broker: the broker is approver-agnostic
+(it just reads a decision file). The human's `approve.sh` must remain able to
+grant *anything* (the human is the top authority); only the **boss's** grant tool
+is ceiling-bounded. Two grant tools, one queue, different ceilings — the human's
+ceiling is unbounded, the boss's is the denylist above.
+
+`boss deny` has no ceiling — the boss may always deny. Ceiling only bounds
+*granting*.
+
+This keeps the human as final authority on irreversible/external actions while
+the boss handles everything routine without human involvement. The ceiling is
+per-boss and editable, so a trusted boss in a sandboxed project can be widened.
+
+**Threat model — this is a cooperative guardrail, not a hard boundary.** The boss
+is an LLM with a Bash tool; it *could* write a `perm-decisions/<id>.json` file
+directly and bypass `boss approve`'s ceiling check entirely. On a single-UID
+local machine there is no authentication boundary between the boss process and
+the human — both can write any file under `~/.culture/`. The ceiling therefore
+**shapes a cooperative boss's behavior** (the tool refuses + the system prompt
+tells it to escalate); it does **not** defend against an adversarial or
+malfunctioning boss that forges decision files. Hard enforcement would require an
+auth boundary (separate UID, signed decisions) that is out of scope for v1. The
+ceiling matcher reuses `match_policy` from `_perm_broker.py` (the ceiling is
+structurally a denylist), so there is one matcher implementation, not two.
+
+The matching reuse and the soft-boundary caveat must both be stated in the
+`boss-agent.md` docs so an operator doesn't over-trust the ceiling.
+
+## Boss system prompt
+
+A manager identity, set via the boss's `culture.yaml` `system_prompt`. Shape
+(not final wording):
+
+```text
+You are <boss-nick>, a manager agent on the culture mesh. A human briefs you in
+your IRC channel; that brief is your mission. You do not do the implementation
+work yourself — you drive worker agents that do.
+
+On a new mission:
+1. Read CLAUDE.md and any referenced plan/spec to ground yourself in the
+   project's purpose and conventions.
+2. Decide the work. Ask clarifying questions in your channel if the brief is
+   ambiguous.
+3. Spawn workers (boss spawn) and drive each like a Claude Code session:
+   ask what's open, scope what fits together, tell them to plan, review and
+   CHALLENGE their plan before they implement, then their implementation, then
+   their claims (verify against the audit log — never take "done" on faith).
+4. Approve worker tool requests as they arrive (boss approve/deny). Grant
+   "always" for tools you trust for a worker; deny with a reason otherwise.
+   Some high-risk tools (external MCP sends, destructive commands) are above
+   your grant ceiling — when `boss approve` tells you so, do NOT retry; post the
+   request to your human in the boss channel and let them grant it.
+5. Report progress and blockers to the human in your channel. Escalate genuine
+   judgment calls and above-ceiling tool requests; handle the rest yourself.
+
+When you approach your context limit you will be asked to write a handoff and
+will be reminded to re-read it — re-ground on the mission, CLAUDE.md, and plan.
+```
+
+The challenge discipline ("never take 'done' on faith; verify against the audit
+log") is the heart of the manager role and must be explicit in the prompt.
+
+## Re-grounding (context-watch for the boss)
+
+The boss is a long-lived Claude daemon, so #411's `context_watch` already
+applies: at 90% it writes a handoff and is reminded to read it post-compact. For
+the boss, the handoff content is the *mission state* (what the workers are doing,
+what's approved, what's left), and the reminder should also nudge it to re-read
+CLAUDE.md + the plan. No new mechanism — just ensure the boss has
+`context_watch.enabled: true` (the default) and a system-prompt instruction to
+re-ground on the mission, not just resume.
+
+## Briefing & steering (live IRC)
+
+- `ensure-mesh.sh` creates a boss channel (e.g. `#boss` or per-boss `#boss-<n>`)
+  the human and boss both join.
+- The human briefs by messaging the channel; the boss's mention handler treats
+  channel messages as mission input / amendments.
+- Multiple bosses: each is its own daemon agent with its own channel and its own
+  set of workers. They do not share workers (one worker, one boss — see #411
+  non-goals).
+
+## Backend coverage
+
+The boss agent is **Claude-only** in v1 — it depends on the broker (Claude-only)
+to gate workers and on `context_watch` (Claude-only) to re-ground. Workers may be
+any backend (a Claude boss can spawn and converse with a Codex/ACP worker over
+IRC), but those workers are audit-only (no synchronous gate), so the boss
+oversees them by reviewing their audit logs and conversing, not by approving
+individual tool calls. Documented in the backend matrix.
+
+## Files
+
+New:
+- `culture/clients/claude/skill/boss/` (or a sibling skill dir) — orchestration
+  SKILL.md + a `boss` CLI/script shim that calls the shared operations, including
+  the `boss approve` grant-ceiling check (reusing `match_policy`).
+
+Changed (`on_request` plumbing path is daemon → AgentRunner → PermissionBroker,
+because the broker is constructed inside `AgentRunner.__init__`, not the daemon):
+- `culture/clients/_perm_broker.py` — `PermissionBroker.__init__` accepts an
+  optional `on_request` async callback; `_request_from_boss` invokes it
+  best-effort (try/except) after writing the queue file, before polling.
+- `culture/clients/claude/agent_runner.py` — new optional `on_perm_request`
+  ctor param, threaded into `PermissionBroker(nick, on_request=...)` alongside
+  the existing `has_policy_file` gate.
+- `culture/clients/claude/daemon.py` — supply `on_perm_request` to the runner; it
+  posts the `@<boss-nick> [perm] …` notice via `self._transport.send_privmsg` to
+  the worker's task channel (reads `agent.boss` for the boss nick).
+- `culture/clients/claude/config.py` — new optional `boss: str = ""` field on
+  `AgentConfig` (a worker records its owning boss nick; default empty for
+  unmanaged agents). Coerced like the existing `context_watch` field in
+  `load_config`.
+- `~/.claude/skills/culture-boss/` (out of repo) — the human-facing skill gains
+  a "run the boss as an agent" path (spawn a boss daemon, brief it, let it run);
+  `ensure-mesh.sh` ensures the boss has the orchestration skill in its cwd, a
+  manager `system_prompt`, a boss channel, and **no** policy file.
+- Docs: `docs/agentirc/boss-agent.md`; update `helper-permissions.md` to note the
+  approver can be a boss agent; index.
+
+## Testing strategy
+
+Per project convention: real I/O, no mocks; pytest + xdist; `CULTURE_HOME`
+isolation. The boss-agent layer is mostly skill/prose + a thin Python callback,
+so the automated surface is small and focused:
+
+| Test | Verifies |
+|---|---|
+| `test_perm_broker_on_request.py` | `PermissionBroker(on_request=cb)` invokes `cb(payload)` once, after the queue file is written and before the decision is awaited; a callback that raises is swallowed and the gate still resolves on the decision file (best-effort contract). Existing `gate()` flow with `on_request=None` is unchanged. |
+| `test_boss_grant_ceiling.py` | The ceiling matcher (reusing `match_policy`) classifies `mcp__*` and destructive-Bash inputs as above-ceiling and routine Edit/Write/safe-Bash as grantable. Drives the `boss approve` shim: above-ceiling id → non-zero exit + escalation message + **no** decision file written; in-ceiling id → decision written. |
+| `test_worker_boss_notice.py` | `_on_perm_request`: with `agent.boss` set, DMs the boss (`send_privmsg(boss_nick, "[perm] …")`); with `agent.boss` empty, sends nothing (no crash). `_perm_input_preview` truncates Bash/Edit/Write/MCP inputs to ≤80 chars. Unit-level with a fake transport capturing `send_privmsg` calls. |
+| `test_boss_no_policy_invariant.py` | After `ensure-mesh`-style boss setup, `has_policy_file(boss_nick)` is False and `boss spawn <boss-short-name>` is refused. |
+
+Manual smoke (documented, not automated): spawn a boss, brief it in its channel
+to drive one worker through plan→implement→challenge, observe routine tools
+auto-granted and one high-risk tool escalated to the human.
+
+## Open questions
+
+1. **"Open dev tasks" source.** This repo has no task store. v1: the boss infers
+   open work from `CLAUDE.md` + `docs/development-plans/` + `docs/superpowers/specs/`
+   + what the human tells it. A real task tracker (or a `culture task` CLI) is a
+   possible follow-up — out of scope here.
+2. **Boss spawning across projects.** *Resolved: allowed.* `boss spawn <name>
+   <cwd>` with `cwd` at another project works mechanically (the worker inherits
+   *that* project's CLAUDE.md). The human tells the boss which projects are in
+   scope for the mission. One boss may manage workers across several projects.
+3. **Boss-of-bosses.** Out of scope. A boss does not spawn other bosses in v1
+   (would need the regress-guard reasoning extended). Flag if wanted later.
+4. **Boss grant ceiling.** *Resolved: human-over-boss gate.* The boss may
+   auto-grant routine tools but not high-risk ones (MCP sends, destructive
+   Bash); those escalate to the human via `approve.sh`. See
+   [Boss grant ceiling](#boss-grant-ceiling-human-over-boss-gate).
+
+## Non-goals
+
+- Boss-of-bosses hierarchies (v1: human → boss → workers, two levels).
+- A task-tracking system / `culture task` CLI.
+- Replacing the human-facing culture-boss skill — it stays for hands-on use; the
+  boss-agent is an additional, autonomous mode.
+- Cross-mesh / multi-machine boss coordination.
+- Letting a boss agent run unsupervised with no human channel — the human must
+  have a steering channel even if they rarely use it (kill-switch + redirect).
+
+## Phases (provisional — finalize after review)
+
+| Phase | Work | Gate |
+|---|---|---|
+| P1 | `on_request` plumbing: broker callback + worker-daemon IRC post of perm requests. Tests. | Worker perm request appears in its task channel; boss-less path unchanged. |
+| P2 | Orchestration skill (`boss` shim + SKILL.md) reusing the shared scripts, incl. `boss approve` grant-ceiling enforcement + escalation message. | Boss agent can spawn/brief/read/approve/deny/close a worker via Bash; above-ceiling approve refuses and instructs escalation. |
+| P3 | Boss identity: `ensure-mesh.sh` gives the boss the orchestration skill, a manager `system_prompt`, a boss channel, a seeded `boss-policy/<nick>.yaml` grant ceiling, and **no** perm-policy file. | A spawned boss daemon, briefed in its channel, drives a worker end-to-end; routine tools auto-granted, high-risk escalated to the human. |
+| P4 | Re-grounding: confirm `context_watch` on the boss; system-prompt re-ground instruction. | Boss re-reads mission + CLAUDE.md after a compact. |
+| P5 | Docs (`boss-agent.md` + matrix + index), version bump, PR. | doc-test-alignment clean; CI green. |
+
+## Acceptance summary
+
+The feature ships when a human can: create a boss agent, brief it in an IRC
+channel with a mission ("ship feature X in project Y"), and walk away — and the
+boss then spawns workers, converses with them like a human would (asks, scopes,
+tells them to plan), challenges their plans/implementations/claims, approves
+their tool requests inline, re-grounds itself on long contexts, and reports back
+— with the human only steering occasionally over IRC.

--- a/docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
+++ b/docs/superpowers/specs/2026-05-28-helper-boss-permission-broker.md
@@ -1,0 +1,878 @@
+---
+title: "Helper Boss Permission Broker"
+parent: "Design"
+nav_order: 24
+---
+
+# Helper Boss Permission Broker
+
+**Status:** Draft
+**Date:** 2026-05-28
+**Branch:** `feat/helper-boss-permission-broker`
+
+> **Scope note (rev 2):** This PR ships three related boss-supervision pillars,
+> aligned with the user during authoring:
+>
+> 1. **Permission broker** — boss-as-human approval for helper tool calls (the
+>    bulk of this spec).
+> 2. **Context-watermark handoff** — daemon self-monitors context usage; at 90%
+>    it asks the agent to write a handoff for its post-compact self, compacts,
+>    then reminds it to read the handoff. See
+>    [Context-watermark handoff](#context-watermark-handoff).
+> 3. **Daemon action log** — structured control-plane JSONL per agent, all
+>    backends. See [Daemon action log](#daemon-action-log).
+>
+> All three share the same `~/.culture/` file conventions, `CULTURE_HOME`
+> resolution, atomic-write discipline, and JSONL shapes.
+
+## Problem
+
+The `culture-boss` skill lets a regular Claude Code session ("boss") spawn helper Claude Code sessions on a local culture IRC mesh. Today, helpers run with:
+
+```python
+# culture/clients/claude/agent_runner.py:132-143
+opts = ClaudeAgentOptions(
+    model=self.model,
+    cwd=self.directory,
+    permission_mode="bypassPermissions",
+    setting_sources=["project"],
+)
+```
+
+Two consequences:
+
+1. **Helpers don't inherit the boss's tools.** `setting_sources=["project"]` reads only the helper's `cwd` `.claude/` directory. The boss's user-level MCP servers (Gmail, Drive, Atlassian, Cloudflare, Context7, Playwright), skills (`~/.claude/skills/`), and plugins are unavailable to helpers.
+2. **Helpers are silently autonomous.** `permission_mode="bypassPermissions"` means tool calls never prompt — and there is no other gating dial. A helper with a wider toolbox could autonomously send email, edit Drive files, or run arbitrary Bash, with the boss only seeing the IRC chatter after the fact.
+
+The user wants: *boss is the human-in-the-loop*. Helpers should inherit the boss's full tool surface, but every dangerous tool call should route through the boss for approval — same UX a human gets in standard Claude Code, transposed onto IRC.
+
+## Why `bypassPermissions` stays on
+
+`permission_mode` controls the **terminal UI prompts**. Helpers are headless daemon processes with no tty; the SDK's other modes (`default`, `acceptEdits`, `plan`) all expect a human reading stdin. `bypassPermissions` is the only mode that doesn't block on a prompt that nobody is reading.
+
+The actual safety lever is independent: `ClaudeAgentOptions.can_use_tool` (verified at `claude_agent_sdk/types.py:1075`). It's a programmatic callback fired **before every tool invocation**, returning `PermissionResultAllow` or `PermissionResultDeny`. It is honored even in `bypassPermissions` mode — that mode just turns off the *UI* prompt path, not the programmatic callback.
+
+The signature (`claude_agent_sdk/types.py:159-161`):
+
+```python
+CanUseTool = Callable[
+    [str, dict[str, Any], ToolPermissionContext],
+    Awaitable[PermissionResult]
+]
+```
+
+This is the SDK hook we use to make the boss the gatekeeper.
+
+### SDK consequence: `can_use_tool` forces streaming-mode prompts
+
+`claude_agent_sdk/_internal/client.py:54-60` enforces:
+
+```python
+if options.can_use_tool:
+    if isinstance(prompt, str):
+        raise ValueError(
+            "can_use_tool callback requires streaming mode. "
+            "Please provide prompt as an AsyncIterable instead of a string."
+        )
+```
+
+The current `AgentRunner` at `culture/clients/claude/agent_runner.py:173-176` calls `query(prompt=prompt, …)` with `prompt: str` from `_prompt_queue: asyncio.Queue[str]`. **Adding `can_use_tool` without converting the prompt to an `AsyncIterable[dict]` raises immediately on first turn.**
+
+The implementation must wrap each queued prompt at the `_process_turn` call site:
+
+```python
+async def _as_stream(text: str) -> AsyncIterable[dict[str, Any]]:
+    yield {"type": "user", "message": {"role": "user", "content": text}}
+
+async for message in query(
+    prompt=_as_stream(prompt),  # was: prompt=prompt
+    options=self._make_options(),
+):
+    ...
+```
+
+This change is required in Phase 2 alongside the callback wiring. No other call sites change — `_prompt_queue` stays `asyncio.Queue[str]`; only the SDK-call surface adapts.
+
+### SDK consequence: no timeout on the callback
+
+`claude_agent_sdk/_internal/query.py:258-262` calls `await self.can_use_tool(...)` with no timeout wrapper. The CLI subprocess does not impose its own deadline either. "Queue and wait indefinitely" is structurally supported by the SDK.
+
+### SDK consequence: deny without interrupt
+
+`claude_agent_sdk/types.py:154` defines `PermissionResultDeny.interrupt: bool = False`. The broker returns `interrupt=False` so a deny scopes to the single tool call (model receives the denial in its `tool_result` and decides what to do next) rather than aborting the entire turn. Spec mandates `interrupt=False` everywhere unless future work explicitly opts into hard abort.
+
+## Architecture overview
+
+```text
+┌──────────────────────┐                ┌─────────────────────┐
+│ Boss Claude Code     │                │ Helper daemon       │
+│ session (interactive)│                │ (culture-agent-*)   │
+│                      │                │                     │
+│ - pending-perms.sh   │   reads /      │ - AgentRunner       │
+│ - approve.sh         │   writes       │ - can_use_tool=     │
+│ - deny.sh            │ ◄────────────► │     broker.gate()   │
+│ - watch-perms.sh     │                │                     │
+└──────────────────────┘                └─────────────────────┘
+              │                                    │
+              │                                    │
+              ▼                                    ▼
+   ┌──────────────────────────────────────────────────┐
+   │  ~/.culture/                                     │
+   │   ├── perm-queue/<id>.json     (requests)        │
+   │   ├── perm-decisions/<id>.json (verdicts)        │
+   │   ├── perm-policy/<nick>.yaml  (auto-rules)      │
+   │   └── audit/<nick>.jsonl       (after-the-fact)  │
+   └──────────────────────────────────────────────────┘
+```
+
+Three concerns separated:
+
+| Concern | Mechanism | Files |
+|---|---|---|
+| **Tool inheritance** | Widen `setting_sources` (Claude); populate `skill_directories` (Copilot) | `culture/clients/claude/agent_runner.py`, `culture/clients/copilot/agent_runner.py` |
+| **Synchronous boss approval** | `can_use_tool` callback (Claude) / `PermissionHandler` (Copilot) wired to a file-backed broker | New `culture/clients/_perm_broker.py` |
+| **Post-hoc visibility** | Per-helper JSONL audit log of every AssistantMessage | All four `daemon.py` files, hooked in existing `_on_agent_message` |
+
+## File layouts
+
+All paths under `~/.culture/`. Directories are created on demand by `ensure-mesh.sh` and `spawn-helper.sh`.
+
+### `perm-queue/<id>.json` — helper request
+
+```json
+{
+  "id": "req-2026-05-28T14-32-17-abc12",
+  "helper_nick": "local-research",
+  "tool_name": "Bash",
+  "input": {"command": "gh pr create --title ...", "description": "..."},
+  "context": {
+    "task_channel": "#task-research",
+    "session_id": "uuid-from-sdk"
+  },
+  "created_at": "2026-05-28T14:32:17.123Z"
+}
+```
+
+- Filename = `<id>.json`. ID format: `req-<ISO8601 with dashes>-<5 hex chars>`. Sortable by creation order, unique under timer collision.
+- Written atomically via `tempfile + os.replace`. Helpers `os.fsync` before the rename so a kernel-level crash doesn't leave a partial file.
+- Persists until the matching decision file is consumed.
+
+### `perm-decisions/<id>.json` — boss verdict
+
+```json
+{
+  "id": "req-2026-05-28T14-32-17-abc12",
+  "verdict": "allow",
+  "scope": "once",
+  "reason": "ok",
+  "decided_by": "boss",
+  "decided_at": "2026-05-28T14:32:21.456Z"
+}
+```
+
+- `verdict`: `"allow" | "deny"`.
+- `scope`: `"once" | "always"`. If `"always"`, the decision is appended to `perm-policy/<helper_nick>.yaml` before the file is written.
+- `reason`: optional free text. Returned to the SDK's `PermissionResultDeny.message` on deny. Surfaces in the model's tool_result.
+- Written atomically via `tempfile + os.replace`. The helper watches for this file's appearance.
+
+### `perm-policy/<nick>.yaml` — per-helper sticky rules
+
+Seeded by `spawn-helper.sh` with safe-read defaults; mutated by `approve.sh ... always`.
+
+```yaml
+# auto_allow: rules matched before any IRC round-trip — return allow immediately
+auto_allow:
+  - tool: Read
+  - tool: Glob
+  - tool: Grep
+  - tool: Bash
+    input_regex: '^(ls|cat|head|tail|wc|file|stat|pwd|which|rg|grep|find|tree|git (status|log|diff|blame|show)|gh (.* )?(list|view))(\s|$)'
+
+# auto_deny: rules matched before any IRC round-trip — return deny immediately
+auto_deny: []
+
+# require_approval: explicitly route to boss (default fallthrough for anything
+# not matched above is also "require approval", so this section is informational
+# unless you want to surface specific tool classes explicitly)
+require_approval:
+  - tool: Edit
+  - tool: Write
+  - tool: 'mcp__.*'
+  - tool: Bash  # matches everything not in auto_allow's regex
+```
+
+Matching order: `auto_deny` → `auto_allow` → require approval (fallthrough). First match wins. `input_regex` is Python `re.search`-style; absence of `input_regex` means "any input matches".
+
+For MCP tools, `tool` is matched as a regex when it contains regex metacharacters; otherwise an exact string match.
+
+### Path resolution — `CULTURE_HOME`
+
+All four directories (`perm-queue/`, `perm-decisions/`, `perm-policy/`, `audit/`) are rooted under a single `CULTURE_HOME`. Every Python module that touches these paths uses a single helper:
+
+```python
+# culture/clients/_perm_broker.py
+def _culture_home() -> str:
+    return os.environ.get("CULTURE_HOME", os.path.expanduser("~/.culture"))
+```
+
+Every bash script uses the parallel:
+
+```bash
+CULTURE_HOME="${CULTURE_HOME:-$HOME/.culture}"
+```
+
+Tests override via `monkeypatch.setenv("CULTURE_HOME", str(tmp_path))`; the broker, scripts, and `spawn-helper.sh` all see the same root.
+
+**Caveat:** systemd/launchd-spawned agent daemons do not inherit the user's shell `CULTURE_HOME` unless the service file sets it. For v1, this is documented in `docs/agentirc/helper-permissions.md` as a known gotcha — agents started via the standard `cu agent start` flow inherit the shell environment, which is the common path.
+
+### `audit/<nick>.jsonl` — post-hoc activity log
+
+One line per AssistantMessage. Grows forever (rotation is non-goal; see "Non-goals"). Schema:
+
+```json
+{
+  "ts": "2026-05-28T14:32:17.123Z",
+  "nick": "local-research",
+  "type": "assistant",
+  "model": "claude-opus-4-7",
+  "text": "I'll search for PR #123 …",
+  "tool_uses": [
+    {"name": "Bash", "input_digest": "sha256:abc..."}
+  ],
+  "tool_results": [
+    {"name": "Bash", "content_digest": "sha256:def...", "preview": "first 200 chars"}
+  ]
+}
+```
+
+`input_digest`/`content_digest` lets the audit log stay compact while still letting the boss correlate to the in-flight `perm-queue/<id>.json` (which contains the full input).
+
+### `daemon-log/<nick>.jsonl` — control-plane action log
+
+One line per daemon action (see [Daemon action log](#daemon-action-log) for the vocabulary). Grows forever. Schema:
+
+```json
+{"ts": "2026-05-28T14:32:17.123Z", "nick": "local-research", "action": "compact", "detail": {"trigger": "context_watermark", "pct": 0.91}}
+```
+
+### `handoff/<nick>.md` — context-handoff document
+
+Plain markdown, overwritten each context-fill cycle. Written by the agent (via its `Write` tool, auto-allowed for this path) when the daemon detects the 90% watermark. Read by the agent after compact (daemon injects a reminder) and by the boss for visibility. See [Context-watermark handoff](#context-watermark-handoff).
+
+## Permission lifecycle
+
+```text
+┌─────────┐     ┌─────────────┐    ┌──────────────┐    ┌────────┐
+│ SDK     │ ──► │ broker.gate │──► │ policy match │──► │ allow  │
+│ tool    │     │ (callback)  │    │              │    │ (fast) │
+│ wants to│     └─────────────┘    └──────────────┘    └────────┘
+│ run     │                                │
+└─────────┘                                │ no match
+                                           ▼
+                              ┌──────────────────────┐
+                              │ write perm-queue/    │
+                              │ <id>.json            │
+                              │ (atomic rename)      │
+                              └──────────────────────┘
+                                           │
+                                           ▼
+                              ┌──────────────────────┐
+                              │ await decision file  │
+                              │ (poll + asyncio.sleep│
+                              │  or watchdog/inotify)│
+                              │ NO TIMEOUT           │
+                              └──────────────────────┘
+                                           │
+                                           ▼
+                              ┌──────────────────────┐
+                              │ read decision; if    │
+                              │ scope=always, append │
+                              │ to perm-policy yaml  │
+                              └──────────────────────┘
+                                           │
+                              ┌────────────┴────────────┐
+                              ▼                         ▼
+                  ┌──────────────────┐      ┌──────────────────┐
+                  │ PermissionResult │      │ PermissionResult │
+                  │ Allow            │      │ Deny(message=    │
+                  │                  │      │   reason)        │
+                  └──────────────────┘      └──────────────────┘
+```
+
+**Steps in detail:**
+
+1. SDK fires `can_use_tool(tool_name, input, context)`.
+2. Broker reads `perm-policy/<nick>.yaml` (cached, mtime-checked).
+3. If a rule matches: return `PermissionResultAllow` or `PermissionResultDeny` immediately. **No round-trip.**
+4. Otherwise: mint `id`, write request to `perm-queue/<id>.json` atomically.
+5. `await` decision file. Poll every 250ms with `os.path.exists`, then re-stat on appearance to handle the atomic-rename race. Indefinite — no timeout. (IRC summary post to `#perm-<name>` is **deferred to v1.1**: the broker module sits below the daemon's IRC transport and has no clean plumbing to it today; threading an `on_perm_request` callback from daemon → runner → broker is a follow-up. v1 boss UX is `pending-perms.sh`/`watch-perms.sh`.)
+6. Read decision JSON. If `scope == "always"`, append to policy YAML *before* returning, so subsequent matching calls auto-resolve.
+7. Delete `perm-queue/<id>.json` and `perm-decisions/<id>.json` after consuming (both files are single-use).
+8. Return `PermissionResultAllow(updated_input=None)` or `PermissionResultDeny(message=reason, interrupt=False)`.
+
+## Race conditions and atomicity
+
+| Scenario | Mitigation |
+|---|---|
+| Boss writes two decisions for one ID | `approve.sh`/`deny.sh` refuse to write if `perm-decisions/<id>.json` exists. Race-window: two concurrent boss invocations. Mitigated by `os.O_CREAT \| os.O_EXCL` open before the rename target. First-writer-wins; second exits non-zero. |
+| Helper dies waiting | Request file stays in `perm-queue/`. On next `spawn-helper.sh`, `--reattach` is non-goal; the orphan is shown by `pending-perms.sh` but cannot be resolved (no helper to unblock). `cleanup-stale-perms.sh` (new) garbage-collects requests whose helper is not running. |
+| Helper task cancelled by SDK / `close-helper.sh` mid-`await` | The broker's `gate()` wraps its poll loop in `try/finally` — on `asyncio.CancelledError` it deletes its in-flight `perm-queue/<id>.json` and re-raises the cancellation. Past asyncio incidents in this codebase (commit `d0902f9`, "fix: re-raise CancelledError and save create_task results") mandate explicit re-raise discipline; broker code follows the same rule. |
+| Boss decides but file write is partial | Atomic `tempfile + os.replace`. Readers only see the post-rename inode. Partial writes never become visible. |
+| Helper reads policy mid-update by `approve.sh always` | Policy YAML is also written via atomic `tempfile + os.replace`. Broker checks mtime before each request; stale cache is benign (one extra round-trip until next read). |
+| Multiple helpers on the same boss | Each helper has its own policy file (`<nick>.yaml`), audit log, and request IDs. No shared state besides directory layout. |
+| `perm-queue/` directory missing | Broker creates it (and `perm-decisions/`, `perm-policy/`, `audit/`) on first request with `os.makedirs(..., exist_ok=True)`. `ensure-mesh.sh` also pre-creates them. |
+
+**Concurrent file-watcher latency:** poll cadence of 250ms is an explicit trade-off — fast enough that human-typed approvals feel instant (boss-to-helper unblock under 500ms typical), slow enough that 4 helpers waiting don't burn measurable CPU. inotify (Linux) and FSEvents (macOS) are available via `watchdog` but add a dependency; deferred to follow-up if poll cadence proves too slow.
+
+## Policy matcher semantics
+
+Implemented in `culture/clients/_perm_broker.py` as a pure-Python matcher (no third-party dep beyond PyYAML, already in `pyproject.toml` for culture.yaml parsing).
+
+```python
+def match(tool_name: str, input_dict: dict, policy: dict) -> Literal["allow", "deny", None]:
+    for section, verdict in (("auto_deny", "deny"), ("auto_allow", "allow")):
+        for rule in policy.get(section, []) or []:
+            if _rule_matches(tool_name, input_dict, rule):
+                return verdict
+    return None  # caller routes to boss
+```
+
+`_rule_matches`:
+
+- `rule["tool"]` is a string. If it contains any of `.*+?[]^$|`, treat as `re.fullmatch`; else exact equality.
+- `rule["input_regex"]` (optional) is `re.search`-style against a tool-specific projection of `input_dict`:
+  - `Bash` → `input_dict["command"]` (string).
+  - `Edit` / `Write` → `input_dict["file_path"]` (string).
+  - `mcp__*` → `json.dumps(input_dict, sort_keys=True)` (string).
+  - Other tools → no input projection; rule with `input_regex` against them is a no-match.
+- All rule keys other than `tool` and `input_regex` are reserved (silently ignored to allow forward-compatible additions).
+
+Policy file is parsed once at broker init and re-loaded on `os.path.getmtime` change (checked at the start of every `gate()` call). Stale policy cache → one extra round-trip; not a correctness issue.
+
+## Backend matrix
+
+| Backend | Tool inheritance | Permission broker | Context-watch | Audit log | Daemon-action log |
+|---|---|---|---|---|---|
+| **Claude** | `setting_sources=["user","project","local"]` (`agent_runner.py`) | **Full** — native `can_use_tool` (SDK `types.py:1075`) | **Full** — `ResultMessage.usage.input_tokens` | Yes | Yes |
+| **Copilot** | `skill_directories` (deferred — SDK not verifiable in venv) | **Deferred → audit-only** this PR (Copilot SDK `PermissionHandler` signature not verifiable in the current venv; see Unverified Assumptions) | No — no token counts on responses (issue #299) | Yes | Yes |
+| **Codex** | No setting_sources surface in app-server JSON-RPC | **Audit-only** — no per-tool callback in protocol | No — no token counts | Yes | Yes |
+| **ACP** | No skill/MCP inheritance hook in ACP surface | **Audit-only** — no per-tool callback | No — no token counts | Yes | Yes |
+
+**All-backends rule honored via documentation**, per CLAUDE.md ("a feature that only exists in one backend is a bug" — addressed by the **audit log** and **daemon-action log** providing parity-of-visibility on every backend, even where parity-of-control or context-watch is technically impossible). The two universal pillars (audit log, daemon-action log) ship on all four backends; the two Claude-only pillars (synchronous broker approval, context-watermark) are gated by SDK capability and documented as such.
+
+`spawn-helper.sh` does **not** restrict backend choice. A boss spawning a non-Claude backend gets a warning printed to stderr ("audit-only mode: this helper will not request boss approval before tool calls and has no context-watch") but is allowed to proceed.
+
+## Boss-side script surface
+
+All under `~/.claude/skills/culture-boss/scripts/`. Existing scripts that grow new behavior are noted.
+
+| Script | Argv | Behavior |
+|---|---|---|
+| `pending-perms.sh` | (none) | Lists every `perm-queue/*.json`. Columns: `id`, `nick`, `tool`, `input-preview`, `age`. Empty list → exit 0 with no output. Exit 1 if `perm-queue/` is missing (mesh not bootstrapped). |
+| `approve.sh` | `<id> [always [<tool-pattern>]]` | Writes `perm-decisions/<id>.json` with `verdict=allow`, `scope` per argv. `always` without a pattern uses `tool: <tool_name>` (exact match); `always <pattern>` uses pattern as `tool` field. Fails if decision file already exists. **Atomic-write discipline:** the script writes to a temp path via `python3 -c "import os, json, tempfile; …"` using `O_CREAT \| O_EXCL` on the temp file, then `os.replace(tmp, dest)` for atomic install. The `O_CREAT \| O_EXCL` on the *destination* path is the first-writer-wins guard. |
+| `deny.sh` | `<id> [reason...]` | Writes `perm-decisions/<id>.json` with `verdict=deny`. Reason joined into `reason` field. Fails if decision file already exists. **Atomic-write discipline:** identical to `approve.sh` — temp file + `os.replace` + `O_CREAT \| O_EXCL` first-writer-wins. |
+| `watch-perms.sh` | (none) | `tail -F` style live view. Combines `inotifywait` (Linux) / `fswatch` (macOS) when available, else polls every 1s. Prints new requests with timestamp + helper nick + tool. |
+| `policy.sh` | `list <nick>` / `add <nick> <yaml-snippet>` / `remove <nick> <rule-index>` | Inspect/edit `perm-policy/<nick>.yaml`. Adds run through a YAML re-emit so formatting stays consistent. |
+| `cleanup-stale-perms.sh` | (none) | Walk `perm-queue/`; for each request whose `helper_nick` has no running daemon (check via `cu agent status`), delete the file. Idempotent. |
+| `daemon-log.sh` | `<name> [limit]` | Tail + pretty-print `daemon-log/local-<name>.jsonl`. Default limit 30. |
+| `context-status.sh` | `[name]` | Read-only context-watch visibility. Reports last-known context `pct` per helper (from the daemon-action log's most recent `compact`/`handoff_written` entries, or a dedicated `context` action emitted each turn). With a name, shows just that helper. |
+| `spawn-helper.sh` | `<name> [cwd]` (unchanged argv) | **Now also** seeds `perm-policy/<name>.yaml` with safe-read defaults + the handoff-write auto-allow rule. Creates `audit/`, `perm-queue/`, `perm-decisions/`, `perm-policy/`, `daemon-log/`, `handoff/` if missing. |
+| `status.sh` | (unchanged) | **Now also** prints `[N pending perms]` and the most recent daemon-action per helper. |
+| `read-replies.sh` | `<name> [limit]` (unchanged) | **Now also** prepends `[N pending perms]` summary line if any exist for that helper. |
+
+Per-script bash files target POSIX `bash`, follow the existing `_common.sh` sourcing pattern, and use `python -c` for atomic file writes (avoiding the need to add a write-fence dependency).
+
+## Helper-side wiring
+
+### Claude backend
+
+`culture/clients/claude/agent_runner.py:_make_options` becomes:
+
+```python
+def _make_options(self) -> ClaudeAgentOptions:
+    opts = ClaudeAgentOptions(
+        model=self.model,
+        cwd=self.directory,
+        permission_mode="bypassPermissions",
+        setting_sources=["user", "project", "local"],   # widen
+        can_use_tool=self._can_use_tool,                # conditional — see below
+    )
+    if self.system_prompt:
+        opts.system_prompt = self.system_prompt
+    if self._session_id:
+        opts.resume = self._session_id
+    return opts
+```
+
+**Critical: `_can_use_tool` is conditionally set.** Setting it unconditionally would route every Claude agent's tool calls through the broker, including standalone mesh agents (e.g. `spark-culture`, future agents started directly via `cu agent start`) where no boss is watching the queue — those agents would hang indefinitely on the first non-auto-allow tool call.
+
+`AgentRunner.__init__` decides at construction time whether to attach the callback:
+
+```python
+def __init__(self, ..., nick: str = "", ...) -> None:
+    ...
+    policy_path = os.path.expanduser(f"~/.culture/perm-policy/{nick}.yaml")
+    if nick and os.path.exists(policy_path):
+        self._broker = PermissionBroker(nick=nick)
+        self._can_use_tool = self._broker.gate  # bound method
+    else:
+        self._broker = None
+        self._can_use_tool = None  # SDK skips the streaming-mode check too
+```
+
+`spawn-helper.sh` seeds the policy file before starting the helper daemon, so helpers always get supervision. Standalone agents (no policy file) get `can_use_tool=None`, preserving pre-broker behavior identically.
+
+Also: the `query()` call at `_process_turn` is modified to use the streaming-prompt wrapper described in [SDK consequence: `can_use_tool` forces streaming-mode prompts](#sdk-consequence-can_use_tool-forces-streaming-mode-prompts) **only when** `_can_use_tool is not None`. When it's `None`, the existing string-prompt path is preserved (no SDK error, no unnecessary refactor of non-supervised agents).
+
+### Copilot backend
+
+`culture/clients/copilot/agent_runner.py:start` builds `session_kwargs` (line 87). Today:
+
+```python
+session_kwargs = {
+    "on_permission_request": PermissionHandler.approve_all,
+    "model": self.model,
+}
+```
+
+Becomes:
+
+```python
+policy_path = os.path.expanduser(f"~/.culture/perm-policy/{self._nick}.yaml")
+if self._nick and os.path.exists(policy_path):
+    broker = PermissionBroker(nick=self._nick)
+    handler = broker.copilot_handler()  # adapter
+else:
+    broker = None
+    handler = PermissionHandler.approve_all  # preserve current behavior
+
+session_kwargs = {
+    "on_permission_request": handler,
+    "model": self.model,
+}
+if user_skill_dirs := _discover_user_skill_dirs():
+    session_kwargs["skill_directories"] = user_skill_dirs + self.skill_directories
+```
+
+Same gate as Claude: standalone Copilot agents without a policy file keep `PermissionHandler.approve_all` and are unaffected. Boss-spawned helpers get the broker.
+
+`_discover_user_skill_dirs()` returns `[~/.claude/skills/]` if the directory exists, plus any subdirectory matching `*/skills/` under `~/.claude/plugins/` (mirrors the SDK's plugin layout).
+
+`broker.copilot_handler()` is an adapter that closes over the same `gate()` function but adapts the argv/return shape to the Copilot SDK's expected `PermissionHandler` callable.
+
+> **Unverified assumption (Copilot SDK):** the actual `PermissionHandler` callable signature is not visible in this venv (lazy import — `from copilot import CopilotClient, PermissionHandler, SubprocessConfig`). The exact adapter shape must be confirmed at implementation time against the `github-copilot-sdk` package version pinned in `pyproject.toml`. Fallback: if the SDK exposes only `approve_all`/`deny_all` static methods (no callable interface), Copilot reverts to **audit-only** mode (same as Codex/ACP) and the matrix entry is downgraded with a note in the docs page.
+
+### Codex + ACP backends
+
+No agent_runner changes. Daemon-level audit log only.
+
+### Audit log (all four backends)
+
+Each backend's `daemon._on_agent_message` grows one new call. Reference implementation lives in a new `culture/clients/_audit.py`:
+
+```python
+# culture/clients/_audit.py
+class AuditWriter:
+    def __init__(self, nick: str, *, root: str | None = None) -> None: ...
+    async def write(self, msg: dict) -> None: ...  # JSONL append, fsync at end
+```
+
+Per-backend `daemon.__init__` instantiates `self._audit = AuditWriter(self.agent.nick)`. Each `_on_agent_message` adds one line:
+
+```python
+async def _on_agent_message(self, msg: dict) -> None:
+    await self._audit.write(msg)              # new
+    # ... existing supervisor/relay/status code unchanged
+```
+
+Hook points already exist verbatim:
+
+- `culture/clients/claude/daemon.py:426`
+- `culture/clients/codex/daemon.py:529`
+- `culture/clients/copilot/daemon.py:511`
+- `culture/clients/acp/daemon.py:536`
+
+All four files get the same one-line addition. Per the "cite, don't import" rule for `packages/`, `_audit.py` is in `culture/clients/` (not `packages/`) because it's runtime-internal to the harnesses, not a backend template.
+
+## Migration and backward compatibility
+
+- **Helpers spawned before this change**: have no `perm-policy/<nick>.yaml`. **By design, the absence of a policy file means `can_use_tool=None` is set on the SDK call — the agent behaves exactly as it does today (`bypassPermissions` semantics, no broker involvement, no hang).** To bring an existing helper under boss supervision, re-run `spawn-helper.sh <name>` (idempotent — seeds the policy file if missing and restarts the daemon).
+- **Boss sessions running an older culture-boss skill**: the new scripts coexist with the old ones (no script is removed; only new scripts added and three existing scripts gain extra output lines). `status.sh`'s extra `[N pending perms]` line is additive and downstream `awk`/`grep` consumers in any other scripts would need to skip the new prefix — but no such consumers exist within this repo.
+- **Existing `bypassPermissions` agents that are not helpers** (e.g. long-running mesh agents started directly via `cu agent start`, such as `spark-culture`): no `can_use_tool` callback because there's no policy file. The change to `setting_sources=["user","project","local"]` *does* affect them — they now inherit the user's MCP servers and skills. This is intentional: any agent on the mesh can use the boss's tool surface. They run autonomously as before (no broker gate), with the new audit log providing post-hoc visibility. **Documented as an upgrade note in `docs/agentirc/helper-tool-inheritance.md`.**
+- **Config schema**: no breaking changes to `culture.yaml`. The broker reads only `perm-policy/<nick>.yaml`, a separate file written by tooling, not by the user.
+
+## Security threat model
+
+Same-machine, same-UID only. The broker's authority surface (`~/.culture/perm-decisions/`) is filesystem-protected by standard POSIX permissions (`0700` on the directory, `0600` on files — set explicitly by `ensure-mesh.sh` and the broker on creation). Anyone who can write to this directory as the user already has shell access to the user's home dir; the broker offers no protection against that case.
+
+Out of scope: multi-user systems, attacker-controlled supply chain on the helper itself (a malicious skill installed under `~/.claude/skills/` is trusted by the user's normal Claude Code session anyway). The broker is a *boss-as-human* mechanism, not a sandbox.
+
+In scope: race conditions between concurrent boss script invocations (covered by `O_CREAT|O_EXCL` first-writer-wins above), partial-write recovery (atomic rename), and orphaned requests from dead helpers (covered by `cleanup-stale-perms.sh`).
+
+## Context-watermark handoff
+
+**Problem.** A long-running helper accumulates context until the model's window is full. The SDK auto-compacts, but a naive compact loses the working state the agent built up — what it was doing, what it learned, what's left. The fix: just before the window fills, have the agent write a durable handoff for its post-compact self, then remind it to read that handoff after the compact.
+
+**Who monitors.** The **daemon** self-monitors (decided during authoring — reliable, can't blow past the limit between async boss polls). The boss gets read-only visibility via `context-status.sh`.
+
+**Signal.** The Claude SDK's `ResultMessage.usage` exposes per-turn `input_tokens`. Under session resume, each turn's `input_tokens` reflects the *full* context sent to the model (history + new prompt), so it is a direct proxy for current context-window occupancy. The daemon computes:
+
+```
+pct = last_input_tokens / context_window_tokens
+```
+
+`context_window_tokens` is resolved per-model (see table). At `pct >= 0.90` (configurable; default 0.90) the daemon enters the handoff flow **once** per fill cycle (a latch prevents re-firing every turn while still above threshold; it resets after a compact drops usage below a low-water mark of 0.5).
+
+| Model family | Context window |
+|---|---|
+| `claude-opus-4-*` (1M beta) | 1_000_000 |
+| `claude-opus-4-*`, `claude-sonnet-4-*` | 200_000 |
+| `claude-haiku-4-*` | 200_000 |
+| unknown | 200_000 (conservative default) |
+
+The window map lives in `culture/clients/_context_watch.py`; unknown models default to 200K and log a warning so the map can be extended.
+
+**Flow (daemon-side, after each turn's ResultMessage):**
+
+```text
+turn completes → ResultMessage.usage.input_tokens
+       │
+       ▼
+pct >= 0.90 AND not already latched?
+       │ yes
+       ▼
+1. send handoff prompt to the agent:
+   "You are approaching your context limit. Write a concise handoff to
+    <CULTURE_HOME>/handoff/<nick>.md for your post-compact self: what you're
+    doing, key decisions, what's left, important file paths. Then stop."
+       │  (wait for the turn to complete — agent writes the file via its
+       │   normal Write tool, which the broker auto-allows for the handoff
+       │   path; see policy note below)
+       ▼
+2. trigger compact (existing _ipc_compact path / runner.send_prompt("/compact"))
+       │
+       ▼
+3. set "reminder pending" latch
+       │
+       ▼
+next activation (mention/poll) → prepend to the prompt:
+   "[context-handoff] You recently compacted. Read your handoff at
+    <CULTURE_HOME>/handoff/<nick>.md before continuing."
+       │
+       ▼
+clear reminder latch
+```
+
+**Handoff file.** `~/.culture/handoff/<nick>.md` — plain markdown, overwritten each cycle (the latest handoff is the only relevant one). Not JSONL; it is meant to be read by the agent (and the boss) as prose.
+
+**Policy interaction.** For a *supervised* helper, the handoff `Write` must not block on boss approval (the agent is mid-context-crisis; a stalled approval defeats the purpose). The daemon seeds an `auto_allow` rule for `Write` to the handoff path into the helper's policy at spawn time:
+
+```yaml
+auto_allow:
+  - tool: Write
+    input_regex: '/handoff/<nick>\.md$'
+```
+
+(Added by `spawn-helper.sh` policy seed and by `_context_watch` defensively if absent.) All *other* `Write` calls still route to the boss.
+
+**Config.** New optional fields on the agent `culture.yaml`:
+
+```yaml
+context_watch:
+  enabled: true          # default true
+  high_water: 0.90       # fraction of context window that triggers handoff
+  low_water: 0.50        # fraction below which the latch resets
+```
+
+Absent config → defaults (`enabled: true`, `0.90`, `0.50`). This is additive; no breaking change to existing `culture.yaml` files.
+
+**Module.** `culture/clients/_context_watch.py` holds the pure logic:
+
+```python
+@dataclass
+class ContextWatchState:
+    high_water: float = 0.90
+    low_water: float = 0.50
+    handoff_latched: bool = False
+    reminder_pending: bool = False
+
+def context_window_for(model: str) -> int: ...
+def evaluate(state, input_tokens, model) -> WatchAction: ...
+#   WatchAction ∈ {NONE, WRITE_HANDOFF, REMINDER_DUE}
+```
+
+The daemon owns an instance per agent, feeds it each `ResultMessage`, and acts on the returned `WatchAction`. Pure-function `evaluate` is unit-tested without a live SDK.
+
+**Backend coverage.** Claude exposes per-turn `input_tokens` (`ResultMessage.usage`) — full support. Codex/Copilot do **not** expose token counts on their responses today (Copilot: documented at `copilot/agent_runner.py:210`, issue #299; Codex: same gap). For those backends the watermark cannot be computed, so context-watch is **Claude-only** in this PR; documented in the backend matrix. The daemon-action log still records compaction events on all backends when they occur via the existing `_ipc_compact` path.
+
+## Daemon action log
+
+**Problem.** The agent-message audit log captures what the *agent* says and which tools it calls. It does not capture what the *daemon* does to manage the agent — starts, stops, compactions, crashes, pause/resume, watermark-triggered handoffs. The boss wants a control-plane record.
+
+**Shape.** One JSONL line per daemon action at `~/.culture/daemon-log/<nick>.jsonl`. Universal across all four backends. Schema:
+
+```json
+{
+  "ts": "2026-05-28T14:32:17.123Z",
+  "nick": "local-research",
+  "action": "compact",
+  "detail": {"trigger": "context_watermark", "pct": 0.91}
+}
+```
+
+**Action vocabulary** (string `action` + free-form `detail` dict):
+
+| action | when | detail |
+|---|---|---|
+| `agent_start` | daemon starts the runner | `{model, directory}` |
+| `agent_stop` | graceful stop | `{}` |
+| `agent_exit` | runner exits (incl. crash) | `{exit_code}` |
+| `crash` | crash recorded in sliding window | `{exit_code, count}` |
+| `circuit_open` | circuit breaker trips | `{count, window_s}` |
+| `pause` / `resume` | pause state changes | `{manual: bool}` |
+| `compact` | compact triggered | `{trigger: "ipc"\|"context_watermark", pct?}` |
+| `clear` | context cleared | `{}` |
+| `handoff_written` | watermark handoff prompt sent | `{pct, path}` |
+| `handoff_reminder` | post-compact reminder injected | `{path}` |
+
+**Module.** `culture/clients/_daemon_log.py` with a `DaemonLog` writer mirroring `AuditWriter`'s atomic-append discipline:
+
+```python
+class DaemonLog:
+    def __init__(self, nick: str) -> None: ...
+    async def record(self, action: str, **detail: Any) -> None: ...
+```
+
+Each backend's `daemon.__init__` instantiates `self._daemon_log = DaemonLog(nick=agent.nick)`. Existing lifecycle methods gain one `await self._daemon_log.record(...)` line each at the points in the vocabulary table. These are surgical additions; no control-flow changes.
+
+**Relationship to Python logging.** The daemon keeps its existing `logger.info/warning` calls (human-readable, systemd journal). The action log is the *structured, boss-readable* complement — not a replacement. Where both fire for the same event, that's intentional (one for ops, one for the boss).
+
+**Boss-side.** `daemon-log.sh <name> [limit]` tails `~/.culture/daemon-log/<nick>.jsonl` and pretty-prints. `status.sh` additionally prints the most recent action per helper.
+
+## Testing strategy
+
+Per project convention (CLAUDE.md): no mocks for the server; real I/O. Pytest + pytest-asyncio + pytest-xdist (already in use). `/run-tests` for execution.
+
+| Test | Location | What it verifies |
+|---|---|---|
+| `test_perm_broker_policy.py` | `tests/clients/` | Policy matcher: exact tool match, regex tool match, `input_regex` against Bash command, MCP wildcards, fallthrough to None, malformed YAML graceful degrade. Pure-function tests; no filesystem. |
+| `test_perm_broker_fs.py` | `tests/clients/` | End-to-end with a real tmp dir as `~/.culture`. Spin a broker, fire `gate()` in a task, verify request file appears, write decision file, verify task completes with correct verdict. Cover allow/deny/timeout-via-cancel/scope-always-mutates-policy/missing-policy-file. |
+| `test_perm_broker_atomic.py` | `tests/clients/` | Concurrent `approve.sh`-equivalent calls for the same ID — verify exactly one wins. Verify partial-write recovery (write to tmpfile, kill before rename, broker doesn't see it). |
+| `test_audit_writer.py` | `tests/clients/` | Append-only JSONL semantics across re-opens. Verify each line is valid JSON. Verify timestamps are monotonic ISO8601. |
+| `test_spawn_helper_seeds_policy.py` | `tests/integration/` | Pytest. Runs `spawn-helper.sh foo` via subprocess against an isolated `CULTURE_HOME` temp dir, then asserts `<CULTURE_HOME>/perm-policy/local-foo.yaml` exists and matches the default-content fixture. (Repo convention is pytest, not shell — even for shell-driven flows.) |
+| `test_claude_agent_runner_inheritance.py` | `tests/clients/` (or `tests/harness/` alongside existing `test_agent_runner_claude.py`) | Construct an `AgentRunner` two ways: (a) without a policy file → assert `_make_options().setting_sources == ["user","project","local"]` and `can_use_tool is None`; (b) with a fixture-written policy file → assert `can_use_tool is not None` and is a callable bound to a `PermissionBroker`. |
+| `test_claude_runner_streaming_mode.py` | `tests/harness/` | Verify the conditional prompt-wrapping branch in `_process_turn`. With no policy file: `_can_use_tool is None`, and the `query()` call site receives `prompt` as a `str` (today's behavior). With a policy file: `_can_use_tool` is set, and the call site receives `prompt` as an `AsyncIterable[dict]` whose first yielded item is `{"type": "user", "message": {"role": "user", "content": <text>}}`. Use a Transport stub injected via `ClaudeAgentOptions(...)` to capture what `query()` was called with — no live Claude CLI required. |
+| `test_context_watch.py` | `tests/` | Pure-function `evaluate()`: below high-water → NONE; at/above high-water and not latched → WRITE_HANDOFF + latch set; still above while latched → NONE; after drop below low-water → latch reset; reminder_pending → REMINDER_DUE then cleared. `context_window_for()` maps known models and defaults unknown to 200K. |
+| `test_daemon_log.py` | `tests/` | `DaemonLog.record()` appends one valid-JSON line per call; action + detail round-trip; concurrent records serialize; timestamps ISO8601-UTC. Real tmp `CULTURE_HOME`. |
+
+xdist-safe via `tmp_path` fixture for the `~/.culture`-root isolation; environment variable `CULTURE_HOME` (new, defaults to `~/.culture`) lets tests override.
+
+**AgentRunner constructor change — callsite enumeration.** Adding the policy-file gate at `AgentRunner.__init__` does not change the constructor *signature* (no new required kwargs — `nick` already exists), so existing callsites continue to compile. However, runtime behavior changes: any test that constructs an `AgentRunner` with a `nick` value that happens to match an existing policy file path will see `can_use_tool` set. Phase 2 must verify the seven existing callsites (`culture/clients/claude/daemon.py:326`; `tests/test_agent_runner.py:64, 90, 120, 143, 175, 204`; `tests/harness/test_agent_runner_claude.py:180`) and confirm:
+
+1. Production callsite — gets supervised iff its policy file exists (correct by design).
+2. Test callsites use either a sentinel nick (`"test-..."`) that has no policy file, OR an explicit `CULTURE_HOME` env override pointing at an empty tmp dir.
+
+Existing tests using `nick="spark-claude"` (`test_agent_runner_claude.py:178`) are safe as long as no `~/.culture/perm-policy/spark-claude.yaml` exists on the developer's machine. CI is clean by definition. Local-dev test runs that *happen* to have a real `spark-claude` agent registered will see different behavior — flagged as a known dev-environment caveat in the testing docs.
+
+## Project conventions applied
+
+From `culture/CLAUDE.md`:
+
+- **All-backends rule** — addressed via documentation parity (audit log universal) + matrix table calling out where control parity is impossible.
+- **Citation pattern** — `_perm_broker.py`, `_audit.py`, `_context_watch.py`, `_daemon_log.py` live in `culture/clients/` (runtime-internal). They are **not** added to `packages/agent-harness/`. Backend daemons import them directly. (Rationale: these are cross-backend infrastructure; the "cite, don't import" rule applies to per-backend templates that are reflected into each backend, not to genuinely shared runtime code.)
+- **Documentation** — four new pages: `docs/agentirc/helper-permissions.md` (broker), `docs/agentirc/helper-tool-inheritance.md` (setting_sources widening + skill_directories), `docs/agentirc/helper-context-handoff.md` (context-watermark), `docs/agentirc/helper-daemon-log.md` (daemon-action log). Linked from `docs/agentirc/index.md`.
+- **Idempotent migrations** — N/A; no DDL.
+- **Pre-push review** — touches transport-adjacent daemon code in all four backends. Invoke `Agent(subagent_type="feature-dev:code-reviewer", ...)` on staged diff before first push.
+- **Doc-test-alignment** — new boss-side scripts, new config file paths (`perm-policy/<nick>.yaml`), new `CULTURE_HOME` env var convention. (No new IRC verbs or channel patterns in v1 — those land in v1.1 with the IRC-summary follow-up.) Invoke `Agent(subagent_type="doc-test-alignment", ...)` before first push.
+- **Version bump** — minor (new feature). Per CLAUDE.md, run `/version-bump minor` before opening PR.
+- **Format before commit** — run `uv run black <files>` and `uv run isort <files>` on staged Python files before `git commit`.
+
+## Unverified assumptions
+
+| Assumption | Required check | When |
+|---|---|---|
+| Copilot SDK's `PermissionHandler` exposes a callable interface that can be substituted for `PermissionHandler.approve_all` | Read `github-copilot-sdk` source at the version pinned in `pyproject.toml`; confirm `on_permission_request` accepts a custom callable matching `Callable[[PermissionRequest], Awaitable[PermissionDecision]]` (or similar) | Before wiring Copilot — if it doesn't, Copilot drops to audit-only and the matrix is downgraded |
+| `~/.claude/skills/` exists for the user running the boss | At broker init in Copilot wiring, log a warning if absent; do not fail | Implementation time |
+| `os.replace` is atomic on the user's filesystem | True on POSIX local filesystems including macOS/Linux; non-atomic on NFS or some FUSE mounts | Documented limitation; flag in `docs/agentirc/helper-permissions.md` |
+| `CULTURE_HOME` env var doesn't collide with an existing convention | `grep -rn "CULTURE_HOME" culture/` | Implementation time |
+
+## Open questions
+
+1. **Should `auto_allow` rules be re-evaluated after a session-resume?** A helper that crashes and resumes via SDK `resume` could face a different policy if `approve.sh always` was used during the prior session. Decision: re-read on each `gate()` call (already in design), so resume picks up the latest policy automatically. Documented behavior, not a question — listed here as confirmation.
+2. **Watchdog/inotify vs polling**: poll-only for v1. If approval latency feedback is bad, add `watchdog` as a dep and switch in v1.1. Tracked as a follow-up issue, not in scope.
+
+## Non-goals
+
+- **Multi-boss arbitration on a single helper.** One helper, one boss. If two boss sessions share a helper name (against the documented convention), behavior is undefined — first-writer-wins on decisions.
+- **Web UI.** Boss UX is shell + IRC only.
+- **RBAC / per-channel policy.** All policy is per-helper-nick. No "this user can approve Bash but not Edit."
+- **Audit log rotation.** Grows forever. Operator concern, not feature scope.
+- **Reversing the gate** (allow by default, ask for deny). Default is "ask boss"; safe-read auto-allow is the only fast-path concession.
+- **Boss notifications outside the boss session** (push to phone, etc). Boss is responsible for noticing pending requests in its own conversation flow.
+- **IRC `#perm-<name>` channel posts.** Deferred to v1.1. The broker module sits below the daemon's IRC transport with no clean plumbing today. v1 boss UX is the file-backed queue surfaced via `pending-perms.sh` and `watch-perms.sh`.
+
+## Phases
+
+| Phase | Work | Acceptance gate |
+|---|---|---|
+| **P0** | Spec authored and reviewed. | `/review-plan` reports no critical findings. |
+| **P1** | `culture/clients/_perm_broker.py` + `culture/clients/_audit.py`. Pure modules, no backend wiring. Unit tests pass. | `test_perm_broker.py`, `test_audit_writer.py` all green. |
+| **P2** | Claude backend wiring. `agent_runner.py` widens settings + adds callback + streaming-prompt branch. `daemon.py` adds audit writer. | `test_claude_runner_inheritance.py` green. Existing claude tests still pass. |
+| **P3** | Codex/ACP audit-only wiring. Just the audit writer in each daemon. | Existing codex/acp tests still pass. |
+| **P4** | Copilot wiring (subject to PermissionHandler verification). If verification fails, demote Copilot to audit-only and update the matrix. | Manual inspection + existing copilot tests still pass. |
+| **P5** | Boss-side scripts: `pending-perms.sh`, `approve.sh`, `deny.sh`, `watch-perms.sh`, `policy.sh`, `cleanup-stale-perms.sh`, `daemon-log.sh`, `context-status.sh`. Modify `spawn-helper.sh`, `ensure-mesh.sh`, `status.sh`, `read-replies.sh`, `_common.sh`. | `test_spawn_helper_seeds_policy.py` green; manual smoke test (spawn helper, see policy seeded). |
+| **P6 (context-watch)** | `culture/clients/_context_watch.py` (pure). Wire into Claude `daemon.py`: feed `ResultMessage.usage` per turn, act on `WatchAction` (write-handoff prompt → compact → reminder). Add `context_watch` config to `culture/clients/claude/config.py`. | `test_context_watch.py` green. |
+| **P7 (daemon-log)** | `culture/clients/_daemon_log.py` (atomic JSONL). Instantiate `DaemonLog` in all four `daemon.__init__`; add `record(...)` calls at lifecycle points (start/stop/exit/crash/circuit/pause/resume/compact/clear/handoff). | `test_daemon_log.py` green. Existing daemon tests still pass. |
+| **P8** | Docs: `docs/agentirc/helper-permissions.md`, `docs/agentirc/helper-tool-inheritance.md`, `docs/agentirc/helper-context-handoff.md`, `docs/agentirc/helper-daemon-log.md`. Update `docs/agentirc/index.md`. Update culture-boss `SKILL.md`. | `doc-test-alignment` subagent reports no missing coverage. |
+| **P9** | Format, `/run-tests`, code-reviewer subagent on staged diff. | All green + reviewer findings addressed or explicitly accepted. |
+| **P10** | `/version-bump minor` + CHANGELOG entry. Commit, push, open PR. | PR exists, CI green. |
+
+## Out of scope
+
+- Any change to the IRC server (`culture/agentirc/`).
+- Any change to `packages/agent-harness/` template files (broker is runtime-internal; not reflected).
+- Web UI, dashboards, metrics dashboards. (Audit JSONL feeds whatever the operator wants.)
+- Permission rule import/export (e.g. share a policy file between machines). Operator concern.
+- Long-term audit log archival, redaction, or compliance features.
+
+## Acceptance summary
+
+The feature ships when:
+
+1. A boss can run `spawn-helper.sh foo`, brief the helper, and see all of the boss's MCP servers + skills available to the helper.
+2. When the helper tries to invoke Edit/Write/Bash-with-side-effects/any MCP, the boss receives a pending request via `pending-perms.sh`.
+3. `approve.sh <id>` unblocks the helper within ~500ms; `deny.sh <id> <reason>` causes the model to receive a denial in its tool result.
+4. `approve.sh <id> always` makes subsequent identical requests auto-approve with no round-trip.
+5. `~/.culture/audit/<nick>.jsonl` contains a line per AssistantMessage for every helper in every backend.
+6. Helpers in Codex/ACP backends do not block on `can_use_tool` (no broker hook) and have audit logs.
+7. A Claude helper approaching 90% context writes `~/.culture/handoff/<nick>.md`, compacts, and is reminded to read it on next activation (verifiable via `daemon-log/<nick>.jsonl` `handoff_written` + `compact` + `handoff_reminder` entries).
+8. `~/.culture/daemon-log/<nick>.jsonl` records control-plane actions (start/stop/compact/crash/handoff) for every helper in every backend; `daemon-log.sh <name>` tails it.
+9. `/run-tests` green. `doc-test-alignment` reports no gaps. `feature-dev:code-reviewer` finds no high-confidence issues unaddressed.
+
+---
+
+## Evidence Log
+
+### Cited source — SDK supports `can_use_tool`
+
+`claude_agent_sdk/types.py:159-161`:
+
+```python
+CanUseTool = Callable[
+    [str, dict[str, Any], ToolPermissionContext], Awaitable[PermissionResult]
+]
+```
+
+`claude_agent_sdk/types.py:1075`:
+
+```python
+# Tool permission callback
+can_use_tool: CanUseTool | None = None
+```
+
+`claude_agent_sdk/types.py:139-157` defines `PermissionResultAllow(behavior="allow", updated_input, updated_permissions)` and `PermissionResultDeny(behavior="deny", message, interrupt)`.
+
+### Cited source — SDK supports `setting_sources` with `user|project|local`
+
+`claude_agent_sdk/types.py:1090`:
+
+```python
+# Setting sources to load (user, project, local)
+setting_sources: list[SettingSource] | None = None
+```
+
+### Cited source — current Claude wiring uses project-only
+
+`culture/clients/claude/agent_runner.py:132-143` (verbatim, current main):
+
+```python
+def _make_options(self) -> ClaudeAgentOptions:
+    opts = ClaudeAgentOptions(
+        model=self.model,
+        cwd=self.directory,
+        permission_mode="bypassPermissions",
+        setting_sources=["project"],
+    )
+    if self.system_prompt:
+        opts.system_prompt = self.system_prompt
+    if self._session_id:
+        opts.resume = self._session_id
+    return opts
+```
+
+### Cited source — Copilot's existing PermissionHandler swap point
+
+`culture/clients/copilot/agent_runner.py:85-96`:
+
+```python
+session_kwargs: dict[str, Any] = {
+    "on_permission_request": PermissionHandler.approve_all,
+    "model": self.model,
+}
+if self.system_prompt:
+    session_kwargs["system_message"] = {"content": self.system_prompt}
+if self.skill_directories:
+    session_kwargs["skill_directories"] = self.skill_directories
+
+self._session = await self._client.create_session(**session_kwargs)
+```
+
+### Cited source — `_on_agent_message` hook points across all four backends
+
+- `culture/clients/claude/daemon.py:426-431`:
+
+  ```python
+  async def _on_agent_message(self, msg: dict) -> None:
+      """Feed agent activity to the supervisor for observation."""
+      if self._supervisor:
+          await self._supervisor.observe(msg)
+
+      self._capture_agent_status(msg)
+  ```
+
+- `culture/clients/codex/daemon.py:529-537`:
+
+  ```python
+  async def _on_agent_message(self, msg: dict) -> None:
+      """Relay agent text to IRC and feed to supervisor."""
+      self._consecutive_turn_failures = 0
+      await self._relay_response_to_irc(msg)
+
+      if self._supervisor:
+          await self._supervisor.observe(msg)
+
+      self._capture_agent_status(msg)
+  ```
+
+- `culture/clients/copilot/daemon.py:511-519`: same shape as codex (verified by grep + 20-line read).
+- `culture/clients/acp/daemon.py:536-544`: same shape as codex (verified by grep + 20-line read).
+
+### Cited source — spawn-helper.sh script (insertion point for policy seeding)
+
+`~/.claude/skills/culture-boss/scripts/spawn-helper.sh:1-45` (verbatim, current):
+
+```bash
+#!/usr/bin/env bash
+# Spawn a helper agent into its own private task channel.
+# Usage: spawn-helper <name> [cwd]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+
+NAME="${1:?usage: spawn-helper <name> [cwd]}"
+CWD="${2:-}"
+if [ -z "$CWD" ]; then
+  CWD="${HOME}/.culture/helpers/${NAME}"
+  mkdir -p "$CWD"
+fi
+NICK="local-${NAME}"
+TASK_CHAN="#task-${NAME}"
+# ... agent registration ...
+echo "[boss] spawned $NICK; private channel $TASK_CHAN; cwd $CWD."
+```
+
+Policy seed insertion lands after the `mkdir -p "$CWD"` block and before agent registration.
+
+---
+
+*End of spec.*

--- a/docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md
+++ b/docs/superpowers/specs/2026-05-29-mission-control-dashboard-design.md
@@ -1,0 +1,170 @@
+---
+title: "Mission Control Dashboard"
+parent: "Design"
+nav_order: 26
+---
+
+# Mission Control Dashboard
+
+**Status:** Draft
+**Date:** 2026-05-29
+**Depends on:** #411 (permission broker, audit + daemon logs) and #412 (boss agent, `culture boss`, grant ceiling)
+**Branch:** `feat/mission-control-dashboard`
+
+## Problem
+
+The boss/worker machinery produces everything needed to watch and steer a run —
+per-agent audit logs, daemon-action logs, a permission queue, IRC channels — but
+there is no single place to *see it all and intervene*. Today you assemble
+terminal panes (`watch-channels.sh`, `tail audit/<nick>.jsonl`,
+`culture boss pending`, …). The operator wants **one local control panel**: watch
+the boss and every worker live, and when something goes out of hand, take the
+wheel — approve/deny, pause/resume, kill, or stop everything.
+
+## Goal
+
+A **local web app** (`culture dashboard`) that, read-side, streams every agent's
+activity + pending approvals + status into one browser view, and, control-side,
+exposes the full intervention surface. Localhost-only; reuses the existing data
+files and control levers (no new control semantics, just a UI over them).
+
+## Why web (not desktop)
+
+Everything the panel needs is already local: JSONL logs under `~/.culture/`, the
+permission queue, daemon IPC sockets, and the `culture` CLI. A small
+`aiohttp` server (aiohttp is already a dependency — `pyproject.toml`,
+used by `culture/bots/http_listener.py`) serving a vanilla-JS single-page app
+needs **no new dependency and no build step**. Desktop (Electron/Tauri) would add
+packaging overhead for no gain on a single-user local machine.
+
+## Architecture
+
+```text
+ browser (SPA, vanilla JS + EventSource)
+        │  GET /  /static/*           (UI)
+        │  GET /api/agents            (poll: status grid)
+        │  GET /api/stream/audit/<nick>      (SSE: agent session)
+        │  GET /api/stream/daemon-log/<nick> (SSE: control-plane actions)
+        │  GET /api/stream/pending           (SSE: pending approvals)
+        │  GET /api/channel/<chan>    (poll: IRC exchanges, read-only)
+        │  POST /api/approve|deny|pause|resume|close|stop-all|policy  (control)
+        ▼
+ aiohttp.web.Application  (culture/dashboard/server.py)
+        │  reuses: _perm_broker (list_pending/read_request/write_decision,
+        │          policy files), _audit/_daemon_log paths, shared.ipc
+        │          (agent_socket_path/ipc_request), `culture agent` CLI
+        ▼
+ ~/.culture/{audit,daemon-log,perm-queue,perm-decisions,perm-policy}/  + daemon sockets
+```
+
+- **Bind `127.0.0.1` only** (like `serve_web` in `culture/overview/renderer_web.py:251`).
+- **No build step**: the SPA is hand-written HTML/CSS/JS served as static files
+  from `culture/dashboard/static/`. `EventSource` (SSE) for live streams; `fetch`
+  for control POSTs. (Polling fallback for `/api/agents` and channel reads.)
+- **One CLI command**: `culture dashboard [--port 8787] [--host 127.0.0.1]`,
+  registered as a `mesh` subcommand or top-level group, mirroring `serve_web`.
+
+## Read side (live views)
+
+| Endpoint | Source | Shape |
+|---|---|---|
+| `GET /api/agents` | **programmatic** (not CLI-text): `load_config_or_default` for the agent manifest + `pidfile.read_pid("agent-<nick>")` + `process.is_process_alive(pid)` for state + `perm-queue` counts | `[{nick, state, pending, last_action}]`, polled ~2s |
+| `GET /api/stream/audit/<nick>` | tail `~/.culture/audit/<nick>.jsonl` | SSE, one event per new line (agent text + tool_uses + tool_results) — **the agent's session screen** |
+| `GET /api/stream/daemon-log/<nick>` | tail `~/.culture/daemon-log/<nick>.jsonl` | SSE, one event per action |
+| `GET /api/stream/pending` | watch `~/.culture/perm-queue/` | SSE, current pending list on change |
+| `GET /api/channel/<chan>` | read-only via `culture.observer` (same path as `culture channel read`) | recent messages — **the exchanges** |
+
+SSE tailers: an async task per connection that emits a bounded backlog (last N
+lines) then `seek`s to EOF and polls for appended lines (250ms), emitting each as
+an SSE `data:` line. On client disconnect, writing to the closed
+`StreamResponse` raises `ConnectionResetError`/`asyncio.CancelledError` — the
+handler catches it, stops the tail task, and returns (no leaked tasks/handles). A
+periodic SSE comment (`: keepalive`) keeps proxies/idle connections open.
+
+## Control side (full intervention)
+
+All reuse existing levers; the dashboard is the **human** operator, so it is the
+top authority — its approvals are **not** ceiling-bounded (unlike `culture boss
+approve`).
+
+| Endpoint | Action | Implementation |
+|---|---|---|
+| `POST /api/approve {id, scope?, pattern?}` | grant a pending request | `_perm_broker.write_decision(id, verdict="allow", decided_by="dashboard")` — no ceiling check (human is top authority) |
+| `POST /api/deny {id, reason?}` | deny a request | `write_decision(id, verdict="deny", reason)` |
+| `POST /api/pause {nick}` / `resume {nick}` | pause/resume an agent | `shared.ipc.ipc_request(agent_socket_path(nick), "pause"/"resume")` |
+| `POST /api/close {nick}` | kill one agent | `culture agent stop <nick>` (subprocess) |
+| `POST /api/stop-all {mode}` | **emergency**: `mode=pause` → pause every agent; `mode=kill` → `culture agent stop --all` | the big red button |
+| `GET/POST /api/policy/<nick>` | view/edit a worker's grant policy | read/write `perm-policy/<nick>.yaml` via `_perm_broker` helpers (atomic) |
+
+Control POSTs return `{ok, error?}`. The UI confirms destructive actions
+(close, stop-all kill) with a modal.
+
+## Security model
+
+Same-machine, same-UID, **localhost-bound**. The panel can approve tool calls and
+kill agents — but anyone who can reach `127.0.0.1:<port>` as this user already
+has shell access and could do the same via the CLI/files. Consistent with the
+broker's threat model (the dashboard adds no privilege). v1: no auth token (note
+it as a possible hardening if the host is shared). Never bind a non-loopback
+interface; the CLI rejects a non-loopback `--host` unless `--unsafe-bind` is
+passed (explicit opt-in, documented as dangerous).
+
+## Live verification (folded into the build — the missing proof)
+
+The dashboard is also how we first prove the #411/#412 stack runs live. Phase L:
+bootstrap a real mesh, `culture boss init`, start the boss daemon, brief it to
+spawn + drive one worker, and confirm in the browser that (a) the worker's audit
+stream shows activity, (b) a permission request appears in the pending panel,
+(c) approving it from the panel unblocks the worker, (d) pause/close/stop-all
+work. Any failure here is a real bug in #411/#412 to fix.
+
+## Testing strategy
+
+Per project convention: real I/O, no mocks; `aiohttp.test_utils` for the server.
+
+| Test | Verifies |
+|---|---|
+| `test_dashboard_api.py` | `/api/agents` shape from a seeded `CULTURE_HOME`; `/api/stream/pending` emits the seeded queue; control POSTs (`approve`/`deny`) write the correct decision files via the broker (human authority — above-ceiling tool still approved). Uses `aiohttp` test client + isolated `CULTURE_HOME`. |
+| `test_dashboard_control.py` | `approve` writes `decided_by=dashboard` with no ceiling refusal; `deny` carries reason; double-decision returns the broker's `DecisionExistsError` as a 409; `stop-all` invokes the expected CLI/IPC (patched at the subprocess boundary). |
+| `test_dashboard_tail.py` | The SSE file-tailer emits appended JSONL lines in order and survives a missing/rotated file. |
+
+The SPA itself is verified live in-browser (Playwright) during Phase L, not unit-tested.
+
+## Files
+
+New:
+- `culture/dashboard/__init__.py`, `culture/dashboard/server.py` (aiohttp app + endpoints + SSE tailer), `culture/dashboard/static/{index.html,app.js,style.css}`.
+- `culture/cli/` — register `culture dashboard` (new group or `mesh dashboard` subcommand).
+- `docs/agentirc/dashboard.md`.
+- Tests above.
+
+Changed:
+- `culture/cli/__init__.py` — register the dashboard command.
+- `_perm_broker.py` — only if a small read/write-policy helper is missing (reuse existing where possible).
+
+## Phases
+
+| Phase | Work | Gate |
+|---|---|---|
+| D1 | aiohttp server skeleton + `/api/agents` + `culture dashboard` CLI (localhost bind). | `test_dashboard_api.py` agents endpoint green; `culture dashboard` serves. |
+| D2 | SSE tailer + audit/daemon-log/pending streams. | `test_dashboard_tail.py` green. |
+| D3 | Control endpoints (approve/deny/pause/resume/close/stop-all/policy). | `test_dashboard_control.py` green. |
+| D4 | Vanilla-JS SPA: agent grid, per-agent session stream, pending-approvals panel with buttons, control bar (pause/resume/close/STOP-ALL), channel view. | Loads in browser; renders seeded data. |
+| L  | Live bring-up: real boss + worker; verify watch + intervene in-browser (Playwright). | The 4 live checks above pass; fix any #411/#412 bug surfaced. |
+| D5 | Docs (`dashboard.md`) + version bump + quality gates + PR. | doc-test-alignment + code-reviewer clean; CI green. |
+
+## Non-goals (v1)
+
+- Auth/multi-user/remote access (localhost single-user only).
+- Editing/replaying agent history; only view + intervene.
+- Redirect/message-injection into agent channels from the panel (deferred — watch + stop/approve/policy is v1; two-way steering is a follow-up).
+- A build-tooling frontend (React/Vite); vanilla JS only, no node build.
+- Mobile layout / theming polish beyond a usable dark UI.
+
+## Open questions
+
+1. **Channel view fidelity.** `/api/channel` reads via the observer (recent
+   buffer). Full live channel streaming (SSE) is deferred unless the per-agent
+   audit stream proves insufficient for "seeing exchanges".
+2. **Top-level `culture dashboard` vs `culture mesh dashboard`.** Leaning
+   top-level for discoverability; confirm during build.

--- a/packages/agent-harness/culture.yaml
+++ b/packages/agent-harness/culture.yaml
@@ -12,6 +12,15 @@ tags:
   - harness
   - template
 
+# Context-watermark handoff (Claude backend only).
+# When the daemon detects the agent is approaching its context window, it asks
+# the agent to write a handoff for its post-compact self, compacts, then reminds
+# it to read the handoff. See docs/agentirc/helper-context-handoff.md.
+context_watch:
+  enabled: true       # master switch
+  high_water: 0.90    # fraction of the context window that triggers a handoff
+  low_water: 0.50     # fraction below which the handoff latch resets
+
 # OpenTelemetry configuration for the agent harness.
 # Set enabled: true once your OTLP collector is running.
 # See docs/agentirc/harness-telemetry.md for a setup guide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.8.0"
+version = "8.9.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.6.0"
+version = "8.7.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "8.7.0"
+version = "8.8.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/_sdk_stub.py
+++ b/tests/_sdk_stub.py
@@ -1,0 +1,121 @@
+"""Shared claude_agent_sdk stub for tests that need it.
+
+Calling :func:`install_claude_sdk_stub` is idempotent — it only installs the
+stub if ``claude_agent_sdk`` is not already in ``sys.modules``. Test files
+that need a deterministic stub should call this at module top *before*
+importing any culture module that imports the SDK (notably
+``culture.clients._perm_broker`` and ``culture.clients.claude.agent_runner``).
+
+The stub mirrors the subset of the SDK surface that culture's harnesses
+touch. New SDK surface that culture starts importing should be added here.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+
+class _StubAsyncIter:
+    def __init__(self, messages: list[Any]) -> None:
+        self._iter = iter(messages)
+
+    def __aiter__(self):  # type: ignore[no-untyped-def]
+        return self
+
+    async def __anext__(self):  # type: ignore[no-untyped-def]
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+def install_claude_sdk_stub() -> None:
+    """Install a minimal stub for claude_agent_sdk if not already loaded."""
+    if "claude_agent_sdk" in sys.modules:
+        return
+
+    mod = types.ModuleType("claude_agent_sdk")
+
+    class _Base:
+        pass
+
+    class AssistantMessage(_Base):
+        def __init__(self, model: str = "stub-model", content: list[Any] | None = None) -> None:
+            self.model = model
+            self.content = content or []
+
+    class ResultMessage(_Base):
+        def __init__(
+            self,
+            session_id: str = "sid-1",
+            is_error: bool = False,
+            result: str = "",
+            usage: Any = None,
+        ) -> None:
+            self.session_id = session_id
+            self.is_error = is_error
+            self.result = result
+            self.usage = usage
+
+    class ClaudeAgentOptions(_Base):
+        def __init__(self, **kwargs: Any) -> None:
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    class TextBlock(_Base):
+        pass
+
+    class ThinkingBlock(_Base):
+        pass
+
+    class ToolUseBlock(_Base):
+        pass
+
+    class ToolResultBlock(_Base):
+        pass
+
+    class PermissionResultAllow(_Base):
+        def __init__(
+            self,
+            behavior: str = "allow",
+            updated_input: Any = None,
+            updated_permissions: Any = None,
+        ) -> None:
+            self.behavior = behavior
+            self.updated_input = updated_input
+            self.updated_permissions = updated_permissions
+
+    class PermissionResultDeny(_Base):
+        def __init__(
+            self,
+            behavior: str = "deny",
+            message: str = "",
+            interrupt: bool = False,
+        ) -> None:
+            self.behavior = behavior
+            self.message = message
+            self.interrupt = interrupt
+
+    class ToolPermissionContext(_Base):
+        def __init__(self, signal: Any = None, suggestions: list[Any] | None = None) -> None:
+            self.signal = signal
+            self.suggestions = suggestions or []
+
+    def query(**kwargs: Any) -> _StubAsyncIter:  # noqa: ARG001
+        return _StubAsyncIter([])
+
+    mod.AssistantMessage = AssistantMessage
+    mod.ResultMessage = ResultMessage
+    mod.ClaudeAgentOptions = ClaudeAgentOptions
+    mod.TextBlock = TextBlock
+    mod.ThinkingBlock = ThinkingBlock
+    mod.ToolUseBlock = ToolUseBlock
+    mod.ToolResultBlock = ToolResultBlock
+    mod.PermissionResultAllow = PermissionResultAllow
+    mod.PermissionResultDeny = PermissionResultDeny
+    mod.ToolPermissionContext = ToolPermissionContext
+    mod.query = query
+
+    sys.modules["claude_agent_sdk"] = mod

--- a/tests/harness/test_agent_runner_claude.py
+++ b/tests/harness/test_agent_runner_claude.py
@@ -101,6 +101,23 @@ def _stub_claude_sdk():
     class ToolResultBlock(_Base):
         pass
 
+    class PermissionResultAllow(_Base):
+        def __init__(self, behavior="allow", updated_input=None, updated_permissions=None):
+            self.behavior = behavior
+            self.updated_input = updated_input
+            self.updated_permissions = updated_permissions
+
+    class PermissionResultDeny(_Base):
+        def __init__(self, behavior="deny", message="", interrupt=False):
+            self.behavior = behavior
+            self.message = message
+            self.interrupt = interrupt
+
+    class ToolPermissionContext(_Base):
+        def __init__(self, signal=None, suggestions=None):
+            self.signal = signal
+            self.suggestions = suggestions or []
+
     def query(**kwargs):
         return _StubAsyncIter([])
 
@@ -111,6 +128,9 @@ def _stub_claude_sdk():
     mod.ThinkingBlock = ThinkingBlock
     mod.ToolUseBlock = ToolUseBlock
     mod.ToolResultBlock = ToolResultBlock
+    mod.PermissionResultAllow = PermissionResultAllow
+    mod.PermissionResultDeny = PermissionResultDeny
+    mod.ToolPermissionContext = ToolPermissionContext
     mod.query = query
 
     sys.modules["claude_agent_sdk"] = mod

--- a/tests/test_audit_writer.py
+++ b/tests/test_audit_writer.py
@@ -1,0 +1,119 @@
+"""Tests for the per-helper JSONL audit log."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients._audit import AuditWriter, audit_path_for  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestAuditWriter:
+    def test_path_under_culture_home(self, culture_root):
+        assert audit_path_for("local-foo").startswith(str(culture_root))
+
+    @pytest.mark.asyncio
+    async def test_write_assistant_message_appends_line(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        msg = {
+            "type": "assistant",
+            "model": "claude-opus-4-7",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+            ],
+        }
+        await writer.write(msg)
+
+        with open(writer.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["type"] == "assistant"
+        assert record["nick"] == "local-foo"
+        assert record["model"] == "claude-opus-4-7"
+        assert record["text"] == "Hello"
+        assert record["tool_uses"][0]["name"] == "Bash"
+        assert record["tool_uses"][0]["input_digest"].startswith("sha256:")
+        assert record["ts"].endswith("Z")  # ISO8601 UTC
+
+    @pytest.mark.asyncio
+    async def test_non_assistant_messages_are_skipped(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        await writer.write({"type": "user", "content": [{"type": "text", "text": "hi"}]})
+        await writer.write({"type": "result", "session_id": "x"})
+        assert not os.path.exists(writer.path)
+
+    @pytest.mark.asyncio
+    async def test_multiple_writes_preserve_order(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        for i in range(5):
+            await writer.write(
+                {
+                    "type": "assistant",
+                    "model": "m",
+                    "content": [{"type": "text", "text": f"line-{i}"}],
+                }
+            )
+        with open(writer.path) as f:
+            lines = [json.loads(line) for line in f.readlines()]
+        assert [record["text"] for record in lines] == [f"line-{i}" for i in range(5)]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_serialize(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+
+        async def write_one(i: int) -> None:
+            await writer.write(
+                {
+                    "type": "assistant",
+                    "model": "m",
+                    "content": [{"type": "text", "text": f"line-{i:02d}"}],
+                }
+            )
+
+        await asyncio.gather(*(write_one(i) for i in range(20)))
+
+        with open(writer.path) as f:
+            lines = f.readlines()
+        # All 20 lines must be present and individually valid JSON.
+        assert len(lines) == 20
+        for line in lines:
+            json.loads(line)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_preview_truncated(self, culture_root):
+        writer = AuditWriter(nick="local-foo")
+        big = "x" * 1000
+        await writer.write(
+            {
+                "type": "assistant",
+                "model": "m",
+                "content": [
+                    {"type": "tool_result", "name": "Bash", "content": big},
+                ],
+            }
+        )
+        with open(writer.path) as f:
+            record = json.loads(f.readlines()[0])
+        preview = record["tool_results"][0]["preview"]
+        assert len(preview) <= 200
+        assert preview.startswith("x")
+
+    @pytest.mark.asyncio
+    async def test_empty_nick_rejected(self, culture_root):
+        with pytest.raises(ValueError):
+            AuditWriter(nick="")

--- a/tests/test_boss_cli.py
+++ b/tests/test_boss_cli.py
@@ -1,0 +1,151 @@
+"""Tests for the `culture boss` CLI (orchestration surface).
+
+Drives the CLI via subprocess against an isolated CULTURE_HOME so the
+queue/decision/ceiling/identity behavior is exercised end-to-end. Commands that
+need a running daemon (brief/read/spawn/status/close) are not covered here — they
+require a live mesh and are covered by manual smoke per the spec.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+
+def _run(args, culture_home, nick="local-boss", **kw):
+    env = dict(os.environ)
+    env["CULTURE_HOME"] = str(culture_home)
+    if nick is not None:
+        env["CULTURE_NICK"] = nick
+    elif "CULTURE_NICK" in env:
+        del env["CULTURE_NICK"]
+    return subprocess.run(
+        [sys.executable, "-m", "culture", "boss", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        **kw,
+    )
+
+
+@pytest.fixture
+def home(tmp_path):
+    return tmp_path
+
+
+def _write_request(culture_home, rid, tool, input_dict, nick="local-w"):
+    qdir = os.path.join(str(culture_home), "perm-queue")
+    os.makedirs(qdir, exist_ok=True)
+    with open(os.path.join(qdir, f"{rid}.json"), "w", encoding="utf-8") as f:
+        json.dump({"id": rid, "helper_nick": nick, "tool_name": tool, "input": input_dict}, f)
+
+
+def _decision(culture_home, rid):
+    path = os.path.join(str(culture_home), "perm-decisions", f"{rid}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _seed_ceiling(culture_home, nick="local-boss"):
+    from culture.clients._perm_broker import DEFAULT_BOSS_CEILING
+
+    d = os.path.join(str(culture_home), "boss-policy")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, f"{nick}.yaml"), "w", encoding="utf-8") as f:
+        yaml.safe_dump({"grant_ceiling": DEFAULT_BOSS_CEILING}, f)
+
+
+class TestApproveDeny:
+    def test_approve_in_ceiling_writes_decision(self, home):
+        _seed_ceiling(home)
+        _write_request(home, "req-ok", "Edit", {"file_path": "/a.py"})
+        res = _run(["approve", "req-ok"], home)
+        assert res.returncode == 0, res.stderr
+        d = _decision(home, "req-ok")
+        assert d is not None and d["verdict"] == "allow" and d["scope"] == "once"
+
+    def test_approve_always_sets_scope(self, home):
+        _write_request(home, "req-always", "Write", {"file_path": "/a.py"})
+        res = _run(["approve", "req-always", "--always"], home)
+        assert res.returncode == 0, res.stderr
+        assert _decision(home, "req-always")["scope"] == "always"
+
+    def test_approve_above_ceiling_refused(self, home):
+        _seed_ceiling(home)
+        _write_request(home, "req-mcp", "mcp__gmail__send", {"to": "x@y.z"})
+        res = _run(["approve", "req-mcp"], home)
+        assert res.returncode == 2, (res.returncode, res.stderr)
+        assert "above your grant ceiling" in res.stderr
+        # No decision written — escalation, not grant.
+        assert _decision(home, "req-mcp") is None
+
+    def test_deny_writes_decision_with_reason(self, home):
+        _write_request(home, "req-deny", "Bash", {"command": "rm -rf /"})
+        res = _run(["deny", "req-deny", "too", "dangerous"], home)
+        assert res.returncode == 0, res.stderr
+        d = _decision(home, "req-deny")
+        assert d["verdict"] == "deny" and d["reason"] == "too dangerous"
+
+    def test_approve_missing_request(self, home):
+        res = _run(["approve", "nope"], home)
+        assert res.returncode == 1
+        assert "no pending request" in res.stderr
+
+    def test_double_decision_refused(self, home):
+        _write_request(home, "req-dup", "Edit", {"file_path": "/a"})
+        first = _run(["approve", "req-dup"], home)
+        assert first.returncode == 0
+        second = _run(["deny", "req-dup", "changed mind"], home)
+        assert second.returncode == 1
+        assert "already exists" in second.stderr
+
+    def test_no_culture_nick_errors(self, home):
+        _write_request(home, "req-x", "Edit", {"file_path": "/a"})
+        res = _run(["approve", "req-x"], home, nick=None)
+        assert res.returncode == 1
+        assert "CULTURE_NICK" in res.stderr
+
+
+class TestPending:
+    def test_pending_lists_requests(self, home):
+        _write_request(home, "req-1", "Edit", {"file_path": "/a.py"})
+        _write_request(home, "req-2", "Bash", {"command": "ls"})
+        res = _run(["pending"], home)
+        assert res.returncode == 0
+        assert "req-1" in res.stdout and "req-2" in res.stdout
+        assert "Edit" in res.stdout and "Bash" in res.stdout
+
+
+class TestInit:
+    def test_init_creates_boss_identity(self, home):
+        res = _run(["init", "--nick", "boss", "--server", "local", "--channel", "#boss"], home)
+        assert res.returncode == 0, res.stderr
+        # Ceiling seeded.
+        ceiling = os.path.join(str(home), "boss-policy", "local-boss.yaml")
+        assert os.path.exists(ceiling)
+        # Boss cwd culture.yaml has a manager system_prompt + boss tag, no perm-policy.
+        boss_cwd = os.path.join(str(home), "boss")
+        with open(os.path.join(boss_cwd, "culture.yaml"), encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+        assert "boss" in cfg.get("tags", [])
+        assert "manager agent" in cfg.get("system_prompt", "")
+        assert not os.path.exists(os.path.join(str(home), "perm-policy", "local-boss.yaml"))
+        # Skill copied into the boss cwd.
+        assert os.path.exists(os.path.join(boss_cwd, ".claude", "skills", "boss", "SKILL.md"))
+
+    def test_init_removes_stray_perm_policy(self, home):
+        # A boss must never be permission-supervised.
+        ppdir = os.path.join(str(home), "perm-policy")
+        os.makedirs(ppdir, exist_ok=True)
+        with open(os.path.join(ppdir, "local-boss.yaml"), "w", encoding="utf-8") as f:
+            f.write("auto_allow: []\n")
+        res = _run(["init", "--nick", "boss", "--server", "local"], home)
+        assert res.returncode == 0, res.stderr
+        assert not os.path.exists(os.path.join(ppdir, "local-boss.yaml"))

--- a/tests/test_boss_cli.py
+++ b/tests/test_boss_cli.py
@@ -113,6 +113,44 @@ class TestApproveDeny:
         assert "CULTURE_NICK" in res.stderr
 
 
+class TestSpawnValidation:
+    def test_spawn_rejects_path_traversal_name(self, home):
+        res = _run(["spawn", "../../evil"], home)
+        assert res.returncode == 1
+        assert "invalid worker name" in res.stderr
+        # Nothing was created outside the helpers dir.
+        assert not os.path.exists(os.path.join(str(home), "..", "evil"))
+
+    def test_spawn_rejects_slash_name(self, home):
+        res = _run(["spawn", "a/b"], home)
+        assert res.returncode == 1
+        assert "invalid worker name" in res.stderr
+
+
+class TestWriteDecisionCleanup:
+    def test_failed_write_leaves_no_placeholder(self, home, monkeypatch):
+        # If the atomic write fails after the O_EXCL placeholder is created, the
+        # placeholder must be removed so the worker doesn't poll a 0-byte file
+        # forever and a retry isn't blocked.
+        import culture.clients._perm_broker as pb
+
+        monkeypatch.setenv("CULTURE_HOME", str(home))
+
+        def _boom(dest, payload):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(pb, "_atomic_write_json", _boom)
+        with pytest.raises(OSError):
+            pb.write_decision("req-fail", verdict="allow")
+        dest = os.path.join(str(home), "perm-decisions", "req-fail.json")
+        assert not os.path.exists(dest)
+        # A retry is now possible (not blocked by a stale placeholder).
+        monkeypatch.undo()
+        monkeypatch.setenv("CULTURE_HOME", str(home))
+        pb.write_decision("req-fail", verdict="allow")
+        assert os.path.exists(dest)
+
+
 class TestPending:
     def test_pending_lists_requests(self, home):
         _write_request(home, "req-1", "Edit", {"file_path": "/a.py"})

--- a/tests/test_boss_grant_ceiling.py
+++ b/tests/test_boss_grant_ceiling.py
@@ -1,0 +1,83 @@
+"""Tests for the boss grant ceiling (human-over-boss gate)."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import os  # noqa: E402
+
+import pytest  # noqa: E402
+import yaml  # noqa: E402
+
+from culture.clients._perm_broker import (  # noqa: E402
+    DEFAULT_BOSS_CEILING,
+    boss_policy_path_for,
+    is_above_ceiling,
+    load_boss_ceiling,
+    write_default_boss_ceiling,
+)
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestBossCeilingFile:
+    def test_seed_writes_default(self, culture_root):
+        path = write_default_boss_ceiling("local-boss")
+        assert os.path.exists(path)
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data == {"grant_ceiling": DEFAULT_BOSS_CEILING}
+
+    def test_seed_idempotent(self, culture_root):
+        path = write_default_boss_ceiling("local-boss")
+        with open(path, "w") as f:
+            yaml.safe_dump({"grant_ceiling": [{"tool": "Custom"}]}, f)
+        write_default_boss_ceiling("local-boss")
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert data == {"grant_ceiling": [{"tool": "Custom"}]}
+
+    def test_load_empty_when_missing(self, culture_root):
+        assert load_boss_ceiling("local-boss") == []
+
+    def test_path_under_culture_home(self, culture_root):
+        assert boss_policy_path_for("local-boss").startswith(str(culture_root))
+
+
+class TestIsAboveCeiling:
+    def test_no_file_nothing_above(self, culture_root):
+        # With no ceiling file, the boss may grant anything (the human seeds the
+        # ceiling via ensure-mesh; absent it, no restriction).
+        assert is_above_ceiling("mcp__gmail__send", {"to": "x"}, "local-boss") is False
+
+    def test_mcp_above_ceiling(self, culture_root):
+        write_default_boss_ceiling("local-boss")
+        assert is_above_ceiling("mcp__gmail__send", {"to": "x"}, "local-boss") is True
+        assert is_above_ceiling("mcp__drive__create_file", {}, "local-boss") is True
+
+    def test_destructive_bash_above_ceiling(self, culture_root):
+        write_default_boss_ceiling("local-boss")
+        for cmd in ("rm -rf /tmp/x", "git push origin main", "gh pr merge 5", "kubectl apply"):
+            assert is_above_ceiling("Bash", {"command": cmd}, "local-boss") is True, cmd
+
+    def test_routine_tools_in_ceiling(self, culture_root):
+        write_default_boss_ceiling("local-boss")
+        assert is_above_ceiling("Edit", {"file_path": "/a.py"}, "local-boss") is False
+        assert is_above_ceiling("Write", {"file_path": "/a.py"}, "local-boss") is False
+        assert is_above_ceiling("Bash", {"command": "ls -la"}, "local-boss") is False
+        assert is_above_ceiling("Bash", {"command": "pytest"}, "local-boss") is False
+
+    def test_custom_ceiling_respected(self, culture_root):
+        path = boss_policy_path_for("local-boss")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            yaml.safe_dump({"grant_ceiling": [{"tool": "Write"}]}, f)
+        # This boss may not grant Write, but may grant MCP (not in its ceiling).
+        assert is_above_ceiling("Write", {"file_path": "/a"}, "local-boss") is True
+        assert is_above_ceiling("mcp__gmail__send", {}, "local-boss") is False

--- a/tests/test_claude_runner_inheritance.py
+++ b/tests/test_claude_runner_inheritance.py
@@ -40,6 +40,16 @@ class TestSettingSources:
         opts = runner._make_options()
         assert opts.permission_mode == "bypassPermissions"
 
+    def test_culture_nick_in_subprocess_env(self, culture_root):
+        runner = _runner(nick="local-foo")
+        opts = runner._make_options()
+        assert opts.env.get("CULTURE_NICK") == "local-foo"
+
+    def test_empty_nick_no_culture_nick_env(self, culture_root):
+        runner = _runner(nick="")
+        opts = runner._make_options()
+        assert "CULTURE_NICK" not in opts.env
+
 
 class TestConditionalCanUseTool:
     def test_no_policy_file_no_callback(self, culture_root):
@@ -71,6 +81,4 @@ class TestStreamingPromptWrapper:
         from culture.clients.claude.agent_runner import _single_user_message_stream
 
         items = [item async for item in _single_user_message_stream("hello world")]
-        assert items == [
-            {"type": "user", "message": {"role": "user", "content": "hello world"}}
-        ]
+        assert items == [{"type": "user", "message": {"role": "user", "content": "hello world"}}]

--- a/tests/test_claude_runner_inheritance.py
+++ b/tests/test_claude_runner_inheritance.py
@@ -1,0 +1,76 @@
+"""Tests for the Claude AgentRunner's setting_sources widening and the
+conditional can_use_tool wiring tied to perm-policy file existence."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import tempfile  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients._perm_broker import write_default_policy  # noqa: E402
+from culture.clients.claude.agent_runner import AgentRunner  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _runner(nick: str) -> AgentRunner:
+    return AgentRunner(
+        model="claude-opus-4-7",
+        directory=tempfile.mkdtemp(prefix="culture-test-claude-"),
+        nick=nick,
+    )
+
+
+class TestSettingSources:
+    def test_setting_sources_widened(self, culture_root):
+        runner = _runner(nick="local-foo")
+        opts = runner._make_options()
+        assert opts.setting_sources == ["user", "project", "local"]
+
+    def test_permission_mode_still_bypass(self, culture_root):
+        runner = _runner(nick="local-foo")
+        opts = runner._make_options()
+        assert opts.permission_mode == "bypassPermissions"
+
+
+class TestConditionalCanUseTool:
+    def test_no_policy_file_no_callback(self, culture_root):
+        runner = _runner(nick="local-no-policy")
+        opts = runner._make_options()
+        assert opts.can_use_tool is None
+        assert runner._broker is None
+
+    def test_policy_file_present_wires_callback(self, culture_root):
+        write_default_policy("local-with-policy")
+        runner = _runner(nick="local-with-policy")
+        opts = runner._make_options()
+        assert opts.can_use_tool is not None
+        assert callable(opts.can_use_tool)
+        assert runner._broker is not None
+        assert runner._broker.nick == "local-with-policy"
+
+    def test_empty_nick_no_callback(self, culture_root):
+        # Even with a policy file present, empty nick means no broker.
+        runner = _runner(nick="")
+        opts = runner._make_options()
+        assert opts.can_use_tool is None
+        assert runner._broker is None
+
+
+class TestStreamingPromptWrapper:
+    @pytest.mark.asyncio
+    async def test_single_user_message_stream_shape(self):
+        from culture.clients.claude.agent_runner import _single_user_message_stream
+
+        items = [item async for item in _single_user_message_stream("hello world")]
+        assert items == [
+            {"type": "user", "message": {"role": "user", "content": "hello world"}}
+        ]

--- a/tests/test_context_watch.py
+++ b/tests/test_context_watch.py
@@ -1,0 +1,109 @@
+"""Tests for the pure context-watermark logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from culture.clients._context_watch import (
+    ContextWatchState,
+    WatchAction,
+    context_window_for,
+    evaluate,
+    fraction,
+    mark_reminder_pending,
+    take_reminder,
+)
+
+
+class TestContextWindowFor:
+    def test_opus_default_200k(self):
+        assert context_window_for("claude-opus-4-6") == 200_000
+
+    def test_opus_1m_marker(self):
+        assert context_window_for("claude-opus-4-7[1m]") == 1_000_000
+
+    def test_sonnet_200k(self):
+        assert context_window_for("claude-sonnet-4-6") == 200_000
+
+    def test_haiku_200k(self):
+        assert context_window_for("claude-haiku-4-5-20251001") == 200_000
+
+    def test_unknown_defaults_200k(self):
+        assert context_window_for("some-future-model") == 200_000
+
+    def test_empty_defaults_200k(self):
+        assert context_window_for("") == 200_000
+
+
+class TestEvaluate:
+    def test_below_high_water_none(self):
+        st = ContextWatchState()
+        # 100K of 200K = 50% — at low_water boundary, not high.
+        assert evaluate(st, 100_000, "claude-opus-4-6") is WatchAction.NONE
+        assert st.handoff_latched is False
+
+    def test_at_high_water_triggers_handoff(self):
+        st = ContextWatchState()
+        # 185K of 200K = 92.5% >= 90%.
+        assert evaluate(st, 185_000, "claude-opus-4-6") is WatchAction.WRITE_HANDOFF
+        assert st.handoff_latched is True
+
+    def test_latched_does_not_refire(self):
+        st = ContextWatchState()
+        assert evaluate(st, 190_000, "claude-opus-4-6") is WatchAction.WRITE_HANDOFF
+        # Still above threshold, latched → no re-fire.
+        assert evaluate(st, 192_000, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_latch_resets_below_low_water_signals_reminder(self):
+        st = ContextWatchState()
+        evaluate(st, 190_000, "claude-opus-4-6")  # latched (handoff written)
+        # Drop below 50% (e.g. after compact) → reminder is now due.
+        assert evaluate(st, 50_000, "claude-opus-4-6") is WatchAction.REMINDER_DUE
+        assert st.handoff_latched is False
+        # Re-fills → fires handoff again.
+        assert evaluate(st, 190_000, "claude-opus-4-6") is WatchAction.WRITE_HANDOFF
+
+    def test_low_usage_without_prior_latch_is_none(self):
+        st = ContextWatchState()
+        # Never latched — a low reading is just NONE (no spurious reminder).
+        assert evaluate(st, 50_000, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_disabled_never_fires(self):
+        st = ContextWatchState(enabled=False)
+        assert evaluate(st, 199_000, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_none_tokens_no_fire(self):
+        st = ContextWatchState()
+        assert evaluate(st, None, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_zero_tokens_no_fire(self):
+        st = ContextWatchState()
+        assert evaluate(st, 0, "claude-opus-4-6") is WatchAction.NONE
+
+    def test_1m_model_threshold(self):
+        st = ContextWatchState()
+        # 185K of 1M = 18.5% — well below high-water for a 1M model.
+        assert evaluate(st, 185_000, "claude-opus-4-7[1m]") is WatchAction.NONE
+        # 920K of 1M = 92%.
+        assert evaluate(st, 920_000, "claude-opus-4-7[1m]") is WatchAction.WRITE_HANDOFF
+
+
+class TestFraction:
+    def test_fraction_basic(self):
+        assert fraction(100_000, "claude-opus-4-6") == pytest.approx(0.5)
+
+    def test_fraction_none(self):
+        assert fraction(None, "claude-opus-4-6") is None
+
+    def test_fraction_zero(self):
+        assert fraction(0, "claude-opus-4-6") is None
+
+
+class TestReminder:
+    def test_reminder_roundtrip(self):
+        st = ContextWatchState()
+        assert take_reminder(st) is False
+        mark_reminder_pending(st)
+        assert take_reminder(st) is True
+        # Consumed — second take returns False.
+        assert take_reminder(st) is False

--- a/tests/test_daemon_log.py
+++ b/tests/test_daemon_log.py
@@ -1,0 +1,70 @@
+"""Tests for the per-agent daemon-action log."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients._daemon_log import DaemonLog, daemon_log_path_for  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestDaemonLog:
+    def test_path_under_culture_home(self, culture_root):
+        assert daemon_log_path_for("local-foo").startswith(str(culture_root))
+
+    @pytest.mark.asyncio
+    async def test_record_appends_line(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        await log.record("agent_start", model="claude-opus-4-7", directory="/tmp/x")
+        with open(log.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        rec = json.loads(lines[0])
+        assert rec["action"] == "agent_start"
+        assert rec["nick"] == "local-foo"
+        assert rec["detail"]["model"] == "claude-opus-4-7"
+        assert rec["ts"].endswith("Z")
+
+    @pytest.mark.asyncio
+    async def test_detail_roundtrip(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        await log.record("compact", trigger="context_watermark", pct=0.91)
+        with open(log.path) as f:
+            rec = json.loads(f.readlines()[0])
+        assert rec["detail"] == {"trigger": "context_watermark", "pct": 0.91}
+
+    @pytest.mark.asyncio
+    async def test_multiple_records_ordered(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        for action in ("agent_start", "compact", "agent_stop"):
+            await log.record(action)
+        with open(log.path) as f:
+            recs = [json.loads(line) for line in f.readlines()]
+        assert [r["action"] for r in recs] == ["agent_start", "compact", "agent_stop"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_records_serialize(self, culture_root):
+        log = DaemonLog(nick="local-foo")
+        await asyncio.gather(*(log.record("tick", i=i) for i in range(20)))
+        with open(log.path) as f:
+            lines = f.readlines()
+        assert len(lines) == 20
+        for line in lines:
+            json.loads(line)
+
+    @pytest.mark.asyncio
+    async def test_empty_nick_rejected(self, culture_root):
+        with pytest.raises(ValueError):
+            DaemonLog(nick="")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,197 @@
+"""Tests for the Mission Control dashboard backend (aiohttp)."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import json  # noqa: E402
+import os  # noqa: E402
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+from culture.dashboard.server import build_app, serve_dashboard  # noqa: E402
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_request(home, rid, tool, input_dict, nick="local-w"):
+    qdir = os.path.join(str(home), "perm-queue")
+    os.makedirs(qdir, exist_ok=True)
+    with open(os.path.join(qdir, f"{rid}.json"), "w", encoding="utf-8") as f:
+        json.dump({"id": rid, "helper_nick": nick, "tool_name": tool, "input": input_dict}, f)
+
+
+def _decision(home, rid):
+    path = os.path.join(str(home), "perm-decisions", f"{rid}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest_asyncio.fixture
+async def client(home):
+    app = build_app(config_path=os.path.join(str(home), "server.yaml"))
+    async with TestClient(TestServer(app)) as c:
+        yield c
+
+
+class TestReadEndpoints:
+    @pytest.mark.asyncio
+    async def test_agents_empty(self, client):
+        resp = await client.get("/api/agents")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data == {"agents": []}
+
+    @pytest.mark.asyncio
+    async def test_pending_lists_requests(self, client, home):
+        _write_request(home, "req-1", "Edit", {"file_path": "/a.py"})
+        resp = await client.get("/api/pending")
+        data = await resp.json()
+        ids = [p["id"] for p in data["pending"]]
+        assert "req-1" in ids
+
+    @pytest.mark.asyncio
+    async def test_index_served(self, client):
+        resp = await client.get("/")
+        assert resp.status == 200
+        body = await resp.text()
+        assert "mission control" in body.lower()
+
+
+class TestControlEndpoints:
+    @pytest.mark.asyncio
+    async def test_approve_writes_decision_no_ceiling(self, client, home):
+        # Human (dashboard) is top authority — even an above-boss-ceiling tool
+        # like an MCP send is approvable here.
+        _write_request(home, "req-mcp", "mcp__gmail__send", {"to": "x@y.z"})
+        resp = await client.post("/api/approve", json={"id": "req-mcp"})
+        assert resp.status == 200
+        d = _decision(home, "req-mcp")
+        assert d["verdict"] == "allow" and d["decided_by"] == "dashboard"
+
+    @pytest.mark.asyncio
+    async def test_approve_always(self, client, home):
+        _write_request(home, "req-a", "Edit", {"file_path": "/a"})
+        resp = await client.post("/api/approve", json={"id": "req-a", "always": True})
+        assert resp.status == 200
+        assert _decision(home, "req-a")["scope"] == "always"
+
+    @pytest.mark.asyncio
+    async def test_deny_with_reason(self, client, home):
+        _write_request(home, "req-d", "Bash", {"command": "rm -rf /"})
+        resp = await client.post("/api/deny", json={"id": "req-d", "reason": "nope"})
+        assert resp.status == 200
+        d = _decision(home, "req-d")
+        assert d["verdict"] == "deny" and d["reason"] == "nope"
+
+    @pytest.mark.asyncio
+    async def test_approve_missing_id(self, client):
+        resp = await client.post("/api/approve", json={})
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_double_decision_conflict(self, client, home):
+        _write_request(home, "req-dup", "Edit", {"file_path": "/a"})
+        first = await client.post("/api/approve", json={"id": "req-dup"})
+        assert first.status == 200
+        second = await client.post("/api/deny", json={"id": "req-dup", "reason": "x"})
+        assert second.status == 409
+
+    @pytest.mark.asyncio
+    async def test_policy_get_put_roundtrip(self, client, home):
+        policy = {"auto_allow": [{"tool": "Read"}], "auto_deny": []}
+        put = await client.put("/api/policy/local-w", json={"policy": policy})
+        assert put.status == 200
+        get = await client.get("/api/policy/local-w")
+        data = await get.json()
+        assert data["policy"] == policy
+
+    @pytest.mark.asyncio
+    async def test_pause_missing_nick(self, client):
+        resp = await client.post("/api/pause", json={})
+        assert resp.status == 400
+
+
+class TestStream:
+    @pytest.mark.asyncio
+    async def test_audit_stream_emits_backlog(self, client, home):
+        # Seed an audit log line, then connect — backlog should be delivered.
+        adir = os.path.join(str(home), "audit")
+        os.makedirs(adir, exist_ok=True)
+        rec = {"ts": "2026-05-29T00:00:00Z", "type": "assistant", "text": "hello", "tool_uses": []}
+        with open(os.path.join(adir, "local-w.jsonl"), "w", encoding="utf-8") as f:
+            f.write(json.dumps(rec) + "\n")
+        resp = await client.get("/api/stream/audit/local-w")
+        assert resp.status == 200
+        # Read one SSE event from the backlog.
+        chunk = await resp.content.readuntil(b"\n\n")
+        assert b"hello" in chunk
+        resp.close()
+
+    @pytest.mark.asyncio
+    async def test_unknown_stream_kind_404(self, client):
+        resp = await client.get("/api/stream/bogus/local-w")
+        assert resp.status == 404
+
+
+class TestServeGuard:
+    def test_refuses_non_loopback_bind(self):
+        with pytest.raises(ValueError):
+            serve_dashboard(host="0.0.0.0", port=8787)
+
+
+class TestSecurity:
+    @pytest.mark.asyncio
+    async def test_nick_path_traversal_rejected_stream(self, client):
+        # A nick that isn't <server>-<agent> form must be rejected (path safety).
+        resp = await client.get("/api/stream/audit/bad.nick")
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_nick_path_traversal_rejected_policy_put(self, client):
+        resp = await client.put("/api/policy/evil.path", json={"policy": {}})
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_nick_rejected_control(self, client):
+        resp = await client.post("/api/close", json={"nick": "../etc"})
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_cross_origin_blocked(self, client):
+        # A malicious page (DNS-rebinding) sends a non-loopback Origin → 403.
+        resp = await client.post(
+            "/api/approve",
+            json={"id": "x"},
+            headers={"Origin": "http://evil.com"},
+        )
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_loopback_origin_allowed(self, client, home):
+        _write_request(home, "req-ok", "Edit", {"file_path": "/a"})
+        resp = await client.post(
+            "/api/approve",
+            json={"id": "req-ok"},
+            headers={"Origin": "http://localhost:8787"},
+        )
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_non_loopback_host_blocked(self, client):
+        resp = await client.post(
+            "/api/stop-all",
+            json={"mode": "pause"},
+            headers={"Host": "evil.com"},
+        )
+        assert resp.status == 403

--- a/tests/test_perm_broker.py
+++ b/tests/test_perm_broker.py
@@ -1,0 +1,351 @@
+"""Tests for the file-backed permission broker.
+
+Per project convention: real I/O against an isolated tmp dir.  No mocks of
+the broker's filesystem layer.  Tests honor ``CULTURE_HOME`` via monkeypatch
+so they are xdist-safe.
+"""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+from typing import Any  # noqa: E402
+
+import pytest  # noqa: E402
+import yaml  # noqa: E402
+from claude_agent_sdk import (  # noqa: E402
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+
+from culture.clients._perm_broker import (  # noqa: E402
+    DEFAULT_POLICY,
+    PermissionBroker,
+    culture_home,
+    has_policy_file,
+    match_policy,
+    policy_path_for,
+    write_default_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    """Isolate ``CULTURE_HOME`` per test."""
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _empty_context() -> ToolPermissionContext:
+    return ToolPermissionContext(signal=None, suggestions=[])
+
+
+# ---------------------------------------------------------------------------
+# Pure policy matcher
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyMatcher:
+    def test_exact_tool_match_allows(self):
+        policy = {"auto_allow": [{"tool": "Read"}]}
+        assert match_policy("Read", {}, policy) == "allow"
+
+    def test_exact_tool_match_misses(self):
+        policy = {"auto_allow": [{"tool": "Read"}]}
+        assert match_policy("Write", {}, policy) is None
+
+    def test_regex_tool_pattern(self):
+        policy = {"auto_allow": [{"tool": "mcp__.*"}]}
+        assert match_policy("mcp__gmail__send", {}, policy) == "allow"
+        assert match_policy("Bash", {}, policy) is None
+
+    def test_auto_deny_takes_priority_over_auto_allow(self):
+        policy = {
+            "auto_deny": [{"tool": "Bash"}],
+            "auto_allow": [{"tool": "Bash"}],
+        }
+        assert match_policy("Bash", {"command": "ls"}, policy) == "deny"
+
+    def test_bash_input_regex_match(self):
+        policy = {"auto_allow": [{"tool": "Bash", "input_regex": r"^ls\b"}]}
+        assert match_policy("Bash", {"command": "ls -la"}, policy) == "allow"
+        assert match_policy("Bash", {"command": "rm -rf /"}, policy) is None
+
+    def test_bash_default_safe_read_regex(self):
+        policy = DEFAULT_POLICY
+        for cmd in ("ls", "ls -la", "git status", "git diff HEAD", "rg foo src/"):
+            assert match_policy("Bash", {"command": cmd}, policy) == "allow", cmd
+        for cmd in ("rm -rf /", "curl https://evil.tld", "git push"):
+            assert match_policy("Bash", {"command": cmd}, policy) is None, cmd
+
+    def test_empty_policy_falls_through(self):
+        assert match_policy("Read", {}, {}) is None
+        assert match_policy("Read", {}, {"auto_allow": []}) is None
+
+    def test_malformed_rule_is_skipped(self):
+        policy = {"auto_allow": [{"not_a_tool_field": 1}, {"tool": "Read"}]}
+        assert match_policy("Read", {}, policy) == "allow"
+
+    def test_input_regex_against_non_projectable_tool_does_not_match(self):
+        # ``Read`` has no input projection; a rule with input_regex against
+        # Read should never match.
+        policy = {"auto_allow": [{"tool": "Read", "input_regex": ".*"}]}
+        assert match_policy("Read", {"file_path": "x"}, policy) is None
+
+
+# ---------------------------------------------------------------------------
+# Policy file seed / load
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyFile:
+    def test_write_default_policy_creates_file(self, culture_root):
+        path = write_default_policy("local-foo")
+        assert os.path.exists(path)
+        with open(path) as f:
+            policy = yaml.safe_load(f)
+        assert policy == DEFAULT_POLICY
+
+    def test_write_default_policy_is_idempotent(self, culture_root):
+        path = write_default_policy("local-foo")
+        # Mutate the file then re-seed; existing file must not be overwritten.
+        with open(path, "w") as f:
+            yaml.safe_dump({"auto_allow": [{"tool": "Custom"}]}, f)
+        write_default_policy("local-foo")
+        with open(path) as f:
+            policy = yaml.safe_load(f)
+        assert policy == {"auto_allow": [{"tool": "Custom"}]}
+
+    def test_has_policy_file_reflects_filesystem(self, culture_root):
+        assert has_policy_file("local-foo") is False
+        write_default_policy("local-foo")
+        assert has_policy_file("local-foo") is True
+
+    def test_has_policy_file_empty_nick(self, culture_root):
+        write_default_policy("local-foo")
+        assert has_policy_file("") is False
+        assert has_policy_file(None) is False  # type: ignore[arg-type]
+
+    def test_policy_path_uses_culture_home(self, culture_root):
+        assert policy_path_for("x").startswith(str(culture_root))
+        assert culture_home() == str(culture_root)
+
+
+# ---------------------------------------------------------------------------
+# Broker end-to-end (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerEndToEnd:
+    @pytest.mark.asyncio
+    async def test_policy_match_returns_immediately_allow(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+        result = await asyncio.wait_for(
+            broker.gate("Read", {"file_path": "/x"}, _empty_context()),
+            timeout=1.0,
+        )
+        assert isinstance(result, PermissionResultAllow)
+
+    @pytest.mark.asyncio
+    async def test_policy_match_returns_immediately_deny(self, culture_root):
+        # Write a custom policy that hard-denies Bash.
+        path = policy_path_for("local-helper")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            yaml.safe_dump({"auto_deny": [{"tool": "Bash"}], "auto_allow": []}, f)
+        broker = PermissionBroker(nick="local-helper")
+        result = await asyncio.wait_for(
+            broker.gate("Bash", {"command": "rm -rf /"}, _empty_context()),
+            timeout=1.0,
+        )
+        assert isinstance(result, PermissionResultDeny)
+        assert result.interrupt is False
+
+    @pytest.mark.asyncio
+    async def test_unmatched_tool_routes_to_boss_and_allows_on_decision(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        # Boss-side: poll for the request, write a decision.
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "allow",
+                "scope": "once",
+                "reason": "",
+                "decided_by": "test",
+            },
+        )
+
+        result = await asyncio.wait_for(gate_task, timeout=2.0)
+        assert isinstance(result, PermissionResultAllow)
+
+        # Queue and decision files are consumed on success.
+        assert not os.path.exists(os.path.join(queue_dir, f"{request_id}.json"))
+        assert not os.path.exists(os.path.join(decisions_dir, f"{request_id}.json"))
+
+    @pytest.mark.asyncio
+    async def test_boss_deny_propagates_reason(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "deny",
+                "scope": "once",
+                "reason": "not approved",
+            },
+        )
+        result = await asyncio.wait_for(gate_task, timeout=2.0)
+        assert isinstance(result, PermissionResultDeny)
+        assert "not approved" in result.message
+        assert result.interrupt is False
+
+    @pytest.mark.asyncio
+    async def test_scope_always_appends_to_policy(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "allow",
+                "scope": "always",
+            },
+        )
+        await asyncio.wait_for(gate_task, timeout=2.0)
+
+        with open(policy_path_for("local-helper")) as f:
+            policy = yaml.safe_load(f)
+        tools_allowed = [rule.get("tool") for rule in policy.get("auto_allow", [])]
+        assert "Edit" in tools_allowed
+
+    @pytest.mark.asyncio
+    async def test_scope_always_with_pattern_uses_pattern(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        # Use Edit — guaranteed to fall through to boss (no auto-allow for it).
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {
+                "id": request_id,
+                "verdict": "allow",
+                "scope": "always",
+                "pattern": "Custom.*",  # pattern field overrides tool match
+            },
+        )
+        await asyncio.wait_for(gate_task, timeout=2.0)
+
+        with open(policy_path_for("local-helper")) as f:
+            policy = yaml.safe_load(f)
+        tools_allowed = [rule.get("tool") for rule in policy.get("auto_allow", [])]
+        # The pattern is stored verbatim as the tool field.
+        assert "Custom.*" in tools_allowed
+
+    @pytest.mark.asyncio
+    async def test_cancellation_cleans_up_queue_file(self, culture_root):
+        write_default_policy("local-helper")
+        broker = PermissionBroker(nick="local-helper")
+
+        gate_task = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        await _wait_for_request(queue_dir)
+
+        gate_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await gate_task
+
+        # Queue dir should be empty — the in-flight request was cleaned up.
+        entries = [e for e in os.listdir(queue_dir) if not e.startswith(".")]
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_missing_policy_file_routes_everything_to_boss(self, culture_root):
+        # No policy file written; broker treats as empty → boss-routed.
+        broker = PermissionBroker(nick="local-orphan")
+
+        gate_task = asyncio.create_task(broker.gate("Read", {"file_path": "/x"}, _empty_context()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        request_id = await _wait_for_request(queue_dir)
+        _write_decision_atomic(
+            os.path.join(decisions_dir, f"{request_id}.json"),
+            {"id": request_id, "verdict": "allow", "scope": "once"},
+        )
+        result = await asyncio.wait_for(gate_task, timeout=2.0)
+        assert isinstance(result, PermissionResultAllow)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — boss-side simulation
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_request(queue_dir: str, timeout: float = 2.0) -> str:
+    """Poll until one request file appears in ``queue_dir``; return its ID."""
+
+    async def _poll() -> str:
+        while True:
+            try:
+                entries = [
+                    e
+                    for e in os.listdir(queue_dir)
+                    if e.endswith(".json") and not e.startswith(".")
+                ]
+            except FileNotFoundError:
+                entries = []
+            if entries:
+                return entries[0][: -len(".json")]
+            await asyncio.sleep(0.05)
+
+    return await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def _write_decision_atomic(path: str, payload: dict[str, Any]) -> None:
+    """Mirror the boss-script atomic-write contract for tests."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)

--- a/tests/test_perm_broker_on_request.py
+++ b/tests/test_perm_broker_on_request.py
@@ -49,6 +49,24 @@ def _write_decision(path: str, payload: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
+class TestListPendingExcludesDecided:
+    def test_decided_request_excluded_from_pending(self, culture_root):
+        from culture.clients._perm_broker import list_pending
+
+        qdir = os.path.join(str(culture_root), "perm-queue")
+        ddir = os.path.join(str(culture_root), "perm-decisions")
+        os.makedirs(qdir, exist_ok=True)
+        os.makedirs(ddir, exist_ok=True)
+        for rid in ("req-a", "req-b"):
+            with open(os.path.join(qdir, f"{rid}.json"), "w", encoding="utf-8") as f:
+                json.dump({"id": rid, "helper_nick": "local-w", "tool_name": "Edit"}, f)
+        # Decide req-a only.
+        with open(os.path.join(ddir, "req-a.json"), "w", encoding="utf-8") as f:
+            json.dump({"id": "req-a", "verdict": "allow"}, f)
+        ids = [r["id"] for r in list_pending()]
+        assert ids == ["req-b"]  # req-a is decided, awaiting worker consumption
+
+
 class TestOnRequestCallback:
     @pytest.mark.asyncio
     async def test_callback_fires_once_with_payload(self, culture_root):

--- a/tests/test_perm_broker_on_request.py
+++ b/tests/test_perm_broker_on_request.py
@@ -1,0 +1,131 @@
+"""Tests for the broker's on_request notification callback (boss-agent layer)."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import os  # noqa: E402
+from typing import Any  # noqa: E402
+
+import pytest  # noqa: E402
+from claude_agent_sdk import PermissionResultAllow, ToolPermissionContext  # noqa: E402
+
+from culture.clients._perm_broker import PermissionBroker, write_default_policy  # noqa: E402
+
+
+@pytest.fixture
+def culture_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("CULTURE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _ctx() -> ToolPermissionContext:
+    return ToolPermissionContext(signal=None, suggestions=[])
+
+
+async def _wait_for_request(queue_dir: str, timeout: float = 2.0) -> str:
+    async def _poll() -> str:
+        while True:
+            try:
+                entries = [e for e in os.listdir(queue_dir) if e.endswith(".json")]
+            except FileNotFoundError:
+                entries = []
+            if entries:
+                return entries[0][: -len(".json")]
+            await asyncio.sleep(0.05)
+
+    return await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+def _write_decision(path: str, payload: dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+    os.replace(tmp, path)
+
+
+class TestOnRequestCallback:
+    @pytest.mark.asyncio
+    async def test_callback_fires_once_with_payload(self, culture_root):
+        write_default_policy("local-w")
+        seen: list[dict] = []
+
+        async def on_request(payload: dict) -> None:
+            seen.append(payload)
+
+        broker = PermissionBroker(nick="local-w", on_request=on_request)
+        gate = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _ctx()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        rid = await _wait_for_request(queue_dir)
+        _write_decision(
+            os.path.join(decisions_dir, f"{rid}.json"),
+            {"id": rid, "verdict": "allow", "scope": "once"},
+        )
+        result = await asyncio.wait_for(gate, timeout=2.0)
+
+        assert isinstance(result, PermissionResultAllow)
+        assert len(seen) == 1
+        assert seen[0]["tool_name"] == "Edit"
+        assert seen[0]["helper_nick"] == "local-w"
+        assert seen[0]["id"] == rid
+
+    @pytest.mark.asyncio
+    async def test_callback_not_fired_on_policy_fast_path(self, culture_root):
+        write_default_policy("local-w")
+        seen: list[dict] = []
+
+        async def on_request(payload: dict) -> None:
+            seen.append(payload)
+
+        broker = PermissionBroker(nick="local-w", on_request=on_request)
+        # Read auto-allows → no boss routing → callback must not fire.
+        result = await asyncio.wait_for(
+            broker.gate("Read", {"file_path": "/x"}, _ctx()), timeout=1.0
+        )
+        assert isinstance(result, PermissionResultAllow)
+        assert seen == []
+
+    @pytest.mark.asyncio
+    async def test_raising_callback_is_swallowed_gate_still_resolves(self, culture_root):
+        write_default_policy("local-w")
+
+        async def on_request(payload: dict) -> None:
+            raise RuntimeError("transport down")
+
+        broker = PermissionBroker(nick="local-w", on_request=on_request)
+        gate = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _ctx()))
+
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        rid = await _wait_for_request(queue_dir)
+        # Despite the callback raising, the request file exists and the gate
+        # resolves normally once the decision lands.
+        _write_decision(
+            os.path.join(decisions_dir, f"{rid}.json"),
+            {"id": rid, "verdict": "allow", "scope": "once"},
+        )
+        result = await asyncio.wait_for(gate, timeout=2.0)
+        assert isinstance(result, PermissionResultAllow)
+
+    @pytest.mark.asyncio
+    async def test_no_callback_is_fine(self, culture_root):
+        # on_request=None must preserve the existing gate flow.
+        write_default_policy("local-w")
+        broker = PermissionBroker(nick="local-w")  # no on_request
+        gate = asyncio.create_task(broker.gate("Edit", {"file_path": "/x"}, _ctx()))
+        queue_dir = os.path.join(str(culture_root), "perm-queue")
+        decisions_dir = os.path.join(str(culture_root), "perm-decisions")
+        rid = await _wait_for_request(queue_dir)
+        _write_decision(
+            os.path.join(decisions_dir, f"{rid}.json"),
+            {"id": rid, "verdict": "allow", "scope": "once"},
+        )
+        result = await asyncio.wait_for(gate, timeout=2.0)
+        assert isinstance(result, PermissionResultAllow)

--- a/tests/test_runtime_agent_config.py
+++ b/tests/test_runtime_agent_config.py
@@ -1,0 +1,64 @@
+"""Regression: the runtime AgentConfig (culture.config) must expose boss +
+context_watch from culture.yaml extras, and the Claude daemon must normalize
+either config flavor. Caught live: the daemon read agent.context_watch on the
+runtime config (which lacked it) and crashed every Claude agent on startup.
+"""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+from culture.config import AgentConfig as RuntimeAgentConfig  # noqa: E402
+
+
+class TestRuntimeAgentConfigProperties:
+    def test_boss_from_extras(self):
+        a = RuntimeAgentConfig(nick="local-w", extras={"boss": "local-boss"})
+        assert a.boss == "local-boss"
+
+    def test_boss_default_empty(self):
+        assert RuntimeAgentConfig(nick="local-w").boss == ""
+
+    def test_context_watch_from_extras(self):
+        a = RuntimeAgentConfig(
+            nick="local-w", extras={"context_watch": {"high_water": 0.8, "enabled": False}}
+        )
+        assert a.context_watch == {"high_water": 0.8, "enabled": False}
+
+    def test_context_watch_default_empty_dict(self):
+        assert RuntimeAgentConfig(nick="local-w").context_watch == {}
+
+
+class TestDaemonNormalizers:
+    def test_context_watch_state_from_dict(self):
+        from culture.clients.claude.daemon import _context_watch_state
+
+        a = RuntimeAgentConfig(
+            nick="local-w", extras={"context_watch": {"high_water": 0.8, "low_water": 0.4}}
+        )
+        st = _context_watch_state(a)
+        assert st.high_water == 0.8 and st.low_water == 0.4 and st.enabled is True
+
+    def test_context_watch_state_empty_defaults(self):
+        from culture.clients.claude.daemon import _context_watch_state
+
+        st = _context_watch_state(RuntimeAgentConfig(nick="local-w"))
+        assert st.high_water == 0.90 and st.low_water == 0.50 and st.enabled is True
+
+    def test_context_watch_state_from_object(self):
+        # The backend-specific config exposes a ContextWatchConfig object.
+        from culture.clients.claude.config import AgentConfig as ClaudeAgentConfig
+        from culture.clients.claude.daemon import _context_watch_state
+
+        a = ClaudeAgentConfig(nick="local-w")
+        a.context_watch.high_water = 0.95
+        st = _context_watch_state(a)
+        assert st.high_water == 0.95
+
+    def test_boss_nick_runtime_and_default(self):
+        from culture.clients.claude.daemon import _boss_nick
+
+        assert _boss_nick(RuntimeAgentConfig(nick="w", extras={"boss": "local-boss"})) == "local-boss"
+        assert _boss_nick(RuntimeAgentConfig(nick="w")) == ""

--- a/tests/test_worker_boss_notice.py
+++ b/tests/test_worker_boss_notice.py
@@ -1,0 +1,72 @@
+"""Tests for the worker daemon's boss permission-notice DM (boss-agent layer)."""
+
+from __future__ import annotations
+
+from tests._sdk_stub import install_claude_sdk_stub
+
+install_claude_sdk_stub()
+
+from unittest.mock import AsyncMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+from culture.clients.claude.config import AgentConfig, DaemonConfig  # noqa: E402
+from culture.clients.claude.daemon import AgentDaemon  # noqa: E402
+
+
+def _daemon(boss: str) -> AgentDaemon:
+    config = DaemonConfig()
+    agent = AgentConfig(
+        nick="local-worker", directory="/tmp", channels=["#team", "#task-worker"], boss=boss
+    )
+    return AgentDaemon(config, agent, socket_dir="/tmp", skip_claude=True)
+
+
+class TestOnPermRequest:
+    @pytest.mark.asyncio
+    async def test_dms_boss_when_configured(self):
+        d = _daemon(boss="local-boss")
+        d._transport = AsyncMock()
+        await d._on_perm_request(
+            {"id": "req-1", "tool_name": "Edit", "input": {"file_path": "/etc/hosts"}}
+        )
+        d._transport.send_privmsg.assert_awaited_once()
+        target, text = d._transport.send_privmsg.await_args.args
+        assert target == "local-boss"
+        assert "req-1" in text
+        assert "Edit" in text
+        assert "/etc/hosts" in text
+
+    @pytest.mark.asyncio
+    async def test_no_boss_sends_nothing(self):
+        d = _daemon(boss="")
+        d._transport = AsyncMock()
+        await d._on_perm_request({"id": "req-2", "tool_name": "Bash", "input": {"command": "ls"}})
+        d._transport.send_privmsg.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_transport_sends_nothing(self):
+        d = _daemon(boss="local-boss")
+        d._transport = None
+        # Must not raise even though there's a boss but no transport yet.
+        await d._on_perm_request({"id": "req-3", "tool_name": "Bash", "input": {"command": "ls"}})
+
+
+class TestPermInputPreview:
+    def test_bash_preview(self):
+        assert (
+            AgentDaemon._perm_input_preview("Bash", {"command": "git push origin main"})
+            == "git push origin main"
+        )
+
+    def test_edit_preview(self):
+        assert AgentDaemon._perm_input_preview("Write", {"file_path": "/a/b.py"}) == "/a/b.py"
+
+    def test_mcp_preview_is_json(self):
+        out = AgentDaemon._perm_input_preview("mcp__gmail__send", {"to": "x@y.z"})
+        assert "x@y.z" in out
+
+    def test_preview_truncated_to_80(self):
+        long_cmd = "echo " + "a" * 200
+        out = AgentDaemon._perm_input_preview("Bash", {"command": long_cmd})
+        assert len(out) <= 80

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.6.0"
+version = "8.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.8.0"
+version = "8.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },

--- a/uv.lock
+++ b/uv.lock
@@ -591,7 +591,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "8.7.0"
+version = "8.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

**Stacked on #412 (which is stacked on #411) — merge #411 → #412 → this.** The dashboard work is the last commit (`bfcb34b`); earlier commits belong to #411/#412.

A local **web app** (`culture dashboard`) that turns the boss/worker machinery into a real **mission-control surface**: watch every agent live in one browser view, and when a run goes sideways, take the wheel.

You asked for "full control in case I see things go out of hand" — this is it.

## What you get

Three-pane UI (dark, no build step):
- **Agents** — live state, pending-approval count, last daemon action, BOSS tag; per-agent Pause / Resume / Close.
- **Session** — click an agent to live-stream its session (its own messages + tool calls) or its daemon actions, via SSE.
- **Pending approvals** — every worker tool request with Approve / Always / Deny.
- Top bar: pending badge, **Pause all**, red **STOP ALL** (emergency kill).

Control reuses the existing levers; the dashboard is **you** (top authority — approvals are *not* grant-ceiling-bounded, unlike the boss agent).

## Verified live

Driven in a real browser (st4ck) against a seeded mesh: agent grid renders, the SSE session stream shows audit lines with tool names, and approve→decision-written→pending-refresh works. The live test caught a real bug — `list_pending` showed already-decided requests — now fixed.

## Security (from code review — both fixed + tested)

- **Path traversal** via `{nick}` → every nick reaching a path builder is validated (`^[A-Za-z0-9][A-Za-z0-9_-]*$`).
- **DNS rebinding** → a loopback Origin/Host guard middleware rejects cross-origin / non-loopback requests (localhost bind alone isn't CSRF protection). Plus byte-offset/binary SSE tailer (non-ASCII correctness) and a bounded-deque backlog (no full-file load).

## Stack

`aiohttp` (already a dependency) + vanilla JS. `127.0.0.1`-only; refuses non-loopback `--host` without `--unsafe-bind`.

## Test plan

- [x] 19 dashboard tests (read endpoints, control actions, SSE backlog, **6 security**: path-traversal + cross-origin + non-loopback-host) + `list_pending` exclusion
- [x] Live in-browser verification (st4ck recording at `.st4ck/recordings/`)
- [x] Full suite `-n auto`: 1216 passed; 13 pre-existing baseline failures unchanged
- [x] black/isort/flake8/pylint (10.0 on new modules)/markdownlint clean
- [x] doc-test-alignment + code-reviewer subagents run; all findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)