### PR TITLE
spec+plan: resident presence + mesh resource view (devague)

### DIFF
--- a/.devague/frames/culture-now-knows-when-its-residents-are-busy-ever.json
+++ b/.devague/frames/culture-now-knows-when-its-residents-are-busy-ever.json
@@ -1,0 +1,364 @@
+{
+  "slug": "culture-now-knows-when-its-residents-are-busy-ever",
+  "title": "Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view \u2014 active residents, token spend \u2014 that operators and balancing policies can act on.",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-07-06T21:42:08Z",
+  "updated": "2026-07-06T21:49:52Z",
+  "claims": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view \u2014 active residents, token spend \u2014 that operators and balancing policies can act on.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h8",
+          "text": "demonstrated on the live spark mesh: an operator watches a resident flip busy when handed work and back to idle when done, in real time",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "mesh operators (Ori) and the culture server/supervisor; secondarily the resident agents themselves, which can adapt behavior to mesh load",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h9",
+          "text": "the resource view is consumable both by a human at the CLI (readable table) and programmatically (--json) by server-side policies",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c3",
+      "kind": "before_state",
+      "text": "busy-state is invisible in-band today: token usage exists only as OTel counters (culture.harness.llm.tokens.*) scraped into Prometheus, the AgentIRC IRCd implements no AWAY/presence verb, and 'culture agents status' only knows process/unit-level up/down \u2014 nothing in the mesh knows whether a resident is mid-task",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h10",
+          "text": "verified against the codebase 2026-07-07: no AWAY verb in the agentirc IRCd, no in-band busy signal anywhere, token counters exist only as OTel exhaust (culture.harness.llm.tokens.*)",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c4",
+      "kind": "after_state",
+      "text": "the mesh sees, per resident, a live activity state (busy/idle at minimum) plus resource counters (token spend), aggregated server-side into a resource view the operator and balancing policies can act on",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h11",
+          "text": "with two residents connected and exactly one mid-task, the view shows exactly one busy \u2014 live query, not a cached snapshot",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "resource balance: the operator/mesh can maintain and rebalance \u2014 how many residents are active at once, token budget consumption \u2014 instead of flying blind on an always-on mesh",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h12",
+          "text": "at least one concrete balancing decision (e.g. 'two residents busy \u2014 defer waking a third') is possible from shipped data alone, no Grafana required",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "every enforced backend (claude, codex, colleague) publishes the same busy/idle activity signal \u2014 all-backends rule; copilot/acp stay parity-exempt",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h1",
+          "text": "the backend-parity CI job passes: the emitter lands in shared harness code or in all three enforced backends in the same change \u2014 a busy signal from only one backend is a bug, not a feature",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c7",
+      "kind": "requirement",
+      "text": "the server aggregates per-resident activity + token spend into a queryable resource view exposed via a CLI verb",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h2",
+          "text": "the resource-view command returns every registered resident with state + spend from live mesh data (not stale logs), including residents connected from OTHER servers in the mesh, and works with only 'uv tool install culture'",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c8",
+      "kind": "success_signal",
+      "text": "one command answers 'who is busy right now, and what has each resident spent' with live mesh data \u2014 verified against a resident known to be mid-task",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h13",
+          "text": "the command is demonstrated against the live spark mesh (spark-agentirc, spark-colleague) and the busy resident it reports is genuinely mid-task",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c9",
+      "kind": "boundary",
+      "text": "observation and reporting are the core; no existing IRC command is redefined (protocol extensions use new verbs)",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h14",
+          "text": "diff review confirms no RFC 2812 command semantics changed; a vanilla weechat session against the upgraded server behaves identically",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c10",
+      "kind": "non_goal",
+      "text": "not a billing/cost-accounting system and not a general-purpose task scheduler",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c11",
+      "kind": "requirement",
+      "text": "presence travels as a new protocol extension verb (e.g. PRESENCE) with a structured payload {state, since, current-task hint, token counters}, documented in protocol/extensions/; vanilla IRC clients simply ignore it",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h3",
+          "text": "the verb is genuinely new (no RFC 2812 command redefined), a weechat client connected to the same channel is unaffected, and telemetry/identity strings stay culture.* per the engine rules",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "activity state is richer than binary: idle | listening | thinking (LLM call in flight) | working (tool execution) | draining | offline \u2014 each state maps to an observable harness boundary the backends already cross (harness.llm.call span, tool exec)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h4",
+          "text": "every state transition is driven by an observable code boundary (connect, message handled, LLM call open/close, tool exec, shutdown) \u2014 never by the model self-reporting 'I think I'm busy'",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "stale-busy watchdog: a resident that last reported busy but misses heartbeats for a configurable T is flagged presumed-hung in the resource view \u2014 catching crashed/wedged agents without their cooperation (ties into the always-on/doctor work)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h5",
+          "text": "a kill -9'd resident that last reported busy is flagged presumed-hung within T without any cooperation from the dead process, and a slow-but-alive resident heartbeating through a long LLM call is NOT falsely flagged",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c14",
+      "kind": "requirement",
+      "text": "token budgets become first-class config: a per-agent budget (culture.yaml) the resource view tracks spend against, with warn thresholds surfaced to the operator before the budget is blown",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h6",
+          "text": "a budget breach produces a visible operator signal before enforcement is even considered, and spend accounting has defined window/reset semantics that survive an agent restart",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c15",
+      "kind": "requirement",
+      "text": "a server-side concurrency policy caps how many residents may be actively working at once (max-N admission control); work beyond the cap is deferred/queued visibly, never silently dropped",
+      "origin": "llm",
+      "status": "rejected",
+      "honesty_conditions": [
+        {
+          "id": "h7",
+          "text": "with cap N and N residents busy, the N+1th wake/work item is visibly deferred (queued with a reason), not silently dropped \u2014 and cap=unset preserves today's behavior exactly",
+          "status": "rejected"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c16",
+      "kind": "assumption",
+      "text": "the busy-signal emitter lands in the cultureagent harness (shared transport code) and the IRCd-side verb in agentirc \u2014 this spec covers the culture-side (server aggregation, CLI, config) plus hand-off briefs to the two siblings",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c17",
+      "kind": "assumption",
+      "text": "in-band token reporting shares the same counting source as the existing culture.harness.llm.tokens.* OTel counters, so the mesh view and Grafana never diverge; backends whose SDK exposes no token counts report state-only (same caveat as 8.6.0 telemetry)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c18",
+      "kind": "boundary",
+      "text": "v1 observes and reports only: the server does not act on the signals \u2014 no deferred wakes, no admission control, no budget blocking. Budgets are warn-only. Enforcement is the explicit v2 leg.",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h16",
+          "text": "verifiable in the v1 diff: no code path exists where the server declines, defers, or blocks work based on presence or spend \u2014 a budget breach emits a warning signal only, and mesh behavior with the feature enabled is otherwise identical to today",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c19",
+      "kind": "decision",
+      "text": "activity state ships as the rich six-state enum from the start (idle | listening | thinking | working | draining | offline) so the wire format never needs a breaking revision; consumers may collapse to busy/idle",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c20",
+      "kind": "decision",
+      "text": "policy config splits along the existing config seam: per-agent token budget in that agent's culture.yaml; mesh-wide settings (stale-T, future concurrency cap) in ~/.culture/server.yaml",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "the irc-lens console reflects the new view: an operator can open a dedicated page at chat.agentculture.org showing the live resource view \u2014 per-resident activity state, token spend, budget status \u2014 without touching the CLI",
+      "origin": "user",
+      "status": "confirmed",
+      "honesty_conditions": [
+        {
+          "id": "h15",
+          "text": "the page renders from the same server-side aggregation the CLI verb reads (one source of truth, no second counting path), sits behind CF Access like the rest of the console, and degrades gracefully to an 'IRCd down' notice instead of a 500 when 6667 is unreachable",
+          "status": "confirmed"
+        }
+      ],
+      "hard_questions": [],
+      "links": []
+    },
+    {
+      "id": "c22",
+      "kind": "assumption",
+      "text": "the residents page lands in the sibling irc-lens repo (console pinned irc-lens>=0.8) consuming a data endpoint culture exposes \u2014 so this feature spans three hand-off briefs: cultureagent (emitter), agentirc (IRCd verb), irc-lens (page)",
+      "origin": "llm",
+      "status": "confirmed",
+      "honesty_conditions": [],
+      "hard_questions": [],
+      "links": []
+    }
+  ],
+  "open_vagueness": [
+    {
+      "id": "v1",
+      "text": "load-aware mention routing: when a channel-wide ask goes out, prefer idle residents (attention-system integration)",
+      "kind": "follow_up",
+      "claim_id": null
+    },
+    {
+      "id": "v2",
+      "text": "human-facing presence surfaces: busy indicators next to nicks in the irc-lens console (chat.agentculture.org) and WHOIS enrichment for plain IRC clients",
+      "kind": "follow_up",
+      "claim_id": null
+    },
+    {
+      "id": "v3",
+      "text": "host-level resource signals beyond tokens: GPU/slot capacity per machine (e.g. the vLLM colleague is effectively concurrency-1 on spark)",
+      "kind": "follow_up",
+      "claim_id": null
+    },
+    {
+      "id": "v4",
+      "text": "budget window semantics: is token spend tracked per-session, per-day, or cumulative-with-reset \u2014 and where the counter persists across restarts",
+      "kind": "unknown_nonblocking",
+      "claim_id": null
+    },
+    {
+      "id": "v5",
+      "text": "exact heartbeat transport + interval: piggyback on existing IRC traffic (PING/activity) vs dedicated periodic PRESENCE refresh, and the default stale-T",
+      "kind": "unknown_nonblocking",
+      "claim_id": null
+    },
+    {
+      "id": "v6",
+      "text": "server-side max-N admission control (deferred/queued wakes with visible reason) \u2014 the v2 enforcement leg, rejected from v1 scope by Ori 2026-07-07",
+      "kind": "follow_up",
+      "claim_id": null
+    }
+  ]
+}

--- a/.devague/plans/culture-now-knows-when-its-residents-are-busy-ever.json
+++ b/.devague/plans/culture-now-knows-when-its-residents-are-busy-ever.json
@@ -1,0 +1,335 @@
+{
+  "slug": "culture-now-knows-when-its-residents-are-busy-ever",
+  "title": "Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view \u2014 active residents, token spend \u2014 that operators and balancing policies can act on.",
+  "frame_slug": "culture-now-knows-when-its-residents-are-busy-ever",
+  "schema_version": 1,
+  "status": "exported",
+  "created": "2026-07-06T21:51:38Z",
+  "updated": "2026-07-06T21:55:49Z",
+  "targets": [
+    {
+      "id": "c1",
+      "kind": "announcement",
+      "text": "Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view \u2014 active residents, token spend \u2014 that operators and balancing policies can act on."
+    },
+    {
+      "id": "h8",
+      "kind": "honesty",
+      "text": "demonstrated on the live spark mesh: an operator watches a resident flip busy when handed work and back to idle when done, in real time"
+    },
+    {
+      "id": "c2",
+      "kind": "audience",
+      "text": "mesh operators (Ori) and the culture server/supervisor; secondarily the resident agents themselves, which can adapt behavior to mesh load"
+    },
+    {
+      "id": "h9",
+      "kind": "honesty",
+      "text": "the resource view is consumable both by a human at the CLI (readable table) and programmatically (--json) by server-side policies"
+    },
+    {
+      "id": "c3",
+      "kind": "before_state",
+      "text": "busy-state is invisible in-band today: token usage exists only as OTel counters (culture.harness.llm.tokens.*) scraped into Prometheus, the AgentIRC IRCd implements no AWAY/presence verb, and 'culture agents status' only knows process/unit-level up/down \u2014 nothing in the mesh knows whether a resident is mid-task"
+    },
+    {
+      "id": "h10",
+      "kind": "honesty",
+      "text": "verified against the codebase 2026-07-07: no AWAY verb in the agentirc IRCd, no in-band busy signal anywhere, token counters exist only as OTel exhaust (culture.harness.llm.tokens.*)"
+    },
+    {
+      "id": "c4",
+      "kind": "after_state",
+      "text": "the mesh sees, per resident, a live activity state (busy/idle at minimum) plus resource counters (token spend), aggregated server-side into a resource view the operator and balancing policies can act on"
+    },
+    {
+      "id": "h11",
+      "kind": "honesty",
+      "text": "with two residents connected and exactly one mid-task, the view shows exactly one busy \u2014 live query, not a cached snapshot"
+    },
+    {
+      "id": "c5",
+      "kind": "why_it_matters",
+      "text": "resource balance: the operator/mesh can maintain and rebalance \u2014 how many residents are active at once, token budget consumption \u2014 instead of flying blind on an always-on mesh"
+    },
+    {
+      "id": "h12",
+      "kind": "honesty",
+      "text": "at least one concrete balancing decision (e.g. 'two residents busy \u2014 defer waking a third') is possible from shipped data alone, no Grafana required"
+    },
+    {
+      "id": "c6",
+      "kind": "requirement",
+      "text": "every enforced backend (claude, codex, colleague) publishes the same busy/idle activity signal \u2014 all-backends rule; copilot/acp stay parity-exempt"
+    },
+    {
+      "id": "h1",
+      "kind": "honesty",
+      "text": "the backend-parity CI job passes: the emitter lands in shared harness code or in all three enforced backends in the same change \u2014 a busy signal from only one backend is a bug, not a feature"
+    },
+    {
+      "id": "c7",
+      "kind": "requirement",
+      "text": "the server aggregates per-resident activity + token spend into a queryable resource view exposed via a CLI verb"
+    },
+    {
+      "id": "h2",
+      "kind": "honesty",
+      "text": "the resource-view command returns every registered resident with state + spend from live mesh data (not stale logs), including residents connected from OTHER servers in the mesh, and works with only 'uv tool install culture'"
+    },
+    {
+      "id": "c8",
+      "kind": "success_signal",
+      "text": "one command answers 'who is busy right now, and what has each resident spent' with live mesh data \u2014 verified against a resident known to be mid-task"
+    },
+    {
+      "id": "h13",
+      "kind": "honesty",
+      "text": "the command is demonstrated against the live spark mesh (spark-agentirc, spark-colleague) and the busy resident it reports is genuinely mid-task"
+    },
+    {
+      "id": "c9",
+      "kind": "boundary",
+      "text": "observation and reporting are the core; no existing IRC command is redefined (protocol extensions use new verbs)"
+    },
+    {
+      "id": "h14",
+      "kind": "honesty",
+      "text": "diff review confirms no RFC 2812 command semantics changed; a vanilla weechat session against the upgraded server behaves identically"
+    },
+    {
+      "id": "c11",
+      "kind": "requirement",
+      "text": "presence travels as a new protocol extension verb (e.g. PRESENCE) with a structured payload {state, since, current-task hint, token counters}, documented in protocol/extensions/; vanilla IRC clients simply ignore it"
+    },
+    {
+      "id": "h3",
+      "kind": "honesty",
+      "text": "the verb is genuinely new (no RFC 2812 command redefined), a weechat client connected to the same channel is unaffected, and telemetry/identity strings stay culture.* per the engine rules"
+    },
+    {
+      "id": "c12",
+      "kind": "requirement",
+      "text": "activity state is richer than binary: idle | listening | thinking (LLM call in flight) | working (tool execution) | draining | offline \u2014 each state maps to an observable harness boundary the backends already cross (harness.llm.call span, tool exec)"
+    },
+    {
+      "id": "h4",
+      "kind": "honesty",
+      "text": "every state transition is driven by an observable code boundary (connect, message handled, LLM call open/close, tool exec, shutdown) \u2014 never by the model self-reporting 'I think I'm busy'"
+    },
+    {
+      "id": "c13",
+      "kind": "requirement",
+      "text": "stale-busy watchdog: a resident that last reported busy but misses heartbeats for a configurable T is flagged presumed-hung in the resource view \u2014 catching crashed/wedged agents without their cooperation (ties into the always-on/doctor work)"
+    },
+    {
+      "id": "h5",
+      "kind": "honesty",
+      "text": "a kill -9'd resident that last reported busy is flagged presumed-hung within T without any cooperation from the dead process, and a slow-but-alive resident heartbeating through a long LLM call is NOT falsely flagged"
+    },
+    {
+      "id": "c14",
+      "kind": "requirement",
+      "text": "token budgets become first-class config: a per-agent budget (culture.yaml) the resource view tracks spend against, with warn thresholds surfaced to the operator before the budget is blown"
+    },
+    {
+      "id": "h6",
+      "kind": "honesty",
+      "text": "a budget breach produces a visible operator signal before enforcement is even considered, and spend accounting has defined window/reset semantics that survive an agent restart"
+    },
+    {
+      "id": "c18",
+      "kind": "boundary",
+      "text": "v1 observes and reports only: the server does not act on the signals \u2014 no deferred wakes, no admission control, no budget blocking. Budgets are warn-only. Enforcement is the explicit v2 leg."
+    },
+    {
+      "id": "h16",
+      "kind": "honesty",
+      "text": "verifiable in the v1 diff: no code path exists where the server declines, defers, or blocks work based on presence or spend \u2014 a budget breach emits a warning signal only, and mesh behavior with the feature enabled is otherwise identical to today"
+    },
+    {
+      "id": "c21",
+      "kind": "requirement",
+      "text": "the irc-lens console reflects the new view: an operator can open a dedicated page at chat.agentculture.org showing the live resource view \u2014 per-resident activity state, token spend, budget status \u2014 without touching the CLI"
+    },
+    {
+      "id": "h15",
+      "kind": "honesty",
+      "text": "the page renders from the same server-side aggregation the CLI verb reads (one source of truth, no second counting path), sits behind CF Access like the rest of the console, and degrades gracefully to an 'IRCd down' notice instead of a 500 when 6667 is unreachable"
+    }
+  ],
+  "tasks": [
+    {
+      "id": "t1",
+      "summary": "PRESENCE protocol extension spec: write protocol/extensions/presence.md defining the new verb \u2014 structured payload (six-state enum idle|listening|thinking|working|draining|offline, since, current-task hint, token counters), heartbeat/refresh cadence, stale-T semantics, S2S propagation notes, and explicit backward-compat statement",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "doc defines the full payload schema and maps EACH of the six states to the observable harness boundary that drives it (connect, message handle, LLM call open/close, tool exec, shutdown)",
+        "doc explicitly states no RFC 2812 command is redefined and that vanilla clients ignoring the verb see identical behavior; all wire/identity strings stay culture.*"
+      ],
+      "deps": [],
+      "covers": [
+        "c9",
+        "c11",
+        "c12",
+        "h3"
+      ]
+    },
+    {
+      "id": "t2",
+      "summary": "Engine config schema for budgets + presence policy: per-agent token_budget with warn thresholds in culture.yaml schema; mesh-wide presence settings (stale_after, heartbeat interval) in server.yaml \u2014 warn-only semantics, with defined spend window/reset behavior",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "config round-trips: parse, validate, defaults; budget/presence keys documented in docs/; invalid values produce actionable CultureError, not tracebacks",
+        "spend window/reset semantics are explicitly documented (chosen in-task, e.g. per-UTC-day) and the accounting model survives agent restart; breach computation yields a warn flag in the resource-view data model, never an enforcement action"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c14",
+        "h6"
+      ]
+    },
+    {
+      "id": "t3",
+      "summary": "Hand-off brief to agentirc: IRCd-side PRESENCE verb handling, per-client presence state, S2S propagation so cross-server residents appear, and the stale-busy watchdog (presumed-hung flag after stale-T without heartbeat)",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "brief posted to agentculture/agentirc via the communicate skill, carrying the t1 wire contract and watchdog acceptance tests: a kill -9'd busy resident is flagged within T with zero cooperation; a slow-but-alive resident heartbeating through a long LLM call is NOT flagged",
+        "brief names the query surface contract the culture front door will read (per-resident state, since, spend, hung-flag, server-of-origin)"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c13",
+        "h5"
+      ]
+    },
+    {
+      "id": "t4",
+      "summary": "Hand-off brief to cultureagent: busy-signal emitter in the SHARED harness transport, hooked at observable boundaries only, heartbeating through long LLM calls, token counts sourced from the same registry as the culture.harness.llm.tokens.* OTel counters (state-only where the SDK exposes none)",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "brief posted to agentculture/cultureagent with the state-transition table; requires the emitter in shared code so claude/codex/colleague all emit identically and backend-parity CI stays green \u2014 no per-backend forks",
+        "brief requires transitions driven only by code boundaries (never model self-report) and one counting source shared with existing OTel token counters"
+      ],
+      "deps": [
+        "t1"
+      ],
+      "covers": [
+        "c6",
+        "h1",
+        "h4"
+      ]
+    },
+    {
+      "id": "t5",
+      "summary": "culture residents CLI verb: front-door command reading the live server aggregation \u2014 human table + --json, showing per-resident state, since, token spend, budget %, presumed-hung flag, server of origin",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "against a live server with two residents (one mid-task) the command shows exactly one busy, from a live query; includes residents connected via S2S from other servers",
+        "--json output validates against a documented schema consumable by server-side policies; bare 'uv tool install culture' suffices; unreachable server yields actionable nonzero exit, not a traceback"
+      ],
+      "deps": [
+        "t1",
+        "t3"
+      ],
+      "covers": [
+        "c2",
+        "c7",
+        "h2",
+        "h9"
+      ]
+    },
+    {
+      "id": "t6",
+      "summary": "Live-mesh verification + observe-only audit: after sibling releases land and version floors bump, run the honesty battery on the spark mesh and record a verification log",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "verification log records: a resident flipping busy->idle live; two-residents-one-busy showing exactly one busy; a balancing decision made from shipped data alone; the success-signal command demo against spark-agentirc/spark-colleague; the before-state evidence (no AWAY, no in-band signal, OTel-only counters as of 2026-07-07)",
+        "weechat regression session shows identical vanilla-client behavior; diff audit confirms no RFC 2812 command redefined and no code path where the server declines/defers/blocks work on presence or spend \u2014 budget breach warns only"
+      ],
+      "deps": [
+        "t2",
+        "t4",
+        "t5",
+        "t7",
+        "t8"
+      ],
+      "covers": [
+        "c1",
+        "h8",
+        "c3",
+        "h10",
+        "c4",
+        "h11",
+        "c5",
+        "h12",
+        "c8",
+        "h13",
+        "h14",
+        "c18",
+        "h16"
+      ]
+    },
+    {
+      "id": "t7",
+      "summary": "Resource-view data endpoint for irc-lens: expose the same aggregation the CLI reads as a documented JSON endpoint on the culture side, sharing one serializer with 'culture residents --json' so there is exactly one source of truth",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "endpoint payload is byte-compatible with the CLI --json schema (shared serializer, verified by a test that diffs the two); endpoint contract + auth story documented in docs/ for the irc-lens consumer"
+      ],
+      "deps": [
+        "t5"
+      ],
+      "covers": [
+        "c21"
+      ]
+    },
+    {
+      "id": "t8",
+      "summary": "Hand-off brief to irc-lens: a dedicated residents page at chat.agentculture.org rendering the endpoint data \u2014 per-resident state, spend, budget status \u2014 behind CF Access like the rest of the console, degrading to an 'IRCd down' notice instead of a 500 when 6667 is unreachable",
+      "origin": "llm",
+      "status": "confirmed",
+      "acceptance_criteria": [
+        "brief posted to the irc-lens repo with the t7 endpoint contract, the CF Access requirement, and the graceful-degrade requirement (explicitly citing the known console-500-when-6667-down failure mode)"
+      ],
+      "deps": [
+        "t7"
+      ],
+      "covers": [
+        "c21",
+        "h15"
+      ]
+    }
+  ],
+  "risks": [
+    {
+      "id": "r1",
+      "text": "heartbeat transport + interval: piggyback on existing IRC traffic vs dedicated periodic PRESENCE refresh, and the default stale-T \u2014 decided in t1/t3 design",
+      "kind": "unknown_nonblocking",
+      "task_id": "t1"
+    },
+    {
+      "id": "r2",
+      "text": "budget spend window/reset semantics (per-session vs per-day vs cumulative) and where the counter persists \u2014 decided in t2",
+      "kind": "unknown_nonblocking",
+      "task_id": "t2"
+    },
+    {
+      "id": "r3",
+      "text": "where the aggregation query surface physically lives (inside the agentirc IRCd process vs the culture console seam) shapes t5/t6 plumbing \u2014 settled when the t3 brief is answered",
+      "kind": "unknown_nonblocking",
+      "task_id": "t3"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [14.4.1] - 2026-07-07
+
+### Added
+
+- Converged devague spec + build plan for resident presence and the mesh resource view: every enforced backend publishes a six-state activity signal over a new PRESENCE protocol extension verb; the server aggregates per-resident state + token spend into a resource view surfaced by a culture residents CLI verb, a JSON endpoint, and an irc-lens console page. Observe-only v1 (budgets warn-only; enforcement is the parked v2 leg). 8 tasks over 6 waves with hand-off briefs to agentirc, cultureagent, and irc-lens (docs/specs/, docs/plans/, .devague/ frame state).
+
 ## [14.4.0] - 2026-07-03
 
 ### Added

--- a/docs/plans/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md
+++ b/docs/plans/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md
@@ -1,0 +1,74 @@
+# Build Plan — Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view — active residents, token spend — that operators and balancing policies can act on
+
+slug: `culture-now-knows-when-its-residents-are-busy-ever` · status: `exported` · from frame: `culture-now-knows-when-its-residents-are-busy-ever`
+
+> Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view — active residents, token spend — that operators and balancing policies can act on.
+
+## Tasks
+
+### t1 — PRESENCE protocol extension spec: write protocol/extensions/presence.md defining the new verb — structured payload (six-state enum idle|listening|thinking|working|draining|offline, since, current-task hint, token counters), heartbeat/refresh cadence, stale-T semantics, S2S propagation notes, and explicit backward-compat statement
+
+- covers: c9, c11, c12, h3
+- acceptance:
+  - doc defines the full payload schema and maps EACH of the six states to the observable harness boundary that drives it (connect, message handle, LLM call open/close, tool exec, shutdown)
+  - doc explicitly states no RFC 2812 command is redefined and that vanilla clients ignoring the verb see identical behavior; all wire/identity strings stay culture.*
+
+### t2 — Engine config schema for budgets + presence policy: per-agent token_budget with warn thresholds in culture.yaml schema; mesh-wide presence settings (stale_after, heartbeat interval) in server.yaml — warn-only semantics, with defined spend window/reset behavior
+
+- depends on: t1
+- covers: c14, h6
+- acceptance:
+  - config round-trips: parse, validate, defaults; budget/presence keys documented in docs/; invalid values produce actionable CultureError, not tracebacks
+  - spend window/reset semantics are explicitly documented (chosen in-task, e.g. per-UTC-day) and the accounting model survives agent restart; breach computation yields a warn flag in the resource-view data model, never an enforcement action
+
+### t3 — Hand-off brief to agentirc: IRCd-side PRESENCE verb handling, per-client presence state, S2S propagation so cross-server residents appear, and the stale-busy watchdog (presumed-hung flag after stale-T without heartbeat)
+
+- depends on: t1
+- covers: c13, h5
+- acceptance:
+  - brief posted to agentculture/agentirc via the communicate skill, carrying the t1 wire contract and watchdog acceptance tests: a kill -9'd busy resident is flagged within T with zero cooperation; a slow-but-alive resident heartbeating through a long LLM call is NOT flagged
+  - brief names the query surface contract the culture front door will read (per-resident state, since, spend, hung-flag, server-of-origin)
+
+### t4 — Hand-off brief to cultureagent: busy-signal emitter in the SHARED harness transport, hooked at observable boundaries only, heartbeating through long LLM calls, token counts sourced from the same registry as the culture.harness.llm.tokens.* OTel counters (state-only where the SDK exposes none)
+
+- depends on: t1
+- covers: c6, h1, h4
+- acceptance:
+  - brief posted to agentculture/cultureagent with the state-transition table; requires the emitter in shared code so claude/codex/colleague all emit identically and backend-parity CI stays green — no per-backend forks
+  - brief requires transitions driven only by code boundaries (never model self-report) and one counting source shared with existing OTel token counters
+
+### t5 — culture residents CLI verb: front-door command reading the live server aggregation — human table + --json, showing per-resident state, since, token spend, budget %, presumed-hung flag, server of origin
+
+- depends on: t1, t3
+- covers: c2, c7, h2, h9
+- acceptance:
+  - against a live server with two residents (one mid-task) the command shows exactly one busy, from a live query; includes residents connected via S2S from other servers
+  - --json output validates against a documented schema consumable by server-side policies; bare 'uv tool install culture' suffices; unreachable server yields actionable nonzero exit, not a traceback
+
+### t7 — Resource-view data endpoint for irc-lens: expose the same aggregation the CLI reads as a documented JSON endpoint on the culture side, sharing one serializer with 'culture residents --json' so there is exactly one source of truth
+
+- depends on: t5
+- covers: c21
+- acceptance:
+  - endpoint payload is byte-compatible with the CLI --json schema (shared serializer, verified by a test that diffs the two); endpoint contract + auth story documented in docs/ for the irc-lens consumer
+
+### t8 — Hand-off brief to irc-lens: a dedicated residents page at chat.agentculture.org rendering the endpoint data — per-resident state, spend, budget status — behind CF Access like the rest of the console, degrading to an 'IRCd down' notice instead of a 500 when 6667 is unreachable
+
+- depends on: t7
+- covers: c21, h15
+- acceptance:
+  - brief posted to the irc-lens repo with the t7 endpoint contract, the CF Access requirement, and the graceful-degrade requirement (explicitly citing the known console-500-when-6667-down failure mode)
+
+### t6 — Live-mesh verification + observe-only audit: after sibling releases land and version floors bump, run the honesty battery on the spark mesh and record a verification log
+
+- depends on: t2, t4, t5, t7, t8
+- covers: c1, h8, c3, h10, c4, h11, c5, h12, c8, h13, h14, c18, h16
+- acceptance:
+  - verification log records: a resident flipping busy->idle live; two-residents-one-busy showing exactly one busy; a balancing decision made from shipped data alone; the success-signal command demo against spark-agentirc/spark-colleague; the before-state evidence (no AWAY, no in-band signal, OTel-only counters as of 2026-07-07)
+  - weechat regression session shows identical vanilla-client behavior; diff audit confirms no RFC 2812 command redefined and no code path where the server declines/defers/blocks work on presence or spend — budget breach warns only
+
+## Risks
+
+- [unknown_nonblocking] heartbeat transport + interval: piggyback on existing IRC traffic vs dedicated periodic PRESENCE refresh, and the default stale-T — decided in t1/t3 design (task t1)
+- [unknown_nonblocking] budget spend window/reset semantics (per-session vs per-day vs cumulative) and where the counter persists — decided in t2 (task t2)
+- [unknown_nonblocking] where the aggregation query surface physically lives (inside the agentirc IRCd process vs the culture console seam) shapes t5/t6 plumbing — settled when the t3 brief is answered (task t3)

--- a/docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md
+++ b/docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md
@@ -1,0 +1,75 @@
+# Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view — active residents, token spend — that operators and balancing policies can act on
+
+> Culture now knows when its residents are busy: every agent (claude, codex, colleague, ...) publishes a live busy/idle activity signal to the mesh, and the server aggregates it into a resource view — active residents, token spend — that operators and balancing policies can act on.
+
+## Audience
+
+- mesh operators (Ori) and the culture server/supervisor; secondarily the resident agents themselves, which can adapt behavior to mesh load
+
+## Before → After
+
+- Before: busy-state is invisible in-band today: token usage exists only as OTel counters (culture.harness.llm.tokens.*) scraped into Prometheus, the AgentIRC IRCd implements no AWAY/presence verb, and 'culture agents status' only knows process/unit-level up/down — nothing in the mesh knows whether a resident is mid-task
+- After: the mesh sees, per resident, a live activity state (busy/idle at minimum) plus resource counters (token spend), aggregated server-side into a resource view the operator and balancing policies can act on
+
+## Why it matters
+
+- resource balance: the operator/mesh can maintain and rebalance — how many residents are active at once, token budget consumption — instead of flying blind on an always-on mesh
+
+## Requirements
+
+- every enforced backend (claude, codex, colleague) publishes the same busy/idle activity signal — all-backends rule; copilot/acp stay parity-exempt
+  - honesty: the backend-parity CI job passes: the emitter lands in shared harness code or in all three enforced backends in the same change — a busy signal from only one backend is a bug, not a feature
+- the server aggregates per-resident activity + token spend into a queryable resource view exposed via a CLI verb
+  - honesty: the resource-view command returns every registered resident with state + spend from live mesh data (not stale logs), including residents connected from OTHER servers in the mesh, and works with only 'uv tool install culture'
+- presence travels as a new protocol extension verb (e.g. PRESENCE) with a structured payload {state, since, current-task hint, token counters}, documented in protocol/extensions/; vanilla IRC clients simply ignore it
+  - honesty: the verb is genuinely new (no RFC 2812 command redefined), a weechat client connected to the same channel is unaffected, and telemetry/identity strings stay culture.* per the engine rules
+- activity state is richer than binary: idle | listening | thinking (LLM call in flight) | working (tool execution) | draining | offline — each state maps to an observable harness boundary the backends already cross (harness.llm.call span, tool exec)
+  - honesty: every state transition is driven by an observable code boundary (connect, message handled, LLM call open/close, tool exec, shutdown) — never by the model self-reporting 'I think I'm busy'
+- stale-busy watchdog: a resident that last reported busy but misses heartbeats for a configurable T is flagged presumed-hung in the resource view — catching crashed/wedged agents without their cooperation (ties into the always-on/doctor work)
+  - honesty: a kill -9'd resident that last reported busy is flagged presumed-hung within T without any cooperation from the dead process, and a slow-but-alive resident heartbeating through a long LLM call is NOT falsely flagged
+- token budgets become first-class config: a per-agent budget (culture.yaml) the resource view tracks spend against, with warn thresholds surfaced to the operator before the budget is blown
+  - honesty: a budget breach produces a visible operator signal before enforcement is even considered, and spend accounting has defined window/reset semantics that survive an agent restart
+- the irc-lens console reflects the new view: an operator can open a dedicated page at chat.agentculture.org showing the live resource view — per-resident activity state, token spend, budget status — without touching the CLI
+  - honesty: the page renders from the same server-side aggregation the CLI verb reads (one source of truth, no second counting path), sits behind CF Access like the rest of the console, and degrades gracefully to an 'IRCd down' notice instead of a 500 when 6667 is unreachable
+
+## Honesty conditions
+
+- demonstrated on the live spark mesh: an operator watches a resident flip busy when handed work and back to idle when done, in real time
+- the resource view is consumable both by a human at the CLI (readable table) and programmatically (--json) by server-side policies
+- verified against the codebase 2026-07-07: no AWAY verb in the agentirc IRCd, no in-band busy signal anywhere, token counters exist only as OTel exhaust (culture.harness.llm.tokens.*)
+- with two residents connected and exactly one mid-task, the view shows exactly one busy — live query, not a cached snapshot
+- at least one concrete balancing decision (e.g. 'two residents busy — defer waking a third') is possible from shipped data alone, no Grafana required
+- the command is demonstrated against the live spark mesh (spark-agentirc, spark-colleague) and the busy resident it reports is genuinely mid-task
+- diff review confirms no RFC 2812 command semantics changed; a vanilla weechat session against the upgraded server behaves identically
+- verifiable in the v1 diff: no code path exists where the server declines, defers, or blocks work based on presence or spend — a budget breach emits a warning signal only, and mesh behavior with the feature enabled is otherwise identical to today
+
+## Success signals
+
+- one command answers 'who is busy right now, and what has each resident spent' with live mesh data — verified against a resident known to be mid-task
+
+## Scope / boundaries
+
+- observation and reporting are the core; no existing IRC command is redefined (protocol extensions use new verbs)
+- v1 observes and reports only: the server does not act on the signals — no deferred wakes, no admission control, no budget blocking. Budgets are warn-only. Enforcement is the explicit v2 leg.
+
+## Non-goals
+
+- not a billing/cost-accounting system and not a general-purpose task scheduler
+
+## Assumptions
+
+- the busy-signal emitter lands in the cultureagent harness (shared transport code) and the IRCd-side verb in agentirc — this spec covers the culture-side (server aggregation, CLI, config) plus hand-off briefs to the two siblings
+- in-band token reporting shares the same counting source as the existing culture.harness.llm.tokens.* OTel counters, so the mesh view and Grafana never diverge; backends whose SDK exposes no token counts report state-only (same caveat as 8.6.0 telemetry)
+- the residents page lands in the sibling irc-lens repo (console pinned irc-lens>=0.8) consuming a data endpoint culture exposes — so this feature spans three hand-off briefs: cultureagent (emitter), agentirc (IRCd verb), irc-lens (page)
+
+## Decisions
+
+- activity state ships as the rich six-state enum from the start (idle | listening | thinking | working | draining | offline) so the wire format never needs a breaking revision; consumers may collapse to busy/idle
+- policy config splits along the existing config seam: per-agent token budget in that agent's culture.yaml; mesh-wide settings (stale-T, future concurrency cap) in ~/.culture/server.yaml
+
+## Open / follow-up
+
+- load-aware mention routing: when a channel-wide ask goes out, prefer idle residents (attention-system integration)
+- human-facing presence surfaces: busy indicators next to nicks in the irc-lens console (chat.agentculture.org) and WHOIS enrichment for plain IRC clients
+- host-level resource signals beyond tokens: GPU/slot capacity per machine (e.g. the vLLM colleague is effectively concurrency-1 on spark)
+- server-side max-N admission control (deferred/queued wakes with visible reason) — the v2 enforcement leg, rejected from v1 scope by Ori 2026-07-07

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "14.4.0"
+version = "14.4.1"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "14.4.0"
+version = "14.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "agentfront" },


### PR DESCRIPTION
## Summary

Converged devague spec + build plan for **resident presence and the mesh resource view** — Culture learns when its residents (claude, codex, colleague, …) are busy so the operator and future balancing policies can maintain and rebalance the mesh (active residents at once, token spend) instead of flying blind on an always-on mesh.

Exported from the converged frame `culture-now-knows-when-its-residents-are-busy-ever` (devague `/think` → `/spec-to-plan`, decisions by Ori 2026-07-07). Docs-only: spec, plan, `.devague/` frame state, version bump.

### Spec highlights (observe-only v1)

- Every enforced backend publishes a **six-state activity signal** (`idle | listening | thinking | working | draining | offline`) — each state driven by an observable harness boundary (LLM call open/close, tool exec, shutdown), never model self-report. All-backends rule applies; copilot/acp stay parity-exempt.
- Presence travels as a **new `PRESENCE` protocol extension verb** (no RFC 2812 command redefined; vanilla clients ignore it) with token counters in-band, sharing the same counting source as the existing `culture.harness.llm.tokens.*` OTel counters — one source of truth with Grafana.
- The server aggregates per-resident state + spend into a **resource view**: a `culture residents` CLI verb (table + `--json`), a JSON endpoint (shared serializer with the CLI), and an **irc-lens residents page** at chat.agentculture.org behind CF Access, degrading to an "IRCd down" notice instead of a 500.
- **Stale-busy watchdog**: a resident that reported busy but misses heartbeats past stale-T is flagged presumed-hung — no cooperation from the dead process required.
- **Token budgets** are first-class, warn-only config: per-agent budget in `culture.yaml`, mesh-wide policy (stale-T) in `server.yaml`.
- **v1 never enforces**: no deferred wakes, no admission control, no budget blocking. Max-N admission control is the parked v2 leg (rejected from v1 scope).

### Plan (8 tasks, 6 waves)

`t1` PRESENCE protocol extension doc → `t2` engine config schema + `t3` agentirc brief (IRCd verb, aggregation, watchdog) + `t4` cultureagent brief (shared-harness emitter) → `t5` `culture residents` CLI verb → `t7` data endpoint → `t8` irc-lens page brief → `t6` live spark-mesh verification + observe-only diff audit.

Three sibling hand-offs (agentirc, cultureagent, irc-lens); culture owns aggregation consumption, CLI, config, and the endpoint. Four `unknown_nonblocking` risks parked: heartbeat cadence, budget window semantics, query-surface location, cross-repo floor sequencing.

## Test plan

- [ ] Docs-only change — CI (lint, version-check) green
- [ ] Spec/plan render cleanly; frame + plan state round-trip via `devague show` / `devague plan show`

- culture (Claude)
