### PR TITLE
feat: culture doctor — diagnose manifest ↔ filesystem drift

### DIFF
--- a/.devague/frames/culture-doctor-a-top-level-command-that-diagnoses.json
+++ b/.devague/frames/culture-doctor-a-top-level-command-that-diagnoses.json
@@ -1,0 +1,243 @@
+{
+  "slug": "culture-doctor-a-top-level-command-that-diagnoses",
+  "title": "culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-06-13T17:19:17Z",
+  "updated": "2026-06-13T17:33:53Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "a top-level 'culture doctor' verb is registered in the CLI group list and dispatches without colliding with 'culture agents doctor' (the steward forward)",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "culture operators running a mesh host (e.g. spark) who manage the agent manifest, plus CI/ops automation that needs a machine-checkable gate",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "the command is runnable by an operator with no args (sensible defaults) and emits machine-parseable output (--json) for CI/ops gating",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "an operator runs 'culture doctor' and gets a categorized report of manifest<->filesystem drift (broken registrations, unregistered repos, suffix collisions) with a non-zero exit code when problems exist",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "the report cleanly separates the three drift classes and each problem line names the offending nick/repo and the suggested fix command (e.g. 'culture agents unregister <suffix>' / 'culture agents register <path>')",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "drift is only surfaced as a side-effect WARNING inside resolve_agents() when agents are resolved; there is no first-class command to audit the manifest, and nothing detects unregistered repos or suffix collisions at all",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "doctor reuses the existing resolve_agents()/load_culture_yaml() validation in culture/config.py rather than reimplementing the missing-dir / missing-yaml / suffix-not-in-yaml checks",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "stale manifest entries and unregistered repos silently break agent start/observe; operators discover drift by accident. A doctor makes the existing resolve_agents() validation a first-class, scriptable health check",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "the warning logic in resolve_agents() remains the runtime path; doctor surfaces the same findings as an explicit, exit-coded report without changing resolve-time behavior",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c6",
+      "kind": "boundary",
+      "text": "culture doctor checks manifest<->filesystem consistency ONLY; it does NOT do agent alignment/config-quality doctoring (that stays 'culture agents doctor' forwarded to steward) and it does not auto-fix or mutate the manifest",
+      "origin": "user",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "running 'culture doctor' performs zero writes to server.yaml or any culture.yaml, verified by a test asserting the manifest file is byte-identical before/after",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c7",
+      "kind": "success_signal",
+      "text": "on a healthy host doctor exits 0 with an all-clear; on the current spark host it reports 3 missing-dir registrations, ~44 unregistered culture.yaml repos, and the culture-sonar-cli/daria suffix collision, and exits non-zero",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "exit code is 0 only when zero problems are found in ALL three classes; any class-1 or class-3 problem forces non-zero; class-2 (unregistered repos) severity is a confirmed decision (warning-only vs error)",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c8",
+      "kind": "non_goal",
+      "text": "not an auto-remediation tool (no auto-unregister/auto-register); not a watcher/daemon; does not reach across linked peers or other hosts' manifests",
+      "origin": "user",
+      "status": "rejected",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c9",
+      "kind": "requirement",
+      "text": "doctor scans a configurable repo root (default: parent dir of registered repos / a sensible workspace root) to find on-disk culture.yaml files for the unregistered-repo check",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "the scan root is discoverable without guessing: doctor derives candidate roots from the parent directories of already-registered manifest paths (and accepts an explicit --root override), so it works on any host without hardcoding /home/spark/git",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c10",
+      "kind": "decision",
+      "text": "lives as a top-level 'culture doctor' verb (own CLI group), NOT under 'culture agents', to avoid the steward-forwarded doctor verb",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c11",
+      "kind": "requirement",
+      "text": "for class-2, doctor enumerates the relevant GitHub org(s) remotely and lists repos whose default (main) branch contains a culture.yaml; it compares that org-declared agent set against the local manifest and reports org repos with culture.yaml that are not registered on this host (warning-only)",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "doctor discovers the org(s) to enumerate from the git remotes of already-registered repos (their origin owner) rather than hardcoding an org, and accepts an explicit --org override; detection of culture.yaml on main uses the GitHub API (gh) without cloning",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "for class-2 (unregistered repos), doctor scans the local filesystem one level above the culture repo (the workspace parent, e.g. /home/spark/git) for */culture.yaml and reports any whose directory is not in the manifest \u2014 warning-only, exit 0; default root = the culture repo's parent, overridable with --root",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h10",
+          "text": "the scan root defaults to the parent directory of the culture repo (resolved at runtime, not hardcoded to /home/spark/git) and accepts --root PATH; the comparison is local-disk vs the Culture-CLI-managed manifest only \u2014 no network, no git remotes, no org calls",
+          "status": "rejected"
+        },
+        {
+          "id": "h11",
+          "text": "class-2 findings are warning-only: they print with a 'culture agents register <path>' hint and never change the exit code; only class-1 (broken registration) and class-3 (suffix collision) make doctor exit non-zero",
+          "status": "confirmed"
+        },
+        {
+          "id": "h14",
+          "text": "the class-2 scan root is derived from the culture repo's OWN location at runtime \u2014 its parent directory \u2014 discovered via the manifest's self-entry for this repo (falling back to the in-tree cwd repo root), so moving the workspace to /git2 moves the scan root automatically; never hardcoded; --root overrides",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c13",
+      "kind": "boundary",
+      "text": "culture doctor checks manifest<->filesystem consistency and can REGISTER discovered repos into our own server.yaml manifest (opt-in, e.g. --fix/--register); it never edits the other repos' culture.yaml or any file we don't own, and it never does agent alignment/config-quality doctoring (that stays 'culture agents doctor' forwarded to steward)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "a test proves doctor never modifies any discovered repo's culture.yaml (those files byte-identical before/after, even in --fix mode); only ~/.culture/server.yaml may change, and only when the fix is explicitly requested",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c14",
+      "kind": "non_goal",
+      "text": "not an auto-UNregister tool (removing stale class-1 entries stays a human decision / suggested command); not a watcher/daemon; does not reach across linked peers or other hosts' manifests; never writes to a repo's own culture.yaml",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c15",
+      "kind": "requirement",
+      "text": "doctor offers an opt-in fix that registers class-2 repos (on-disk culture.yaml not in the manifest) by ADDING them to ~/.culture/server.yaml via the existing add_to_manifest()/register path; default run stays read-only/diagnose; the fix writes only server.yaml, never the discovered repo's culture.yaml",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "the fix path reuses add_to_manifest()/the existing register code (not a parallel writer), is idempotent (re-running registers nothing new), and prints exactly which suffix->path entries it added; default invocation makes zero writes",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    }
+  ],
+  "open_vagueness": []
+}

--- a/.devague/plans/culture-doctor-a-top-level-command-that-diagnoses.json
+++ b/.devague/plans/culture-doctor-a-top-level-command-that-diagnoses.json
@@ -1,0 +1,286 @@
+{
+  "slug": "culture-doctor-a-top-level-command-that-diagnoses",
+  "title": "culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems",
+  "frame_slug": "culture-doctor-a-top-level-command-that-diagnoses",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-06-13T17:36:00Z",
+  "updated": "2026-06-13T17:38:53Z",
+  "targets": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems"
+    },
+    {
+      "id": "h4",
+      "kind": "honesty",
+      "text": "a top-level 'culture doctor' verb is registered in the CLI group list and dispatches without colliding with 'culture agents doctor' (the steward forward)"
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "culture operators running a mesh host (e.g. spark) who manage the agent manifest, plus CI/ops automation that needs a machine-checkable gate"
+    },
+    {
+      "id": "h5",
+      "kind": "honesty",
+      "text": "the command is runnable by an operator with no args (sensible defaults) and emits machine-parseable output (--json) for CI/ops gating"
+    },
+    {
+      "id": "c3",
+      "kind": "after_state",
+      "text": "an operator runs 'culture doctor' and gets a categorized report of manifest<->filesystem drift (broken registrations, unregistered repos, suffix collisions) with a non-zero exit code when problems exist"
+    },
+    {
+      "id": "h2",
+      "kind": "honesty",
+      "text": "the report cleanly separates the three drift classes and each problem line names the offending nick/repo and the suggested fix command (e.g. 'culture agents unregister <suffix>' / 'culture agents register <path>')"
+    },
+    {
+      "id": "c4",
+      "kind": "before_state",
+      "text": "drift is only surfaced as a side-effect WARNING inside resolve_agents() when agents are resolved; there is no first-class command to audit the manifest, and nothing detects unregistered repos or suffix collisions at all"
+    },
+    {
+      "id": "h6",
+      "kind": "honesty",
+      "text": "doctor reuses the existing resolve_agents()/load_culture_yaml() validation in culture/config.py rather than reimplementing the missing-dir / missing-yaml / suffix-not-in-yaml checks"
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "stale manifest entries and unregistered repos silently break agent start/observe; operators discover drift by accident. A doctor makes the existing resolve_agents() validation a first-class, scriptable health check"
+    },
+    {
+      "id": "h7",
+      "kind": "honesty",
+      "text": "the warning logic in resolve_agents() remains the runtime path; doctor surfaces the same findings as an explicit, exit-coded report without changing resolve-time behavior"
+    },
+    {
+      "id": "c7",
+      "kind": "success_signal",
+      "text": "on a healthy host doctor exits 0 with an all-clear; on the current spark host it reports 3 missing-dir registrations, ~44 unregistered culture.yaml repos, and the culture-sonar-cli/daria suffix collision, and exits non-zero"
+    },
+    {
+      "id": "h3",
+      "kind": "honesty",
+      "text": "exit code is 0 only when zero problems are found in ALL three classes; any class-1 or class-3 problem forces non-zero; class-2 (unregistered repos) severity is a confirmed decision (warning-only vs error)"
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "for class-2 (unregistered repos), doctor scans the local filesystem one level above the culture repo (the workspace parent, e.g. /home/spark/git) for */culture.yaml and reports any whose directory is not in the manifest \u2014 warning-only, exit 0; default root = the culture repo's parent, overridable with --root"
+    },
+    {
+      "id": "h11",
+      "kind": "honesty",
+      "text": "class-2 findings are warning-only: they print with a 'culture agents register <path>' hint and never change the exit code; only class-1 (broken registration) and class-3 (suffix collision) make doctor exit non-zero"
+    },
+    {
+      "id": "h14",
+      "kind": "honesty",
+      "text": "the class-2 scan root is derived from the culture repo's OWN location at runtime \u2014 its parent directory \u2014 discovered via the manifest's self-entry for this repo (falling back to the in-tree cwd repo root), so moving the workspace to /git2 moves the scan root automatically; never hardcoded; --root overrides"
+    },
+    {
+      "id": "c13",
+      "kind": "boundary",
+      "text": "culture doctor checks manifest<->filesystem consistency and can REGISTER discovered repos into our own server.yaml manifest (opt-in, e.g. --fix/--register); it never edits the other repos' culture.yaml or any file we don't own, and it never does agent alignment/config-quality doctoring (that stays 'culture agents doctor' forwarded to steward)"
+    },
+    {
+      "id": "h12",
+      "kind": "honesty",
+      "text": "a test proves doctor never modifies any discovered repo's culture.yaml (those files byte-identical before/after, even in --fix mode); only ~/.culture/server.yaml may change, and only when the fix is explicitly requested"
+    },
+    {
+      "id": "c15",
+      "kind": "requirement",
+      "text": "doctor offers an opt-in fix that registers class-2 repos (on-disk culture.yaml not in the manifest) by ADDING them to ~/.culture/server.yaml via the existing add_to_manifest()/register path; default run stays read-only/diagnose; the fix writes only server.yaml, never the discovered repo's culture.yaml"
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "the fix path reuses add_to_manifest()/the existing register code (not a parallel writer), is idempotent (re-running registers nothing new), and prints exactly which suffix->path entries it added; default invocation makes zero writes"
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "Define the doctor result model: Finding + DoctorReport dataclasses in culture/doctor/model.py",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "Finding carries drift_class (1|2|3), severity ('error'|'warning'), subject (nick/suffix), path, message, fix_hint; DoctorReport groups class1/class2/class3 finding lists",
+        "DoctorReport.exit_code is nonzero iff any class-1 or class-3 finding exists; class-2-only and empty reports both yield exit_code 0 (unit-tested for all three cases)"
+      ],
+      "deps": [],
+      "covers": [
+        "h3",
+        "h11"
+      ]
+    },
+    {
+      "id": "t2",
+      "summary": "Scan-root resolution + on-disk repo discovery in culture/doctor/discovery.py",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "resolve_scan_root(config, cwd=None, override=None) returns override when given; else the parent of the culture repo derived from the manifest self-entry; else the parent of the cwd git-root \u2014 no path literal hardcoded",
+        "Relocating a fixture culture repo from <tmp>/git to <tmp>/git2 changes the resolved scan root accordingly (tmpdir test)",
+        "discover_ondisk_repos(root) yields exactly one entry per <root>/*/culture.yaml with its declared suffix(es); a fixture of 3 culture.yaml repos + 1 plain dir yields 3 entries"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c12",
+        "h14"
+      ]
+    },
+    {
+      "id": "t3",
+      "summary": "Three drift-class checks (class1 broken-registration, class2 unregistered, class3 suffix-collision) in culture/doctor/checks.py",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "check_registrations(config) reuses load_culture_yaml(); a fixture manifest with one missing-dir + one missing-yaml + one registered-suffix-not-in-yaml yields exactly 3 class-1 findings; a fully valid manifest yields none",
+        "A parity test asserts class-1 findings match exactly what resolve_agents() warns on for the same manifest (proves reuse, not reimplementation; resolve-time warning path is left unchanged)",
+        "check_unregistered(config, discovered) flags discovered repos whose dir is not a manifest value (severity warning); check_suffix_collisions(config, discovered) flags a discovered suffix already bound to a different path in the manifest, and duplicate suffixes across discovered repos (severity error) \u2014 and does NOT flag the ordinary unregistered repos that simply declare their own unique suffix"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c4",
+        "h6",
+        "h7"
+      ]
+    },
+    {
+      "id": "t4",
+      "summary": "Opt-in register fix in culture/doctor/fix.py (adds class-2 repos to server.yaml via add_to_manifest)",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "register_unregistered(config_path, class2_findings) adds each unregistered repo via the existing add_to_manifest() (not a parallel YAML writer) and returns the list of suffix->path entries added",
+        "Idempotent: a second run over the same findings adds nothing; empty findings performs zero writes",
+        "Test asserts every discovered repo's culture.yaml is byte-identical before/after, and only ~/.culture/server.yaml changed"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c15",
+        "h13",
+        "h12",
+        "c13"
+      ]
+    },
+    {
+      "id": "t5",
+      "summary": "run_doctor() orchestrator in culture/doctor/__init__.py composing discovery + 3 checks + optional fix",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "run_doctor(config, root_override=None, fix=False) -> DoctorReport composes discovery + the three checks, applying the fix only when fix=True",
+        "On a fixture mirroring spark (3 missing-dir manifest entries, several unregistered repos incl. one duplicate-suffix collision) the report has 3 class-1, >=1 class-2, >=1 class-3 findings and exit_code != 0; on an all-valid fixture the report is empty with exit_code 0",
+        "With fix=False, run_doctor writes no files (manifest byte-identical)"
+      ],
+      "deps": [
+        "t2",
+        "t3",
+        "t4"
+      ],
+      "covers": [
+        "c1",
+        "c3",
+        "c7"
+      ]
+    },
+    {
+      "id": "t6",
+      "summary": "CLI group 'culture doctor' in culture/cli/doctor.py (flags, rendering, exit codes, --json)",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "Exports NAME='doctor', register(subparsers) and dispatch(args) per the cli module pattern; flags: --json, --root PATH, --fix/--register",
+        "No-args run prints a human report grouped by the 3 drift classes; each problem line names the repo/nick and the exact suggested command ('culture agents unregister <suffix>' for class-1, 'culture agents register <path>' for class-2); --json emits the same findings as a structured payload",
+        "Process exits nonzero iff a class-1 or class-3 finding exists (class-2-only exits 0); --fix registers class-2 repos and prints what it added; a test asserts the manifest is unmodified after a non---fix run"
+      ],
+      "deps": [
+        "t5"
+      ],
+      "covers": [
+        "h4",
+        "h5",
+        "h2",
+        "c2",
+        "h3",
+        "h11"
+      ]
+    },
+    {
+      "id": "t7",
+      "summary": "Register the doctor group in culture/cli/__init__.py GROUPS and prove no steward-forward collision",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "'doctor' module added to the GROUPS registry; 'culture doctor --help' and 'culture doctor' dispatch to the new handler",
+        "Test asserts top-level 'culture doctor' does NOT route through _maybe_forward_to_steward, while 'culture agents doctor' still short-circuits to the steward forward (the existing alignment verb is untouched)"
+      ],
+      "deps": [
+        "t6"
+      ],
+      "covers": [
+        "c1",
+        "h4"
+      ]
+    },
+    {
+      "id": "t8",
+      "summary": "Document the feature in docs/doctor.md",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "docs/doctor.md covers purpose, the 3 drift classes, all flags (--json, --root, --fix), exit-code semantics, and the boundary vs the steward-forwarded 'culture agents doctor'",
+        "markdownlint-cli2 passes on docs/doctor.md"
+      ],
+      "deps": [
+        "t6"
+      ],
+      "covers": [
+        "c5",
+        "c13"
+      ]
+    },
+    {
+      "id": "t9",
+      "summary": "Bump version (minor) and update CHANGELOG.md + uv.lock for the new feature",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "pyproject.toml version bumped minor (new feature) via /version-bump; CHANGELOG.md gets a Keep-a-Changelog entry for 'culture doctor'; uv.lock staged alongside",
+        "version-check CI job passes (version strictly greater than main)"
+      ],
+      "deps": [
+        "t7",
+        "t8"
+      ],
+      "covers": []
+    }
+  ],
+  "risks": [
+    {
+      "id": "r1",
+      "text": "Scan-root self-identification: when culture is installed as a uv tool (not editable / not run from the checkout), discovering 'this repo' from the manifest self-entry vs cwd git-root may need iteration; --root is the always-correct escape hatch",
+      "kind": "unknown_nonblocking",
+      "task_id": "t2"
+    },
+    {
+      "id": "r2",
+      "text": "Class-3 collision scope: must distinguish a genuine duplicate-suffix collision from the ~44 legitimate unregistered repos that each declare their own unique suffix; over-broad matching would flag healthy repos",
+      "kind": "unknown_nonblocking",
+      "task_id": "t3"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [13.6.0] - 2026-06-13
+
+### Added
+
+- `culture doctor` — a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos. Detects three drift classes (broken registrations, unregistered repos, suffix collisions), exits non-zero on class-1/class-3, supports --json for CI gating, --root to override the scan root, and an opt-in --fix/--register that adds unregistered repos to server.yaml via the existing add_to_manifest path (never touching the repos own culture.yaml). Distinct from the steward-forwarded `culture agents doctor` (agent alignment).
+
 ## [13.5.0] - 2026-06-13
 
 ### Added

--- a/culture/cli/__init__.py
+++ b/culture/cli/__init__.py
@@ -32,6 +32,7 @@ from culture.cli import (
     channel,
     console,
     devex,
+    doctor,
     introspect,
     mesh,
     server,
@@ -40,7 +41,7 @@ from culture.cli import (
 from culture.cli._errors import EXIT_USER_ERROR, CultureError
 from culture.cli._output import emit_error
 
-GROUPS = [agents, server, mesh, channel, bot, skills, devex, afi, console, introspect]
+GROUPS = [agents, server, mesh, channel, bot, skills, devex, afi, console, introspect, doctor]
 
 
 def _names_of(group) -> set[str]:

--- a/culture/cli/doctor.py
+++ b/culture/cli/doctor.py
@@ -34,40 +34,45 @@ def register(subparsers):
     )
 
 
+def _emit_json(report) -> None:
+    from dataclasses import asdict
+
+    payload = {
+        "class1": [asdict(f) for f in report.class1],
+        "class2": [asdict(f) for f in report.class2],
+        "class3": [asdict(f) for f in report.class3],
+        "ok": report.ok,
+        "exit_code": report.exit_code,
+    }
+    print(json.dumps(payload, indent=2))
+
+
+def _render_human(report) -> None:
+    if report.ok:
+        print("✓ culture doctor: no drift detected")
+        return
+    sections = [
+        ("Broken registrations (class 1)", report.class1, "✗"),
+        ("Unregistered repos (class 2, warning)", report.class2, "•"),
+        ("Suffix collisions (class 3)", report.class3, "⚠"),
+    ]
+    for label, findings, icon in sections:
+        if not findings:
+            continue
+        print(f"{label}:")
+        for f in findings:
+            print(f"  {icon} {f.subject}: {f.message}")
+            if f.fix_hint:
+                print(f"      fix: {f.fix_hint}")
+
+
 def dispatch(args):
     config = load_config_or_default(args.config)
     report = run_doctor(config, root_override=args.root)  # diagnose only
     if args.json:
-        from dataclasses import asdict
-
-        payload = {
-            "class1": [asdict(f) for f in report.class1],
-            "class2": [asdict(f) for f in report.class2],
-            "class3": [asdict(f) for f in report.class3],
-            "ok": report.ok,
-            "exit_code": report.exit_code,
-        }
-        print(json.dumps(payload, indent=2))
+        _emit_json(report)
     else:
-        if report.ok:
-            print("✓ culture doctor: no drift detected")
-        else:
-            if report.class1:
-                print("Broken registrations (class 1):")
-                for f in report.class1:
-                    print(f"  ✗ {f.subject}: {f.message}")
-                    if f.fix_hint:
-                        print(f"      fix: {f.fix_hint}")
-            if report.class2:
-                print("Unregistered repos (class 2, warning):")
-                for f in report.class2:
-                    print(f"  • {f.subject}: {f.message}")
-                    if f.fix_hint:
-                        print(f"      fix: {f.fix_hint}")
-            if report.class3:
-                print("Suffix collisions (class 3):")
-                for f in report.class3:
-                    print(f"  ⚠ {f.subject}: {f.message}")
+        _render_human(report)
     if args.fix and report.class2:
         added = register_unregistered(args.config, report.class2)
         for suffix, directory in added:

--- a/culture/cli/doctor.py
+++ b/culture/cli/doctor.py
@@ -1,0 +1,75 @@
+"""Doctor subcommand: culture doctor — diagnose drift between manifest and on-disk repos."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from culture.cli.shared.constants import _CONFIG_HELP, DEFAULT_CONFIG
+from culture.config import load_config_or_default
+from culture.doctor import run_doctor
+from culture.doctor.fix import register_unregistered
+
+NAME = "doctor"
+
+
+def register(subparsers):
+    p = subparsers.add_parser(
+        "doctor", help="Diagnose drift between the agent manifest and on-disk culture.yaml repos"
+    )
+    p.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
+    p.add_argument(
+        "--root",
+        default=None,
+        help="Workspace root to scan for on-disk culture.yaml repos (default: the culture repo's parent)",
+    )
+    p.add_argument("--json", action="store_true", help="Emit findings as JSON")
+    p.add_argument(
+        "--fix",
+        "--register",
+        dest="fix",
+        action="store_true",
+        help="Register class-2 (unregistered on-disk) repos into server.yaml",
+    )
+
+
+def dispatch(args):
+    config = load_config_or_default(args.config)
+    report = run_doctor(config, root_override=args.root, config_path=args.config)  # diagnose only
+    if args.json:
+        from dataclasses import asdict
+
+        payload = {
+            "class1": [asdict(f) for f in report.class1],
+            "class2": [asdict(f) for f in report.class2],
+            "class3": [asdict(f) for f in report.class3],
+            "ok": report.ok,
+            "exit_code": report.exit_code,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        if report.ok:
+            print("✓ culture doctor: no drift detected")
+        else:
+            if report.class1:
+                print("Broken registrations (class 1):")
+                for f in report.class1:
+                    print(f"  ✗ {f.subject}: {f.message}")
+                    if f.fix_hint:
+                        print(f"      fix: {f.fix_hint}")
+            if report.class2:
+                print("Unregistered repos (class 2, warning):")
+                for f in report.class2:
+                    print(f"  • {f.subject}: {f.message}")
+                    if f.fix_hint:
+                        print(f"      fix: {f.fix_hint}")
+            if report.class3:
+                print("Suffix collisions (class 3):")
+                for f in report.class3:
+                    print(f"  ⚠ {f.subject}: {f.message}")
+    if args.fix and report.class2:
+        added = register_unregistered(args.config, report.class2)
+        for suffix, directory in added:
+            print(f"registered: {suffix} -> {directory}")
+    sys.exit(report.exit_code)

--- a/culture/cli/doctor.py
+++ b/culture/cli/doctor.py
@@ -36,7 +36,7 @@ def register(subparsers):
 
 def dispatch(args):
     config = load_config_or_default(args.config)
-    report = run_doctor(config, root_override=args.root, config_path=args.config)  # diagnose only
+    report = run_doctor(config, root_override=args.root)  # diagnose only
     if args.json:
         from dataclasses import asdict
 

--- a/culture/doctor/__init__.py
+++ b/culture/doctor/__init__.py
@@ -9,7 +9,6 @@ from culture.doctor.checks import (
     check_unregistered,
 )
 from culture.doctor.discovery import discover_ondisk_repos, resolve_scan_root
-from culture.doctor.fix import register_unregistered
 from culture.doctor.model import DoctorReport, Finding
 
 __all__ = ["run_doctor", "DoctorReport", "Finding"]
@@ -18,11 +17,14 @@ __all__ = ["run_doctor", "DoctorReport", "Finding"]
 def run_doctor(
     config: ServerConfig,
     root_override: str | None = None,
-    fix: bool = False,
-    config_path: str | None = None,
     cwd: str | None = None,
 ) -> DoctorReport:
-    """Run the full culture doctor diagnostic pass."""
+    """Run the full culture doctor diagnostic pass (read-only).
+
+    Diagnosis only — applying the opt-in fix is the caller's job (the CLI calls
+    :func:`culture.doctor.fix.register_unregistered` on ``report.class2``), so
+    the registered-pairs list is surfaced to the operator.
+    """
     report = DoctorReport()
 
     report.class1 = check_registrations(config)
@@ -32,8 +34,5 @@ def run_doctor(
 
     report.class2 = check_unregistered(config, discovered)
     report.class3 = check_suffix_collisions(config, discovered)
-
-    if fix and config_path is not None:
-        register_unregistered(config_path, report.class2)
 
     return report

--- a/culture/doctor/__init__.py
+++ b/culture/doctor/__init__.py
@@ -1,0 +1,39 @@
+"""Culture doctor — run_doctor orchestrator."""
+
+from __future__ import annotations
+
+from culture.config import ServerConfig
+from culture.doctor.checks import (
+    check_registrations,
+    check_suffix_collisions,
+    check_unregistered,
+)
+from culture.doctor.discovery import discover_ondisk_repos, resolve_scan_root
+from culture.doctor.fix import register_unregistered
+from culture.doctor.model import DoctorReport, Finding
+
+__all__ = ["run_doctor", "DoctorReport", "Finding"]
+
+
+def run_doctor(
+    config: ServerConfig,
+    root_override: str | None = None,
+    fix: bool = False,
+    config_path: str | None = None,
+    cwd: str | None = None,
+) -> DoctorReport:
+    """Run the full culture doctor diagnostic pass."""
+    report = DoctorReport()
+
+    report.class1 = check_registrations(config)
+
+    root = resolve_scan_root(config, cwd=cwd, override=root_override)
+    discovered = discover_ondisk_repos(root)
+
+    report.class2 = check_unregistered(config, discovered)
+    report.class3 = check_suffix_collisions(config, discovered)
+
+    if fix and config_path is not None:
+        register_unregistered(config_path, report.class2)
+
+    return report

--- a/culture/doctor/checks.py
+++ b/culture/doctor/checks.py
@@ -80,10 +80,14 @@ def check_suffix_collisions(config, discovered) -> list[Finding]:
                     )
                 )
 
-    # (b) duplicate suffix across two discovered repos
+    # (b) duplicate suffix across two discovered repos. Suffixes already bound
+    # in the manifest are check (a)'s responsibility — skip them here so a
+    # manifest collision isn't double-reported.
     seen: dict[str, str] = {}
     for repo in discovered:
         for s in repo.suffixes:
+            if s in config.manifest:
+                continue
             resolved = str(Path(repo.directory).resolve())
             if s in seen and seen[s] != resolved:
                 findings.append(

--- a/culture/doctor/checks.py
+++ b/culture/doctor/checks.py
@@ -1,0 +1,102 @@
+"""Drift-class checks for the culture doctor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from culture.config import load_culture_yaml
+from culture.doctor.model import Finding
+
+
+def check_registrations(config) -> list[Finding]:
+    """Class 1: manifest entries that cannot be loaded."""
+    findings: list[Finding] = []
+    for suffix, directory in config.manifest.items():
+        nick = f"{config.server.name}-{suffix}"
+        try:
+            load_culture_yaml(directory, suffix=suffix)
+        except FileNotFoundError:
+            findings.append(
+                Finding(
+                    1,
+                    "error",
+                    nick,
+                    directory,
+                    f"culture.yaml missing for {nick} at {directory}",
+                    f"culture agents unregister {suffix}",
+                )
+            )
+        except ValueError as e:
+            findings.append(
+                Finding(
+                    1,
+                    "error",
+                    nick,
+                    directory,
+                    f"{nick}: {e}",
+                    f"culture agents unregister {suffix}",
+                )
+            )
+    return findings
+
+
+def check_unregistered(config, discovered) -> list[Finding]:
+    """Class 2: on-disk repos not registered in the manifest."""
+    manifest_dirs = {str(Path(d).resolve()) for d in config.manifest.values()}
+    findings: list[Finding] = []
+    for repo in discovered:
+        if str(Path(repo.directory).resolve()) not in manifest_dirs:
+            findings.append(
+                Finding(
+                    2,
+                    "warning",
+                    Path(repo.directory).name,
+                    repo.directory,
+                    f"on-disk culture.yaml not registered: {repo.directory}",
+                    f"culture agents register {repo.directory}",
+                )
+            )
+    return findings
+
+
+def check_suffix_collisions(config, discovered) -> list[Finding]:
+    """Class 3: suffix collisions between manifest and discovered repos."""
+    findings: list[Finding] = []
+
+    # (a) a discovered suffix already bound to a DIFFERENT path in the manifest
+    for repo in discovered:
+        for s in repo.suffixes:
+            if s in config.manifest and str(Path(config.manifest[s]).resolve()) != str(
+                Path(repo.directory).resolve()
+            ):
+                findings.append(
+                    Finding(
+                        3,
+                        "error",
+                        s,
+                        repo.directory,
+                        f"suffix '{s}' at {repo.directory} collides with registered {config.manifest[s]}",
+                        "",
+                    )
+                )
+
+    # (b) duplicate suffix across two discovered repos
+    seen: dict[str, str] = {}
+    for repo in discovered:
+        for s in repo.suffixes:
+            resolved = str(Path(repo.directory).resolve())
+            if s in seen and seen[s] != resolved:
+                findings.append(
+                    Finding(
+                        3,
+                        "error",
+                        s,
+                        repo.directory,
+                        f"suffix '{s}' declared by both {seen[s]} and {repo.directory}",
+                        "",
+                    )
+                )
+            else:
+                seen[s] = resolved
+
+    return findings

--- a/culture/doctor/checks.py
+++ b/culture/doctor/checks.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from yaml import YAMLError
+
 from culture.config import load_culture_yaml
 from culture.doctor.model import Finding
 
@@ -26,7 +28,8 @@ def check_registrations(config) -> list[Finding]:
                     f"culture agents unregister {suffix}",
                 )
             )
-        except ValueError as e:
+        except (ValueError, YAMLError) as e:
+            # Malformed/unloadable culture.yaml is itself a broken registration.
             findings.append(
                 Finding(
                     1,
@@ -59,11 +62,9 @@ def check_unregistered(config, discovered) -> list[Finding]:
     return findings
 
 
-def check_suffix_collisions(config, discovered) -> list[Finding]:
-    """Class 3: suffix collisions between manifest and discovered repos."""
+def _manifest_collisions(config, discovered) -> list[Finding]:
+    """A discovered suffix already bound to a DIFFERENT path in the manifest."""
     findings: list[Finding] = []
-
-    # (a) a discovered suffix already bound to a DIFFERENT path in the manifest
     for repo in discovered:
         for s in repo.suffixes:
             if s in config.manifest and str(Path(config.manifest[s]).resolve()) != str(
@@ -79,10 +80,14 @@ def check_suffix_collisions(config, discovered) -> list[Finding]:
                         "",
                     )
                 )
+    return findings
 
-    # (b) duplicate suffix across two discovered repos. Suffixes already bound
-    # in the manifest are check (a)'s responsibility — skip them here so a
-    # manifest collision isn't double-reported.
+
+def _discovered_duplicates(config, discovered) -> list[Finding]:
+    """The same suffix declared by two discovered repos. Suffixes already bound
+    in the manifest are :func:`_manifest_collisions`' responsibility — skip them
+    here so a manifest collision isn't double-reported."""
+    findings: list[Finding] = []
     seen: dict[str, str] = {}
     for repo in discovered:
         for s in repo.suffixes:
@@ -102,5 +107,9 @@ def check_suffix_collisions(config, discovered) -> list[Finding]:
                 )
             else:
                 seen[s] = resolved
-
     return findings
+
+
+def check_suffix_collisions(config, discovered) -> list[Finding]:
+    """Class 3: suffix collisions between manifest and discovered repos."""
+    return _manifest_collisions(config, discovered) + _discovered_duplicates(config, discovered)

--- a/culture/doctor/discovery.py
+++ b/culture/doctor/discovery.py
@@ -1,0 +1,73 @@
+"""On-disk discovery helpers for the culture doctor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from culture.config import load_culture_yaml
+
+
+@dataclass
+class RepoOnDisk:
+    """A repo directory discovered on disk."""
+
+    directory: str  # resolved absolute path
+    suffixes: list[str]  # declared suffix(es) from its culture.yaml
+
+
+def resolve_scan_root(config, cwd=None, override=None) -> Path:
+    """Determine the root directory to scan.
+
+    Priority:
+    1. *override* if provided.
+    2. Parent of the culture repo found via manifest or git walk.
+    """
+    if override is not None:
+        return Path(override).resolve()
+
+    repo_dir = _find_culture_repo(config, Path(cwd) if cwd else Path.cwd())
+    return repo_dir.parent.resolve()
+
+
+def _find_culture_repo(config, start: Path) -> Path:
+    """Find the culture repo directory.
+
+    PRIMARY: check manifest entries for a path that contains this module.
+    FALLBACK: walk up from *start* until a ``.git`` entry is found.
+    """
+    this_file = Path(__file__).resolve()
+    for d in config.manifest.values():
+        rd = Path(d).resolve()
+        if rd == this_file or rd in this_file.parents:
+            return rd
+
+    current = start.resolve()
+    while True:
+        if (current / ".git").exists():
+            return current
+        parent = current.parent
+        if parent == current:
+            return start
+        current = parent
+
+
+def discover_ondisk_repos(root) -> list[RepoOnDisk]:
+    """Discover repos under *root* that have a culture.yaml."""
+
+    root = Path(root)
+    results: list[RepoOnDisk] = []
+
+    for child in sorted(p for p in root.iterdir() if p.is_dir()):
+        try:
+            agents = load_culture_yaml(str(child))
+        except Exception:
+            continue
+        results.append(
+            RepoOnDisk(
+                directory=str(child.resolve()),
+                suffixes=[a.suffix for a in agents],
+            )
+        )
+
+    return results

--- a/culture/doctor/discovery.py
+++ b/culture/doctor/discovery.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from yaml import YAMLError
+
 from culture.config import load_culture_yaml
+
+logger = logging.getLogger("culture")
 
 
 @dataclass
@@ -61,7 +66,10 @@ def discover_ondisk_repos(root) -> list[RepoOnDisk]:
     for child in sorted(p for p in root.iterdir() if p.is_dir()):
         try:
             agents = load_culture_yaml(str(child))
-        except Exception:
+        except (OSError, ValueError, YAMLError) as exc:
+            # No culture.yaml (the common case) or an unreadable/malformed one:
+            # skip it, but don't swallow the reason entirely.
+            logger.debug("skipping %s during doctor scan: %s", child, exc)
             continue
         results.append(
             RepoOnDisk(

--- a/culture/doctor/fix.py
+++ b/culture/doctor/fix.py
@@ -1,0 +1,30 @@
+"""Culture doctor fix actions for unregistered repos."""
+
+from __future__ import annotations
+
+from culture.config import add_to_manifest, load_culture_yaml
+from culture.doctor.model import Finding
+
+
+def register_unregistered(
+    config_path: str, class2_findings: list[Finding]
+) -> list[tuple[str, str]]:
+    """Register each class-2 (unregistered on-disk) repo into the server.yaml at config_path.
+
+    Reuses add_to_manifest (writes ONLY server.yaml; never the repo's culture.yaml).
+    Idempotent: a suffix already in the manifest is skipped. Returns the (suffix, directory)
+    pairs actually added. Empty findings -> no writes, returns [].
+    """
+    added: list[tuple[str, str]] = []
+    for f in class2_findings:
+        try:
+            agents = load_culture_yaml(f.path)
+        except Exception:
+            continue
+        for a in agents:
+            try:
+                add_to_manifest(config_path, a.suffix, f.path)
+                added.append((a.suffix, f.path))
+            except ValueError:
+                continue  # already registered -> idempotent skip
+    return added

--- a/culture/doctor/model.py
+++ b/culture/doctor/model.py
@@ -1,0 +1,34 @@
+"""Data model for culture doctor diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Finding:
+    """A single drift finding from the doctor scan."""
+
+    drift_class: int  # 1, 2, or 3
+    severity: str  # 'error' or 'warning'
+    subject: str  # agent nick or suffix, or repo dir name
+    path: str
+    message: str
+    fix_hint: str  # suggested shell command or ''
+
+
+@dataclass
+class DoctorReport:
+    """Aggregated doctor report grouped by drift class."""
+
+    class1: list[Finding] = field(default_factory=list)
+    class2: list[Finding] = field(default_factory=list)
+    class3: list[Finding] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not (self.class1 or self.class2 or self.class3)
+
+    @property
+    def exit_code(self) -> int:
+        return 1 if (self.class1 or self.class3) else 0

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,115 @@
+# culture doctor
+
+`culture doctor` is a top-level command that diagnoses **drift** between the
+agent manifest (`~/.culture/server.yaml`, the `agents:` map of `suffix ->
+directory`) and the on-disk `culture.yaml` repos in your workspace. It exits
+non-zero when it finds real breakage, so it doubles as a CI/ops health gate.
+
+```bash
+culture doctor                 # human-readable report
+culture doctor --json          # machine-readable, for CI
+culture doctor --fix           # also register unregistered repos (opt-in)
+```
+
+## What it checks
+
+`culture doctor` reports three independent **drift classes**.
+
+### Class 1 — Broken registrations
+
+A manifest entry that cannot be resolved: its directory is missing, its
+`culture.yaml` is missing, or the registered suffix is not declared in that
+`culture.yaml`. **Severity: error** (fails the exit code).
+
+Suggested fix: `culture agents unregister <suffix>`.
+
+This reuses the same validation as `resolve_agents()` in `culture/config.py`
+(which already logs these as warnings at agent-resolution time) — `doctor` just
+surfaces them as a first-class, exit-coded report without changing that
+runtime path.
+
+### Class 2 — Unregistered repos
+
+A directory under the workspace root that has a `culture.yaml` but is **not** in
+the manifest. **Severity: warning** — this is informational and does **not**
+change the exit code, because having an on-disk repo that simply isn't running
+on this host is legitimate.
+
+Suggested fix: `culture agents register <path>` (or `culture doctor --fix`,
+below).
+
+### Class 3 — Suffix collisions
+
+A discovered repo that declares a suffix already bound to a **different** path
+in the manifest, or the same suffix declared by two different repos.
+**Severity: error** (fails the exit code). This catches copy-paste mistakes
+such as a second repo whose `culture.yaml` claims an in-use agent suffix.
+
+## Flags
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--config PATH` | `~/.culture/server.yaml` | The manifest to check. |
+| `--root PATH` | the culture repo's own parent | Workspace root to scan for on-disk `culture.yaml` repos. |
+| `--json` | off | Emit findings as a JSON object instead of text. |
+| `--fix`, `--register` | off | Opt-in: register the class-2 (unregistered) repos into the manifest. |
+
+The default scan root is the **parent directory of the culture repo itself**,
+resolved at runtime — it is discovered from the manifest's self-entry for this
+repo, falling back to the git root of the current directory. It is never a
+hardcoded path, so relocating the workspace (e.g. `~/git` -> `~/git2`) moves the
+scan root with it. Use `--root` to point elsewhere.
+
+## Exit code
+
+`culture doctor` exits `0` only when there are **zero** class-1 and **zero**
+class-3 findings. Class-2 (unregistered) findings are warning-only and never
+change the exit code. So a non-zero exit means genuine breakage — a broken
+registration or a suffix collision — which makes the command a reliable gate:
+
+```bash
+culture doctor || echo "manifest drift detected"
+```
+
+## The `--fix` action
+
+`culture doctor --fix` (alias `--register`) registers each class-2 repo into the
+manifest by reusing the existing `culture agents register` path
+(`add_to_manifest()`). It is **opt-in** — a plain `culture doctor` makes no
+writes at all.
+
+The fix writes **only** `~/.culture/server.yaml`. It never edits a discovered
+repo's `culture.yaml` or any file culture does not own, and it is idempotent
+(re-running registers nothing new). It does not touch class-1 (broken
+registrations) or class-3 (collisions) — those remain a human decision, surfaced
+with their suggested commands.
+
+## Example
+
+```text
+Broken registrations (class 1):
+  ✗ spark-shushu: culture.yaml missing for spark-shushu at /home/spark/git/shushu
+      fix: culture agents unregister shushu
+Unregistered repos (class 2, warning):
+  • guildmaster: on-disk culture.yaml not registered: /home/spark/git/guildmaster
+      fix: culture agents register /home/spark/git/guildmaster
+Suffix collisions (class 3):
+  ⚠ daria: suffix 'daria' at /home/spark/git/culture-sonar-cli collides with registered /home/spark/git/daria
+```
+
+`culture doctor --json` emits the same findings as a structured object
+(`{class1, class2, class3, ok, exit_code}`) for CI consumption.
+
+## Relationship to `culture agents doctor`
+
+`culture doctor` is **distinct** from `culture agents doctor`. The latter is
+forwarded to the [`steward`](https://github.com/agentculture/steward) CLI and
+performs **agent alignment / config-quality** doctoring — a different concern.
+
+| Command | Scope |
+|---------|-------|
+| `culture doctor` | manifest ↔ filesystem consistency (this page) |
+| `culture agents doctor` | agent alignment / config quality (steward) |
+
+The two never collide: `culture doctor` is a native top-level verb, while
+`culture agents doctor` is short-circuited to steward before argparse runs.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -71,6 +71,13 @@ registration or a suffix collision — which makes the command a reliable gate:
 culture doctor || echo "manifest drift detected"
 ```
 
+The `--json` payload also carries an `ok` field, which is **stricter** than the
+exit code: `ok` is `true` only when there are *no findings at all* (including
+class-2 warnings), whereas `exit_code` is `0` as long as there are no class-1 or
+class-3 errors. Gate CI on `exit_code` (or the process exit status); gate on
+`ok` only if you also want unregistered-repo warnings to fail the build. The
+exit code is `0` or `1`.
+
 ## The `--fix` action
 
 `culture doctor --fix` (alias `--register`) registers each class-2 repo into the
@@ -80,9 +87,11 @@ writes at all.
 
 The fix writes **only** `~/.culture/server.yaml`. It never edits a discovered
 repo's `culture.yaml` or any file culture does not own, and it is idempotent
-(re-running registers nothing new). It does not touch class-1 (broken
-registrations) or class-3 (collisions) — those remain a human decision, surfaced
-with their suggested commands.
+(re-running registers nothing new). With no class-2 findings it is a no-op. It
+does not touch class-1 (broken registrations, surfaced with an `unregister`
+hint) or class-3 (suffix collisions, reported for manual resolution — there is
+no safe auto-fix, since resolving a collision means renaming a suffix in a repo
+culture does not own). Those remain a human decision.
 
 ## Example
 

--- a/docs/plans/2026-06-13-culture-doctor-a-top-level-command-that-diagnoses.md
+++ b/docs/plans/2026-06-13-culture-doctor-a-top-level-command-that-diagnoses.md
@@ -1,0 +1,87 @@
+# Build Plan — culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems
+
+slug: `culture-doctor-a-top-level-command-that-diagnoses` · status: `exported` · from frame: `culture-doctor-a-top-level-command-that-diagnoses`
+
+> culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems
+
+## Tasks
+
+### t1 — Define the doctor result model: Finding + DoctorReport dataclasses in culture/doctor/model.py
+
+- covers: h3, h11
+- acceptance:
+  - Finding carries drift_class (1|2|3), severity ('error'|'warning'), subject (nick/suffix), path, message, fix_hint; DoctorReport groups class1/class2/class3 finding lists
+  - DoctorReport.exit_code is nonzero iff any class-1 or class-3 finding exists; class-2-only and empty reports both yield exit_code 0 (unit-tested for all three cases)
+
+### t2 — Scan-root resolution + on-disk repo discovery in culture/doctor/discovery.py
+
+- depends on: t1
+- covers: c12, h14
+- acceptance:
+  - resolve_scan_root(config, cwd=None, override=None) returns override when given; else the parent of the culture repo derived from the manifest self-entry; else the parent of the cwd git-root — no path literal hardcoded
+  - Relocating a fixture culture repo from <tmp>/git to <tmp>/git2 changes the resolved scan root accordingly (tmpdir test)
+  - discover_ondisk_repos(root) yields exactly one entry per <root>/*/culture.yaml with its declared suffix(es); a fixture of 3 culture.yaml repos + 1 plain dir yields 3 entries
+
+### t3 — Three drift-class checks (class1 broken-registration, class2 unregistered, class3 suffix-collision) in culture/doctor/checks.py
+
+- depends on: t1
+- covers: c4, h6, h7
+- acceptance:
+  - check_registrations(config) reuses load_culture_yaml(); a fixture manifest with one missing-dir + one missing-yaml + one registered-suffix-not-in-yaml yields exactly 3 class-1 findings; a fully valid manifest yields none
+  - A parity test asserts class-1 findings match exactly what resolve_agents() warns on for the same manifest (proves reuse, not reimplementation; resolve-time warning path is left unchanged)
+  - check_unregistered(config, discovered) flags discovered repos whose dir is not a manifest value (severity warning); check_suffix_collisions(config, discovered) flags a discovered suffix already bound to a different path in the manifest, and duplicate suffixes across discovered repos (severity error) — and does NOT flag the ordinary unregistered repos that simply declare their own unique suffix
+
+### t4 — Opt-in register fix in culture/doctor/fix.py (adds class-2 repos to server.yaml via add_to_manifest)
+
+- depends on: t1
+- covers: c15, h13, h12, c13
+- acceptance:
+  - register_unregistered(config_path, class2_findings) adds each unregistered repo via the existing add_to_manifest() (not a parallel YAML writer) and returns the list of suffix->path entries added
+  - Idempotent: a second run over the same findings adds nothing; empty findings performs zero writes
+  - Test asserts every discovered repo's culture.yaml is byte-identical before/after, and only ~/.culture/server.yaml changed
+
+### t5 — run_doctor() orchestrator in culture/doctor/__init__.py composing discovery + 3 checks + optional fix
+
+- depends on: t2, t3, t4
+- covers: c1, c3, c7
+- acceptance:
+  - run_doctor(config, root_override=None, fix=False) -> DoctorReport composes discovery + the three checks, applying the fix only when fix=True
+  - On a fixture mirroring spark (3 missing-dir manifest entries, several unregistered repos incl. one duplicate-suffix collision) the report has 3 class-1, >=1 class-2, >=1 class-3 findings and exit_code != 0; on an all-valid fixture the report is empty with exit_code 0
+  - With fix=False, run_doctor writes no files (manifest byte-identical)
+
+### t6 — CLI group 'culture doctor' in culture/cli/doctor.py (flags, rendering, exit codes, --json)
+
+- depends on: t5
+- covers: h4, h5, h2, c2, h3, h11
+- acceptance:
+  - Exports NAME='doctor', register(subparsers) and dispatch(args) per the cli module pattern; flags: --json, --root PATH, --fix/--register
+  - No-args run prints a human report grouped by the 3 drift classes; each problem line names the repo/nick and the exact suggested command ('culture agents unregister <suffix>' for class-1, 'culture agents register <path>' for class-2); --json emits the same findings as a structured payload
+  - Process exits nonzero iff a class-1 or class-3 finding exists (class-2-only exits 0); --fix registers class-2 repos and prints what it added; a test asserts the manifest is unmodified after a non---fix run
+
+### t7 — Register the doctor group in culture/cli/__init__.py GROUPS and prove no steward-forward collision
+
+- depends on: t6
+- covers: c1, h4
+- acceptance:
+  - 'doctor' module added to the GROUPS registry; 'culture doctor --help' and 'culture doctor' dispatch to the new handler
+  - Test asserts top-level 'culture doctor' does NOT route through _maybe_forward_to_steward, while 'culture agents doctor' still short-circuits to the steward forward (the existing alignment verb is untouched)
+
+### t8 — Document the feature in docs/doctor.md
+
+- depends on: t6
+- covers: c5, c13
+- acceptance:
+  - docs/doctor.md covers purpose, the 3 drift classes, all flags (--json, --root, --fix), exit-code semantics, and the boundary vs the steward-forwarded 'culture agents doctor'
+  - markdownlint-cli2 passes on docs/doctor.md
+
+### t9 — Bump version (minor) and update CHANGELOG.md + uv.lock for the new feature
+
+- depends on: t7, t8
+- acceptance:
+  - pyproject.toml version bumped minor (new feature) via /version-bump; CHANGELOG.md gets a Keep-a-Changelog entry for 'culture doctor'; uv.lock staged alongside
+  - version-check CI job passes (version strictly greater than main)
+
+## Risks
+
+- [unknown_nonblocking] Scan-root self-identification: when culture is installed as a uv tool (not editable / not run from the checkout), discovering 'this repo' from the manifest self-entry vs cwd git-root may need iteration; --root is the always-correct escape hatch (task t2)
+- [unknown_nonblocking] Class-3 collision scope: must distinguish a genuine duplicate-suffix collision from the ~44 legitimate unregistered repos that each declare their own unique suffix; over-broad matching would flag healthy repos (task t3)

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -15,6 +15,9 @@ full contract.
 culture while alignment verbs (`doctor`, `show`, `overview`) forward
 to [`steward-cli`](./agents.md). See
 [`culture agents` reference](./agents.md) for the full verb map.
+Note the distinct top-level **`culture doctor`** (manifest ↔ filesystem
+drift), which is unrelated to the steward-forwarded `culture agents
+doctor` (agent alignment) — see [Doctor](#doctor-manifest-health) below.
 `culture skills announce-update` likewise forwards to
 `steward announce-skill-update` (see the
 [`culture agents` reference](./agents.md#culture-skills-announce-update)).
@@ -474,6 +477,23 @@ Restore an archived bot.
 
 ```bash
 culture bot unarchive spark-ori-ghci
+```
+
+## Doctor (manifest health)
+
+`culture doctor` is a top-level command that diagnoses drift between the
+agent manifest (`~/.culture/server.yaml`) and the on-disk `culture.yaml`
+repos: broken registrations (class 1), unregistered repos (class 2,
+warning-only), and suffix collisions (class 3). It exits non-zero on
+class-1/class-3 so it gates CI, supports `--json`, `--root`, and an opt-in
+`--fix`/`--register` that adds unregistered repos to the manifest (writing
+only `server.yaml`). It is distinct from the steward-forwarded `culture
+agents doctor` (agent alignment). Full reference: [Doctor](../../doctor.md).
+
+```bash
+culture doctor            # report drift; exit non-zero on real breakage
+culture doctor --json     # machine-readable, for CI
+culture doctor --fix      # register unregistered repos (opt-in)
 ```
 
 ## Configuration

--- a/docs/specs/2026-06-13-culture-doctor-a-top-level-command-that-diagnoses.md
+++ b/docs/specs/2026-06-13-culture-doctor-a-top-level-command-that-diagnoses.md
@@ -1,0 +1,50 @@
+# culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems
+
+> culture doctor: a top-level command that diagnoses drift between the ~/.culture/server.yaml agent manifest and the on-disk culture.yaml repos, exiting non-zero when it finds problems
+
+## Audience
+
+- culture operators running a mesh host (e.g. spark) who manage the agent manifest, plus CI/ops automation that needs a machine-checkable gate
+
+## Before → After
+
+- Before: drift is only surfaced as a side-effect WARNING inside resolve_agents() when agents are resolved; there is no first-class command to audit the manifest, and nothing detects unregistered repos or suffix collisions at all
+- After: an operator runs 'culture doctor' and gets a categorized report of manifest<->filesystem drift (broken registrations, unregistered repos, suffix collisions) with a non-zero exit code when problems exist
+
+## Why it matters
+
+- stale manifest entries and unregistered repos silently break agent start/observe; operators discover drift by accident. A doctor makes the existing resolve_agents() validation a first-class, scriptable health check
+
+## Requirements
+
+- for class-2 (unregistered repos), doctor scans the local filesystem one level above the culture repo (the workspace parent, e.g. /home/spark/git) for */culture.yaml and reports any whose directory is not in the manifest — warning-only, exit 0; default root = the culture repo's parent, overridable with --root
+  - honesty: class-2 findings are warning-only: they print with a 'culture agents register <path>' hint and never change the exit code; only class-1 (broken registration) and class-3 (suffix collision) make doctor exit non-zero
+  - honesty: the class-2 scan root is derived from the culture repo's OWN location at runtime — its parent directory — discovered via the manifest's self-entry for this repo (falling back to the in-tree cwd repo root), so moving the workspace to /git2 moves the scan root automatically; never hardcoded; --root overrides
+- doctor offers an opt-in fix that registers class-2 repos (on-disk culture.yaml not in the manifest) by ADDING them to ~/.culture/server.yaml via the existing add_to_manifest()/register path; default run stays read-only/diagnose; the fix writes only server.yaml, never the discovered repo's culture.yaml
+  - honesty: the fix path reuses add_to_manifest()/the existing register code (not a parallel writer), is idempotent (re-running registers nothing new), and prints exactly which suffix->path entries it added; default invocation makes zero writes
+
+## Honesty conditions
+
+- a top-level 'culture doctor' verb is registered in the CLI group list and dispatches without colliding with 'culture agents doctor' (the steward forward)
+- the command is runnable by an operator with no args (sensible defaults) and emits machine-parseable output (--json) for CI/ops gating
+- the report cleanly separates the three drift classes and each problem line names the offending nick/repo and the suggested fix command (e.g. 'culture agents unregister <suffix>' / 'culture agents register <path>')
+- doctor reuses the existing resolve_agents()/load_culture_yaml() validation in culture/config.py rather than reimplementing the missing-dir / missing-yaml / suffix-not-in-yaml checks
+- the warning logic in resolve_agents() remains the runtime path; doctor surfaces the same findings as an explicit, exit-coded report without changing resolve-time behavior
+- exit code is 0 only when zero problems are found in ALL three classes; any class-1 or class-3 problem forces non-zero; class-2 (unregistered repos) severity is a confirmed decision (warning-only vs error)
+- a test proves doctor never modifies any discovered repo's culture.yaml (those files byte-identical before/after, even in --fix mode); only ~/.culture/server.yaml may change, and only when the fix is explicitly requested
+
+## Success signals
+
+- on a healthy host doctor exits 0 with an all-clear; on the current spark host it reports 3 missing-dir registrations, ~44 unregistered culture.yaml repos, and the culture-sonar-cli/daria suffix collision, and exits non-zero
+
+## Scope / boundaries
+
+- culture doctor checks manifest<->filesystem consistency and can REGISTER discovered repos into our own server.yaml manifest (opt-in, e.g. --fix/--register); it never edits the other repos' culture.yaml or any file we don't own, and it never does agent alignment/config-quality doctoring (that stays 'culture agents doctor' forwarded to steward)
+
+## Non-goals
+
+- not an auto-UNregister tool (removing stale class-1 entries stays a human decision / suggested command); not a watcher/daemon; does not reach across linked peers or other hosts' manifests; never writes to a repo's own culture.yaml
+
+## Decisions
+
+- lives as a top-level 'culture doctor' verb (own CLI group), NOT under 'culture agents', to avoid the steward-forwarded doctor verb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "13.5.0"
+version = "13.6.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_doctor_checks.py
+++ b/tests/test_doctor_checks.py
@@ -156,3 +156,38 @@ def test_class3_no_false_positive():
 
     findings = check_suffix_collisions(config, discovered)
     assert findings == []
+
+
+def test_class3_manifest_collision_not_double_reported():
+    """A manifest collision is reported once, even when the registered repo
+    is also present on disk (the duplicate-across-discovered check must defer
+    to the manifest-collision check)."""
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"daria": "/path/daria"},
+    )
+    discovered = [
+        RepoOnDisk("/path/daria", ["daria"]),  # the registered repo, on disk
+        RepoOnDisk("/other/sonar", ["daria"]),  # collides with the manifest
+    ]
+
+    findings = check_suffix_collisions(config, discovered)
+    assert len(findings) == 1
+    assert findings[0].subject == "daria"
+    assert "/other/sonar" in findings[0].path
+
+
+def test_class3_pure_ondisk_duplicate_flagged():
+    """Two unregistered repos sharing a suffix (not in the manifest) collide."""
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={},
+    )
+    discovered = [
+        RepoOnDisk("/x/one", ["dup"]),
+        RepoOnDisk("/y/two", ["dup"]),
+    ]
+
+    findings = check_suffix_collisions(config, discovered)
+    assert len(findings) == 1
+    assert findings[0].drift_class == 3

--- a/tests/test_doctor_checks.py
+++ b/tests/test_doctor_checks.py
@@ -1,0 +1,158 @@
+"""Tests for culture/doctor/checks.py — the three drift-class checks."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import yaml
+
+from culture.config import ServerConfig, ServerConnConfig
+from culture.doctor.checks import (
+    check_registrations,
+    check_suffix_collisions,
+    check_unregistered,
+)
+from culture.doctor.discovery import RepoOnDisk
+from culture.doctor.model import Finding
+
+
+def _write_culture_yaml(directory: str, suffix: str) -> None:
+    """Write a minimal culture.yaml into *directory*."""
+    path = Path(directory) / "culture.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"suffix": suffix, "backend": "claude"}, f)
+
+
+def test_class1_three_kinds(tmp_path):
+    """check_registrations catches three kinds of broken manifest entries."""
+    gone_dir = str(tmp_path / "gone")  # nonexistent dir
+    noyaml_dir = str(tmp_path / "noyaml")
+    Path(noyaml_dir).mkdir()  # exists but has no culture.yaml
+    wrong_dir = str(tmp_path / "wrong")
+    _write_culture_yaml(wrong_dir, "other")  # declares a DIFFERENT suffix
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={
+            "gone": gone_dir,
+            "noyaml": noyaml_dir,
+            "wrong": wrong_dir,
+        },
+    )
+
+    findings = check_registrations(config)
+    assert len(findings) == 3
+    assert all(f.drift_class == 1 for f in findings)
+    assert all(f.severity == "error" for f in findings)
+
+
+def test_class1_clean(tmp_path):
+    """A well-formed manifest entry produces no findings."""
+    good_dir = str(tmp_path / "good")
+    _write_culture_yaml(good_dir, "good")
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"good": good_dir},
+    )
+
+    findings = check_registrations(config)
+    assert findings == []
+
+
+def test_class1_parity(tmp_path, caplog):
+    """check_registrations findings match resolve_agents warnings for broken entries."""
+    import culture.config as cfg
+
+    gone_dir = str(tmp_path / "gone")
+    noyaml_dir = str(tmp_path / "noyaml")
+    Path(noyaml_dir).mkdir()
+    wrong_dir = str(tmp_path / "wrong")
+    _write_culture_yaml(wrong_dir, "other")
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={
+            "gone": gone_dir,
+            "noyaml": noyaml_dir,
+            "wrong": wrong_dir,
+        },
+    )
+
+    cfg.reset_manifest_warning_state()
+
+    with caplog.at_level(logging.WARNING, logger="culture"):
+        cfg.resolve_agents(config)
+
+    # Extract suffixes from the "unregister SUFFIX" portion of each warning.
+    warned_suffixes = {
+        re.search(r"unregister (\w+)", record.getMessage()).group(1) for record in caplog.records
+    }
+
+    # check_registrations subjects are like "spark-gone", "spark-noyaml", "spark-wrong"
+    finding_suffixes = {f.subject.split("-")[-1] for f in check_registrations(config)}
+
+    # resolve_agents warns for both FileNotFoundError and ValueError cases,
+    # so parity should hold across all three broken entries.
+    assert warned_suffixes == finding_suffixes
+
+
+def test_class2_warns_unregistered():
+    """Unregistered on-disk repos produce class-2 warnings."""
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={},
+    )
+    discovered = [RepoOnDisk("/x/foo", ["foo"])]
+
+    findings = check_unregistered(config, discovered)
+    assert len(findings) == 1
+    assert findings[0].drift_class == 2
+    assert findings[0].severity == "warning"
+
+
+def test_class2_skips_registered(tmp_path):
+    """A discovered repo whose dir IS in the manifest produces no class-2 finding."""
+    good_dir = str(tmp_path / "good")
+    _write_culture_yaml(good_dir, "good")
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"good": good_dir},
+    )
+    discovered = [RepoOnDisk(good_dir, ["good"])]
+
+    findings = check_unregistered(config, discovered)
+    assert findings == []
+
+
+def test_class3_collision_with_manifest():
+    """A discovered suffix colliding with a manifest entry produces a class-3 error."""
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"daria": "/path/daria"},
+    )
+    discovered = [RepoOnDisk("/other/sonar", ["daria"])]
+
+    findings = check_suffix_collisions(config, discovered)
+    assert len(findings) == 1
+    assert findings[0].drift_class == 3
+    assert findings[0].severity == "error"
+
+
+def test_class3_no_false_positive():
+    """Discovered repos with unique suffixes not in manifest produce no findings."""
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"alpha": "/a/alpha"},
+    )
+    discovered = [
+        RepoOnDisk("/b/beta", ["beta"]),
+        RepoOnDisk("/c/gamma", ["gamma"]),
+    ]
+
+    findings = check_suffix_collisions(config, discovered)
+    assert findings == []

--- a/tests/test_doctor_checks.py
+++ b/tests/test_doctor_checks.py
@@ -49,6 +49,23 @@ def test_class1_three_kinds(tmp_path):
     assert all(f.severity == "error" for f in findings)
 
 
+def test_class1_malformed_yaml_is_finding_not_crash(tmp_path):
+    """A registered repo with a malformed culture.yaml is a class-1 finding,
+    not an uncaught YAMLError crash (Qodo review)."""
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    (bad_dir / "culture.yaml").write_text("suffix: x\nbroken: [1, 2,\n")  # unterminated flow
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"x": str(bad_dir)},
+    )
+
+    findings = check_registrations(config)  # must not raise
+    assert len(findings) == 1
+    assert findings[0].drift_class == 1
+
+
 def test_class1_clean(tmp_path):
     """A well-formed manifest entry produces no findings."""
     good_dir = str(tmp_path / "good")

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -1,0 +1,131 @@
+"""Tests for culture/cli/doctor.py — the doctor CLI group."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from culture.cli.doctor import dispatch
+
+
+def _args(config, root=None, json=False, fix=False):
+    return argparse.Namespace(
+        config=str(config),
+        root=str(root) if root else None,
+        json=json,
+        fix=fix,
+    )
+
+
+def _write_server_yaml(path, manifest=None):
+    """Write a minimal server.yaml at *path*."""
+    data = {"server": {"name": "spark"}, "agents": manifest or {}}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def _write_culture_yaml(directory, suffix):
+    """Write a minimal culture.yaml into *directory*."""
+    path = Path(directory) / "culture.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"suffix": suffix, "backend": "claude"}, f)
+
+
+def test_clean_exits_zero(tmp_path, capsys):
+    """A clean workspace with one valid registered repo exits 0."""
+    server_yaml = tmp_path / "server.yaml"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    culture_dir = ws / "culture"
+    _write_culture_yaml(str(culture_dir), "culture")
+
+    _write_server_yaml(server_yaml, manifest={"culture": str(culture_dir)})
+
+    with pytest.raises(SystemExit) as e:
+        dispatch(_args(server_yaml, root=ws))
+    assert e.value.code == 0
+    assert "no drift" in capsys.readouterr().out
+
+
+def test_problems_exit_nonzero_and_name_repo(tmp_path, capsys):
+    """Broken manifest entries produce nonzero exit and name the repo."""
+    server_yaml = tmp_path / "server.yaml"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    # Broken entry: directory does not exist
+    _write_server_yaml(server_yaml, manifest={"shushu": str(ws / "nope")})
+
+    with pytest.raises(SystemExit) as e:
+        dispatch(_args(server_yaml, root=ws))
+    assert e.value.code != 0
+    out = capsys.readouterr().out
+    assert "shushu" in out
+    assert "culture agents unregister shushu" in out
+
+
+def test_json_output(tmp_path, capsys):
+    """--json emits parseable JSON with class1 findings."""
+    server_yaml = tmp_path / "server.yaml"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    _write_server_yaml(server_yaml, manifest={"shushu": str(ws / "nope")})
+
+    with pytest.raises(SystemExit):
+        dispatch(_args(server_yaml, root=ws, json=True))
+
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert "class1" in data
+    assert data["exit_code"] != 0
+
+
+def test_no_writes_without_fix(tmp_path):
+    """dispatch with fix=False must not modify server.yaml."""
+    server_yaml = tmp_path / "server.yaml"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    # Unregistered repo so class-2 is non-empty
+    rogue_dir = ws / "rogue"
+    _write_culture_yaml(str(rogue_dir), "rogue")
+
+    _write_server_yaml(server_yaml, manifest={})
+    original_bytes = server_yaml.read_bytes()
+
+    with pytest.raises(SystemExit):
+        dispatch(_args(server_yaml, root=ws, fix=False))
+
+    assert server_yaml.read_bytes() == original_bytes
+
+
+def test_fix_registers_class2(tmp_path, capsys):
+    """--fix registers unregistered repos into server.yaml."""
+    server_yaml = tmp_path / "server.yaml"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    rogue_dir = ws / "rogue"
+    _write_culture_yaml(str(rogue_dir), "rogue")
+
+    _write_server_yaml(server_yaml, manifest={})
+
+    with pytest.raises(SystemExit):
+        dispatch(_args(server_yaml, root=ws, fix=True))
+
+    # Reload server.yaml and check the manifest
+    with open(server_yaml) as f:
+        raw = yaml.safe_load(f)
+    assert "rogue" in raw["agents"]
+
+    out = capsys.readouterr().out
+    assert "registered: rogue" in out

--- a/tests/test_doctor_discovery.py
+++ b/tests/test_doctor_discovery.py
@@ -1,0 +1,66 @@
+"""Tests for culture/doctor/discovery.py."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import yaml
+
+from culture.doctor.discovery import discover_ondisk_repos, resolve_scan_root
+
+
+def _write_culture_yaml(directory: str, suffix: str) -> None:
+    """Write a minimal culture.yaml into *directory*."""
+    path = Path(directory) / "culture.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"suffix": suffix, "backend": "claude"}, f)
+
+
+def test_resolve_scan_root_tracks_repo_parent(tmp_path):
+    """resolve_scan_root returns the parent of the git root."""
+    # First repo: .git lives inside the culture checkout, so culture IS the
+    # repo and its parent (the workspace) is the scan root.
+    culture_dir = tmp_path / "git" / "culture"
+    culture_dir.mkdir(parents=True)
+    (culture_dir / ".git").mkdir()
+
+    config = types.SimpleNamespace(manifest={})
+    result = resolve_scan_root(config, cwd=str(culture_dir))
+    assert result == (tmp_path / "git").resolve()
+
+    # Second repo: relocating the checkout to git2/ moves the scan root with it.
+    culture_dir2 = tmp_path / "git2" / "culture"
+    culture_dir2.mkdir(parents=True)
+    (culture_dir2 / ".git").mkdir()
+
+    result2 = resolve_scan_root(config, cwd=str(culture_dir2))
+    assert result2 == (tmp_path / "git2").resolve()
+
+
+def test_resolve_scan_root_override(tmp_path):
+    """An override bypasses all discovery logic."""
+    config = types.SimpleNamespace(manifest={})
+    result = resolve_scan_root(config, override="/tmp/x")
+    assert result == Path("/tmp/x").resolve()
+
+
+def test_discover_finds_only_culture_yaml_repos(tmp_path):
+    """discover_ondisk_repos returns only dirs with a culture.yaml."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    for suffix in ("a", "b", "c"):
+        d = ws / f"repo-{suffix}"
+        d.mkdir()
+        _write_culture_yaml(str(d), suffix)
+
+    (ws / "plain").mkdir()
+
+    results = discover_ondisk_repos(str(ws))
+    assert len(results) == 3
+
+    dirs = {r.directory for r in results}
+    expected = {str((ws / f"repo-{s}").resolve()) for s in ("a", "b", "c")}
+    assert dirs == expected

--- a/tests/test_doctor_fix.py
+++ b/tests/test_doctor_fix.py
@@ -1,0 +1,90 @@
+"""Tests for culture doctor fix actions (register_unregistered)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from culture.doctor.fix import register_unregistered
+from culture.doctor.model import Finding
+
+
+def _write_server_yaml(path: str) -> None:
+    """Write a minimal manifest-format server.yaml."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("server:\n  name: spark\nagents: {}\n")
+
+
+def _write_repo_culture_yaml(repo_dir: str, suffix: str) -> None:
+    """Write a minimal culture.yaml in repo_dir."""
+    Path(repo_dir).mkdir(parents=True, exist_ok=True)
+    culture_path = Path(repo_dir) / "culture.yaml"
+    with open(culture_path, "w") as f:
+        f.write(f"suffix: {suffix}\nbackend: claude\n")
+
+
+def test_registers_unregistered_repo(tmp_path):
+    server_yaml = tmp_path / "server.yaml"
+    repo = tmp_path / "foo"
+    _write_server_yaml(str(server_yaml))
+    _write_repo_culture_yaml(str(repo), "foo")
+
+    finding = Finding(2, "warning", "foo", str(repo), "", "")
+    added = register_unregistered(str(server_yaml), [finding])
+
+    assert added == [("foo", str(repo))]
+
+    with open(server_yaml) as f:
+        data = yaml.safe_load(f)
+    assert data["agents"]["foo"] == str(repo)
+
+
+def test_idempotent(tmp_path):
+    server_yaml = tmp_path / "server.yaml"
+    repo = tmp_path / "foo"
+    _write_server_yaml(str(server_yaml))
+    _write_repo_culture_yaml(str(repo), "foo")
+
+    finding = Finding(2, "warning", "foo", str(repo), "", "")
+    added1 = register_unregistered(str(server_yaml), [finding])
+    assert added1 == [("foo", str(repo))]
+
+    with open(server_yaml) as f:
+        data_after_first = yaml.safe_load(f)
+
+    added2 = register_unregistered(str(server_yaml), [finding])
+    assert added2 == []
+
+    with open(server_yaml) as f:
+        data_after_second = yaml.safe_load(f)
+
+    assert data_after_first["agents"] == data_after_second["agents"]
+
+
+def test_empty_findings_no_writes(tmp_path):
+    server_yaml = tmp_path / "server.yaml"
+    _write_server_yaml(str(server_yaml))
+
+    before = server_yaml.read_bytes()
+    added = register_unregistered(str(server_yaml), [])
+    after = server_yaml.read_bytes()
+
+    assert added == []
+    assert before == after
+
+
+def test_culture_yaml_never_modified(tmp_path):
+    server_yaml = tmp_path / "server.yaml"
+    repo = tmp_path / "foo"
+    _write_server_yaml(str(server_yaml))
+    _write_repo_culture_yaml(str(repo), "foo")
+
+    culture_yaml = repo / "culture.yaml"
+    before = culture_yaml.read_bytes()
+
+    finding = Finding(2, "warning", "foo", str(repo), "", "")
+    register_unregistered(str(server_yaml), [finding])
+
+    after = culture_yaml.read_bytes()
+    assert before == after

--- a/tests/test_doctor_model.py
+++ b/tests/test_doctor_model.py
@@ -1,0 +1,51 @@
+"""Tests for doctor result model."""
+
+from culture.doctor.model import DoctorReport, Finding
+
+
+def test_empty_report_is_ok():
+    report = DoctorReport()
+    assert report.ok is True
+    assert report.exit_code == 0
+
+
+def test_class2_only_report_is_ok_but_not_clean():
+    finding = Finding(
+        drift_class=2,
+        severity="warning",
+        subject="some-agent",
+        path="/some/path",
+        message="Unregistered repo",
+        fix_hint="culture agents register /some/path",
+    )
+    report = DoctorReport(class2=[finding])
+    assert report.ok is False
+    assert report.exit_code == 0
+
+
+def test_class1_finding_makes_exit_code_nonzero():
+    finding = Finding(
+        drift_class=1,
+        severity="error",
+        subject="broken-agent",
+        path="/missing/path",
+        message="Missing directory",
+        fix_hint="culture agents unregister broken-agent",
+    )
+    report = DoctorReport(class1=[finding])
+    assert report.ok is False
+    assert report.exit_code != 0
+
+
+def test_class3_finding_makes_exit_code_nonzero():
+    finding = Finding(
+        drift_class=3,
+        severity="error",
+        subject="colliding-agent",
+        path="/colliding/path",
+        message="Suffix collision",
+        fix_hint="",
+    )
+    report = DoctorReport(class3=[finding])
+    assert report.ok is False
+    assert report.exit_code != 0

--- a/tests/test_doctor_orchestrator.py
+++ b/tests/test_doctor_orchestrator.py
@@ -76,8 +76,8 @@ def test_clean_report_exit_zero(tmp_path):
     assert report.ok is True
 
 
-def test_fix_false_writes_nothing(tmp_path):
-    """When fix=False, run_doctor must not modify the config file."""
+def test_run_doctor_writes_nothing(tmp_path):
+    """run_doctor is diagnosis-only — it must never modify the config file."""
     server_yaml = tmp_path / "server.yaml"
     server_yaml.write_text("server:\n  name: spark\nagents: {}\n")
     original_bytes = server_yaml.read_bytes()
@@ -94,11 +94,6 @@ def test_fix_false_writes_nothing(tmp_path):
         manifest={},
     )
 
-    run_doctor(
-        config,
-        root_override=str(ws),
-        fix=False,
-        config_path=str(server_yaml),
-    )
+    run_doctor(config, root_override=str(ws))
 
     assert server_yaml.read_bytes() == original_bytes

--- a/tests/test_doctor_orchestrator.py
+++ b/tests/test_doctor_orchestrator.py
@@ -1,0 +1,104 @@
+"""Integration tests for culture/doctor/__init__.py — the run_doctor orchestrator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from culture.config import ServerConfig, ServerConnConfig
+from culture.doctor import run_doctor
+
+
+def _write_culture_yaml(directory: str, suffix: str) -> None:
+    """Write a minimal culture.yaml into *directory*."""
+    path = Path(directory) / "culture.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"suffix": suffix, "backend": "claude"}, f)
+
+
+def test_spark_like_report_exit_nonzero(tmp_path):
+    """A workspace with missing, unregistered, and colliding repos yields nonzero exit."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    # Valid registered repo
+    culture_dir = ws / "culture"
+    _write_culture_yaml(str(culture_dir), "culture")
+
+    # Unregistered repo (class-2 only)
+    guildmaster_dir = ws / "guildmaster"
+    _write_culture_yaml(str(guildmaster_dir), "guildmaster")
+
+    # Collision repo: suffix "culture" already in manifest at a different path
+    # → class-2 (unregistered) AND class-3 (suffix collision)
+    sonar_dir = ws / "sonar"
+    _write_culture_yaml(str(sonar_dir), "culture")
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={
+            "culture": str(culture_dir),
+            "shushu": str(ws / "nope-shushu"),
+            "agentpypi": str(ws / "nope-pypi"),
+            "agexcli": str(ws / "nope-agex"),
+        },
+    )
+
+    report = run_doctor(config, root_override=str(ws))
+
+    assert len(report.class1) == 3
+    assert len(report.class2) >= 1  # guildmaster + sonar
+    assert len(report.class3) >= 1  # sonar's "culture" collides
+    assert report.exit_code != 0
+
+
+def test_clean_report_exit_zero(tmp_path):
+    """A perfectly clean workspace produces an empty report with exit code 0."""
+    ws2 = tmp_path / "ws2"
+    ws2.mkdir()
+
+    culture_dir = ws2 / "culture"
+    _write_culture_yaml(str(culture_dir), "culture")
+
+    config2 = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"culture": str(culture_dir)},
+    )
+
+    report = run_doctor(config2, root_override=str(ws2))
+
+    assert report.class1 == []
+    assert report.class2 == []
+    assert report.class3 == []
+    assert report.exit_code == 0
+    assert report.ok is True
+
+
+def test_fix_false_writes_nothing(tmp_path):
+    """When fix=False, run_doctor must not modify the config file."""
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("server:\n  name: spark\nagents: {}\n")
+    original_bytes = server_yaml.read_bytes()
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    # One unregistered repo so class-2 is non-empty
+    rogue_dir = ws / "rogue"
+    _write_culture_yaml(str(rogue_dir), "rogue")
+
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={},
+    )
+
+    run_doctor(
+        config,
+        root_override=str(ws),
+        fix=False,
+        config_path=str(server_yaml),
+    )
+
+    assert server_yaml.read_bytes() == original_bytes

--- a/tests/test_doctor_wiring.py
+++ b/tests/test_doctor_wiring.py
@@ -1,0 +1,52 @@
+"""Wiring tests for the top-level ``culture doctor`` command (t7).
+
+Proves the new verb is registered in the CLI group registry and that it does
+NOT collide with the steward-forwarded ``culture agents doctor`` (agent
+alignment) — the two ``doctor`` surfaces stay distinct.
+"""
+
+from __future__ import annotations
+
+import culture.cli as cli
+
+
+def test_doctor_registered_in_groups():
+    """The doctor module is wired into the GROUPS registry under NAME 'doctor'."""
+    from culture.cli import GROUPS, doctor
+
+    assert doctor in GROUPS
+    assert doctor.NAME == "doctor"
+
+
+def test_doctor_subcommand_parses():
+    """`culture doctor` resolves to the doctor group via argparse."""
+    parser = cli._build_parser()
+    args = parser.parse_args(["doctor"])
+    assert args.command == "doctor"
+
+
+def test_top_level_doctor_does_not_forward_to_steward():
+    """Top-level `culture doctor ...` must never short-circuit to steward."""
+    assert cli._maybe_forward_to_steward(["doctor"]) is None
+    assert cli._maybe_forward_to_steward(["doctor", "--json"]) is None
+    assert cli._maybe_forward_to_steward(["doctor", "--fix"]) is None
+    assert cli._maybe_forward_to_steward(["doctor", "--root", "/x"]) is None
+
+
+def test_agents_doctor_still_forwards_to_steward(monkeypatch):
+    """`culture agents doctor` (alignment) is untouched — still forwarded."""
+    import steward.cli
+
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(steward.cli, "main", fake_main)
+
+    result = cli._maybe_forward_to_steward(["agents", "doctor", "--json"])
+
+    assert result == 0
+    # the 'agents' noun is stripped; the verb + remaining args reach steward
+    assert called["argv"] == ["doctor", "--json"]

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "13.5.0"
+version = "13.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },


### PR DESCRIPTION
## Summary

Adds **`culture doctor`** — a top-level command that diagnoses drift between the
agent manifest (`~/.culture/server.yaml`) and the on-disk `culture.yaml` repos,
exiting non-zero when it finds real breakage so it doubles as a CI/ops gate.

Motivation: stale manifest entries and unregistered repos silently break agent
start/observe today; the only existing signal is a side-effect `WARNING` inside
`resolve_agents()`. This makes that a first-class, scriptable health check and
adds two checks nothing did before.

### Three drift classes

- **Class 1 — broken registrations** (error): a manifest entry whose directory or
  `culture.yaml` is missing, or whose registered suffix isn't declared in that
  `culture.yaml`. Reuses `load_culture_yaml()`/`resolve_agents()` (a parity test
  proves it, not a reimplementation). Fix hint: `culture agents unregister <suffix>`.
- **Class 2 — unregistered repos** (warning, exit 0): an on-disk `culture.yaml`
  repo not in the manifest. Fix hint: `culture agents register <path>`.
- **Class 3 — suffix collisions** (error): a discovered suffix already bound to a
  different path, or two repos declaring the same suffix.

### Surface

- Top-level `culture doctor` (own CLI group) — **distinct** from the
  steward-forwarded `culture agents doctor` (agent alignment); a guard test
  proves the two never collide.
- Flags: `--json` (CI), `--root` (scan-root override), `--fix`/`--register`
  (opt-in: registers class-2 repos via the existing `add_to_manifest` path —
  writes **only** `server.yaml`, never a discovered repo's `culture.yaml`;
  idempotent).
- Exit code `0` only when there are zero class-1 **and** zero class-3 findings;
  class-2 is warning-only.

### Live result (this host)

```text
exit 1 — 3 class-1 (shushu, agentpypi, agex-cli), 46 class-2 warnings,
1 class-3 (culture-sonar-cli declares 'daria', colliding with the registered daria)
```

## How it was built

Specced with `/think`, planned with `/spec-to-plan` (9 tasks, 6 dependency waves),
implemented via `/assign-to-workforce`. Per the operator's request, the bulk was
tiered to a **different backend** (`ask-colleague` → local vLLM `Qwen3.6-27B`):
6 of 9 code tasks were colleague-authored, with the main agent verifying and
TDD-gating every merge. Colleague also did a diverse second-opinion review of the
final diff. Notable catches by main-agent verification: a bug in a colleague test,
and a colleague `--amend` that conflated commits (split back out). The committed
spec (`docs/specs/`) and plan (`docs/plans/`) are included.

## Architecture

`culture/doctor/` engine package — `model` (Finding/DoctorReport) · `discovery`
(repo-relative scan root + on-disk discovery) · `checks` (the 3 classes) · `fix`
(opt-in register) · `__init__` (`run_doctor` orchestrator) — behind a thin
`culture/cli/doctor.py`. Scan root defaults to the culture repo's own parent,
resolved at runtime (follows the checkout if it moves), overridable with `--root`.

Docs: `docs/doctor.md` + an entry in `docs/reference/cli/index.md`.

## Test plan

- [x] Full suite green: **1445 passed, 1 skipped**
- [x] 32 doctor tests across model/discovery/checks/fix/orchestrator/cli/wiring
- [x] Parity test: class-1 findings match `resolve_agents()` warnings
- [x] `--fix` byte-identical-`culture.yaml` safety test
- [x] Steward non-collision guard test
- [x] Live-validated against the real manifest (exit 1, drift classes as above)
- [x] `doc-test-alignment` audit + `ask-colleague` review triaged

## Known follow-ups

- Scan-root self-identification under a `uv tool` install relies on the cwd
  git-root fallback (parked risk **r1**; `--root` is the always-correct override).

- culture (Claude)
