### PR TITLE
PR5a — durable-mesh provisioning: culture server/console install, ordered agent units (three-minds t13, #467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [14.2.0] - 2026-07-02
+
+### Added
+
+- culture server install/uninstall and culture console install/uninstall — CLI-provisioned auto-start units symmetric with culture agents install; agent units now order After=/Wants= the server unit; idempotent installs, friendly no-op uninstalls; docs/durable-mesh.md documents reboot survival and the cloudflared tunnel-unit pattern (PR5a of the three-minds plan, #467).
+
+### Fixed
+
+- `culture console install/uninstall` now fail closed when `~/.culture/server.yaml` is absent instead of silently provisioning under the default server name `culture` (`culture-console-culture` ordered behind a server unit that was never installed) — mirrors `culture server install`'s strict loader (Qodo review, #469).
+- `install_service`/`uninstall_service` validate the systemd unit `name` and `After=`/`Wants=` target before writing a unit file: a server name with whitespace, a newline, or a path separator (from `--name` or mesh config) would otherwise emit a unit systemd refuses to load, silently dropping the intended ordering (Qodo review, #469).
+
+### Changed
+
+- docs/durable-mesh.md: the cloudflared tunnel token moves from `~/.config/cloudflared/` to `~/.culture/cloudflared-<name>.token` (culture's own credential belongs under the `~/.culture/` carve-out; the unit points at it via `TUNNEL_TOKEN_FILE`) (Qodo review, #469).
+
 ## [14.1.4] - 2026-07-02
 
 ### Changed

--- a/culture_core/cli/agents.py
+++ b/culture_core/cli/agents.py
@@ -1410,7 +1410,15 @@ def _cmd_install(args: argparse.Namespace) -> None:
     # tests/test_setup_update_cli.py::test_install_mesh_services_omits_legacy_config_path.
     agent_cmd = [*culture_cmd, "agents", "start", full_nick, "--foreground"]
     svc = f"culture-agent-{full_nick}"
-    path = install_service(svc, agent_cmd, f"culture-core agents {full_nick}")
+    # After=/Wants= the server unit so a reboot brings the mesh up
+    # server-first (durable mesh, docs/durable-mesh.md). The server name
+    # resolves from the same config the agent's nick resolves from.
+    path = install_service(
+        svc,
+        agent_cmd,
+        f"culture-core agents {full_nick}",
+        after=f"culture-server-{config.server.name}.service",
+    )
     print(f"Installed {svc} → {path}")
 
 

--- a/culture_core/cli/console.py
+++ b/culture_core/cli/console.py
@@ -427,10 +427,25 @@ def _console_service_identity() -> tuple[str, str]:
     (``~/.culture/server.yaml``) — the same place agent units resolve
     their server — so the console unit's name and its After=/Wants=
     ordering always match the server unit installed on this machine.
-    """
-    from culture_core.config import load_config_or_default
 
-    config = load_config_or_default(DEFAULT_CONFIG)
+    Fails closed when the manifest is absent: provisioning must not
+    silently fall back to the default server name (``culture``) and target
+    a ``culture-console-culture`` unit ordered behind a
+    ``culture-server-culture`` unit that was never installed. This mirrors
+    ``culture server install``'s strict ``_load_mesh_for_provisioning``
+    (server.py) — both install and uninstall resolve identity here, so
+    both fail loudly rather than operate on a phantom default name.
+    """
+    from culture_core.config import load_config
+
+    if not Path(DEFAULT_CONFIG).exists():
+        raise CultureError(
+            EXIT_USER_ERROR,
+            f"no server config at {DEFAULT_CONFIG}",
+            "start a server first with 'culture server start' (it writes "
+            "~/.culture/server.yaml), then rerun this console command",
+        )
+    config = load_config(DEFAULT_CONFIG)
     server_name = config.server.name
     return f"culture-console-{server_name}", server_name
 

--- a/culture_core/cli/console.py
+++ b/culture_core/cli/console.py
@@ -10,6 +10,8 @@ the lens with culture-aware ergonomics:
     culture console serve --host ...  -> pure passthrough
     culture console explain           -> irc-lens explain (passthrough)
     culture console stop [--web-port] -> stop a locally-running console
+    culture console install [--config PATH] -> auto-start service unit
+    culture console uninstall        -> remove the service unit
 
 The full design lives in
 ``docs/superpowers/specs/2026-05-05-culture-console-design.md``. The
@@ -36,6 +38,7 @@ from culture_core.cli import _passthrough
 from culture_core.cli._errors import EXIT_ENV_ERROR, EXIT_USER_ERROR, CultureError
 from culture_core.cli.shared.console_helpers import resolve_console_nick as _resolve_console_nick
 from culture_core.cli.shared.console_helpers import resolve_server as _resolve_server
+from culture_core.cli.shared.constants import DEFAULT_CONFIG
 
 NAME = "console"
 
@@ -46,8 +49,10 @@ NAME = "console"
 # request for help rather than a server name (common typo for `--help`).
 _IRC_LENS_VERBS = frozenset({"learn", "explain", "overview", "serve", "cli", "help"})
 
-# `stop` is the one culture-owned verb — handled before passthrough.
-# It shadows any culture server literally named "stop".
+# `stop`, `install`, and `uninstall` are the culture-owned verbs —
+# handled in dispatch() before passthrough (irc-lens knows nothing
+# about pidfiles or service units). They shadow any culture server
+# literally named "stop"/"install"/"uninstall".
 
 # Per-port slot keys under ~/.culture/pids/. A `culture console` on port
 # 8765 owns `console-8765.{pid,port,json}`; a side-by-side run on 8766
@@ -399,6 +404,74 @@ def _cmd_stop(args: argparse.Namespace) -> None:
     print(f"force-stopped culture console (pid {pid}, port {web_port}).", file=sys.stderr)
 
 
+# --- install / uninstall verbs (durable mesh) -------------------------------
+
+
+def _parse_install_argv(argv: list[str]) -> str | None:
+    """Extract ``--config PATH`` (or ``--config=PATH``) from an ``install``
+    argv. ``argv[0]`` is the literal ``"install"`` token. Tolerant of
+    unknown flags, mirroring :func:`_parse_stop_argv`."""
+    norm = _normalise_argv(argv[1:])
+    i = 0
+    while i < len(norm):
+        if norm[i] == "--config" and i + 1 < len(norm):
+            return norm[i + 1]
+        i += 1
+    return None
+
+
+def _console_service_identity() -> tuple[str, str]:
+    """Resolve ``(service_name, server_name)`` for the console unit.
+
+    The server name comes from the manifest at ``DEFAULT_CONFIG``
+    (``~/.culture/server.yaml``) — the same place agent units resolve
+    their server — so the console unit's name and its After=/Wants=
+    ordering always match the server unit installed on this machine.
+    """
+    from culture_core.config import load_config_or_default
+
+    config = load_config_or_default(DEFAULT_CONFIG)
+    server_name = config.server.name
+    return f"culture-console-{server_name}", server_name
+
+
+def _cmd_install(args: argparse.Namespace) -> None:
+    """Install an auto-start unit running ``console serve [--config PATH]``.
+
+    Culture-side (never reaches irc-lens). Idempotent: rerunning
+    rewrites the same unit content and re-enables it. Without
+    ``--config``, ExecStart defers to irc-lens's own default config
+    path — no path pinning (same rule as agent units, PR #344).
+    """
+    from culture_core.persistence import install_service
+
+    raw = list(getattr(args, "console_args", []) or [])
+    lens_config = _parse_install_argv(raw)
+    svc, server_name = _console_service_identity()
+    command = [sys.executable, "-m", "culture_core", "console", "serve"]
+    if lens_config:
+        command += ["--config", lens_config]
+    path = install_service(
+        svc,
+        command,
+        f"culture-core console {server_name}",
+        after=f"culture-server-{server_name}.service",
+    )
+    print(f"Installed {svc} → {path}")
+
+
+def _cmd_uninstall(args: argparse.Namespace) -> None:
+    """Remove the console's service unit. Graceful no-op if not installed."""
+    from culture_core.persistence import uninstall_service
+
+    del args  # no flags today; keep the uniform handler signature
+    svc, _ = _console_service_identity()
+    if uninstall_service(svc):
+        print(f"Uninstalled {svc}")
+    else:
+        print(f"{svc} is not installed — nothing to do")
+
+
 # --- entry point ----------------------------------------------------------
 
 
@@ -590,6 +663,12 @@ def dispatch(args: argparse.Namespace) -> None:
     verb = next(iter(raw), None)
     if verb == "stop":
         _cmd_stop(args)
+        sys.exit(0)
+    if verb == "install":
+        _cmd_install(args)
+        sys.exit(0)
+    if verb == "uninstall":
+        _cmd_uninstall(args)
         sys.exit(0)
     argv, server_name = _resolve_argv(raw)
     if argv and argv[0] == "serve":

--- a/culture_core/cli/mesh.py
+++ b/culture_core/cli/mesh.py
@@ -304,7 +304,14 @@ def _install_mesh_services(
             "--foreground",
         ]
         agent_svc = f"culture-agent-{full_nick}"
-        path = install_service(agent_svc, agent_cmd, f"culture-core agents {full_nick}")
+        # After=/Wants= the server unit so a reboot brings the mesh up
+        # server-first (durable mesh, docs/durable-mesh.md).
+        path = install_service(
+            agent_svc,
+            agent_cmd,
+            f"culture-core agents {full_nick}",
+            after=f"{svc_name}.service",
+        )
         print(f"  Installed {agent_svc} → {path}")
 
 
@@ -312,6 +319,10 @@ def _cmd_setup(args: argparse.Namespace) -> None:
     from culture_core.mesh_config import load_mesh_config
     from culture_core.persistence import list_services, uninstall_service
 
+    # Same resolution `culture server install` uses (see
+    # shared.mesh.load_mesh_or_generate) — kept inline here because the
+    # existing test contract patches this module's
+    # generate_mesh_from_agents attribute.
     try:
         mesh = load_mesh_config(args.config)
     except FileNotFoundError:
@@ -561,7 +572,12 @@ def _restart_mesh_services(
             full_nick,
             "--foreground",
         ]
-        install_service(f"culture-agent-{full_nick}", agent_cmd, f"culture-core agents {full_nick}")
+        install_service(
+            f"culture-agent-{full_nick}",
+            agent_cmd,
+            f"culture-core agents {full_nick}",
+            after=f"culture-server-{server_name}.service",
+        )
 
     server_svc = f"culture-server-{server_name}"
     server_fallback = [

--- a/culture_core/cli/server.py
+++ b/culture_core/cli/server.py
@@ -1,13 +1,14 @@
-"""Server subcommands: culture server {start,stop,status,default,rename,archive,unarchive}.
+"""Server subcommands: culture server
+{start,stop,status,default,rename,archive,unarchive,install,uninstall}.
 
 Renamed back from ``culture chat`` in culture 10.0.0 — the surface
-manages a server (lifecycle + agentirc passthrough), not a chat. The 7
+manages a server (lifecycle + agentirc passthrough), not a chat. The 9
 verbs above stay culture-owned; everything else (``restart``, ``link``,
 ``logs``, ``version``, ``serve``, plus any new verb agentirc adds in
 future versions) falls through verbatim to ``agentirc.cli.dispatch`` so
 it lands under ``culture server <verb>`` for free.
 
-The 7 culture-owned verbs are NOT forwarded because:
+The culture-owned verbs are NOT forwarded because:
 
 - ``start`` embeds ``agentirc.ircd.IRCd`` in-process and installs
   culture's system-bot bridge (``culture_core.bots.install_system_bridge``)
@@ -22,6 +23,9 @@ The 7 culture-owned verbs are NOT forwarded because:
 - ``default``, ``rename``, ``archive``, ``unarchive`` operate on
   culture's local config (``~/.culture/server.yaml``). Agentirc has no
   notion of them.
+- ``install`` and ``uninstall`` provision the ``culture-server-<name>``
+  auto-start service unit (durable mesh, ``docs/durable-mesh.md``) via
+  ``culture_core.persistence``. Agentirc knows nothing about units.
 """
 
 from __future__ import annotations
@@ -58,7 +62,12 @@ from .shared.constants import (
     DEFAULT_CONFIG,
     LOG_DIR,
 )
-from .shared.mesh import parse_link, resolve_links_from_mesh
+from .shared.mesh import (
+    build_server_start_cmd,
+    load_mesh_or_generate,
+    parse_link,
+    resolve_links_from_mesh,
+)
 
 logger = logging.getLogger("culture")
 
@@ -168,6 +177,32 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help=_CONFIG_HELP,
     )
 
+    # install/uninstall resolve the server identity from mesh.yaml (falling
+    # back to generating it from ~/.culture/server.yaml), the same config
+    # resolution `culture mesh setup` uses — hence a mesh.yaml --config
+    # default here, not the server.yaml one the other verbs take.
+    _MESH_CONFIG_HELP = (
+        "Path to mesh.yaml (default: ~/.culture/mesh.yaml; generated from "
+        "~/.culture/server.yaml when missing)"
+    )
+    srv_install = server_sub.add_parser(
+        "install", help="Install an auto-start service unit for the server"
+    )
+    srv_install.add_argument(
+        "--config",
+        default=os.path.expanduser("~/.culture/mesh.yaml"),
+        help=_MESH_CONFIG_HELP,
+    )
+
+    srv_uninstall = server_sub.add_parser(
+        "uninstall", help="Remove the server's auto-start service unit"
+    )
+    srv_uninstall.add_argument(
+        "--config",
+        default=os.path.expanduser("~/.culture/mesh.yaml"),
+        help=_MESH_CONFIG_HELP,
+    )
+
 
 def _cmd_default(args: argparse.Namespace) -> None:
     """Set the default server name."""
@@ -219,7 +254,7 @@ def dispatch(args: argparse.Namespace) -> None:
         print(
             "Usage: culture server "
             "{start|stop|status|default|rename|archive|unarchive"
-            "|restart|link|logs|version|serve}",
+            "|install|uninstall|restart|link|logs|version|serve}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -245,6 +280,8 @@ def dispatch(args: argparse.Namespace) -> None:
         "rename": _server_rename,
         "archive": _server_archive,
         "unarchive": _server_unarchive,
+        "install": _server_install,
+        "uninstall": _server_uninstall,
     }
     handler = handlers.get(verb)
     if handler is None:
@@ -717,6 +754,59 @@ def _server_status(args: argparse.Namespace) -> None:
     else:
         print(f"Server '{args.name}': not running (stale PID {pid})")
         remove_pid(pid_name)
+
+
+# -----------------------------------------------------------------------
+# Install / Uninstall — server service unit (durable mesh)
+# -----------------------------------------------------------------------
+
+
+def _load_mesh_for_provisioning(config_path: str):
+    """Resolve the mesh config a provisioning verb operates on.
+
+    Reuses the exact resolution ``culture mesh setup`` uses (mesh.yaml,
+    falling back to generating one from ``~/.culture/server.yaml``) so
+    the unit `culture server install` writes is identical to the one
+    bulk setup would write. Raises a user error when neither exists.
+    """
+    mesh = load_mesh_or_generate(config_path)
+    if mesh is None:
+        raise CultureError(
+            EXIT_USER_ERROR,
+            f"no mesh config at {config_path} and no server config at {DEFAULT_CONFIG}",
+            "start a server with 'culture server start' (and register agents with "
+            "'culture agents register'), then rerun: culture server install",
+        )
+    return mesh
+
+
+def _server_install(args: argparse.Namespace) -> None:
+    """Install a systemd/launchd/scheduled-task unit for the server.
+
+    Idempotent: rerunning rewrites the same unit content and re-enables it.
+    """
+    from culture_core.persistence import install_service
+
+    mesh = _load_mesh_for_provisioning(args.config)
+    server_name = mesh.server.name
+
+    culture_cmd = [sys.executable, "-m", "culture_core"]
+    server_cmd = build_server_start_cmd(mesh, culture_cmd, args.config)
+    svc = f"culture-server-{server_name}"
+    path = install_service(svc, server_cmd, f"culture-core server {server_name}")
+    print(f"Installed {svc} → {path}")
+
+
+def _server_uninstall(args: argparse.Namespace) -> None:
+    """Remove the server's service unit. Graceful no-op if not installed."""
+    from culture_core.persistence import uninstall_service
+
+    mesh = _load_mesh_for_provisioning(args.config)
+    svc = f"culture-server-{mesh.server.name}"
+    if uninstall_service(svc):
+        print(f"Uninstalled {svc}")
+    else:
+        print(f"{svc} is not installed — nothing to do")
 
 
 # -----------------------------------------------------------------------

--- a/culture_core/cli/shared/mesh.py
+++ b/culture_core/cli/shared/mesh.py
@@ -91,6 +91,24 @@ def generate_mesh_from_agents(mesh_config_path: str):
     return mesh
 
 
+def load_mesh_or_generate(config_path: str):
+    """Load mesh.yaml, falling back to generating it from the server manifest.
+
+    This is the one config resolution used by every verb that provisions
+    the server's service unit (``culture mesh setup``,
+    ``culture server install``/``uninstall``): read *config_path*
+    (mesh.yaml); if it doesn't exist, derive one from ``DEFAULT_CONFIG``
+    (``~/.culture/server.yaml``) and save it. Returns ``None`` when
+    neither file exists — callers raise their own user error.
+    """
+    from culture_core.mesh_config import load_mesh_config
+
+    try:
+        return load_mesh_config(config_path)
+    except FileNotFoundError:
+        return generate_mesh_from_agents(config_path)
+
+
 def build_server_start_cmd(
     mesh, culture_cmd: "list[str] | str", mesh_config_path: str
 ) -> list[str]:

--- a/culture_core/persistence.py
+++ b/culture_core/persistence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -15,6 +16,35 @@ LOG_DIR = os.path.expanduser("~/.culture/logs")
 logger = logging.getLogger(__name__)
 
 DEFAULT_CMD_TIMEOUT = 30.0
+
+# A unit identifier interpolated into a generated unit file — the service
+# ``name`` and any ``After=``/``Wants=`` target — must be free of whitespace,
+# path separators, and control characters. Server names reach here from CLI
+# ``--name`` and mesh/server config, neither strictly constrained, and a name
+# carrying a space or newline would emit a unit file systemd refuses to load
+# (silently dropping the intended ordering). Restrict to the character class
+# systemd itself permits in a unit name; the ``.`` allows the ``.service``
+# suffix on ``After=`` targets.
+_UNIT_IDENT_RE = re.compile(r"^[A-Za-z0-9@:._-]+$")
+
+
+def _validate_unit_identifier(value: str, *, kind: str) -> None:
+    """Reject a service ``name`` / ordering target that isn't unit-safe.
+
+    Raises :class:`CultureError` (lazily imported so this low-level module
+    stays out of the CLI import graph, as in :func:`_build_systemd_unit`).
+    """
+    if not _UNIT_IDENT_RE.match(value):
+        from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
+
+        raise CultureError(
+            EXIT_USER_ERROR,
+            f"invalid systemd unit {kind} {value!r}: contains characters not "
+            "allowed in a unit name (whitespace, path separators, or control "
+            "characters)",
+            "use a server name of letters, digits, and '-_.@:' only (set it via "
+            "'culture server start --name <name>' or ~/.culture/server.yaml)",
+        )
 
 
 def get_platform() -> str:
@@ -222,6 +252,9 @@ def install_service(
     (launchd, Windows scheduled tasks) accept and ignore it — their
     retry loops absorb a dependency that isn't up yet.
     """
+    _validate_unit_identifier(name, kind="name")
+    if after is not None:
+        _validate_unit_identifier(after, kind="After= target")
     platform = get_platform()
     installer = _PLATFORM_INSTALLERS.get(platform)
     if installer is None:
@@ -275,6 +308,7 @@ def uninstall_service(name: str) -> bool:
     Returns True if an entry was found and removed, False if there was
     nothing to remove — callers use this for friendly no-op messages.
     """
+    _validate_unit_identifier(name, kind="name")
     uninstaller = _PLATFORM_UNINSTALLERS.get(get_platform())
     if uninstaller is None:
         return False

--- a/culture_core/persistence.py
+++ b/culture_core/persistence.py
@@ -59,12 +59,19 @@ def _run_cmd(args: list[str], timeout: float = DEFAULT_CMD_TIMEOUT) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _build_systemd_unit(name: str, command: list[str], description: str) -> str:
+def _build_systemd_unit(
+    name: str, command: list[str], description: str, after: str | None = None
+) -> str:
     # Lazy import: keep this low-level module from pulling in the whole CLI
     # package (culture_core.cli.__init__ imports every command group) at load.
     from culture_core.cli._errors import EXIT_DAEMON_PERMANENT
 
     exec_start = " ".join(shlex.quote(arg) for arg in command)
+    # After= orders this unit behind *after* (e.g. the server unit) and
+    # Wants= pulls it in, so a reboot brings the mesh up server-first.
+    # Wants (not Requires): a crashed server must not tear down agents
+    # that can outlast a brief server restart via their own reconnects.
+    ordering = f"After={after}\nWants={after}\n" if after else ""
     # RestartPreventExitStatus parks the unit in a clear failed state when
     # the daemon child signals a permanent error (exit contract, #15) —
     # transient crashes still self-heal via Restart=on-failure.
@@ -72,6 +79,7 @@ def _build_systemd_unit(name: str, command: list[str], description: str) -> str:
         f"# {name}\n"
         f"[Unit]\n"
         f"Description={description}\n"
+        f"{ordering}"
         f"\n"
         f"[Service]\n"
         f"Type=simple\n"
@@ -142,17 +150,26 @@ def _build_windows_bat(command: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _install_linux_service(name: str, command: list[str], description: str) -> Path:
+def _install_linux_service(
+    name: str, command: list[str], description: str, after: str | None = None
+) -> Path:
     unit_dir = _systemd_user_dir()
     unit_dir.mkdir(parents=True, exist_ok=True)
     path = unit_dir / f"{name}.service"
-    path.write_text(_build_systemd_unit(name, command, description))
+    path.write_text(_build_systemd_unit(name, command, description, after=after))
     _run_cmd(["systemctl", "--user", "daemon-reload"])
     _run_cmd(["systemctl", "--user", "enable", name])
     return path
 
 
-def _install_macos_service(name: str, command: list[str], description: str) -> Path:
+def _install_macos_service(
+    name: str, command: list[str], description: str, after: str | None = None
+) -> Path:
+    # launchd limitation: user LaunchAgents have no inter-agent ordering
+    # primitive, so *after* is accepted and ignored — KeepAlive retries
+    # until the server is reachable. Same graceful degradation as
+    # RestartPreventExitStatus above.
+    del after
     agent_dir = _launchd_dir()
     agent_dir.mkdir(parents=True, exist_ok=True)
     plist_name = f"com.culture.{name}"
@@ -162,7 +179,12 @@ def _install_macos_service(name: str, command: list[str], description: str) -> P
     return path
 
 
-def _install_windows_service(name: str, command: list[str], description: str) -> Path:
+def _install_windows_service(
+    name: str, command: list[str], description: str, after: str | None = None
+) -> Path:
+    # Scheduled tasks run ONLOGON with no inter-task ordering — *after* is
+    # accepted and ignored; the .bat retry loop absorbs a not-yet-up server.
+    del after
     svc_dir = _windows_service_dir()
     svc_dir.mkdir(parents=True, exist_ok=True)
     bat_path = svc_dir / f"{name}.bat"
@@ -190,37 +212,54 @@ _PLATFORM_INSTALLERS = {
 }
 
 
-def install_service(name: str, command: list[str], description: str) -> Path:
-    """Generate and install a platform-specific auto-start entry."""
+def install_service(
+    name: str, command: list[str], description: str, after: str | None = None
+) -> Path:
+    """Generate and install a platform-specific auto-start entry.
+
+    *after* names a sibling service this one should start after (systemd
+    ``After=``/``Wants=``); platforms without an ordering primitive
+    (launchd, Windows scheduled tasks) accept and ignore it — their
+    retry loops absorb a dependency that isn't up yet.
+    """
     platform = get_platform()
     installer = _PLATFORM_INSTALLERS.get(platform)
     if installer is None:
         raise RuntimeError(f"Unsupported platform: {platform}")
-    return installer(name, command, description)
+    return installer(name, command, description, after=after)
 
 
-def _uninstall_linux_service(name: str) -> None:
+def _uninstall_linux_service(name: str) -> bool:
     _run_cmd(["systemctl", "--user", "disable", name])
     _run_cmd(["systemctl", "--user", "stop", name])
     path = _systemd_user_dir() / f"{name}.service"
-    if path.exists():
+    removed = path.exists()
+    if removed:
         path.unlink()
     _run_cmd(["systemctl", "--user", "daemon-reload"])
+    return removed
 
 
-def _uninstall_macos_service(name: str) -> None:
+def _uninstall_macos_service(name: str) -> bool:
     plist_name = f"com.culture.{name}"
     path = _launchd_dir() / f"{plist_name}.plist"
     if path.exists():
         _run_cmd(["launchctl", "unload", str(path)])
         path.unlink()
+        return True
+    return False
 
 
-def _uninstall_windows_service(name: str) -> None:
+def _uninstall_windows_service(name: str) -> bool:
+    # /Delete runs unconditionally to also reap a stray scheduled task
+    # whose .bat is already gone (partial state); the return value
+    # reports on the .bat, the artifact install_service created.
     _run_cmd(["schtasks", "/Delete", "/TN", f"culture\\{name}", "/F"])
     bat_path = _windows_service_dir() / f"{name}.bat"
-    if bat_path.exists():
+    removed = bat_path.exists()
+    if removed:
         bat_path.unlink()
+    return removed
 
 
 _PLATFORM_UNINSTALLERS = {
@@ -230,11 +269,16 @@ _PLATFORM_UNINSTALLERS = {
 }
 
 
-def uninstall_service(name: str) -> None:
-    """Remove a platform-specific auto-start entry."""
+def uninstall_service(name: str) -> bool:
+    """Remove a platform-specific auto-start entry.
+
+    Returns True if an entry was found and removed, False if there was
+    nothing to remove — callers use this for friendly no-op messages.
+    """
     uninstaller = _PLATFORM_UNINSTALLERS.get(get_platform())
-    if uninstaller is not None:
-        uninstaller(name)
+    if uninstaller is None:
+        return False
+    return uninstaller(name)
 
 
 def _list_systemd_services() -> list[str]:

--- a/docs/durable-mesh.md
+++ b/docs/durable-mesh.md
@@ -115,7 +115,7 @@ Wants=culture-console-<name>.service
 
 [Service]
 Type=simple
-Environment=TUNNEL_TOKEN_FILE=%h/.config/cloudflared/<name>.token
+Environment=TUNNEL_TOKEN_FILE=%h/.culture/cloudflared-<name>.token
 ExecStart=cloudflared tunnel --no-autoupdate run
 Restart=on-failure
 RestartSec=5
@@ -126,13 +126,15 @@ WantedBy=default.target
 
 The token lives in a file, never in the unit (unit files are
 world-readable metadata; `systemctl show` would leak an inline
-`Environment=TUNNEL_TOKEN=…`). Create it with owner-only permissions:
+`Environment=TUNNEL_TOKEN=…`). Keep it under `~/.culture/` (the token is
+culture's own tunnel credential, and the path is free — the unit points at
+it via `TUNNEL_TOKEN_FILE`), created with owner-only permissions:
 
 ```bash
-mkdir -p ~/.config/cloudflared
+mkdir -p ~/.culture
 umask 077
-printf '%s' '<tunnel-token>' > ~/.config/cloudflared/<name>.token
-chmod 0600 ~/.config/cloudflared/<name>.token
+printf '%s' '<tunnel-token>' > ~/.culture/cloudflared-<name>.token
+chmod 0600 ~/.culture/cloudflared-<name>.token
 
 systemctl --user daemon-reload
 systemctl --user enable --now cloudflared-<name>.service

--- a/docs/durable-mesh.md
+++ b/docs/durable-mesh.md
@@ -1,0 +1,157 @@
+# Durable mesh — provisioning the whole node to survive reboots
+
+A mesh node is only useful if it comes back on its own. This page
+covers the provisioning verbs that install auto-start service units for
+every long-running piece of a node — server, console, agents — plus the
+enable/linger story that makes them actually start after a reboot, and
+the documented (not automated) unit pattern for a Cloudflare tunnel in
+front of the console. Provisioning is part of the offering that is
+culture: moving a mesh to a new machine, or handing one to someone
+else, is a short sequence of CLI commands — no hand-written units.
+
+## The provisioning verbs
+
+All verbs are idempotent: installing twice rewrites the same unit
+content and re-enables it (exit 0, no duplicate side effects);
+uninstalling something that isn't installed is a friendly no-op
+(exit 0).
+
+| Verb | Unit | ExecStart |
+|------|------|-----------|
+| `culture server install [--config MESH_YAML]` | `culture-server-<name>.service` | `<python> -m culture_core server start --foreground --name <name> --host <host> --port <port> --mesh-config <mesh.yaml>` |
+| `culture server uninstall [--config MESH_YAML]` | removes the above | — |
+| `culture console install [--config LENS_CONFIG]` | `culture-console-<name>.service` | `<python> -m culture_core console serve [--config <path>]` |
+| `culture console uninstall` | removes the above | — |
+| `culture agents install <nick>` | `culture-agent-<server>-<nick>.service` | `<python> -m culture_core agents start <nick> --foreground` |
+| `culture agents uninstall <nick>` | removes the above | — |
+| `culture mesh setup` | bulk: server + every agent in `mesh.yaml` | as above |
+
+Config resolution:
+
+- **Server** — `culture server install` reuses the exact resolution
+  `culture mesh setup` uses: read `~/.culture/mesh.yaml` (override with
+  `--config`); when it's missing, generate it from the server manifest
+  at `~/.culture/server.yaml` and save it. Host, port, and
+  `--mesh-config` in the unit's ExecStart come from that resolved mesh
+  config — there is no second config story.
+- **Console** — `culture console` is an irc-lens passthrough, but
+  `install`/`uninstall` are culture-side verbs, intercepted before
+  anything reaches irc-lens (which knows nothing about service units).
+  `--config` here is the **irc-lens** config path baked into ExecStart;
+  without it, the unit defers to irc-lens's own default
+  (`~/.config/irc-lens/config.yaml`), which `console serve`
+  auto-initializes on first run. The `<name>` in the unit name is the
+  server name from `~/.culture/server.yaml` — the same place agent
+  units resolve their server.
+- **Agents** — see [Agent systemd units](reference/cli/agent-systemd.md).
+  ExecStart deliberately carries no `--config`; the daemon falls
+  through to the manifest at `~/.culture/server.yaml`.
+
+## Start ordering
+
+On Linux, console and agent units carry ordering on the server unit:
+
+```ini
+[Unit]
+After=culture-server-<name>.service
+Wants=culture-server-<name>.service
+```
+
+A reboot brings the mesh up server-first; `Wants=` (not `Requires=`)
+pulls the server in without tearing agents down when the server unit
+restarts — agents ride out brief server outages via their own
+reconnect logic.
+
+macOS (launchd) and Windows (scheduled tasks) have no equivalent
+ordering primitive; the ordering hint is accepted and ignored there.
+launchd's `KeepAlive` and the Windows retry loop absorb a
+not-yet-listening server the same way they absorb any transient
+failure — everything converges, just less tidily.
+
+## Reboot survival: enable + linger
+
+Installing a unit runs `systemctl --user enable`, which links it into
+`default.target` — but **user** units only start when the user's
+systemd instance starts, and by default that only happens at login. For
+a headless mesh node that must come up unattended, enable lingering
+once:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+With lingering on, the user manager (and every enabled culture unit)
+starts at boot, no login required. The full durable-node checklist:
+
+```bash
+culture server install                 # culture-server-<name>.service
+culture console install                # culture-console-<name>.service
+culture agents install <nick>          # one per registered agent
+loginctl enable-linger "$USER"         # start units at boot, not at login
+```
+
+Verify after a reboot with `systemctl --user status
+'culture-*.service'` and `culture agents status`.
+
+Units restart on failure (`Restart=on-failure`, `RestartSec=5`) and
+park on permanent errors (`RestartPreventExitStatus=78` — the daemon
+exit contract) instead of crash-looping.
+
+## Fronting the console: the cloudflared tunnel unit pattern
+
+A public console (e.g. `chat.agentculture.org`) typically sits behind a
+Cloudflare tunnel. The CLI does **not** provision this — minting and
+rotating tunnel tokens is Cloudflare account state the CLI can't own,
+and on a machine move the token must be re-issued by the operator. The
+unit pattern below is documented so the by-hand step is one file, not
+an afternoon:
+
+```ini
+# ~/.config/systemd/user/cloudflared-<name>.service
+[Unit]
+Description=cloudflared tunnel for culture console (<name>)
+After=culture-console-<name>.service
+Wants=culture-console-<name>.service
+
+[Service]
+Type=simple
+Environment=TUNNEL_TOKEN_FILE=%h/.config/cloudflared/<name>.token
+ExecStart=cloudflared tunnel --no-autoupdate run
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+The token lives in a file, never in the unit (unit files are
+world-readable metadata; `systemctl show` would leak an inline
+`Environment=TUNNEL_TOKEN=…`). Create it with owner-only permissions:
+
+```bash
+mkdir -p ~/.config/cloudflared
+umask 077
+printf '%s' '<tunnel-token>' > ~/.config/cloudflared/<name>.token
+chmod 0600 ~/.config/cloudflared/<name>.token
+
+systemctl --user daemon-reload
+systemctl --user enable --now cloudflared-<name>.service
+```
+
+`--no-autoupdate` keeps cloudflared from replacing its own binary out
+from under systemd. With lingering enabled the tunnel survives reboots
+alongside the console it fronts.
+
+## Platform notes
+
+The persistence layer (`culture_core/persistence.py`) targets three
+platforms; every install/uninstall verb on this page goes through it:
+
+| Platform | Mechanism | Location |
+|----------|-----------|----------|
+| Linux | systemd user units | `~/.config/systemd/user/<unit>.service` |
+| macOS | launchd LaunchAgents | `~/Library/LaunchAgents/com.culture.<unit>.plist` |
+| Windows | scheduled task + `.bat` retry loop | `%USERPROFILE%\.culture\services\<unit>.bat` |
+
+Unsupported platforms fail installs with a clean `Unsupported platform`
+error; uninstalls no-op.

--- a/docs/reference/cli/agent-systemd.md
+++ b/docs/reference/cli/agent-systemd.md
@@ -22,6 +22,20 @@ argparse default — `~/.culture/server.yaml`, the manifest the rest of
 the CLI uses. Anything specified in that manifest (workdir, channels,
 backend) is what the daemon reads.
 
+Agent units are ordered behind the server unit:
+
+```text
+After=culture-server-<name>.service
+Wants=culture-server-<name>.service
+```
+
+The server name resolves from the same manifest as the agent's nick,
+so a reboot brings the mesh up server-first. `Wants=` (not
+`Requires=`) means a server restart does not tear agents down — they
+reconnect on their own. The sibling `culture server install` /
+`culture console install` verbs provision the units agents order
+behind; see [Durable mesh](../../durable-mesh.md).
+
 ## Recovering from stale pre-10.3.5 units
 
 Before culture 10.3.5, the unit generator pinned a legacy

--- a/docs/reference/cli/console.md
+++ b/docs/reference/cli/console.md
@@ -46,11 +46,14 @@ invocation). See `irc-lens config init --help` for available flags.
 | `culture console overview` | Pure passthrough to `irc-lens overview`. |
 | `culture console learn` | Pure passthrough to `irc-lens learn`. |
 | `culture console stop` | **Culture-owned.** Stop the locally-running console. |
+| `culture console install [--config PATH]` | **Culture-owned.** Install the `culture-console-<name>` auto-start unit. |
+| `culture console uninstall` | **Culture-owned.** Remove the auto-start unit (no-op if absent). |
 | `culture console --help` | irc-lens's own help. |
 
-`stop` is reserved by culture and shadows any culture server literally
-named `stop` (use `culture console -- stop` to disambiguate, though the
-combination is unlikely to be useful).
+`stop`, `install`, and `uninstall` are reserved by culture and shadow
+any culture server literally named after them (use `culture console --
+<name>` to disambiguate, though the combination is unlikely to be
+useful).
 
 ## Port-conflict UX
 
@@ -140,6 +143,25 @@ culture console stop --web-port 8766  # stop a side-by-side console
 
 `stop` does not affect the AgentIRC server or any agents — only the
 local console process for the requested port.
+
+## `culture console install` / `uninstall`
+
+```bash
+culture console install                                   # ExecStart defers to irc-lens's default config
+culture console install --config ~/.config/irc-lens/config.yaml
+culture console uninstall
+```
+
+Installs `culture-console-<name>.service` (Linux systemd user unit;
+launchd/scheduled-task on macOS/Windows) running `<python> -m
+culture_core console serve [--config <path>]`. The `<name>` is the
+server name from `~/.culture/server.yaml` — the same place agent units
+resolve their server — and the unit is ordered `After=`/`Wants=`
+`culture-server-<name>.service`. Both verbs are culture-side,
+intercepted before passthrough (irc-lens knows nothing about service
+units), and idempotent: install twice rewrites the identical unit and
+re-enables; uninstall of an absent unit is a friendly no-op (exit 0).
+See [Durable mesh](../../durable-mesh.md).
 
 ## See also
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -108,6 +108,32 @@ culture server unarchive --name spark
 
 Clears the archived flag but does not start any services.
 
+### `culture server install`
+
+Install an auto-start unit (`culture-server-<name>.service` on Linux)
+for the server. Host, port, and `--mesh-config` in the unit's
+`ExecStart` come from the same resolution `culture mesh setup` uses:
+`~/.culture/mesh.yaml` (override with `--config`), generated from
+`~/.culture/server.yaml` when missing. Idempotent — rerunning rewrites
+the identical unit and re-enables it.
+
+```bash
+culture server install
+culture server install --config ~/.culture/mesh.yaml
+```
+
+See [Durable mesh](../../durable-mesh.md) for the full reboot-survival
+story (unit ordering, linger, the cloudflared tunnel pattern).
+
+### `culture server uninstall`
+
+Remove the server's auto-start unit. Friendly no-op (exit 0) if the
+unit isn't installed.
+
+```bash
+culture server uninstall
+```
+
 ## Agent Lifecycle
 
 ### `culture agents create`
@@ -268,9 +294,12 @@ culture agents install claude          # bare suffix — resolved against server
 
 The generated `ExecStart` is `culture agents start <full-nick>
 --foreground` with no `--config` flag — the daemon falls through to
-the manifest at `~/.culture/server.yaml`. Decoupled from `mesh.yaml`:
-use this when you manage agents directly rather than via
-`culture mesh setup`. See
+the manifest at `~/.culture/server.yaml`. On Linux the unit is ordered
+`After=`/`Wants=` the `culture-server-<name>.service` unit (server
+name resolved from the same manifest), so a reboot brings the mesh up
+server-first — see [Durable mesh](../../durable-mesh.md). Decoupled
+from `mesh.yaml`: use this when you manage agents directly rather than
+via `culture mesh setup`. See
 [Agent systemd units](./agent-systemd.html) for unit-body details and
 recovery.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "14.1.4"
+version = "14.2.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_agent_install_cli.py
+++ b/tests/test_agent_install_cli.py
@@ -122,6 +122,23 @@ def test_install_rejects_unknown_nick(tmp_path):
     mock_install.assert_not_called()
 
 
+def test_install_orders_agent_unit_after_server_unit(tmp_path):
+    """Agent units gain After=/Wants= ordering on the server unit (durable
+    mesh): the server name resolves from the same config the agent's nick
+    resolves from."""
+    from culture_core.cli.agents import _cmd_install
+
+    server_yaml = _write_manifest(tmp_path, server_name="spark", suffixes=("claude",))
+    args = argparse.Namespace(config=str(server_yaml), nick="claude")
+
+    with patch("culture_core.persistence.install_service") as mock_install:
+        mock_install.return_value = Path("/tmp/fake.service")
+        _cmd_install(args)
+
+    _args_, kwargs = mock_install.call_args
+    assert kwargs.get("after") == "culture-server-spark.service"
+
+
 def test_uninstall_calls_uninstall_service_with_correct_name(tmp_path):
     """`culture agents uninstall <suffix>` calls uninstall_service('culture-agent-<full>')."""
     from culture_core.cli.agents import _cmd_uninstall

--- a/tests/test_console_install_cli.py
+++ b/tests/test_console_install_cli.py
@@ -1,0 +1,173 @@
+# tests/test_console_install_cli.py
+"""Tests for `culture console install/uninstall` (durable-mesh provisioning).
+
+`culture console` is an irc-lens passthrough — these verbs are
+culture-side, intercepted in dispatch() before anything reaches
+irc-lens (which knows nothing about service units). The generated
+`culture-console-<name>` unit runs `<python> -m culture_core console
+serve [--config <path>]` and is ordered After=/Wants= the server unit.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from culture_core.cli import console
+
+
+def _server_yaml(tmp_path, name="spark"):
+    """Write a minimal ~/.culture/server.yaml stand-in and return its path."""
+    from culture_core.config import (
+        ServerConfig,
+        ServerConnConfig,
+        save_server_config,
+    )
+
+    path = tmp_path / "server.yaml"
+    save_server_config(str(path), ServerConfig(server=ServerConnConfig(name=name)))
+    return path
+
+
+def _args(argv):
+    return argparse.Namespace(console_args=argv)
+
+
+class TestConsoleInstall:
+    def test_install_intercepted_before_passthrough(self, tmp_path):
+        """`install` must never reach irc-lens — it's a culture-side verb."""
+        server_yaml = _server_yaml(tmp_path)
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.install_service") as mock_install,
+            patch.object(console, "_invoke_irc_lens") as mock_lens,
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            mock_install.return_value = Path("/tmp/fake.service")
+            console.dispatch(_args(["install"]))
+
+        assert excinfo.value.code == 0
+        mock_lens.assert_not_called()
+        mock_install.assert_called_once()
+
+    def test_install_unit_name_command_and_ordering(self, tmp_path):
+        """Unit is culture-console-<name>, runs `console serve --config <path>`,
+        and orders After=/Wants= the server unit."""
+        server_yaml = _server_yaml(tmp_path, name="spark")
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.install_service") as mock_install,
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            mock_install.return_value = Path("/tmp/fake.service")
+            console.dispatch(_args(["install", "--config", "/etc/irc-lens/lens.yaml"]))
+
+        assert excinfo.value.code == 0
+        args_, kwargs = mock_install.call_args
+        svc_name, command, description = args_[0], args_[1], args_[2]
+        assert svc_name == "culture-console-spark"
+        assert command == [
+            sys.executable,
+            "-m",
+            "culture_core",
+            "console",
+            "serve",
+            "--config",
+            "/etc/irc-lens/lens.yaml",
+        ]
+        assert description == "culture-core console spark"
+        assert kwargs.get("after") == "culture-server-spark.service"
+
+    def test_install_accepts_equals_form_config(self, tmp_path):
+        server_yaml = _server_yaml(tmp_path, name="spark")
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.install_service") as mock_install,
+            pytest.raises(SystemExit),
+        ):
+            mock_install.return_value = Path("/tmp/fake.service")
+            console.dispatch(_args(["install", "--config=/x/lens.yaml"]))
+
+        command = mock_install.call_args[0][1]
+        assert command[-2:] == ["--config", "/x/lens.yaml"]
+
+    def test_install_without_config_omits_flag(self, tmp_path):
+        """No --config -> ExecStart defers to irc-lens's own default config
+        path (mirrors the agents-install rule of not pinning config paths)."""
+        server_yaml = _server_yaml(tmp_path, name="spark")
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.install_service") as mock_install,
+            pytest.raises(SystemExit),
+        ):
+            mock_install.return_value = Path("/tmp/fake.service")
+            console.dispatch(_args(["install"]))
+
+        command = mock_install.call_args[0][1]
+        assert command == [sys.executable, "-m", "culture_core", "console", "serve"]
+        assert "--config" not in command
+
+    def test_install_twice_is_idempotent(self, tmp_path):
+        """Install twice = identical unit content, re-enabled, exit 0 both
+        times. Targets a tmp XDG path — never the real ~/.config/systemd."""
+        server_yaml = _server_yaml(tmp_path, name="spark")
+        unit_dir = tmp_path / "systemd" / "user"
+
+        for _ in range(2):
+            with (
+                patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+                patch("culture_core.persistence.get_platform", return_value="linux"),
+                patch("culture_core.persistence._systemd_user_dir", return_value=unit_dir),
+                patch("culture_core.persistence._run_cmd"),
+                pytest.raises(SystemExit) as excinfo,
+            ):
+                console.dispatch(_args(["install"]))
+            assert excinfo.value.code == 0
+
+        units = list(unit_dir.glob("*.service"))
+        assert [u.name for u in units] == ["culture-console-spark.service"]
+        content = units[0].read_text()
+        assert "After=culture-server-spark.service" in content
+        assert "Wants=culture-server-spark.service" in content
+
+
+class TestConsoleUninstall:
+    def test_uninstall_removes_unit(self, tmp_path, capsys):
+        server_yaml = _server_yaml(tmp_path, name="spark")
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.uninstall_service", return_value=True) as mock_un,
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            console.dispatch(_args(["uninstall"]))
+
+        assert excinfo.value.code == 0
+        mock_un.assert_called_once_with("culture-console-spark")
+        assert "Uninstalled culture-console-spark" in capsys.readouterr().out
+
+    def test_uninstall_when_absent_is_friendly_noop(self, tmp_path, capsys):
+        server_yaml = _server_yaml(tmp_path, name="spark")
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.uninstall_service", return_value=False),
+            pytest.raises(SystemExit) as excinfo,
+        ):
+            console.dispatch(_args(["uninstall"]))
+
+        assert excinfo.value.code == 0
+        out = capsys.readouterr().out
+        assert "culture-console-spark" in out
+        assert "not installed" in out
+
+    def test_uninstall_intercepted_before_passthrough(self, tmp_path):
+        server_yaml = _server_yaml(tmp_path)
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(server_yaml)),
+            patch("culture_core.persistence.uninstall_service", return_value=True),
+            patch.object(console, "_invoke_irc_lens") as mock_lens,
+            pytest.raises(SystemExit),
+        ):
+            console.dispatch(_args(["uninstall"]))
+        mock_lens.assert_not_called()

--- a/tests/test_console_install_cli.py
+++ b/tests/test_console_install_cli.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 
 from culture_core.cli import console
+from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
 
 
 def _server_yaml(tmp_path, name="spark"):
@@ -171,3 +172,33 @@ class TestConsoleUninstall:
         ):
             console.dispatch(_args(["uninstall"]))
         mock_lens.assert_not_called()
+
+
+class TestConsoleProvisioningFailsClosedWithoutManifest:
+    """Qodo #469: with no ~/.culture/server.yaml, provisioning must fail loudly
+    rather than silently default to the `culture` server name and target a
+    `culture-console-culture` unit ordered behind a server that was never
+    installed. Mirrors `culture server install`'s strict loader."""
+
+    def test_install_without_manifest_raises_user_error(self, tmp_path):
+        missing = tmp_path / "absent" / "server.yaml"
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(missing)),
+            patch("culture_core.persistence.install_service") as mock_install,
+            pytest.raises(CultureError) as excinfo,
+        ):
+            console.dispatch(_args(["install"]))
+        assert excinfo.value.code == EXIT_USER_ERROR
+        assert str(missing) in excinfo.value.message
+        mock_install.assert_not_called()
+
+    def test_uninstall_without_manifest_raises_user_error(self, tmp_path):
+        missing = tmp_path / "absent" / "server.yaml"
+        with (
+            patch.object(console, "DEFAULT_CONFIG", str(missing)),
+            patch("culture_core.persistence.uninstall_service") as mock_un,
+            pytest.raises(CultureError) as excinfo,
+        ):
+            console.dispatch(_args(["uninstall"]))
+        assert excinfo.value.code == EXIT_USER_ERROR
+        mock_un.assert_not_called()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -7,12 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
-from culture_core.cli._errors import EXIT_DAEMON_PERMANENT
+from culture_core.cli._errors import EXIT_DAEMON_PERMANENT, EXIT_USER_ERROR, CultureError
 from culture_core.persistence import (
     _build_launchd_plist,
     _build_systemd_unit,
     _build_windows_bat,
     _run_cmd,
+    _validate_unit_identifier,
     get_platform,
     install_service,
     list_services,
@@ -153,6 +154,67 @@ def test_install_service_windows_accepts_after(tmp_path):
             after="culture-server-spark.service",
         )
     assert path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Unit-identifier validation (Qodo #469): a name/After= target with
+# whitespace, path separators, or control chars would emit a unit file
+# systemd refuses to load. install/uninstall reject it before writing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "culture-server-a b",  # space
+        "culture-server-a\nb",  # newline
+        "culture-server-a\tb",  # tab
+        "culture-server-a\rb",  # carriage return
+        "culture/server",  # path separator
+        "culture\\server",  # backslash
+        "",  # empty
+    ],
+)
+def test_install_service_rejects_unsafe_name(bad):
+    with pytest.raises(CultureError) as excinfo:
+        install_service(bad, ["echo", "hi"], "desc")
+    assert excinfo.value.code == EXIT_USER_ERROR
+
+
+def test_install_service_rejects_unsafe_after(tmp_path):
+    # A valid name but a malformed ordering target is still rejected — before
+    # any file is written (unit_dir stays empty).
+    unit_dir = tmp_path / "systemd" / "user"
+    with (
+        patch("culture_core.persistence.get_platform", return_value="linux"),
+        patch("culture_core.persistence._systemd_user_dir", return_value=unit_dir),
+        patch("culture_core.persistence._run_cmd"),
+        pytest.raises(CultureError),
+    ):
+        install_service(
+            "culture-agent-spark-claude",
+            ["echo", "hi"],
+            "desc",
+            after="culture-server-a b.service",
+        )
+    assert not unit_dir.exists() or not list(unit_dir.glob("*.service"))
+
+
+def test_uninstall_service_rejects_unsafe_name():
+    with pytest.raises(CultureError) as excinfo:
+        uninstall_service("bad name\n")
+    assert excinfo.value.code == EXIT_USER_ERROR
+
+
+def test_validate_unit_identifier_accepts_real_unit_names():
+    # The names/targets the provisioning verbs actually generate must pass.
+    for good in (
+        "culture-server-spark",
+        "culture-agent-spark-claude",
+        "culture-console-spark.service",
+        "culture-server-node_1.service",
+    ):
+        _validate_unit_identifier(good, kind="name")  # no raise
 
 
 def test_uninstall_service_reports_removal(tmp_path):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -74,6 +74,133 @@ def test_build_systemd_unit_parks_permanent_failures():
     assert "RestartPreventExitStatus=78" in unit
 
 
+def test_build_systemd_unit_with_after_ordering():
+    """An `after` unit renders as After=/Wants= lines in the [Unit] section
+    so dependent units start once the server unit is up (durable mesh)."""
+    unit = _build_systemd_unit(
+        name="culture-agent-spark-claude",
+        command=["culture", "agents", "start", "spark-claude", "--foreground"],
+        description="culture-core agents spark-claude",
+        after="culture-server-spark.service",
+    )
+    assert "After=culture-server-spark.service" in unit
+    assert "Wants=culture-server-spark.service" in unit
+    # Ordering directives belong to [Unit], before [Service] begins.
+    assert unit.index("After=") < unit.index("[Service]")
+    assert unit.index("Wants=") < unit.index("[Service]")
+
+
+def test_build_systemd_unit_without_after_has_no_ordering():
+    unit = _build_systemd_unit(
+        name="culture-server-spark",
+        command=["culture", "server", "start", "--foreground"],
+        description="culture-core server spark",
+    )
+    assert "After=" not in unit
+    assert "Wants=" not in unit
+
+
+def test_install_service_linux_threads_after_into_unit(tmp_path):
+    unit_dir = tmp_path / "systemd" / "user"
+    with (
+        patch("culture_core.persistence.get_platform", return_value="linux"),
+        patch("culture_core.persistence._systemd_user_dir", return_value=unit_dir),
+        patch("culture_core.persistence._run_cmd"),
+    ):
+        path = install_service(
+            "culture-console-spark",
+            ["culture", "console", "serve"],
+            "culture-core console spark",
+            after="culture-server-spark.service",
+        )
+    content = path.read_text()
+    assert "After=culture-server-spark.service" in content
+    assert "Wants=culture-server-spark.service" in content
+
+
+def test_install_service_macos_accepts_after(tmp_path):
+    """launchd has no user-agent ordering primitive — `after` is accepted
+    and ignored (KeepAlive retries until the server is reachable), the same
+    graceful degradation as RestartPreventExitStatus."""
+    agent_dir = tmp_path / "LaunchAgents"
+    with (
+        patch("culture_core.persistence.get_platform", return_value="macos"),
+        patch("culture_core.persistence._launchd_dir", return_value=agent_dir),
+        patch("culture_core.persistence._run_cmd"),
+    ):
+        path = install_service(
+            "console-spark",
+            ["culture", "console", "serve"],
+            "culture-core console spark",
+            after="culture-server-spark.service",
+        )
+    assert path.exists()
+
+
+def test_install_service_windows_accepts_after(tmp_path):
+    """Scheduled tasks run ONLOGON with no inter-task ordering — `after` is
+    accepted and ignored (the .bat retry loop absorbs a not-yet-up server)."""
+    svc_dir = tmp_path / "services"
+    with (
+        patch("culture_core.persistence.get_platform", return_value="windows"),
+        patch("culture_core.persistence._windows_service_dir", return_value=svc_dir),
+        patch("culture_core.persistence._run_cmd"),
+    ):
+        path = install_service(
+            "console-spark",
+            ["culture", "console", "serve"],
+            "culture-core console spark",
+            after="culture-server-spark.service",
+        )
+    assert path.exists()
+
+
+def test_uninstall_service_reports_removal(tmp_path):
+    """uninstall_service returns True when it removed an entry, False when
+    there was nothing to remove — so CLI verbs can print a friendly no-op."""
+    unit_dir = tmp_path / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    (unit_dir / "culture-server-spark.service").write_text("[Unit]\n")
+    with (
+        patch("culture_core.persistence.get_platform", return_value="linux"),
+        patch("culture_core.persistence._systemd_user_dir", return_value=unit_dir),
+        patch("culture_core.persistence._run_cmd"),
+    ):
+        assert uninstall_service("culture-server-spark") is True
+        assert uninstall_service("culture-server-spark") is False
+
+
+def test_uninstall_service_reports_removal_macos(tmp_path):
+    agent_dir = tmp_path / "LaunchAgents"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "com.culture.console-spark.plist").write_text("<plist/>\n")
+    with (
+        patch("culture_core.persistence.get_platform", return_value="macos"),
+        patch("culture_core.persistence._launchd_dir", return_value=agent_dir),
+        patch("culture_core.persistence._run_cmd"),
+    ):
+        assert uninstall_service("console-spark") is True
+        assert uninstall_service("console-spark") is False
+
+
+def test_uninstall_service_reports_removal_windows(tmp_path):
+    svc_dir = tmp_path / "services"
+    svc_dir.mkdir(parents=True)
+    (svc_dir / "console-spark.bat").write_text("@echo off\n")
+    with (
+        patch("culture_core.persistence.get_platform", return_value="windows"),
+        patch("culture_core.persistence._windows_service_dir", return_value=svc_dir),
+        patch("culture_core.persistence._run_cmd"),
+    ):
+        assert uninstall_service("console-spark") is True
+        assert uninstall_service("console-spark") is False
+
+
+def test_uninstall_service_unsupported_platform_returns_false():
+    with patch("culture_core.persistence.get_platform", return_value="aix"):
+        assert uninstall_service("x") is False
+
+
 def test_build_launchd_plist():
     plist = _build_launchd_plist(
         name="com.culture.server-spark",

--- a/tests/test_server_install_cli.py
+++ b/tests/test_server_install_cli.py
@@ -1,0 +1,201 @@
+# tests/test_server_install_cli.py
+"""Tests for `culture server install/uninstall` (durable-mesh provisioning).
+
+Symmetric with `culture agents install` (tests/test_agent_install_cli.py):
+the verbs generate + enable a `culture-server-<name>` auto-start unit whose
+ExecStart reuses the same config resolution `culture mesh setup` uses —
+mesh.yaml, falling back to generating it from ~/.culture/server.yaml.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_mesh(tmp_path, name="spark", host="0.0.0.0", port=6667):
+    """Write a minimal mesh.yaml and return its path."""
+    from culture_core.mesh_config import (
+        MeshConfig,
+        MeshServerConfig,
+        save_mesh_config,
+    )
+
+    mesh_yaml = tmp_path / "mesh.yaml"
+    mesh = MeshConfig(server=MeshServerConfig(name=name, host=host, port=port))
+    save_mesh_config(mesh, mesh_yaml)
+    return mesh_yaml
+
+
+def test_install_passes_correct_argv_to_install_service(tmp_path):
+    """The unit's ExecStart reuses build_server_start_cmd — same argv as
+    the units `culture mesh setup` generates (host/port/mesh-config from
+    the resolved mesh config, --foreground for the service manager)."""
+    from culture_core.cli.server import _server_install
+
+    mesh_yaml = _write_mesh(tmp_path, name="spark", host="0.0.0.0", port=6667)
+    args = argparse.Namespace(config=str(mesh_yaml))
+
+    with patch("culture_core.persistence.install_service") as mock_install:
+        mock_install.return_value = Path("/tmp/fake.service")
+        _server_install(args)
+
+    assert mock_install.call_count == 1
+    args_, _kwargs = mock_install.call_args
+    svc_name, command, description = args_[0], args_[1], args_[2]
+
+    assert svc_name == "culture-server-spark"
+    assert command == [
+        sys.executable,
+        "-m",
+        "culture_core",
+        "server",
+        "start",
+        "--foreground",
+        "--name",
+        "spark",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "6667",
+        "--mesh-config",
+        str(mesh_yaml),
+    ]
+    assert description == "culture-core server spark"
+
+
+def test_install_generates_mesh_from_server_manifest_when_missing(tmp_path):
+    """No mesh.yaml -> fall back to generating one from ~/.culture/server.yaml,
+    exactly like `culture mesh setup` (reuse, not a new resolution)."""
+    from culture_core.cli.server import _server_install
+    from culture_core.config import (
+        ServerConfig,
+        ServerConnConfig,
+        save_server_config,
+    )
+
+    server_yaml = tmp_path / "server.yaml"
+    save_server_config(str(server_yaml), ServerConfig(server=ServerConnConfig(name="thor")))
+    mesh_yaml = tmp_path / "mesh.yaml"  # does not exist
+
+    args = argparse.Namespace(config=str(mesh_yaml))
+    with (
+        patch("culture_core.cli.shared.mesh.DEFAULT_CONFIG", str(server_yaml)),
+        patch("culture_core.persistence.install_service") as mock_install,
+    ):
+        mock_install.return_value = Path("/tmp/fake.service")
+        _server_install(args)
+
+    svc_name = mock_install.call_args[0][0]
+    assert svc_name == "culture-server-thor"
+    # The fallback saves the generated mesh.yaml (same side effect as setup).
+    assert mesh_yaml.exists()
+
+
+def test_install_errors_when_no_config_anywhere(tmp_path):
+    """Neither mesh.yaml nor server.yaml -> CultureError exit 1 with remediation."""
+    from culture_core.cli._errors import CultureError
+    from culture_core.cli.server import _server_install
+
+    args = argparse.Namespace(config=str(tmp_path / "mesh.yaml"))
+    with (
+        patch("culture_core.cli.shared.mesh.DEFAULT_CONFIG", str(tmp_path / "server.yaml")),
+        patch("culture_core.persistence.install_service") as mock_install,
+        pytest.raises(CultureError) as exc,
+    ):
+        _server_install(args)
+
+    assert exc.value.code == 1
+    mock_install.assert_not_called()
+
+
+def test_install_twice_is_idempotent(tmp_path):
+    """Running install twice rewrites identical unit content and re-enables —
+    exit 0 both times, no duplicate units. Targets a tmp XDG path; never the
+    real ~/.config/systemd of this machine."""
+    from culture_core.cli.server import _server_install
+
+    mesh_yaml = _write_mesh(tmp_path, name="spark")
+    unit_dir = tmp_path / "systemd" / "user"
+    args = argparse.Namespace(config=str(mesh_yaml))
+
+    with (
+        patch("culture_core.persistence.get_platform", return_value="linux"),
+        patch("culture_core.persistence._systemd_user_dir", return_value=unit_dir),
+        patch("culture_core.persistence._run_cmd") as mock_run,
+    ):
+        _server_install(args)
+        first = (unit_dir / "culture-server-spark.service").read_text()
+        _server_install(args)
+        second = (unit_dir / "culture-server-spark.service").read_text()
+
+    assert first == second
+    assert len(list(unit_dir.glob("*.service"))) == 1
+    # enable fired on both runs (re-enable is part of the idempotent contract)
+    enables = [c for c in mock_run.call_args_list if "enable" in c.args[0]]
+    assert len(enables) == 2
+
+
+def test_uninstall_removes_unit(tmp_path, capsys):
+    """`culture server uninstall` removes the unit resolved from the config."""
+    from culture_core.cli.server import _server_uninstall
+
+    mesh_yaml = _write_mesh(tmp_path, name="spark")
+    args = argparse.Namespace(config=str(mesh_yaml))
+
+    with patch("culture_core.persistence.uninstall_service", return_value=True) as mock_un:
+        _server_uninstall(args)
+
+    mock_un.assert_called_once_with("culture-server-spark")
+    assert "Uninstalled culture-server-spark" in capsys.readouterr().out
+
+
+def test_uninstall_when_absent_is_friendly_noop(tmp_path, capsys):
+    """Uninstalling a unit that isn't installed is a friendly no-op, exit 0."""
+    from culture_core.cli.server import _server_uninstall
+
+    mesh_yaml = _write_mesh(tmp_path, name="spark")
+    args = argparse.Namespace(config=str(mesh_yaml))
+
+    with patch("culture_core.persistence.uninstall_service", return_value=False):
+        _server_uninstall(args)  # must not raise
+
+    out = capsys.readouterr().out
+    assert "culture-server-spark" in out
+    assert "not installed" in out
+
+
+def test_install_uninstall_parsers_registered():
+    """Both verbs appear on the argparse surface with a --config flag."""
+    import os
+
+    from culture_core.cli import _build_parser
+
+    p = _build_parser()
+    args = p.parse_args(["server", "install"])
+    assert args.command == "server"
+    assert args.server_command == "install"
+    assert args.config == os.path.expanduser("~/.culture/mesh.yaml")
+
+    args = p.parse_args(["server", "install", "--config", "/tmp/mesh.yaml"])
+    assert args.config == "/tmp/mesh.yaml"
+
+    args = p.parse_args(["server", "uninstall"])
+    assert args.server_command == "uninstall"
+
+
+def test_install_uninstall_in_dispatch():
+    """Handlers are wired into the dispatch table."""
+    from culture_core.cli import server
+
+    args = argparse.Namespace(server_command="install", config="/nonexistent/mesh.yaml")
+    with patch.object(server, "_server_install") as mock_handler:
+        server.dispatch(args)
+    mock_handler.assert_called_once_with(args)
+
+    args = argparse.Namespace(server_command="uninstall", config="/nonexistent/mesh.yaml")
+    with patch.object(server, "_server_uninstall") as mock_handler:
+        server.dispatch(args)
+    mock_handler.assert_called_once_with(args)

--- a/tests/test_setup_update_cli.py
+++ b/tests/test_setup_update_cli.py
@@ -286,6 +286,49 @@ def test_install_mesh_services_omits_legacy_config_path():
         assert "agents" in command and "start" in command and "--foreground" in command
 
 
+def test_install_mesh_services_orders_agent_units_after_server_unit():
+    """Bulk setup installs agent units with After=/Wants= on the server unit
+    (durable mesh); the server unit itself carries no ordering."""
+    from culture_core.cli.mesh import _install_mesh_services
+
+    mesh = MeshConfig(
+        server=MeshServerConfig(name="spark", host="127.0.0.1", port=6667),
+        agents=[MeshAgentConfig(nick="claude", workdir="/home/u/work")],
+    )
+
+    with (
+        patch("culture_core.persistence.install_service") as mock_install,
+        patch(f"{_MESH_MOD}.build_server_start_cmd", return_value=["culture", "server", "start"]),
+    ):
+        _install_mesh_services(mesh, "spark", "/usr/bin/culture", "/etc/mesh.yaml")
+
+    by_name = {call.args[0]: call.kwargs for call in mock_install.call_args_list}
+    assert by_name["culture-server-spark"].get("after") is None
+    assert by_name["culture-agent-spark-claude"].get("after") == "culture-server-spark.service"
+
+
+def test_restart_mesh_services_orders_agent_units_after_server_unit():
+    """The update/restart path regenerates units with the same ordering."""
+    from culture_core.cli.mesh import _restart_mesh_services
+
+    mesh = MeshConfig(
+        server=MeshServerConfig(name="spark", host="127.0.0.1", port=6667),
+        agents=[MeshAgentConfig(nick="claude", workdir="/home/u/work")],
+    )
+
+    with (
+        patch("culture_core.persistence.install_service") as mock_install,
+        patch("culture_core.persistence.restart_service", return_value=True),
+        patch(f"{_MESH_MOD}.build_server_start_cmd", return_value=["culture", "server", "start"]),
+        patch(f"{_MESH_MOD}._wait_for_server_port", return_value=True),
+    ):
+        _restart_mesh_services(mesh, "spark", "/usr/bin/culture", "/etc/mesh.yaml", False)
+
+    by_name = {call.args[0]: call.kwargs for call in mock_install.call_args_list}
+    assert by_name["culture-server-spark"].get("after") is None
+    assert by_name["culture-agent-spark-claude"].get("after") == "culture-server-spark.service"
+
+
 def test_restart_mesh_services_uses_plural_agents_noun():
     """Regenerated agent units (restart path) must invoke `culture agents start`.
 

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "14.1.4"
+version = "14.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "agentfront" },


### PR DESCRIPTION
## What

The durable mesh becomes a **CLI-supported product capability, not hand-ops** — task **t13** / PR5a of the three-minds plan (#467, spec+plan in #466): anyone (or a machine move) reaches a reboot-surviving mesh from documented commands alone.

- **`culture server install [--config MESH_YAML]` / `uninstall`** — writes + enables `culture-server-<name>.service` (`server start --foreground` with host/port/mesh-config resolved by the same mesh.yaml→server.yaml resolution `culture mesh setup` uses; reused via a new `load_mesh_or_generate()` helper, not reinvented).
- **`culture console install [--config PATH]` / `uninstall`** — culture-side verbs intercepted before the irc-lens passthrough; unit runs `console serve` ordered `After=/Wants=` the server unit.
- **Agent units gain ordering** — all three agent-unit generators (`agents install`, `mesh setup`, `mesh update`) now order behind the server unit. Wants (not Requires): a brief server restart must not tear agents down; their reconnect logic outlasts it.
- **Idempotency contract** — install twice rewrites identical content and re-enables (exit 0); uninstall-when-absent is a friendly no-op (exit 0). `uninstall_service()` now reports whether anything was removed. launchd/Windows accept-and-ignore the ordering parameter (no primitive there), matching the `RestartPreventExitStatus` graceful-degradation precedent.
- **`docs/durable-mesh.md`** — verb table, contracts, reboot survival (enable + linger checklist), and the **documented-not-automated** cloudflared tunnel-unit pattern (`TUNNEL_TOKEN_FILE`, 0600 token file); cross-linked from the CLI reference pages.

## Verification

- Strict TDD: failing tests first (`test_server_install_cli.py` +201, `test_console_install_cli.py` +173, `test_persistence.py` +127, plus ordering coverage in agent/mesh tests); all unit writes patched to tmp paths — no real systemd session touched.
- Full suite on this branch, run twice (builder + independent orchestrator gate): **1724 passed, 1 skipped** (Playwright, environmental).
- black/isort/flake8/pylint/bandit/markdownlint clean; backend-parity guard vs main: PASS.

## Follow-up (t14, not this PR)

Replacing spark's hand-written server/console/tunnel units with CLI-provisioned ones and the unattended-reboot verification — deliberately excluded here (tests must not touch the live session).

Rebase note: parallel wave-0 PRs (#466 → 14.1.1, #468 → 14.1.1) each bump from main; whichever merges later rebases its CHANGELOG entry — this one claims 14.2.0 (new commands ⇒ minor).

- culture (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkifhHMT74KAteRMXGo975