### PR TITLE
PR2b — unknown agent backends fail loudly instead of running as claude (three-minds t2, #467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - An explicitly set unknown agent backend no longer silently runs the claude daemon: _resolve_daemon_factory raises CultureError naming the valid backends (observed in production: an agent configured with a not-yet-existing backend ran as claude unnoticed). Unset/empty backend keeps the claude default; the opencode alias is unchanged (PR2b of the three-minds plan, #467).
+- `classify_daemon_exit` now treats `CultureError` as a permanent daemon failure (exit `EXIT_DAEMON_PERMANENT`/78) — an unknown backend in a supervised daemon child parks the unit instead of restart-looping every `RestartSec`, honoring the daemon exit contract (#15).
 
 ## [14.1.2] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [14.1.3] - 2026-07-02
+
+### Fixed
+
+- An explicitly set unknown agent backend no longer silently runs the claude daemon: _resolve_daemon_factory raises CultureError naming the valid backends (observed in production: an agent configured with a not-yet-existing backend ran as claude unnoticed). Unset/empty backend keeps the claude default; the opencode alias is unchanged (PR2b of the three-minds plan, #467).
+
 ## [14.1.2] - 2026-07-02
 
 ### Added

--- a/culture_core/cli/_errors.py
+++ b/culture_core/cli/_errors.py
@@ -48,8 +48,13 @@ def classify_daemon_exit(exc: BaseException) -> int:
     (port briefly taken, peer down) and anything unknown stay
     :data:`EXIT_DAEMON_TRANSIENT` — it is safer to keep restarting crashes
     we can't positively classify.
+
+    A :class:`CultureError` is always a deliberate, structured
+    config/user/environment error carrying a remediation hint — restarting
+    never resolves it (e.g. an unknown agent ``backend:`` raised by
+    ``_resolve_daemon_factory``), so it parks the unit too.
     """
-    if isinstance(exc, _PERMANENT_DAEMON_EXC):
+    if isinstance(exc, (CultureError, *_PERMANENT_DAEMON_EXC)):
         return EXIT_DAEMON_PERMANENT
     return EXIT_DAEMON_TRANSIENT
 

--- a/culture_core/cli/agents.py
+++ b/culture_core/cli/agents.py
@@ -745,18 +745,43 @@ def _create_claude_daemon(config: DaemonConfig, agent: AgentConfig):
 
 
 _BACKEND_DAEMON_FACTORIES = {
+    "claude": _create_claude_daemon,
     "codex": _create_codex_daemon,
     "acp": _create_acp_daemon,
-    "opencode": _create_acp_daemon,
+    "opencode": _create_acp_daemon,  # alias for acp
     "copilot": _create_copilot_daemon,
 }
+
+
+def _resolve_daemon_factory(backend: str | None):
+    """Resolve the daemon factory for *backend*, failing loudly on unknowns.
+
+    An unset/empty backend keeps the historical claude default. An
+    explicitly set unknown value raises :class:`CultureError` naming the
+    valid backends — the old ``.get(backend, _create_claude_daemon)``
+    fallback silently ran unknown backends as claude (observed in
+    production: an agent configured with a not-yet-existing backend ran
+    as a claude agent unnoticed).
+    """
+    if not backend:
+        return _create_claude_daemon
+    factory = _BACKEND_DAEMON_FACTORIES.get(backend)
+    if factory is None:
+        valid = ", ".join(sorted(_BACKEND_DAEMON_FACTORIES))
+        raise CultureError(
+            EXIT_USER_ERROR,
+            f"unknown agent backend '{backend}' (valid backends: {valid})",
+            "fix the 'backend:' value in the agent's culture.yaml "
+            "(or omit it to default to claude)",
+        )
+    return factory
 
 
 async def _run_single_agent(config: DaemonConfig, agent: AgentConfig) -> None:
     """Run a single agent daemon in the foreground."""
     backend = getattr(agent, "agent", "claude")
 
-    factory = _BACKEND_DAEMON_FACTORIES.get(backend, _create_claude_daemon)
+    factory = _resolve_daemon_factory(backend)
     daemon = factory(config, agent)
 
     stop_event = asyncio.Event()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "14.1.2"
+version = "14.1.3"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -5,7 +5,9 @@ layer; integration-territory functions (`_probe_server_connection`,
 `_start_foreground`, `_start_background`, `_run_single_agent`,
 `_run_multi_agents`) are NOT exercised here —
 `tests/test_integration_agent_runner.py` runs them against a real
-`agentirc.ircd.IRCd`.
+`agentirc.ircd.IRCd`. One carve-out: `_run_single_agent`'s
+unknown-backend guard raises before any daemon exists, so it is unit
+territory (TestResolveDaemonFactory).
 
 Mocking conventions (matches `tests/test_cli_server.py`):
 
@@ -30,7 +32,7 @@ import sys
 import pytest
 
 from culture_core.cli import agents as agent_mod
-from culture_core.cli._errors import CultureError
+from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
 from culture_core.config import AgentConfig, ServerConfig, ServerConnConfig
 
 # ---------------------------------------------------------------------------
@@ -684,6 +686,131 @@ class TestBackendDaemonFactories:
         )
         result = agent_mod._coerce_to_acp_agent(acp)
         assert result is acp
+
+
+# ---------------------------------------------------------------------------
+# Backend resolution — unknown backends fail loudly
+# ---------------------------------------------------------------------------
+#
+# The old `.get(backend, _create_claude_daemon)` fallback silently ran any
+# unknown `backend:` value as a claude daemon — observed in production: an
+# agent configured with a not-yet-existing backend ran as claude unnoticed.
+
+_VALID_BACKEND_NAMES = ("acp", "claude", "codex", "copilot", "opencode")
+
+
+class _StubDaemon:
+    """Inert daemon: lets ``_run_single_agent`` complete without sockets."""
+
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    def set_stop_event(self, event):
+        # Pre-set so `await stop_event.wait()` returns immediately.
+        event.set()
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def _restore_signal_handlers():
+    """Save/restore SIGINT+SIGTERM so `_run_single_agent`'s handler
+    registration can't leak into other tests."""
+    import signal as _signal
+
+    saved = {sig: _signal.getsignal(sig) for sig in (_signal.SIGINT, _signal.SIGTERM)}
+    yield
+    for sig, handler in saved.items():
+        _signal.signal(sig, handler)
+
+
+class TestResolveDaemonFactory:
+    def test_unknown_backend_raises_culture_error(self):
+        with pytest.raises(CultureError) as excinfo:
+            agent_mod._resolve_daemon_factory("bogus")
+        err = excinfo.value
+        assert err.code == EXIT_USER_ERROR
+        assert "bogus" in err.message
+        for name in _VALID_BACKEND_NAMES:
+            assert name in err.message
+        # The valid names are listed in sorted order.
+        positions = [err.message.index(name) for name in sorted(_VALID_BACKEND_NAMES)]
+        assert positions == sorted(positions)
+        # Actionable remediation, pointing at the config knob.
+        assert "backend" in err.remediation
+
+    @pytest.mark.parametrize("backend", [None, ""])
+    def test_unset_backend_defaults_to_claude(self, backend):
+        assert agent_mod._resolve_daemon_factory(backend) is agent_mod._create_claude_daemon
+
+    def test_explicit_claude_resolves_to_claude_factory(self):
+        assert agent_mod._resolve_daemon_factory("claude") is agent_mod._create_claude_daemon
+
+    def test_opencode_alias_resolves_to_acp_factory(self):
+        assert agent_mod._resolve_daemon_factory("opencode") is agent_mod._create_acp_daemon
+
+    @pytest.mark.parametrize(
+        ("backend", "factory_attr"),
+        [
+            ("codex", "_create_codex_daemon"),
+            ("acp", "_create_acp_daemon"),
+            ("copilot", "_create_copilot_daemon"),
+        ],
+    )
+    def test_known_backends_resolve_to_their_factory(self, backend, factory_attr):
+        assert agent_mod._resolve_daemon_factory(backend) is getattr(agent_mod, factory_attr)
+
+    def test_run_single_agent_bogus_backend_raises_before_daemon_creation(
+        self, monkeypatch, _restore_signal_handlers
+    ):
+        """Starting an agent whose backend is 'bogus' fails loudly.
+
+        The guard raises before any daemon is constructed, so no server is
+        needed (cf. the module docstring's `_run_single_agent` carve-out).
+        The claude factory is stubbed as a safety net: if resolution ever
+        regresses to the silent claude fallback, the test fails with
+        DID-NOT-RAISE instead of opening real sockets.
+        """
+        import asyncio
+
+        created = []
+
+        def _record_claude_factory(config, agent):
+            created.append(agent.nick)
+            return _StubDaemon()
+
+        monkeypatch.setattr(agent_mod, "_create_claude_daemon", _record_claude_factory)
+
+        agent = _make_agent(suffix="ada", backend="bogus")
+        cfg = _make_config(agent)
+        with pytest.raises(CultureError) as excinfo:
+            asyncio.run(agent_mod._run_single_agent(cfg, agent))
+        assert "bogus" in excinfo.value.message
+        assert created == []  # never silently fell back to a claude daemon
+
+    def test_run_single_agent_unset_backend_still_runs_claude(
+        self, monkeypatch, _restore_signal_handlers
+    ):
+        """PRESERVE: an empty backend keeps the historical claude default."""
+        import asyncio
+
+        created = []
+
+        def _record_claude_factory(config, agent):
+            created.append(agent.nick)
+            return _StubDaemon()
+
+        monkeypatch.setattr(agent_mod, "_create_claude_daemon", _record_claude_factory)
+
+        agent = _make_agent(suffix="ada", backend="")
+        cfg = _make_config(agent)
+        asyncio.run(agent_mod._run_single_agent(cfg, agent))
+        assert created == [agent.nick]
 
 
 class TestMakeBackendConfig:

--- a/tests/test_daemon_exit_contract.py
+++ b/tests/test_daemon_exit_contract.py
@@ -31,6 +31,9 @@ from culture_core.cli import server as srv_mod
 from culture_core.cli._errors import (
     EXIT_DAEMON_PERMANENT,
     EXIT_DAEMON_TRANSIENT,
+    EXIT_ENV_ERROR,
+    EXIT_USER_ERROR,
+    CultureError,
     classify_daemon_exit,
 )
 from culture_core.pidfile import is_process_alive
@@ -49,8 +52,18 @@ class TestClassifyDaemonExit:
             TypeError("bad config type"),
             PermissionError(errno.EACCES, "permission denied"),
             FileNotFoundError(errno.ENOENT, "no such file"),
+            CultureError(EXIT_USER_ERROR, "unknown agent backend 'bogus'"),
+            CultureError(EXIT_ENV_ERROR, "missing credentials"),
         ],
-        ids=["ValueError", "KeyError", "TypeError", "PermissionError", "FileNotFoundError"],
+        ids=[
+            "ValueError",
+            "KeyError",
+            "TypeError",
+            "PermissionError",
+            "FileNotFoundError",
+            "CultureError-user",
+            "CultureError-env",
+        ],
     )
     def test_permanent_errors_exit_78(self, exc):
         assert classify_daemon_exit(exc) == EXIT_DAEMON_PERMANENT

--- a/uv.lock
+++ b/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "14.1.2"
+version = "14.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "agentfront" },


### PR DESCRIPTION
## What

Removes the silent claude fallback in daemon factory resolution — task **t2** / PR2b of the three-minds plan (#467, spec+plan in #466).

`culture_core/cli/agents.py` resolved factories via `_BACKEND_DAEMON_FACTORIES.get(backend, _create_claude_daemon)`, so any unknown `backend:` value in `culture.yaml` silently ran the claude daemon. Observed in production on 2026-07-02: `spark-colleague`, configured with a backend that doesn't exist yet, ran as a claude agent unnoticed.

- New `_resolve_daemon_factory(backend)`: an **explicitly set** unknown backend raises `CultureError` — `unknown agent backend 'bogus' (valid backends: acp, claude, codex, copilot, opencode)` with the remediation `fix the 'backend:' value in the agent's culture.yaml (or omit it to default to claude)`.
- Preserved: unset/empty backend keeps the historical claude default; the `opencode` alias still maps to acp; `claude` added to the registry as a first-class entry so the listing names all five valid values.

## Verification

- TDD-first: 10 new tests (red stage reproduced the bug with a DID-NOT-RAISE), covering the error contract, that no daemon is constructed before the failure, the claude default, the alias, and per-backend resolution.
- Full suite, builder run + independent orchestrator gate: **1706 passed, 1 skipped** (Playwright, environmental).
- `backend-parity --base main` → PASS (shared resolution logic; no per-backend factory bodies touched). black/isort + pre-commit clean.

Rebase note: wave-0 PRs (#466, #468, #470 → 14.1.1; #469 → 14.2.0) each bump from main; whichever merges later rebases its CHANGELOG entry.

- culture (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkifhHMT74KAteRMXGo975