### PR TITLE
PR1 — agentfront migration: afi-cli → agentfront 0.20 (three-minds t5, #467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [14.1.1] - 2026-07-02
+
+### Changed
+
+- Dependency afi-cli>=0.3,<0.4 replaced by agentfront>=0.20,<0.21 — the renamed successor of the retired afi-cli dist. `culture afi` passthrough now imports agentfront.cli (verb name unchanged); tests and uv.lock updated. PR1 of the three-minds plan (#467).
+
 ## [14.1.0] - 2026-07-02
 
 ### Added

--- a/culture_core/cli/__init__.py
+++ b/culture_core/cli/__init__.py
@@ -9,7 +9,7 @@ Commands are organized into noun-based groups:
     culture bot      {create,start,stop,list,inspect,archive,unarchive}
     culture skills   {install}
     culture devex    {...developer-experience passthrough (powered by agex-cli)...}
-    culture afi      {...agent-first interface passthrough (powered by afi-cli)...}
+    culture afi      {...agent-first interface passthrough (powered by agentfront)...}
 
 Universal verbs (available at the root):
     culture explain [topic]    full description of topic (default: culture)

--- a/culture_core/cli/_passthrough.py
+++ b/culture_core/cli/_passthrough.py
@@ -20,7 +20,7 @@ an ``int`` return code (for the universal-verb handlers, which must
 return ``(stdout, rc)``).
 
 The long-term target is every embedded CLI exposing a clean
-``main(argv) -> int`` (agent-first CLI contract owned by afi-cli). Until
+``main(argv) -> int`` (agent-first CLI contract owned by agentfront). Until
 then, typer-backed CLIs like agex-cli can be wrapped in a small entry
 adapter that calls the typer ``app`` — the plumbing here stays unchanged.
 """

--- a/culture_core/cli/afi.py
+++ b/culture_core/cli/afi.py
@@ -1,20 +1,20 @@
-"""`culture afi` — passthrough to the standalone afi CLI.
+"""`culture afi` — passthrough to the standalone agentfront CLI.
 
-afi (Agent First Interface) scaffolds and audits agent-first CLIs, MCP
+agentfront (Agent First Interface) scaffolds and audits agent-first CLIs, MCP
 servers, and HTTP sites. Culture embeds it as a first-class namespace so
-the culture CLI exposes the same agent-first affordances afi enforces.
+the culture CLI exposes the same agent-first affordances agentfront enforces.
 
 This module is a thin adapter: it supplies a package-specific ``Entry``
 callable and wires the three universal verbs
 (``explain`` / ``overview`` / ``learn``) through
-:mod:`culture_core.cli._passthrough`. afi already implements the agent-first
+:mod:`culture_core.cli._passthrough`. agentfront already implements the agent-first
 CLI contract (``main(argv) -> int``), so the entry is a direct
 delegation — no typer adapter needed.
 
-``afi-cli`` owns the rubric the contract is measured against. See
-`agentculture/afi-cli#5 <https://github.com/agentculture/afi-cli/issues/5>`_
+``agentfront`` owns the rubric the contract is measured against. See
+`agentculture/agentfront#5 <https://github.com/agentculture/agentfront/issues/5>`_
 for the tracking issue that adds an ``overview`` verb + rubric bundle so
-afi models every check it enforces.
+agentfront models every check it enforces.
 """
 
 from __future__ import annotations
@@ -28,16 +28,16 @@ NAME = "afi"
 
 
 def _entry(argv: list[str]) -> "int | None":
-    """In-process call into ``afi.cli.main(argv)``.
+    """In-process call into ``agentfront.cli.main(argv)``.
 
-    afi's ``main`` returns an ``int`` on normal completion and raises
+    agentfront's ``main`` returns an ``int`` on normal completion and raises
     ``SystemExit`` only for argparse-level exits (``--help``, ``--version``,
     unknown flag). Both paths are handled by :mod:`culture_core.cli._passthrough`.
     """
     try:
-        from afi.cli import main
+        from agentfront.cli import main
     except ImportError as exc:  # pragma: no cover — declared dep
-        print(f"afi-cli is not installed: {exc}", file=sys.stderr)
+        print(f"agentfront is not installed: {exc}", file=sys.stderr)
         sys.exit(2)
     return main(argv)
 
@@ -57,14 +57,14 @@ _passthrough.register_topic(
 def register(subparsers: "argparse._SubParsersAction") -> None:
     # prefix_chars=chr(0): every token (including --help, --version) is
     # treated as positional and captured in afi_args for the underlying
-    # afi argparse parser to handle.
+    # agentfront argparse parser to handle.
     p = subparsers.add_parser(
         NAME,
-        help="Run the afi agent-first CLI via passthrough",
+        help="Run the agentfront agent-first CLI via passthrough",
         add_help=False,
         prefix_chars=chr(0),
     )
-    p.add_argument("afi_args", nargs=argparse.REMAINDER, help="Arguments passed to afi")
+    p.add_argument("afi_args", nargs=argparse.REMAINDER, help="Arguments passed to agentfront")
 
 
 def dispatch(args: argparse.Namespace) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,17 @@ dependencies = [
     "cultureagent~=0.4.0",
     "mistune>=3.0",
     "aiohttp>=3.9",
-    # afi-cli/agex-cli capped at the minor series culture validated against:
+    # agex-cli capped at the minor series culture validated against:
     # the import modules were renamed in later 0.x releases (agex-cli's
-    # `agent_experience` -> `devex` by 0.29; afi-cli's `afi` gone by 0.8), so
-    # the engine's `from agent_experience.cli import app` / `from afi.cli import
-    # main` break on a fresh `<1.0` resolve. Bump only alongside the code that
-    # adapts to the renamed modules, and re-run the full suite.
+    # `agent_experience` -> `devex` by 0.29), so the engine's
+    # `from agent_experience.cli import app` breaks on a fresh `<1.0` resolve.
+    # Bump only alongside the code that adapts to the renamed modules, and
+    # re-run the full suite.
+    # agentfront is afi-cli's renamed successor; cap at the validated minor
+    # per this repo's pin philosophy.
     "agex-cli>=0.13,<0.14",
     "agtag>=0.1,<1.0",
-    "afi-cli>=0.3,<0.4",
+    "agentfront>=0.20,<0.21",
     "steward-cli>=0.16,<1.0",
     "irc-lens>=0.5.3,<1.0",
     # OTel capped below 1.42 (the 0.6x track below 0.63b0): the metric-reader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "14.1.0"
+version = "14.1.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_cli_afi.py
+++ b/tests/test_cli_afi.py
@@ -12,8 +12,8 @@ def test_culture_afi_version_runs():
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    # afi --version prints "afi X.Y.Z"
-    assert result.stdout.strip().startswith("afi ")
+    # agentfront --version prints "agentfront X.Y.Z"
+    assert result.stdout.strip().startswith("agentfront ")
 
 
 def test_culture_afi_explain_runs():
@@ -39,7 +39,7 @@ def test_culture_afi_learn_runs():
 
 
 def test_culture_afi_overview_runs():
-    # afi-cli 0.3+ exposes `overview`; our pin guarantees it.
+    # agentfront 0.20+ exposes `overview`; our pin guarantees it.
     result = subprocess.run(
         [sys.executable, "-m", "culture_core", "afi", "overview"],
         capture_output=True,

--- a/tests/test_cli_afi_devex.py
+++ b/tests/test_cli_afi_devex.py
@@ -1,6 +1,6 @@
 """Tests for culture_core.cli.afi + culture_core.cli.devex — passthrough wrappers.
 
-Both modules wrap an external CLI (afi-cli / agex-cli) in the
+Both modules wrap an external CLI (agentfront / agex-cli) in the
 `culture_core.cli._passthrough` plumbing. The shared plumbing itself is
 covered by `tests/test_cli_passthrough.py`; this file exercises the
 two thin adapters' `dispatch`, `_entry`, and `register` surfaces.
@@ -50,14 +50,14 @@ def test_afi_dispatch_handles_missing_afi_args(monkeypatch):
 
 
 def test_afi_entry_exits_when_afi_not_installed(monkeypatch):
-    """`_entry` exits with rc 2 when `afi.cli` import fails."""
+    """`_entry` exits with rc 2 when `agentfront.cli` import fails."""
     real_import = (
         __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
     )
 
     def _blocked(name, *a, **kw):
-        if name == "afi.cli":
-            raise ImportError("afi-cli not installed in this env")
+        if name == "agentfront.cli" or name == "agentfront":
+            raise ImportError("agentfront not installed in this env")
         return real_import(name, *a, **kw)
 
     monkeypatch.setattr("builtins.__import__", _blocked)

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "14.1.0"
+version = "14.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "agentfront" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,12 +8,12 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "afi-cli"
-version = "0.3.0"
+name = "agentfront"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/20/c5172963bf440aba92b68a9d043151fb3dd543626fdad1cf846520d1e418/afi_cli-0.3.0.tar.gz", hash = "sha256:884aa1a5b539eedac8b38ea7c89f3c77f4ad1fe4e9d8c0659d306e45d16240ae", size = 92435, upload-time = "2026-04-23T14:55:41.684Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/c2/acf94fc4274161b3c6983b9308544ff7f6ea376ade72c13f7bfeb3dd0711/agentfront-0.20.0.tar.gz", hash = "sha256:990901c75b04cff4d6413eeb510f2fb1c33332a8d43267aa86e5c0e2380f2c37", size = 485014, upload-time = "2026-07-02T06:04:58.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/c1/af36f135cde37206333fd318bd92d49c4e2152d5122687653274fb54300e/afi_cli-0.3.0-py3-none-any.whl", hash = "sha256:f760a92bf1782fc470c3a1cdffef3c4f8014e749475332f45ce43811855ada7f", size = 54411, upload-time = "2026-04-23T14:55:42.662Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/95/8fd2a19d2b92fe1500bb28587af722d28638f95e70a0d8ac191cd45b2a72/agentfront-0.20.0-py3-none-any.whl", hash = "sha256:1c6b20006e3aad858ed6cb4ef6c3f7181c2b27c54e82eb269f31658707bdfd98", size = 140246, upload-time = "2026-07-02T06:04:57.696Z" },
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ name = "culture"
 version = "14.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "afi-cli" },
+    { name = "agentfront" },
     { name = "agentirc-cli" },
     { name = "agex-cli" },
     { name = "agtag" },
@@ -679,7 +679,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "afi-cli", specifier = ">=0.3,<0.4" },
+    { name = "agentfront", specifier = ">=0.20,<0.21" },
     { name = "agentirc-cli", specifier = ">=9.7.0,<10" },
     { name = "agex-cli", specifier = ">=0.13,<0.14" },
     { name = "agtag", specifier = ">=0.1,<1.0" },


### PR DESCRIPTION
## What

Migrates culture off the retired `afi-cli` dist onto **agentfront** (its renamed successor, 0.20.0 on PyPI) — task **t5** / PR1 of the three-minds plan (#467, spec+plan in #466).

- `pyproject.toml`: `afi-cli>=0.3,<0.4` → `agentfront>=0.20,<0.21`, pin comment rewritten (cap at the validated minor, same philosophy as before).
- `culture_core/cli/afi.py`: imports `agentfront.cli` instead of the vanished `afi.cli`; docstring/error text updated. **The `culture afi` verb name is unchanged** (any rename is a parked follow-up).
- `tests/test_cli_afi.py`, `tests/test_cli_afi_devex.py`: assertions track the new package; the import-block test now blocks `agentfront.cli`.
- `uv.lock` refreshed.

## Verification

- Full engine suite on this branch: **1696 passed, 1 skipped** (Playwright, expected), 64s.
- `uv run culture afi overview` exits 0; `explain`/`learn` verbs forward correctly.
- afi-cli is absent from the lock; nothing imports `afi.*` anymore.

## Provenance

Implementation by a colleague drive (local Qwen3.6-27B via `ask-colleague write`, drive `c83acd50a9b7`), verified and gated by the orchestrating session. Rebase note: #466 also bumps to 14.1.1 — whichever merges second rebases its CHANGELOG entry.

- culture (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkifhHMT74KAteRMXGo975