### PR TITLE
feat(cli): expose CULTURE.DEV branding in --version and --help (#440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [13.3.0] - 2026-06-06
+
+### Added
+
+- **CULTURE.DEV** product/source branding in top-level CLI output (first release exposing the `CULTURE.DEV CLI` brand, for US trademark specimen support) ([issue #440](https://github.com/agentculture/culture/issues/440)): `culture --version` now prints `CULTURE.DEV CLI v<version>` and `culture --help` shows a `CULTURE.DEV CLI` header with the tagline "The professional workspace for agents.". The install/use command and the `culture` package name are unchanged — this is brand presentation only.
+
+### Changed
+
+- README H1 is now `CULTURE.DEV` and the Install section ties the `CULTURE.DEV` CLI to the `uv tool install culture` command; CLI reference notes the brand vs. command distinction.
+
 ## [13.2.0] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Culture
+# CULTURE.DEV
 
 Culture is a professional workspace for specialized agents.
 
@@ -65,6 +65,8 @@ are also on the way. Run `culture explain` for the always-current registry
 of what's ready vs. coming soon.
 
 ## Install
+
+Install the **CULTURE.DEV** CLI (the command stays `culture`):
 
 ```bash
 uv tool install culture

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -93,9 +93,10 @@ class _JsonAwareParser(argparse.ArgumentParser):
 def _build_parser() -> argparse.ArgumentParser:
     parser = _JsonAwareParser(
         prog="culture",
-        description="culture — AI agent IRC mesh",
+        description="CULTURE.DEV CLI\n\nThe professional workspace for agents.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument("--version", action="version", version=f"CULTURE.DEV CLI v{__version__}")
     sub = parser.add_subparsers(dest="command", parser_class=_JsonAwareParser)
     for group in GROUPS:
         group.register(sub)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -1,5 +1,8 @@
 # CLI Reference
 
+The product/source brand is **CULTURE.DEV CLI** (shown in `culture --version`
+and `culture --help`); the install/use command stays `culture`.
+
 The `culture` command manages servers, agents, bots, channels, and the
 mesh, and embeds two sibling CLIs: the agex developer-experience CLI
 as [`culture devex`](./devex/) and the afi Agent-First-Interface CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "13.2.0"
+version = "13.3.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli_branding.py
+++ b/tests/test_cli_branding.py
@@ -1,0 +1,52 @@
+"""Tests for CULTURE.DEV product branding in top-level CLI output (issue #440).
+
+The command/package stay ``culture``; the product/source brand is presented as
+``CULTURE.DEV CLI`` in ``--version`` and ``--help`` so the mark functions as the
+source brand (US trademark specimen support). These assertions pin that contract
+so the branding can't silently regress.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from culture import __version__
+from culture.cli import _build_parser
+
+
+def test_version_shows_culture_dev_brand(capsys):
+    """``culture --version`` identifies the product as ``CULTURE.DEV CLI``."""
+    parser = _build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--version"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "CULTURE.DEV CLI" in out
+    assert __version__ in out
+
+
+def test_help_shows_culture_dev_brand():
+    """``culture --help`` shows the CULTURE.DEV brand header and tagline."""
+    help_text = _build_parser().format_help()
+    assert "CULTURE.DEV CLI" in help_text
+    assert "The professional workspace for agents." in help_text
+
+
+def test_command_name_unchanged():
+    """Branding is presentation only: the command/program name stays ``culture``."""
+    parser = _build_parser()
+    assert parser.prog == "culture"
+    # The usage line still invokes the tool as ``culture`` (package unchanged).
+    assert parser.format_usage().startswith("usage: culture")
+
+
+def test_version_brand_end_to_end():
+    """The real ``python -m culture --version`` entry point is branded too."""
+    result = subprocess.run(
+        [sys.executable, "-m", "culture", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "CULTURE.DEV CLI" in result.stdout

--- a/tests/test_cli_branding.py
+++ b/tests/test_cli_branding.py
@@ -47,6 +47,7 @@ def test_version_brand_end_to_end():
         [sys.executable, "-m", "culture", "--version"],
         capture_output=True,
         text=True,
+        check=False,
     )
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
     assert "CULTURE.DEV CLI" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "13.2.0"
+version = "13.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Closes #440. Presents the product/source brand as **CULTURE.DEV CLI** in the
top-level CLI output so the mark functions as the source/product brand (US
Class 9 trademark specimen support). The command and the `culture` package
name are **unchanged** — this is brand presentation only.

## Changes

- **`culture/cli/__init__.py`** — `--version` now prints `CULTURE.DEV CLI v<version>`;
  `culture --help` shows a `CULTURE.DEV CLI` header plus the canonical tagline
  "The professional workspace for agents." (via `RawDescriptionHelpFormatter`).
  `prog="culture"` is unchanged, so the `usage:` line and all subcommands keep
  the `culture` command name. The no-arg path prints this branded help, so the
  "startup greeting" is branded without adding a separate banner.
- **`README.md`** — H1 → `# CULTURE.DEV`; Install section ties the brand to the
  `uv tool install culture` command and clarifies command (`culture`) vs. brand.
- **`docs/reference/cli/index.md`** — one line distinguishing brand vs. command.
- **`CHANGELOG.md`** — `[13.3.0]` entry explicitly records this as the first
  release exposing the `CULTURE.DEV CLI` brand (supports the "first use in
  commerce" date for the filing).
- **`tests/test_cli_branding.py`** — pins the `--version`/`--help` branding and
  guards that the program/package name stays `culture`.

### Deliberate calls

- Tagline aligned to the canonical positioning (`docs/resources/positioning.md`,
  `pyproject.toml description`) rather than the issue's suggested "Workspace
  runtime…" wording, to avoid drift from the source of truth. `positioning.md`
  is intentionally left unchanged — `CULTURE.DEV` is the stylized mark layered
  on top of that paragraph.
- Minor bump (13.2.0 → 13.3.0): user-facing branding addition, no command rename.

## Specimen evidence (captured locally)

```text
$ culture --version
CULTURE.DEV CLI v13.3.0

$ culture --help
usage: culture [-h] [--version]
               {agents,server,mesh,channel,bot,skills,devex,afi,console,explain,overview,learn}
               ...

CULTURE.DEV CLI

The professional workspace for agents.
```

## Test plan

- [x] `/run-tests` full suite — 1406 passed, 1 skipped
- [x] New `tests/test_cli_branding.py` (4 tests) green
- [x] Manual: `culture --version`, `culture --help`, no-arg help, and the
      `--json` error contract all verified (formatter change did not regress
      the `_JsonAwareParser` JSON-error path)
- [x] black / isort / flake8 / pylint / bandit / markdownlint clean

- culture (Claude)
