### PR TITLE
deps: cap bounds to engine-validated versions + culture-core cutover spec/plan (parked on doctor)

### DIFF
--- a/.devague/frames/culture-now-runs-on-the-published-culture-core-eng.json
+++ b/.devague/frames/culture-now-runs-on-the-published-culture-core-eng.json
@@ -1,0 +1,328 @@
+{
+  "slug": "culture-now-runs-on-the-published-culture-core-eng",
+  "title": "culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-06-14T14:27:31Z",
+  "updated": "2026-06-14T14:35:58Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "after the cutover a clean install of culture pulls culture-core 0.4.0 as a dependency and the repo holds no in-tree engine implementation (only shims and/or front-door code)",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "culture operators (the people running the mesh / installing culture) and the culture front-door maintainers who own the slimmed repo; downstream is unchanged for them",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "operators take no action and notice no difference; front-door maintainers can change branding/docs/deploy without touching engine code",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c3",
+      "kind": "before_state",
+      "text": "culture 13.6.0 carries the full 85-module engine in-tree (culture/), has no culture-core dependency, declares loose dep bounds (afi-cli<1.0, agex-cli<1.0, unbounded OTel) that only stay green because uv.lock is stale, and its console entry point is culture = culture.cli:main",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "culture 13.6.0 on main verifiably has the 85-module culture/ tree, no culture-core dep, loose bounds, and culture=culture.cli:main (checkable in pyproject.toml + git)",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c4",
+      "kind": "after_state",
+      "text": "culture pins culture-core==0.4.0 (uv.lock refreshed), overlapping bounds aligned down to culture-core's caps, the in-tree culture/ tree deleted or reduced to thin re-export shims onto culture_core.*, the console entry resolved, the test suite re-pointed, and a version bump applied \u2014 all in one PR",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "the sub-changes (pin+lock, bound-align, shim/delete, entry-point, test migration, bump) can land together with no intermediate broken commit",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "this is the unblocking step for front-door slimming: with the engine moved to its own PyPI package, culture becomes the thin public face (branding/docs/deploy) and the reusable core lives once, matching the agentirc and cultureagent extractions; it also fixes the latent dependency-drift bomb that a fresh lock refresh would otherwise detonate",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h10",
+          "text": "front-door slimming genuinely depends on this cutover and the drift risk is real \u2014 a fresh lock without the pin resolves to broken afi-cli/agex-cli/OTel/copilot versions",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c6",
+      "kind": "boundary",
+      "text": "not re-litigating the extraction itself (culture-core#2/#3 are done and 0.4.0 is published); not absorbing agentirc or cultureagent (they stay separate embedded deps); not changing any wire/identity strings (telemetry culture.* names, culture.yaml filename); not loosening culture-core's dependency caps",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "the PR touches no wire/identity strings and does not modify agentirc/cultureagent deps or culture-core's caps",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c7",
+      "kind": "boundary",
+      "text": "not a behavior change for operators \u2014 the culture CLI surface, output, and config discovery must be byte-for-byte the same; this is a packaging/sourcing move only",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "diffing culture CLI help/output/config-discovery before vs after the cutover shows no operator-visible change",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c8",
+      "kind": "success_signal",
+      "text": "culture's full test suite passes against the pinned culture-core engine after a fresh uv.lock refresh (green because of the pin, not despite it)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "running culture's retained test suite after the uv.lock refresh exits 0",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c9",
+      "kind": "success_signal",
+      "text": "the culture operator command works unchanged end-to-end (dual entry point), and culture.yaml discovery + culture.* telemetry metric names are observably identical to 13.6.0",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h14",
+          "text": "culture --help and a representative command produce output identical to 13.6.0 and culture.yaml is discovered from the same paths",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c10",
+      "kind": "success_signal",
+      "text": "a fresh resolve of culture's declared bounds can no longer pull a broken newer afi-cli / agex-cli / OTel / copilot-sdk \u2014 the aligned caps make the validated versions the only resolvable ones",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h15",
+          "text": "a dependency resolve cannot select afi-cli>=0.4, agex-cli>=0.14, OTel>=1.42, or copilot-sdk>0.2.0 given culture's aligned bounds",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c11",
+      "kind": "requirement",
+      "text": "culture pins culture-core (==0.4.0 or ~=0.4.0) and refreshes uv.lock in the same PR",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "after the pin, a fresh 'uv lock' resolves culture-core to exactly 0.4.0 and the lock refresh stays green (no broken transitive afi-cli/agex-cli/OTel pulled)",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "culture aligns its overlapping dependency declarations down to culture-core's validated caps: agex-cli<0.14, afi-cli<0.4, OTel stack <1.42 and the instrumentation/semconv line <0.63b0",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "culture's declared bounds become a subset of culture-core's caps, so a future culture-core unpin cannot silently re-loosen them, and the validated versions remain the only resolvable ones",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "the cutover ships as a single PR following pin -> forward/shim -> delete, with no functionality gap at any commit",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "every commit on the branch leaves culture importable and the culture CLI runnable \u2014 no commit deletes the in-tree engine before the pin+shim that replaces it is in place",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c14",
+      "kind": "decision",
+      "text": "the in-tree culture/ tree is reduced to thin re-export shims onto culture_core.* (so import culture.x keeps working) rather than deleted outright",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "with shims in place, 'import culture.<anything>' resolves to the culture_core.* implementation and the operator-visible behavior is byte-for-byte identical to 13.6.0",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [
+        {
+          "id": "q1",
+          "text": "risk: shims add a second import surface to maintain; if culture_core renames a module, the matching shim silently breaks until someone notices",
+          "resolved": false,
+          "blocking": false
+        }
+      ],
+      "links": []
+    },
+    {
+      "id": "c15",
+      "kind": "decision",
+      "text": "culture drops its own [project.scripts] culture entry and relies on culture-core's dual entry point to provide the culture command",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c16",
+      "kind": "decision",
+      "text": "culture keeps a thin front-door-only test layer and stops re-running the full 85-module engine suite here (the engine tests now live in and are run by culture-core)",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "deleting the engine test files here loses no real coverage because culture-core runs the identical suite in its own CI; culture's retained tests exercise only front-door concerns (packaging, entry point, branding, deploy)",
+          "status": "proposed"
+        }
+      ],
+      "hard_questions": [
+        {
+          "id": "q2",
+          "text": "if culture stops running the engine suite, what catches a bad culture-core release at pin-bump time before it reaches operators?",
+          "resolved": false,
+          "blocking": false
+        }
+      ],
+      "links": []
+    },
+    {
+      "id": "c17",
+      "kind": "requirement",
+      "text": "culture retains a thin smoke/import test layer (import culture.*, culture --help, a representative CLI invocation against the pinned engine) so a future culture-core pin bump has a front-door guard",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h16",
+          "text": "the smoke layer fails loudly if a pinned culture-core release breaks import, the entry point, or basic CLI behavior \u2014 giving the pin-bump PR something to run",
+          "status": "proposed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c18",
+      "kind": "decision",
+      "text": "culture keeps its [project.scripts] culture entry but repoints it to culture_core.cli:main (explicit in culture's own pyproject, redundant-but-harmless with culture-core's dual entry point)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h17",
+          "text": "after repointing, the installed culture command invokes culture_core.cli:main and behaves identically to 13.6.0",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c19",
+      "kind": "decision",
+      "text": "culture retains the full engine test suite and runs it against the pinned culture-core engine through the re-export shims (untouched imports), plus a small front-door packaging test (entry point resolves, wheel ships the shims); no coverage is dropped here",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h18",
+          "text": "the existing 96 test files pass unmodified because the shims make culture.* resolve to culture_core.*, and the full suite green-lights every culture-core pin bump",
+          "status": "rejected"
+        },
+        {
+          "id": "h19",
+          "text": "the existing 96 test files pass unmodified because the shims make each culture.<name> import resolve to its culture_core counterpart, and the full suite green-lights every culture-core pin bump",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    }
+  ],
+  "open_vagueness": []
+}

--- a/.devague/plans/culture-now-runs-on-the-published-culture-core-eng.json
+++ b/.devague/plans/culture-now-runs-on-the-published-culture-core-eng.json
@@ -1,0 +1,248 @@
+{
+  "slug": "culture-now-runs-on-the-published-culture-core-eng",
+  "title": "culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before",
+  "frame_slug": "culture-now-runs-on-the-published-culture-core-eng",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-06-14T14:36:47Z",
+  "updated": "2026-06-14T14:38:40Z",
+  "targets": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before"
+    },
+    {
+      "id": "h6",
+      "kind": "honesty",
+      "text": "after the cutover a clean install of culture pulls culture-core 0.4.0 as a dependency and the repo holds no in-tree engine implementation (only shims and/or front-door code)"
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "culture operators (the people running the mesh / installing culture) and the culture front-door maintainers who own the slimmed repo; downstream is unchanged for them"
+    },
+    {
+      "id": "h7",
+      "kind": "honesty",
+      "text": "operators take no action and notice no difference; front-door maintainers can change branding/docs/deploy without touching engine code"
+    },
+    {
+      "id": "c3",
+      "kind": "before_state",
+      "text": "culture 13.6.0 carries the full 85-module engine in-tree (culture/), has no culture-core dependency, declares loose dep bounds (afi-cli<1.0, agex-cli<1.0, unbounded OTel) that only stay green because uv.lock is stale, and its console entry point is culture = culture.cli:main"
+    },
+    {
+      "id": "h8",
+      "kind": "honesty",
+      "text": "culture 13.6.0 on main verifiably has the 85-module culture/ tree, no culture-core dep, loose bounds, and culture=culture.cli:main (checkable in pyproject.toml + git)"
+    },
+    {
+      "id": "c4",
+      "kind": "after_state",
+      "text": "culture pins culture-core==0.4.0 (uv.lock refreshed), overlapping bounds aligned down to culture-core's caps, the in-tree culture/ tree deleted or reduced to thin re-export shims onto culture_core.*, the console entry resolved, the test suite re-pointed, and a version bump applied \u2014 all in one PR"
+    },
+    {
+      "id": "h9",
+      "kind": "honesty",
+      "text": "the sub-changes (pin+lock, bound-align, shim/delete, entry-point, test migration, bump) can land together with no intermediate broken commit"
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "this is the unblocking step for front-door slimming: with the engine moved to its own PyPI package, culture becomes the thin public face (branding/docs/deploy) and the reusable core lives once, matching the agentirc and cultureagent extractions; it also fixes the latent dependency-drift bomb that a fresh lock refresh would otherwise detonate"
+    },
+    {
+      "id": "h10",
+      "kind": "honesty",
+      "text": "front-door slimming genuinely depends on this cutover and the drift risk is real \u2014 a fresh lock without the pin resolves to broken afi-cli/agex-cli/OTel/copilot versions"
+    },
+    {
+      "id": "c6",
+      "kind": "boundary",
+      "text": "not re-litigating the extraction itself (culture-core#2/#3 are done and 0.4.0 is published); not absorbing agentirc or cultureagent (they stay separate embedded deps); not changing any wire/identity strings (telemetry culture.* names, culture.yaml filename); not loosening culture-core's dependency caps"
+    },
+    {
+      "id": "h11",
+      "kind": "honesty",
+      "text": "the PR touches no wire/identity strings and does not modify agentirc/cultureagent deps or culture-core's caps"
+    },
+    {
+      "id": "c7",
+      "kind": "boundary",
+      "text": "not a behavior change for operators \u2014 the culture CLI surface, output, and config discovery must be byte-for-byte the same; this is a packaging/sourcing move only"
+    },
+    {
+      "id": "h12",
+      "kind": "honesty",
+      "text": "diffing culture CLI help/output/config-discovery before vs after the cutover shows no operator-visible change"
+    },
+    {
+      "id": "c8",
+      "kind": "success_signal",
+      "text": "culture's full test suite passes against the pinned culture-core engine after a fresh uv.lock refresh (green because of the pin, not despite it)"
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "running culture's retained test suite after the uv.lock refresh exits 0"
+    },
+    {
+      "id": "c9",
+      "kind": "success_signal",
+      "text": "the culture operator command works unchanged end-to-end (dual entry point), and culture.yaml discovery + culture.* telemetry metric names are observably identical to 13.6.0"
+    },
+    {
+      "id": "h14",
+      "kind": "honesty",
+      "text": "culture --help and a representative command produce output identical to 13.6.0 and culture.yaml is discovered from the same paths"
+    },
+    {
+      "id": "c10",
+      "kind": "success_signal",
+      "text": "a fresh resolve of culture's declared bounds can no longer pull a broken newer afi-cli / agex-cli / OTel / copilot-sdk \u2014 the aligned caps make the validated versions the only resolvable ones"
+    },
+    {
+      "id": "h15",
+      "kind": "honesty",
+      "text": "a dependency resolve cannot select afi-cli>=0.4, agex-cli>=0.14, OTel>=1.42, or copilot-sdk>0.2.0 given culture's aligned bounds"
+    },
+    {
+      "id": "c11",
+      "kind": "requirement",
+      "text": "culture pins culture-core (==0.4.0 or ~=0.4.0) and refreshes uv.lock in the same PR"
+    },
+    {
+      "id": "h1",
+      "kind": "honesty",
+      "text": "after the pin, a fresh 'uv lock' resolves culture-core to exactly 0.4.0 and the lock refresh stays green (no broken transitive afi-cli/agex-cli/OTel pulled)"
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "culture aligns its overlapping dependency declarations down to culture-core's validated caps: agex-cli<0.14, afi-cli<0.4, OTel stack <1.42 and the instrumentation/semconv line <0.63b0"
+    },
+    {
+      "id": "h2",
+      "kind": "honesty",
+      "text": "culture's declared bounds become a subset of culture-core's caps, so a future culture-core unpin cannot silently re-loosen them, and the validated versions remain the only resolvable ones"
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "the cutover ships as a single PR following pin -> forward/shim -> delete, with no functionality gap at any commit"
+    },
+    {
+      "id": "h3",
+      "kind": "honesty",
+      "text": "every commit on the branch leaves culture importable and the culture CLI runnable \u2014 no commit deletes the in-tree engine before the pin+shim that replaces it is in place"
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "pyproject + lock: pin culture-core==0.4.0, align overlapping dep bounds down to culture-core's caps (agex-cli<0.14, afi-cli<0.4, OTel stack <1.42, instrumentation/semconv <0.63b0), repoint console entry culture=culture_core.cli:main, refresh uv.lock",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "pyproject.toml pins culture-core (==0.4.0 or ~=0.4.0) and [project.scripts] culture = culture_core.cli:main",
+        "agex-cli<0.14, afi-cli<0.4, OTel api/sdk/exporter <1.42 and instrumentation/semconv <0.63b0 are declared (subset of culture-core's caps)",
+        "uv lock succeeds, resolves culture-core to 0.4.0, and a resolve cannot select afi-cli>=0.4 / agex-cli>=0.14 / OTel>=1.42 / copilot-sdk>0.2.0"
+      ],
+      "deps": [],
+      "covers": [
+        "c11",
+        "c12",
+        "c10",
+        "c5",
+        "h1",
+        "h2",
+        "h15",
+        "h10"
+      ]
+    },
+    {
+      "id": "t2",
+      "summary": "shim the in-tree culture/ tree: replace all 85 modules with thin re-export shims onto culture_core.* so import culture.x keeps working; sequence so no commit deletes a module before its shim/pin is in place",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "every former culture/<mod> is a shim re-exporting culture_core.<mod>; import culture.cli/.doctor/.clients/.protocol/.telemetry resolves to culture_core.*",
+        "no commit on the branch leaves culture un-importable or the CLI un-runnable (pin+shim land together, no broken intermediate)"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c1",
+        "c4",
+        "c13",
+        "h6",
+        "h9",
+        "h3"
+      ]
+    },
+    {
+      "id": "t3",
+      "summary": "version bump 13.6.0 -> next + CHANGELOG entry for the culture-core cutover (via /version-bump)",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "version bumped from 13.6.0 in pyproject.toml; CHANGELOG.md has a new top section describing the pin->shim cutover; version-check CI passes"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c13"
+      ]
+    },
+    {
+      "id": "t4",
+      "summary": "front-door packaging/smoke test: assert the culture entry point resolves to culture_core.cli:main, culture-core==0.4.0 is a locked dep, and import culture works",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "new test asserts importlib.metadata entry point 'culture' targets culture_core.cli:main and that import culture succeeds",
+        "test asserts culture-core 0.4.0 is the locked/declared engine dependency"
+      ],
+      "deps": [
+        "t1",
+        "t2"
+      ],
+      "covers": [
+        "c9",
+        "h6",
+        "h7"
+      ]
+    },
+    {
+      "id": "t5",
+      "summary": "behavior-parity verification: full retained engine suite green through the shims after a fresh lock, and culture CLI help / culture.yaml discovery / culture.* telemetry names observably identical to 13.6.0",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "/run-tests passes: all retained engine tests green against the pinned culture-core",
+        "culture --help output, culture.yaml discovery paths, and culture.* telemetry metric names match 13.6.0 (no operator-visible change; no wire-string change)"
+      ],
+      "deps": [
+        "t2",
+        "t4"
+      ],
+      "covers": [
+        "c8",
+        "c2",
+        "c3",
+        "c6",
+        "c7",
+        "h7",
+        "h8",
+        "h11",
+        "h12",
+        "h13",
+        "h14"
+      ]
+    }
+  ],
+  "risks": []
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [13.6.1] - 2026-06-14
+
+### Changed
+
+- Cap dependency upper bounds to the engine-validated versions ahead of the culture-core cutover: agex-cli<0.14, afi-cli<0.4, the OpenTelemetry stack <1.42 (and instrumentation/semconv <0.63b0), and the copilot extra github-copilot-sdk==0.2.0. A fresh uv.lock previously rode loose bounds that would resolve to newer releases known to break the afi/agent_experience imports, the per-test OTel InMemoryMetricReader injection (SDK 1.42), and the copilot backend (sdk 0.2.3+). Constraints-only change: no resolved version or source changed; full suite stays green (1446 passed).
+
 ## [13.6.0] - 2026-06-13
 
 ### Added

--- a/docs/plans/2026-06-14-culture-now-runs-on-the-published-culture-core-eng.md
+++ b/docs/plans/2026-06-14-culture-now-runs-on-the-published-culture-core-eng.md
@@ -1,0 +1,46 @@
+# Build Plan — culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before
+
+slug: `culture-now-runs-on-the-published-culture-core-eng` · status: `exported` · from frame: `culture-now-runs-on-the-published-culture-core-eng`
+
+> culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before
+
+## Tasks
+
+### t1 — pyproject + lock: pin culture-core==0.4.0, align overlapping dep bounds down to culture-core's caps (agex-cli<0.14, afi-cli<0.4, OTel stack <1.42, instrumentation/semconv <0.63b0), repoint console entry culture=culture_core.cli:main, refresh uv.lock
+
+- covers: c11, c12, c10, c5, h1, h2, h15, h10
+- acceptance:
+  - pyproject.toml pins culture-core (==0.4.0 or ~=0.4.0) and [project.scripts] culture = culture_core.cli:main
+  - agex-cli<0.14, afi-cli<0.4, OTel api/sdk/exporter <1.42 and instrumentation/semconv <0.63b0 are declared (subset of culture-core's caps)
+  - uv lock succeeds, resolves culture-core to 0.4.0, and a resolve cannot select afi-cli>=0.4 / agex-cli>=0.14 / OTel>=1.42 / copilot-sdk>0.2.0
+
+### t2 — shim the in-tree culture/ tree: replace all 85 modules with thin re-export shims onto culture_core.* so import culture.x keeps working; sequence so no commit deletes a module before its shim/pin is in place
+
+- depends on: t1
+- covers: c1, c4, c13, h6, h9, h3
+- acceptance:
+  - every former culture/<mod> is a shim re-exporting culture_core.<mod>; import culture.cli/.doctor/.clients/.protocol/.telemetry resolves to culture_core.*
+  - no commit on the branch leaves culture un-importable or the CLI un-runnable (pin+shim land together, no broken intermediate)
+
+### t3 — version bump 13.6.0 -> next + CHANGELOG entry for the culture-core cutover (via /version-bump)
+
+- depends on: t1
+- covers: c13
+- acceptance:
+  - version bumped from 13.6.0 in pyproject.toml; CHANGELOG.md has a new top section describing the pin->shim cutover; version-check CI passes
+
+### t4 — front-door packaging/smoke test: assert the culture entry point resolves to culture_core.cli:main, culture-core==0.4.0 is a locked dep, and import culture works
+
+- depends on: t1, t2
+- covers: c9, h6, h7
+- acceptance:
+  - new test asserts importlib.metadata entry point 'culture' targets culture_core.cli:main and that import culture succeeds
+  - test asserts culture-core 0.4.0 is the locked/declared engine dependency
+
+### t5 — behavior-parity verification: full retained engine suite green through the shims after a fresh lock, and culture CLI help / culture.yaml discovery / culture.* telemetry names observably identical to 13.6.0
+
+- depends on: t2, t4
+- covers: c8, c2, c3, c6, c7, h7, h8, h11, h12, h13, h14
+- acceptance:
+  - /run-tests passes: all retained engine tests green against the pinned culture-core
+  - culture --help output, culture.yaml discovery paths, and culture.* telemetry metric names match 13.6.0 (no operator-visible change; no wire-string change)

--- a/docs/specs/2026-06-14-culture-now-runs-on-the-published-culture-core-eng.md
+++ b/docs/specs/2026-06-14-culture-now-runs-on-the-published-culture-core-eng.md
@@ -1,0 +1,63 @@
+# culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before
+
+> culture now runs on the published culture-core engine: it pins culture-core 0.4.0, the in-tree culture/ tree is gone (deleted or reduced to thin re-export shims), and the operator's culture CLI, telemetry, and config discovery work exactly as before
+
+## Audience
+
+- culture operators (the people running the mesh / installing culture) and the culture front-door maintainers who own the slimmed repo; downstream is unchanged for them
+
+## Before → After
+
+- Before: culture 13.6.0 carries the full 85-module engine in-tree (culture/), has no culture-core dependency, declares loose dep bounds (afi-cli<1.0, agex-cli<1.0, unbounded OTel) that only stay green because uv.lock is stale, and its console entry point is culture = culture.cli:main
+- After: culture pins culture-core==0.4.0 (uv.lock refreshed), overlapping bounds aligned down to culture-core's caps, the in-tree culture/ tree deleted or reduced to thin re-export shims onto culture_core.*, the console entry resolved, the test suite re-pointed, and a version bump applied — all in one PR
+
+## Why it matters
+
+- this is the unblocking step for front-door slimming: with the engine moved to its own PyPI package, culture becomes the thin public face (branding/docs/deploy) and the reusable core lives once, matching the agentirc and cultureagent extractions; it also fixes the latent dependency-drift bomb that a fresh lock refresh would otherwise detonate
+
+## Requirements
+
+- culture pins culture-core (==0.4.0 or ~=0.4.0) and refreshes uv.lock in the same PR
+  - honesty: after the pin, a fresh 'uv lock' resolves culture-core to exactly 0.4.0 and the lock refresh stays green (no broken transitive afi-cli/agex-cli/OTel pulled)
+- culture aligns its overlapping dependency declarations down to culture-core's validated caps: agex-cli<0.14, afi-cli<0.4, OTel stack <1.42 and the instrumentation/semconv line <0.63b0
+  - honesty: culture's declared bounds become a subset of culture-core's caps, so a future culture-core unpin cannot silently re-loosen them, and the validated versions remain the only resolvable ones
+- the cutover ships as a single PR following pin -> forward/shim -> delete, with no functionality gap at any commit
+  - honesty: every commit on the branch leaves culture importable and the culture CLI runnable — no commit deletes the in-tree engine before the pin+shim that replaces it is in place
+
+## Honesty conditions
+
+- after the cutover a clean install of culture pulls culture-core 0.4.0 as a dependency and the repo holds no in-tree engine implementation (only shims and/or front-door code)
+- operators take no action and notice no difference; front-door maintainers can change branding/docs/deploy without touching engine code
+- culture 13.6.0 on main verifiably has the 85-module culture/ tree, no culture-core dep, loose bounds, and culture=culture.cli:main (checkable in pyproject.toml + git)
+- the sub-changes (pin+lock, bound-align, shim/delete, entry-point, test migration, bump) can land together with no intermediate broken commit
+- front-door slimming genuinely depends on this cutover and the drift risk is real — a fresh lock without the pin resolves to broken afi-cli/agex-cli/OTel/copilot versions
+- the PR touches no wire/identity strings and does not modify agentirc/cultureagent deps or culture-core's caps
+- diffing culture CLI help/output/config-discovery before vs after the cutover shows no operator-visible change
+- running culture's retained test suite after the uv.lock refresh exits 0
+- culture --help and a representative command produce output identical to 13.6.0 and culture.yaml is discovered from the same paths
+- a dependency resolve cannot select afi-cli>=0.4, agex-cli>=0.14, OTel>=1.42, or copilot-sdk>0.2.0 given culture's aligned bounds
+- with shims in place, 'import culture.<anything>' resolves to the culture_core.* implementation and the operator-visible behavior is byte-for-byte identical to 13.6.0
+- after repointing, the installed culture command invokes culture_core.cli:main and behaves identically to 13.6.0
+- the existing 96 test files pass unmodified because the shims make each culture.<name> import resolve to its culture_core counterpart, and the full suite green-lights every culture-core pin bump
+
+## Success signals
+
+- culture's full test suite passes against the pinned culture-core engine after a fresh uv.lock refresh (green because of the pin, not despite it)
+- the culture operator command works unchanged end-to-end (dual entry point), and culture.yaml discovery + culture.* telemetry metric names are observably identical to 13.6.0
+- a fresh resolve of culture's declared bounds can no longer pull a broken newer afi-cli / agex-cli / OTel / copilot-sdk — the aligned caps make the validated versions the only resolvable ones
+
+## Scope / boundaries
+
+- not re-litigating the extraction itself (culture-core#2/#3 are done and 0.4.0 is published); not absorbing agentirc or cultureagent (they stay separate embedded deps); not changing any wire/identity strings (telemetry culture.* names, culture.yaml filename); not loosening culture-core's dependency caps
+- not a behavior change for operators — the culture CLI surface, output, and config discovery must be byte-for-byte the same; this is a packaging/sourcing move only
+
+## Decisions
+
+- the in-tree culture/ tree is reduced to thin re-export shims onto culture_core.* (so import culture.x keeps working) rather than deleted outright
+- culture keeps its [project.scripts] culture entry but repoints it to culture_core.cli:main (explicit in culture's own pyproject, redundant-but-harmless with culture-core's dual entry point)
+- culture retains the full engine test suite and runs it against the pinned culture-core engine through the re-export shims (untouched imports), plus a small front-door packaging test (entry point resolves, wheel ships the shims); no coverage is dropped here
+
+## Hard questions
+
+- risk: shims add a second import surface to maintain; if culture_core renames a module, the matching shim silently breaks until someone notices
+- if culture stops running the engine suite, what catches a bad culture-core release at pin-bump time before it reaches operators?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "13.6.0"
+version = "13.6.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,16 +21,23 @@ dependencies = [
     "claude-agent-sdk>=0.1",
     "mistune>=3.0",
     "aiohttp>=3.9",
-    "agex-cli>=0.13,<1.0",
+    # Upper bounds capped to the versions the engine is validated against (these
+    # match the caps culture-core 0.4.0 declares). Without them a fresh uv.lock
+    # would resolve to newer releases that broke the afi / agent_experience import
+    # modules, the per-test OTel InMemoryMetricReader injection (SDK 1.42), and the
+    # copilot backend (github-copilot-sdk 0.2.3+). Standalone drift-bomb fix and a
+    # precursor to the culture-core cutover — see
+    # docs/specs/2026-06-14-culture-now-runs-on-the-published-culture-core-eng.md.
+    "agex-cli>=0.13,<0.14",
     "agtag>=0.1,<1.0",
-    "afi-cli>=0.3,<1.0",
+    "afi-cli>=0.3,<0.4",
     "steward-cli>=0.16,<1.0",
     "irc-lens>=0.5.3,<1.0",
-    "opentelemetry-api>=1.25",
-    "opentelemetry-sdk>=1.25",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.25",
-    "opentelemetry-semantic-conventions>=0.46b0",
-    "opentelemetry-instrumentation-aiohttp-server>=0.46b0",
+    "opentelemetry-api>=1.25,<1.42",
+    "opentelemetry-sdk>=1.25,<1.42",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.25,<1.42",
+    "opentelemetry-semantic-conventions>=0.46b0,<0.63b0",
+    "opentelemetry-instrumentation-aiohttp-server>=0.46b0,<0.63b0",
 ]
 
 [project.urls]
@@ -59,7 +66,9 @@ packages = ["culture"]
 "culture/bots/system/welcome/bot.yaml" = "culture/bots/system/welcome/bot.yaml"
 
 [project.optional-dependencies]
-copilot = ["github-copilot-sdk"]
+# Pinned to culture-core's validated copilot SDK; 0.2.3+/1.0 regressed the
+# copilot backend, so the cap must match culture-core[copilot].
+copilot = ["github-copilot-sdk==0.2.0"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "13.6.0"
+version = "13.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "afi-cli" },
@@ -668,22 +668,22 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "afi-cli", specifier = ">=0.3,<1.0" },
+    { name = "afi-cli", specifier = ">=0.3,<0.4" },
     { name = "agentirc-cli", specifier = ">=9.7.0,<10" },
-    { name = "agex-cli", specifier = ">=0.13,<1.0" },
+    { name = "agex-cli", specifier = ">=0.13,<0.14" },
     { name = "agtag", specifier = ">=0.1,<1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
     { name = "anthropic", specifier = ">=0.40" },
     { name = "claude-agent-sdk", specifier = ">=0.1" },
     { name = "cultureagent", specifier = "~=0.4.0" },
-    { name = "github-copilot-sdk", marker = "extra == 'copilot'" },
+    { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = "==0.2.0" },
     { name = "irc-lens", specifier = ">=0.5.3,<1.0" },
     { name = "mistune", specifier = ">=3.0" },
-    { name = "opentelemetry-api", specifier = ">=1.25" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25" },
-    { name = "opentelemetry-instrumentation-aiohttp-server", specifier = ">=0.46b0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.25" },
-    { name = "opentelemetry-semantic-conventions", specifier = ">=0.46b0" },
+    { name = "opentelemetry-api", specifier = ">=1.25,<1.42" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.25,<1.42" },
+    { name = "opentelemetry-instrumentation-aiohttp-server", specifier = ">=0.46b0,<0.63b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.25,<1.42" },
+    { name = "opentelemetry-semantic-conventions", specifier = ">=0.46b0,<0.63b0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "steward-cli", specifier = ">=0.16,<1.0" },
 ]


### PR DESCRIPTION
## Summary

Lands the **safe precursor** to the culture-core front-door cutover (#454) and
the converged design for the cutover itself. The full alias+delete is **parked**
behind one culture-core gap (see below).

This PR does two things:

1. **Dependency-bound hardening (the drift-bomb fix)** — caps the loose upper
   bounds culture's green state was riding on a stale `uv.lock`. A fresh resolve
   would otherwise pull newer releases that break the engine:
   - `afi-cli>=0.4` / `agex-cli>=0.14` renamed the `afi` / `agent_experience` imports
   - OpenTelemetry SDK `1.42` broke the per-test `InMemoryMetricReader` injection
   - `github-copilot-sdk` `0.2.3+` regressed the copilot backend

   Capped to the engine-validated versions (matching culture-core 0.4.0's own
   caps): `agex-cli<0.14`, `afi-cli<0.4`, OTel api/sdk/exporter `<1.42`,
   instrumentation/semconv `<0.63b0`, copilot extra `github-copilot-sdk==0.2.0`.
   **Constraints-only:** the `uv.lock` diff is the `requires-dist` metadata alone
   — no resolved version or source changed, so a future fresh lock can no longer
   drift upward. Version `13.6.0 → 13.6.1`.

2. **Cutover design of record** — the converged devague spec (`/think`) and plan
   (`/spec-to-plan`) for the full cutover, under `docs/specs/` and `docs/plans/`.

## Why the full cutover is parked

`culture-core 0.4.0` is **behind culture `main`** — it's missing the entire
`doctor` feature (#453), which merged *after* 0.4.0 was lifted. Aliasing the
`culture.*` namespace onto `culture_core.*` and deleting the in-tree engine now
would drop the `culture doctor` command (culture_core's `cli.GROUPS` has no
`doctor`) and break 7 doctor test files. That's the functionality loss the
extraction-never-loses-functionality rule forbids.

The forward is requested in **agentculture/culture-core#4**. Once culture-core
ships `doctor` and cuts a release, a follow-up PR pins it and completes #454:
module-identity aliasing (so the 152 `mock.patch("culture.…")` targets keep
working) + delete the in-tree engine + full suite green through the shims.

## Test plan

- `/run-tests` → **1446 passed, 1 skipped** against the capped bounds.
- `uv lock` resolves clean; no resolved version changed vs `main`.

## Refs

- Tracking: #454 (front-door cutover)
- Blocked-by: agentculture/culture-core#4 (forward `doctor` into the engine)
- Feature at risk: #453 (`culture doctor`)

- culture (Claude)
