### PR TITLE
feat: resident presence + mesh resource view — observe-only v1 (culture residents, /residents.json, PRESENCE extension)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [14.5.0] - 2026-07-07
+
+### Added
+
+- Resident presence + mesh resource view, observe-only v1 (spec docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md): PRESENCE protocol extension page (publish verb + anticipated query surface, protocol/extensions/presence.md); per-agent token_budget / token_budget_warn_pct (warn-only, degrade-on-invalid) in culture.yaml and a presence policy block (heartbeat_interval_seconds, stale_after_seconds) in server.yaml; culture residents CLI verb (live table + --json) with graceful supported:false degrade until the agentirc floor bump (agentirc#53); GET /residents.json on the overview web server (now ThreadingHTTPServer), byte-compatible with the CLI via one canonical serializer (culture_core/resource_view.py); docs/resident-presence.md reference. Hand-off briefs: agentirc#53 (IRCd verb + aggregation + watchdog), cultureagent#47 (shared-harness emitter), irc-lens#53 (residents console page). Live-mesh verification (plan t6) deferred pending sibling releases + floor bumps.
+
 ## [14.4.1] - 2026-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - Resident presence + mesh resource view, observe-only v1 (spec docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md): PRESENCE protocol extension page (publish verb + query surface, protocol/extensions/presence.md); per-agent token_budget / token_budget_warn_pct (warn-only, degrade-on-invalid) in culture.yaml and a presence policy block (heartbeat_interval_seconds, stale_after_seconds) in server.yaml; culture residents CLI verb (live table + --json) with graceful supported:false degrade against a pre-9.12 server; GET /residents.json on the overview web server (now ThreadingHTTPServer), byte-compatible with the CLI via one canonical serializer (culture_core/resource_view.py); docs/resident-presence.md reference. Hand-off briefs: agentirc#53 (IRCd verb + aggregation + watchdog), cultureagent#47 (shared-harness emitter), irc-lens#53 (residents console page).
+- Live-mesh verification log for plan task t6 (docs/verification/2026-07-07-resident-presence-t6.md): before-state degrade capture, busy->idle flip, one-busy-of-three snapshot, balancing decision from shipped data alone, live /residents.json, vanilla-client zero-relay regression, observe-only diff audit — run on the upgraded spark mesh (agentirc 9.12.0 IRCd + cultureagent 0.13.0 emitters).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- Resident presence + mesh resource view, observe-only v1 (spec docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md): PRESENCE protocol extension page (publish verb + anticipated query surface, protocol/extensions/presence.md); per-agent token_budget / token_budget_warn_pct (warn-only, degrade-on-invalid) in culture.yaml and a presence policy block (heartbeat_interval_seconds, stale_after_seconds) in server.yaml; culture residents CLI verb (live table + --json) with graceful supported:false degrade until the agentirc floor bump (agentirc#53); GET /residents.json on the overview web server (now ThreadingHTTPServer), byte-compatible with the CLI via one canonical serializer (culture_core/resource_view.py); docs/resident-presence.md reference. Hand-off briefs: agentirc#53 (IRCd verb + aggregation + watchdog), cultureagent#47 (shared-harness emitter), irc-lens#53 (residents console page). Live-mesh verification (plan t6) deferred pending sibling releases + floor bumps.
+- Resident presence + mesh resource view, observe-only v1 (spec docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md): PRESENCE protocol extension page (publish verb + query surface, protocol/extensions/presence.md); per-agent token_budget / token_budget_warn_pct (warn-only, degrade-on-invalid) in culture.yaml and a presence policy block (heartbeat_interval_seconds, stale_after_seconds) in server.yaml; culture residents CLI verb (live table + --json) with graceful supported:false degrade against a pre-9.12 server; GET /residents.json on the overview web server (now ThreadingHTTPServer), byte-compatible with the CLI via one canonical serializer (culture_core/resource_view.py); docs/resident-presence.md reference. Hand-off briefs: agentirc#53 (IRCd verb + aggregation + watchdog), cultureagent#47 (shared-harness emitter), irc-lens#53 (residents console page).
+
+### Changed
+
+- Dependency floors raised for the presence legs both siblings shipped: `agentirc-cli>=9.12.0,<10` (PRESENCE verb, aggregation, S2S, stale-busy watchdog, PRESENCE LIST query surface — adopted culture's proposed wire shape verbatim, agentirc#53) and `cultureagent~=0.13.0` (shared-harness PRESENCE emitter, heartbeat, one token-counting source — cultureagent#47), in `pyproject.toml` (base + all backend extras) and `uv.lock`.
+- protocol/extensions/presence.md: query surface Anticipated -> Adopted (agentirc-cli 9.12.0 row semantics inlined); activity-state refinements from the shipped emitter (`listening` scoped to agent-work dispatch — edge-triggered emission, no per-PING amplification; `working` defined but not yet emitted by any backend); stale-busy watchdog semantics as shipped (read-time computation, clean-FIN deaths read as `offline`, offline rows retained); r1 heartbeat/stale-T defaults resolved (30s/90s, one server.yaml section drives both daemons).
+
+### Fixed
+
+- PRESENCE reply framing is now byte-level: a multi-byte UTF-8 character split across TCP reads no longer corrupts resident/task fields (each complete CRLF line decodes on its own; Qodo review).
+- `apply_budgets` sanitizes `token_budget_warn_pct` (plain int 1..100, else the field default) so a directly-constructed AgentConfig can never produce a misleading budget_warning flag, and `_load_legacy_config` now runs the same warn-and-degrade budget sanitizing as the culture.yaml path (Qodo review).
+- `culture_core/cli/residents.py` exports only NAME/register/dispatch again (`render_table` -> private `_render_table`), per the command-group API convention.
+- SonarCloud: `_new_config_error` carries a precise `CultureError` return type (S112 x4) and the PRESENCE reply parsing is split into per-line handlers under the cognitive-complexity ceiling (S3776).
 
 ## [14.4.1] - 2026-07-07
 

--- a/culture_core/cli/CLAUDE.md
+++ b/culture_core/cli/CLAUDE.md
@@ -17,6 +17,7 @@ cli/
 ├── console.py           # culture console — irc-lens passthrough (reactive web console)
 ├── channel.py           # culture channel {list,read,message,who,join,part,ask,...}
 ├── bot.py               # culture bot {create,start,stop,list,inspect,archive,...}
+├── residents.py         # culture residents — live resource view (presence, token spend, budgets)
 ├── skills.py            # culture skills {install}
 └── shared/
     ├── constants.py     # Paths (DEFAULT_CONFIG, LOG_DIR), help strings

--- a/culture_core/cli/__init__.py
+++ b/culture_core/cli/__init__.py
@@ -10,6 +10,7 @@ Commands are organized into noun-based groups:
     culture skills   {install}
     culture devex    {...developer-experience passthrough (powered by agex-cli)...}
     culture afi      {...agent-first interface passthrough (powered by agentfront)...}
+    culture residents  live resource view: per-resident presence state + token spend
 
 Universal verbs (available at the root):
     culture explain [topic]    full description of topic (default: culture)
@@ -36,13 +37,27 @@ from culture_core.cli import (
     doctor,
     introspect,
     mesh,
+    residents,
     server,
     skills,
 )
 from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
 from culture_core.cli._output import emit_error
 
-GROUPS = [agents, server, mesh, channel, bot, skills, devex, afi, console, introspect, doctor]
+GROUPS = [
+    agents,
+    server,
+    mesh,
+    channel,
+    bot,
+    skills,
+    devex,
+    afi,
+    console,
+    introspect,
+    doctor,
+    residents,
+]
 
 
 def _names_of(group) -> set[str]:
@@ -164,7 +179,7 @@ def _maybe_forward_to_steward(argv: list[str]) -> int | None:
 
 # Command groups that read the server config; the first-run notice below
 # only applies to them (introspection/passthrough verbs work configless).
-_CONFIG_CONSUMING_GROUPS = {"agents", "server", "channel", "bot", "mesh", "skills"}
+_CONFIG_CONSUMING_GROUPS = {"agents", "server", "channel", "bot", "mesh", "skills", "residents"}
 
 
 def _notice_first_run(args: argparse.Namespace) -> None:

--- a/culture_core/cli/residents.py
+++ b/culture_core/cli/residents.py
@@ -6,11 +6,11 @@ the server-side presence aggregation through the shared seam in
 ``--json``, as exactly the canonical ``serialize_residents`` payload the
 t7 HTTP endpoint shares byte-for-byte.
 
-Degrade contract (plan risks r3/r4): today's agentirc has no PRESENCE
-query surface (pending agentirc#53), so against a live server this verb
-reports "not supported" and exits 0 — that is a known mesh state, not an
-error. Only an unreachable server is an error (nonzero, CultureError
-style, no traceback).
+Degrade contract (plan risks r3/r4): the PRESENCE query surface shipped
+in agentirc-cli 9.12.0 (agentirc#53). Against a server still running an
+older agentirc this verb reports "not supported" and exits 0 — that is a
+known mesh state, not an error. Only an unreachable server is an error
+(nonzero, CultureError style, no traceback).
 """
 
 from __future__ import annotations
@@ -39,8 +39,8 @@ NAME = "residents"
 _MISSING = "-"
 
 _UNSUPPORTED_NOTICE = (
-    "server does not support PRESENCE — needs agentirc release per "
-    "agentirc#53, then culture floor bump"
+    "server does not support PRESENCE — upgrade the mesh server to "
+    "agentirc-cli >= 9.12.0 and restart it (agentirc#53)"
 )
 
 
@@ -106,7 +106,7 @@ def _row(resident: Resident) -> tuple[str, ...]:
     )
 
 
-def render_table(residents: list[Resident]) -> str:
+def _render_table(residents: list[Resident]) -> str:
     """Render the human table — readable even for state-only residents.
 
     Rows are sorted by nick (same order as the JSON payload); every missing
@@ -178,4 +178,4 @@ def dispatch(args: argparse.Namespace) -> None:
         print("No residents connected.")
         return
 
-    print(render_table(residents))
+    print(_render_table(residents))

--- a/culture_core/cli/residents.py
+++ b/culture_core/cli/residents.py
@@ -1,0 +1,155 @@
+"""Residents verb: culture residents — live resource view of mesh residents.
+
+Front door for the resident-presence resource view (plan task t5): reads
+the server-side presence aggregation through the shared seam in
+``culture_core.resource_view`` and renders it as a human table or, with
+``--json``, as exactly the canonical ``serialize_residents`` payload the
+t7 HTTP endpoint shares byte-for-byte.
+
+Degrade contract (plan risks r3/r4): today's agentirc has no PRESENCE
+query surface (pending agentirc#53), so against a live server this verb
+reports "not supported" and exits 0 — that is a known mesh state, not an
+error. Only an unreachable server is an error (nonzero, CultureError
+style, no traceback).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
+from culture_core.cli._output import emit_error
+from culture_core.cli.shared.constants import _CONFIG_HELP, DEFAULT_CONFIG
+from culture_core.resource_view import (
+    PresenceUnsupportedError,
+    Resident,
+    fetch_residents,
+    serialize_residents,
+)
+
+NAME = "residents"
+
+_MISSING = "-"
+
+_UNSUPPORTED_NOTICE = (
+    "server does not support PRESENCE — needs agentirc release per "
+    "agentirc#53, then culture floor bump"
+)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    p = subparsers.add_parser(
+        "residents",
+        help="Live resource view: per-resident presence state, token spend, budget status",
+    )
+    p.add_argument("--config", default=DEFAULT_CONFIG, help=_CONFIG_HELP)
+    p.add_argument(
+        "--json",
+        action="store_true",
+        dest="json",
+        help="Emit the canonical resource-view JSON payload (shared with the t7 endpoint)",
+    )
+
+
+def _tokens_cell(resident: Resident) -> str:
+    if resident.tokens_in is None and resident.tokens_out is None:
+        return _MISSING
+    left = _MISSING if resident.tokens_in is None else str(resident.tokens_in)
+    right = _MISSING if resident.tokens_out is None else str(resident.tokens_out)
+    return f"{left}/{right}"
+
+
+def _budget_cell(resident: Resident) -> str:
+    if resident.budget_used_pct is None:
+        return _MISSING
+    return f"{resident.budget_used_pct:g}%"
+
+
+def _flags_cell(resident: Resident) -> str:
+    flags = []
+    if resident.presumed_hung:
+        flags.append("HUNG?")
+    if resident.budget_warning:
+        flags.append("BUDGET")
+    return ",".join(flags) or _MISSING
+
+
+_COLUMNS: tuple[str, ...] = (
+    "NICK",
+    "SERVER",
+    "STATE",
+    "SINCE",
+    "TASK",
+    "TOKENS (IN/OUT)",
+    "BUDGET %",
+    "FLAGS",
+)
+
+
+def _row(resident: Resident) -> tuple[str, ...]:
+    return (
+        resident.nick or _MISSING,
+        resident.server or _MISSING,
+        resident.state or _MISSING,
+        resident.since or _MISSING,
+        resident.task or _MISSING,
+        _tokens_cell(resident),
+        _budget_cell(resident),
+        _flags_cell(resident),
+    )
+
+
+def render_table(residents: list[Resident]) -> str:
+    """Render the human table — readable even for state-only residents.
+
+    Rows are sorted by nick (same order as the JSON payload); every missing
+    field renders as a dash.
+    """
+    rows = [_row(r) for r in sorted(residents, key=lambda r: r.nick)]
+    widths = [
+        max(len(_COLUMNS[i]), *(len(row[i]) for row in rows)) if rows else len(_COLUMNS[i])
+        for i in range(len(_COLUMNS))
+    ]
+    lines = ["  ".join(_COLUMNS[i].ljust(widths[i]) for i in range(len(_COLUMNS))).rstrip()]
+    for row in rows:
+        lines.append("  ".join(row[i].ljust(widths[i]) for i in range(len(_COLUMNS))).rstrip())
+    return "\n".join(lines)
+
+
+def dispatch(args: argparse.Namespace) -> None:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        try:
+            residents = fetch_residents(args.config)
+            supported = True
+        except PresenceUnsupportedError:
+            residents, supported = [], False
+    except OSError as exc:
+        # Covers ConnectionRefusedError, the observer's registration
+        # ConnectionError, and TimeoutError — all OSError subclasses.
+        err = CultureError(
+            EXIT_USER_ERROR,
+            "cannot connect to IRC server. Is the server running?",
+            "start it with: culture server start",
+        )
+        err.__cause__ = exc
+        emit_error(err, json_mode=json_mode)
+        sys.exit(err.code)
+
+    if json_mode:
+        # Exactly the shared serializer's payload — the t7 endpoint emits
+        # the same json.dumps(serialize_residents(...)) bytes.
+        print(json.dumps(serialize_residents(residents, supported)))
+        return
+
+    if not supported:
+        print(_UNSUPPORTED_NOTICE)
+        return
+
+    if not residents:
+        print("No residents connected.")
+        return
+
+    print(render_table(residents))

--- a/culture_core/cli/residents.py
+++ b/culture_core/cli/residents.py
@@ -16,17 +16,22 @@ style, no traceback).
 from __future__ import annotations
 
 import argparse
-import json
+import os
 import sys
+from pathlib import Path
 
 from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
 from culture_core.cli._output import emit_error
 from culture_core.cli.shared.constants import _CONFIG_HELP, DEFAULT_CONFIG
+from culture_core.config import load_config_or_default
 from culture_core.resource_view import (
+    UNREACHABLE_MESSAGE,
+    UNREACHABLE_REMEDIATION,
     PresenceUnsupportedError,
     Resident,
-    fetch_residents,
+    fetch_residents_for,
     serialize_residents,
+    to_json,
 )
 
 NAME = "residents"
@@ -120,28 +125,49 @@ def render_table(residents: list[Resident]) -> str:
 
 def dispatch(args: argparse.Namespace) -> None:
     json_mode = bool(getattr(args, "json", False))
+
+    # Config loading is its own failure domain: an unreadable server.yaml
+    # must surface as a config error, never be swallowed by the connection
+    # handling below and misreported as "cannot connect to IRC server".
+    config_path = Path(os.path.expanduser(str(args.config)))
     try:
-        try:
-            residents = fetch_residents(args.config)
-            supported = True
-        except PresenceUnsupportedError:
-            residents, supported = [], False
+        config = load_config_or_default(config_path)
+    except CultureError as err:
+        # Config validation (e.g. a bad presence section) — emit through
+        # the verb's json-aware path so --json consumers always get the
+        # {code, message, remediation} contract.
+        emit_error(err, json_mode=json_mode)
+        sys.exit(err.code)
     except OSError as exc:
-        # Covers ConnectionRefusedError, the observer's registration
-        # ConnectionError, and TimeoutError — all OSError subclasses.
         err = CultureError(
             EXIT_USER_ERROR,
-            "cannot connect to IRC server. Is the server running?",
-            "start it with: culture server start",
+            f"cannot read server config at {config_path}: {exc}",
+            "check the file exists and is readable, or pass --config",
         )
         err.__cause__ = exc
         emit_error(err, json_mode=json_mode)
         sys.exit(err.code)
 
+    parent_nick = os.environ.get("CULTURE_NICK", "").strip() or None
+    try:
+        try:
+            residents = fetch_residents_for(config, parent_nick=parent_nick)
+            supported = True
+        except PresenceUnsupportedError:
+            residents, supported = [], False
+    except OSError as exc:
+        # Covers ConnectionRefusedError, the observer's registration
+        # ConnectionError, TimeoutError, and the mid-stream stall
+        # ConnectionError — all OSError subclasses.
+        err = CultureError(EXIT_USER_ERROR, UNREACHABLE_MESSAGE, UNREACHABLE_REMEDIATION)
+        err.__cause__ = exc
+        emit_error(err, json_mode=json_mode)
+        sys.exit(err.code)
+
     if json_mode:
-        # Exactly the shared serializer's payload — the t7 endpoint emits
-        # the same json.dumps(serialize_residents(...)) bytes.
-        print(json.dumps(serialize_residents(residents, supported)))
+        # Exactly the shared serializer AND the shared dumps site — the t7
+        # endpoint emits the same to_json(serialize_residents(...)) bytes.
+        print(to_json(serialize_residents(residents, supported)))
         return
 
     if not supported:

--- a/culture_core/config.py
+++ b/culture_core/config.py
@@ -12,11 +12,15 @@ import re
 import tempfile
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from agentirc.config import TelemetryConfig
 
 from culture_core._constants import DEFAULT_TURN_TIMEOUT_SECONDS
+
+if TYPE_CHECKING:  # runtime import would be circular — see _new_config_error
+    from culture_core.cli._errors import CultureError
 
 logger = logging.getLogger("culture")
 
@@ -169,11 +173,12 @@ _KNOWN_AGENT_FIELDS = {f.name for f in AgentConfig.__dataclass_fields__.values()
 }
 
 
-def _new_config_error(message: str, remediation: str) -> Exception:
+def _new_config_error(message: str, remediation: str) -> CultureError:
     """Build a :class:`CultureError` for an invalid config value.
 
     Imported lazily: ``culture_core.cli`` imports this module at load time,
-    so a module-level import here would be circular.
+    so a module-level import here would be circular (the typing-only import
+    above never runs at runtime).
     """
     from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
 
@@ -461,7 +466,12 @@ def _load_legacy_config(path: str | Path) -> ServerConfig:
                 known_fields[k] = v
             else:
                 extras[k] = v
-        agents.append(AgentConfig(**known_fields, extras=extras))
+        agent = AgentConfig(**known_fields, extras=extras)
+        # Same warn-and-degrade sanitizing the culture.yaml path gets in
+        # resolve_agents — a budget typo in a legacy manifest must neither
+        # drop the agent nor leak an invalid value into the resource view.
+        _validate_agent_budget(agent, str(path))
+        agents.append(agent)
 
     return ServerConfig(
         server=server,

--- a/culture_core/config.py
+++ b/culture_core/config.py
@@ -63,6 +63,25 @@ class WebhookConfig:
 
 
 @dataclass
+class PresenceConfig:
+    """Mesh-wide presence policy from the ``presence`` section of server.yaml.
+
+    ``heartbeat_interval_seconds`` is how often a busy resident refreshes its
+    PRESENCE signal; ``stale_after_seconds`` (stale-T) is how long the server
+    waits without a heartbeat before flagging a busy resident presumed-hung.
+    ``stale_after_seconds`` must be strictly greater than
+    ``heartbeat_interval_seconds`` so a live resident heartbeating on schedule
+    is never flagged between beats. The defaults (30/90) are open tuning
+    values (plan risk r1) — expect them to move once the mesh gathers real
+    heartbeat data. See protocol/extensions/presence.md and
+    docs/resident-presence.md.
+    """
+
+    heartbeat_interval_seconds: int = 30
+    stale_after_seconds: int = 90
+
+
+@dataclass
 class AgentConfig:
     """Per-agent settings loaded from culture.yaml."""
 
@@ -82,6 +101,13 @@ class AgentConfig:
     # them so a wedged stream cannot block _run_loop indefinitely.
     # Default lives in culture/_constants.py for cross-backend reuse.
     turn_timeout_seconds: float = DEFAULT_TURN_TIMEOUT_SECONDS
+    # Tokens per UTC day this agent is expected to stay under. WARN-ONLY:
+    # a breach only sets a warning flag in the resource view — nothing in
+    # v1 enforces, blocks, or defers work on it (docs/resident-presence.md).
+    # None disables budget warnings entirely.
+    token_budget: int | None = None
+    # Percent of token_budget at which the resource view starts warning.
+    token_budget_warn_pct: int = 80
     extras: dict = field(default_factory=dict)
     # Per-agent attention overrides, merged shallowly over daemon defaults by the
     # backend daemons (cultureagent's resolve_attention_config). Falsy => inherit
@@ -113,6 +139,7 @@ class ServerConfig:
     supervisor: SupervisorConfig = field(default_factory=SupervisorConfig)
     webhooks: WebhookConfig = field(default_factory=WebhookConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
+    presence: PresenceConfig = field(default_factory=PresenceConfig)
     buffer_size: int = 500
     poll_interval: int = 60
     sleep_start: str = "23:00"
@@ -142,6 +169,79 @@ _KNOWN_AGENT_FIELDS = {f.name for f in AgentConfig.__dataclass_fields__.values()
 }
 
 
+def _new_config_error(message: str, remediation: str) -> Exception:
+    """Build a :class:`CultureError` for an invalid config value.
+
+    Imported lazily: ``culture_core.cli`` imports this module at load time,
+    so a module-level import here would be circular.
+    """
+    from culture_core.cli._errors import EXIT_USER_ERROR, CultureError
+
+    return CultureError(EXIT_USER_ERROR, message, remediation)
+
+
+def _is_plain_int(value: object) -> bool:
+    """True only for real ints (bool is an int subclass — reject it)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_agent_budget(agent: AgentConfig, source: str) -> None:
+    """Validate the warn-only token-budget fields parsed from culture.yaml."""
+    budget = agent.token_budget
+    if budget is not None and not (_is_plain_int(budget) and budget >= 1):
+        raise _new_config_error(
+            f"Invalid token_budget in {source}: {budget!r} — "
+            "must be a positive integer (tokens per UTC day)",
+            "edit culture.yaml and set token_budget to an integer >= 1, "
+            "or remove the key to disable budget warnings",
+        )
+    pct = agent.token_budget_warn_pct
+    if not (_is_plain_int(pct) and 1 <= pct <= 100):
+        raise _new_config_error(
+            f"Invalid token_budget_warn_pct in {source}: {pct!r} — "
+            "must be an integer between 1 and 100",
+            "edit culture.yaml and set token_budget_warn_pct to a percent "
+            "in 1..100 (default 80)",
+        )
+
+
+def _parse_presence_section(raw: dict, source: str) -> PresenceConfig:
+    """Parse and validate the optional ``presence`` section of server.yaml."""
+    section = raw.get("presence") or {}
+    if not isinstance(section, dict):
+        raise _new_config_error(
+            f"Invalid presence section in {source}: {section!r} — must be a mapping",
+            "edit server.yaml: presence takes nested keys "
+            "heartbeat_interval_seconds and stale_after_seconds",
+        )
+    try:
+        presence = PresenceConfig(**section)
+    except TypeError:
+        known = ", ".join(f.name for f in PresenceConfig.__dataclass_fields__.values())
+        raise _new_config_error(
+            f"Unknown key in presence section of {source}: "
+            f"{sorted(section)!r} — known keys are {known}",
+            "edit server.yaml and remove or rename the unknown presence key",
+        ) from None
+    for key in ("heartbeat_interval_seconds", "stale_after_seconds"):
+        value = getattr(presence, key)
+        if not (_is_plain_int(value) and value >= 1):
+            raise _new_config_error(
+                f"Invalid presence.{key} in {source}: {value!r} — "
+                "must be a positive integer (seconds)",
+                f"edit server.yaml and set presence.{key} to an integer >= 1",
+            )
+    if presence.stale_after_seconds <= presence.heartbeat_interval_seconds:
+        raise _new_config_error(
+            f"Invalid presence.stale_after_seconds in {source}: "
+            f"{presence.stale_after_seconds} — must be strictly greater than "
+            f"heartbeat_interval_seconds ({presence.heartbeat_interval_seconds})",
+            "edit server.yaml so stale_after_seconds > heartbeat_interval_seconds — "
+            "otherwise a live resident would be flagged stale between heartbeats",
+        )
+    return presence
+
+
 def _parse_agent_entry(raw: dict, directory: str) -> AgentConfig:
     """Parse a single agent entry from culture.yaml."""
     raw = dict(raw)
@@ -162,6 +262,7 @@ def _parse_agent_entry(raw: dict, directory: str) -> AgentConfig:
         extras=extras,
         directory=directory,
     )
+    _validate_agent_budget(agent, str(Path(directory) / CULTURE_YAML))
     return agent
 
 
@@ -228,6 +329,7 @@ def load_server_config(path: str | Path) -> ServerConfig:
     supervisor = SupervisorConfig(**raw.get("supervisor", {}))
     webhooks = WebhookConfig(**raw.get("webhooks", {}))
     telemetry = TelemetryConfig(**raw.get("telemetry", {}))
+    presence = _parse_presence_section(raw, str(path))
 
     manifest = raw.get("agents") or {}
     if not isinstance(manifest, dict):
@@ -238,6 +340,7 @@ def load_server_config(path: str | Path) -> ServerConfig:
         supervisor=supervisor,
         webhooks=webhooks,
         telemetry=telemetry,
+        presence=presence,
         buffer_size=raw.get("buffer_size", 500),
         poll_interval=raw.get("poll_interval", 60),
         sleep_start=raw.get("sleep_start", "23:00"),
@@ -268,6 +371,9 @@ def _warn_manifest_entry_once(server_name: str, suffix: str, message: str, *args
 
 def resolve_agents(config: ServerConfig) -> None:
     """Resolve agent configs from manifest paths."""
+    # Lazy: culture_core.cli imports this module at load time.
+    from culture_core.cli._errors import CultureError
+
     config.agents = []
     server_name = config.server.name
 
@@ -286,7 +392,7 @@ def resolve_agents(config: ServerConfig) -> None:
                 suffix,
             )
             continue
-        except ValueError as e:
+        except (ValueError, CultureError) as e:
             _warn_manifest_entry_once(
                 server_name,
                 suffix,
@@ -492,6 +598,10 @@ def _agent_to_yaml_dict(agent: AgentConfig) -> dict:
         data["archived"] = agent.archived
         data["archived_at"] = agent.archived_at
         data["archived_reason"] = agent.archived_reason
+    if agent.token_budget is not None:
+        data["token_budget"] = agent.token_budget
+    if agent.token_budget_warn_pct != defaults.token_budget_warn_pct:
+        data["token_budget_warn_pct"] = agent.token_budget_warn_pct
     data.update(agent.extras)
     # Round-trip the typed attention field back to the author-facing ``attention:``
     # key (written after extras so the typed field stays authoritative). Without
@@ -584,6 +694,7 @@ def save_server_config(path: str | Path, config: ServerConfig) -> None:
         "supervisor": asdict(config.supervisor),
         "webhooks": asdict(config.webhooks),
         "telemetry": asdict(config.telemetry),
+        "presence": asdict(config.presence),
         "buffer_size": config.buffer_size,
         "poll_interval": config.poll_interval,
         "sleep_start": config.sleep_start,

--- a/culture_core/config.py
+++ b/culture_core/config.py
@@ -186,28 +186,52 @@ def _is_plain_int(value: object) -> bool:
 
 
 def _validate_agent_budget(agent: AgentConfig, source: str) -> None:
-    """Validate the warn-only token-budget fields parsed from culture.yaml."""
+    """Sanitize the warn-only token-budget fields parsed from culture.yaml.
+
+    Budget fields are warn-only observability config
+    (docs/resident-presence.md): an invalid value must never stop an agent
+    from loading. Raising here would drop the agent from the manifest in
+    :func:`resolve_agents` and escape the doctor's per-entry catch tuples
+    (``culture_core/doctor/checks.py`` / ``discovery.py``), aborting a whole
+    doctor run over a budget typo. Instead: warn — naming the file, the
+    offending key/value, and the valid range — and reset the field to its
+    default, so only the budget warnings degrade, never the agent.
+    """
+    defaults = AgentConfig()
     budget = agent.token_budget
     if budget is not None and not (_is_plain_int(budget) and budget >= 1):
-        raise _new_config_error(
-            f"Invalid token_budget in {source}: {budget!r} — "
-            "must be a positive integer (tokens per UTC day)",
-            "edit culture.yaml and set token_budget to an integer >= 1, "
-            "or remove the key to disable budget warnings",
+        logger.warning(
+            "Invalid token_budget in %s: %r — must be a positive integer "
+            "(tokens per UTC day); ignoring it (budget warnings disabled "
+            "for this agent)",
+            source,
+            budget,
         )
+        agent.token_budget = defaults.token_budget
     pct = agent.token_budget_warn_pct
     if not (_is_plain_int(pct) and 1 <= pct <= 100):
-        raise _new_config_error(
-            f"Invalid token_budget_warn_pct in {source}: {pct!r} — "
-            "must be an integer between 1 and 100",
-            "edit culture.yaml and set token_budget_warn_pct to a percent "
-            "in 1..100 (default 80)",
+        logger.warning(
+            "Invalid token_budget_warn_pct in %s: %r — must be an integer "
+            "between 1 and 100; using the default (%d)",
+            source,
+            pct,
+            defaults.token_budget_warn_pct,
         )
+        agent.token_budget_warn_pct = defaults.token_budget_warn_pct
 
 
 def _parse_presence_section(raw: dict, source: str) -> PresenceConfig:
-    """Parse and validate the optional ``presence`` section of server.yaml."""
-    section = raw.get("presence") or {}
+    """Parse and validate the optional ``presence`` section of server.yaml.
+
+    Mesh policy fails fast by design: unlike the warn-only agent budget
+    fields, an invalid presence section raises a :class:`CultureError`.
+    Only a missing key (or an explicit YAML null) means "use defaults" —
+    a falsy non-mapping (``presence: false`` / ``[]`` / ``0``) is rejected
+    like any other non-mapping instead of silently coercing to defaults.
+    """
+    section = raw.get("presence")
+    if section is None:
+        return PresenceConfig()
     if not isinstance(section, dict):
         raise _new_config_error(
             f"Invalid presence section in {source}: {section!r} — must be a mapping",
@@ -218,9 +242,12 @@ def _parse_presence_section(raw: dict, source: str) -> PresenceConfig:
         presence = PresenceConfig(**section)
     except TypeError:
         known = ", ".join(f.name for f in PresenceConfig.__dataclass_fields__.values())
+        # map(str, ...): YAML permits non-string keys (an unquoted `30:`
+        # parses as an int) and sorting mixed-type keys raises TypeError —
+        # stringify first so the structured error always builds.
         raise _new_config_error(
             f"Unknown key in presence section of {source}: "
-            f"{sorted(section)!r} — known keys are {known}",
+            f"{sorted(map(str, section))!r} — known keys are {known}",
             "edit server.yaml and remove or rename the unknown presence key",
         ) from None
     for key in ("heartbeat_interval_seconds", "stale_after_seconds"):

--- a/culture_core/overview/renderer_web.py
+++ b/culture_core/overview/renderer_web.py
@@ -10,14 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import atexit
-import json
 import os
 import re
 import signal
 import threading
 import time
 from datetime import datetime
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import HTTPServer, SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import mistune
@@ -33,10 +32,13 @@ from culture_core.pidfile import (
     write_port,
 )
 from culture_core.resource_view import (
+    UNREACHABLE_MESSAGE,
+    UNREACHABLE_REMEDIATION,
     PresenceUnsupportedError,
     Resident,
     fetch_residents_async,
     serialize_residents,
+    to_json,
 )
 
 from .collector import collect_mesh_state
@@ -236,8 +238,9 @@ class _OverviewHandler(SimpleHTTPRequestHandler):
         """GET /residents.json — the resource view (plan task t7).
 
         Read-only, no side effects, and byte-compatible with
-        ``culture residents --json``: both emit exactly ``json.dumps`` of
-        :func:`culture_core.resource_view.serialize_residents`. Three
+        ``culture residents --json``: both emit exactly
+        :func:`culture_core.resource_view.to_json` of
+        :func:`culture_core.resource_view.serialize_residents`. Four
         response cases, never an unhandled traceback (the irc-lens console
         consumes this and must never see a bare 500):
 
@@ -245,7 +248,9 @@ class _OverviewHandler(SimpleHTTPRequestHandler):
         * no PRESENCE surface         -> 200, ``supported: false`` payload
           (a presence-less mesh is a known state, not an error — pending
           agentirc#53);
-        * culture server unreachable  -> 503, ``{code, message, remediation}``.
+        * culture server unreachable  -> 503, ``{code, message, remediation}``;
+        * anything unexpected         -> 500, ``{code, message, remediation}``
+          (defensive last resort — still structured JSON).
         """
         try:
             try:
@@ -254,21 +259,37 @@ class _OverviewHandler(SimpleHTTPRequestHandler):
             except PresenceUnsupportedError:
                 residents, supported = [], False
         except OSError:
-            # Covers ConnectionRefusedError, ConnectionError, TimeoutError —
-            # all OSError subclasses. Same voice as the residents CLI error.
+            # Covers ConnectionRefusedError, ConnectionError (including the
+            # mid-stream presence stall), TimeoutError — all OSError
+            # subclasses. Same voice as the residents CLI error.
             self._send_json(
                 503,
                 {
                     "code": 503,
-                    "message": "cannot connect to IRC server. Is the server running?",
-                    "remediation": "start it with: culture server start",
+                    "message": UNREACHABLE_MESSAGE,
+                    "remediation": UNREACHABLE_REMEDIATION,
+                },
+            )
+            return
+        except Exception as exc:
+            # Defensive catch-all: whatever escapes the fetch seam, the
+            # irc-lens console gets structured JSON — never a traceback
+            # page or the default HTML 500.
+            self._send_json(
+                500,
+                {
+                    "code": 500,
+                    "message": f"internal error building the resource view: {exc}",
+                    "remediation": "check the overview server logs and report a culture bug",
                 },
             )
             return
         self._send_json(200, serialize_residents(residents, supported, now=self.residents_now))
 
     def _send_json(self, status: int, payload: dict) -> None:
-        content = json.dumps(payload).encode()
+        # to_json is the ONE canonical dumps site for the resource view —
+        # the 200 payload here is byte-identical to `culture residents --json`.
+        content = to_json(payload).encode()
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(content)))
@@ -352,7 +373,14 @@ def serve_web(
     # Bound to loopback only — see `_LOOPBACK_HOSTS` / `_dashboard_url`: this is
     # the one and only reason the dashboard may be served over plain HTTP.
     bind_host = "127.0.0.1"
-    httpd = HTTPServer((bind_host, serve_port), handler_cls)
+    # Threading server: every /residents.json request runs a fresh IRC
+    # connect+register (seconds; worst-case the observer's RECV_TIMEOUT),
+    # which on a single-threaded HTTPServer stalled every overview page
+    # load behind it. Daemon threads so in-flight requests never block
+    # shutdown (the SIGTERM handler's httpd.shutdown() and the finally
+    # below behave exactly as before).
+    httpd = ThreadingHTTPServer((bind_host, serve_port), handler_cls)
+    httpd.daemon_threads = True
     actual_port = httpd.server_address[1]
 
     write_pid(pid_name, os.getpid())

--- a/culture_core/overview/renderer_web.py
+++ b/culture_core/overview/renderer_web.py
@@ -1,19 +1,28 @@
-"""Render mesh overview as HTML and serve via HTTP."""
+"""Render mesh overview as HTML and serve via HTTP.
+
+Besides the HTML dashboard, the server exposes the resource view as
+``GET /residents.json`` (docs/resident-presence.md, plan task t7) —
+byte-compatible with ``culture residents --json`` via the one canonical
+serializer in :mod:`culture_core.resource_view`.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import atexit
+import json
 import os
 import re
 import signal
 import threading
 import time
+from datetime import datetime
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 
 import mistune
 
+from culture_core.config import ServerConfig, ServerConnConfig
 from culture_core.pidfile import (
     is_process_alive,
     read_pid,
@@ -22,6 +31,12 @@ from culture_core.pidfile import (
     remove_port,
     write_pid,
     write_port,
+)
+from culture_core.resource_view import (
+    PresenceUnsupportedError,
+    Resident,
+    fetch_residents_async,
+    serialize_residents,
 )
 
 from .collector import collect_mesh_state
@@ -173,8 +188,15 @@ class _OverviewHandler(SimpleHTTPRequestHandler):
     message_limit: int = 4
     refresh_interval: int = 5
     manifest_agents: list | None = None
+    # Deterministic-time seam for the /residents.json payload, mirroring
+    # serialize_residents(now=...): production leaves it None (current UTC
+    # time); tests pin it to a fixed instant for byte-exact assertions.
+    residents_now: datetime | None = None
 
     def do_GET(self):
+        if self.path.split("?", 1)[0] == "/residents.json":
+            self._serve_residents()
+            return
         mesh = asyncio.run(
             collect_mesh_state(
                 host=self.irc_host,
@@ -194,6 +216,61 @@ class _OverviewHandler(SimpleHTTPRequestHandler):
         content = html.encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def _fetch_residents(self) -> list[Resident]:
+        """Seam: query the bound culture server for the presence aggregation.
+
+        Tests override this to inject fixtures; production queries the same
+        server the overview renders, joining budgets from the same manifest.
+        """
+        config = ServerConfig(
+            server=ServerConnConfig(name=self.server_name, host=self.irc_host, port=self.irc_port),
+            agents=list(self.manifest_agents or []),
+        )
+        return asyncio.run(fetch_residents_async(config))
+
+    def _serve_residents(self) -> None:
+        """GET /residents.json — the resource view (plan task t7).
+
+        Read-only, no side effects, and byte-compatible with
+        ``culture residents --json``: both emit exactly ``json.dumps`` of
+        :func:`culture_core.resource_view.serialize_residents`. Three
+        response cases, never an unhandled traceback (the irc-lens console
+        consumes this and must never see a bare 500):
+
+        * presence supported          -> 200, canonical payload;
+        * no PRESENCE surface         -> 200, ``supported: false`` payload
+          (a presence-less mesh is a known state, not an error — pending
+          agentirc#53);
+        * culture server unreachable  -> 503, ``{code, message, remediation}``.
+        """
+        try:
+            try:
+                residents = self._fetch_residents()
+                supported = True
+            except PresenceUnsupportedError:
+                residents, supported = [], False
+        except OSError:
+            # Covers ConnectionRefusedError, ConnectionError, TimeoutError —
+            # all OSError subclasses. Same voice as the residents CLI error.
+            self._send_json(
+                503,
+                {
+                    "code": 503,
+                    "message": "cannot connect to IRC server. Is the server running?",
+                    "remediation": "start it with: culture server start",
+                },
+            )
+            return
+        self._send_json(200, serialize_residents(residents, supported, now=self.residents_now))
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        content = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(content)))
         self.end_headers()
         self.wfile.write(content)

--- a/culture_core/resource_view.py
+++ b/culture_core/resource_view.py
@@ -8,23 +8,17 @@ front doors consume it and MUST stay byte-compatible:
 * the upcoming resource-view HTTP endpoint for irc-lens (plan task t7),
   which reuses :func:`serialize_residents` for its payload.
 
-Transport status (plan risks r3/r4)
------------------------------------
+Transport status (plan risks r3/r4 — RESOLVED)
+----------------------------------------------
 
-The agentirc IRCd does **not** implement the PRESENCE query surface yet —
-the server-side aggregation is the subject of the t3 hand-off brief
-(agentirc#53). Until that lands and culture's agentirc floor is bumped,
-every real server answers the query probe with ``421 Unknown command``,
-which this module surfaces as :class:`PresenceUnsupportedError` so the
-front doors can degrade gracefully (``supported: false``) instead of
-failing.
-
-The transport is deliberately isolated in ONE seam function,
-:func:`_query_presence_wire`, speaking the *anticipated* wire shape
-(``PRESENCE LIST`` -> ``PRESENCELIST :<json>`` lines -> ``PRESENCEEND``).
-When agentirc answers the brief, only that function changes; the
-:class:`Resident` model, the budget join, and the canonical serializer
-stay put.
+agentirc adopted culture's proposed wire shape **verbatim** in
+agentirc-cli 9.12.0 (agentirc#53): ``PRESENCE LIST`` ->
+``PRESENCELIST :<json>`` lines -> ``PRESENCEEND``, with a pre-9.12
+server answering the probe ``421 Unknown command``. The transport stays
+isolated in ONE seam function, :func:`_query_presence_wire`; a ``421``
+still surfaces as :class:`PresenceUnsupportedError` so the front doors
+degrade gracefully (``supported: false``) against a not-yet-upgraded
+server instead of failing.
 """
 
 from __future__ import annotations
@@ -54,6 +48,10 @@ _DEFAULT_CONFIG = "~/.culture/server.yaml"
 UNREACHABLE_MESSAGE = "cannot connect to IRC server. Is the server running?"
 UNREACHABLE_REMEDIATION = "start it with: culture server start"
 
+# The AgentConfig field default, referenced (not copied) so the two can
+# never drift; apply_budgets falls back to it for unsanitized warn-pcts.
+_DEFAULT_WARN_PCT: int = AgentConfig.__dataclass_fields__["token_budget_warn_pct"].default
+
 
 def to_json(payload: dict) -> str:
     """THE single canonical ``json.dumps`` site for the resource view.
@@ -69,10 +67,10 @@ def to_json(payload: dict) -> str:
 class PresenceUnsupportedError(Exception):
     """The server is reachable but has no PRESENCE query surface.
 
-    Raised while the aggregation side of the PRESENCE extension is pending
-    in agentirc (agentirc#53). Front doors catch this and degrade to a
+    Raised when the server predates the PRESENCE aggregation (agentirc-cli
+    < 9.12.0, agentirc#53). Front doors catch this and degrade to a
     ``supported: false`` resource view with exit/status success — a mesh
-    without presence support is a known state, not an error.
+    on a not-yet-upgraded server is a known state, not an error.
     """
 
 
@@ -203,10 +201,11 @@ def apply_budgets(residents: Iterable[Resident], agents: Iterable[AgentConfig]) 
     (docs/resident-presence.md).
 
     Budgets that are not a real int >= 1 are skipped entirely (all derived
-    fields stay ``None``): the legacy agents.yaml loader constructs
-    ``AgentConfig`` directly and bypasses the culture.yaml budget
-    sanitizing, so ``token_budget: 0`` (or a bool, or a negative) can reach
-    this join — it must never reach the division below.
+    fields stay ``None``), and a warn-pct outside 1..100 (or a bool) falls
+    back to the field default: config loading sanitizes both fields, but
+    ``AgentConfig`` objects can also be constructed directly (tests, future
+    callers), and an unsanitized value must never reach the division or
+    produce a misleading ``budget_warning`` flag.
     """
     by_nick = {agent.nick: agent for agent in agents if agent.nick}
     for resident in residents:
@@ -221,24 +220,27 @@ def apply_budgets(residents: Iterable[Resident], agents: Iterable[AgentConfig]) 
             continue  # state-only backend: budget known, spend unknowable
         spend = (resident.tokens_in or 0) + (resident.tokens_out or 0)
         resident.budget_used_pct = round(spend * 100.0 / budget, 1)
-        resident.budget_warning = resident.budget_used_pct >= agent.token_budget_warn_pct
+        warn_pct = agent.token_budget_warn_pct
+        if not isinstance(warn_pct, int) or isinstance(warn_pct, bool) or not 1 <= warn_pct <= 100:
+            warn_pct = _DEFAULT_WARN_PCT  # see docstring
+        resident.budget_warning = resident.budget_used_pct >= warn_pct
 
 
 async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
     """THE transport seam — query the server for the presence aggregation.
 
-    Anticipated wire contract (proposed to agentirc in the t3 brief,
-    agentirc#53 — subject to change when the brief is answered; ONLY this
-    function should need to change):
+    Wire contract (proposed in the t3 brief, adopted verbatim by agentirc
+    in agentirc-cli 9.12.0 — agentirc#53):
 
     * client sends ``PRESENCE LIST`` after registering;
     * server replies with one ``PRESENCELIST :<json resident object>`` line
-      per resident, terminated by ``PRESENCEEND``;
-    * a server without the surface replies ``421 <nick> PRESENCE :Unknown
-      command`` (today's agentirc), raised here as
-      :class:`PresenceUnsupportedError`. A server that stays silent on the
-      probe or drops the connection **before any record arrives** is
-      treated the same way — reachable, but no presence support;
+      per resident (nick-sorted, all nine keys always present), terminated
+      by ``PRESENCEEND``;
+    * a pre-9.12 server replies ``421 <nick> PRESENCE :Unknown command``,
+      raised here as :class:`PresenceUnsupportedError`. A server that stays
+      silent on the probe or drops the connection **before any record
+      arrives** is treated the same way — reachable, but no presence
+      support;
     * a timeout or connection close **mid-stream** — after ``PRESENCELIST``
       records were already received — raises ``ConnectionError`` instead:
       that server clearly speaks the surface but stalled, and classifying
@@ -253,7 +255,7 @@ async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
     try:
         writer.write(b"PRESENCE LIST\r\n")
         await writer.drain()
-        buffer = ""
+        buffer = b""
         while True:
             try:
                 data = await asyncio.wait_for(reader.read(4096), timeout=RECV_TIMEOUT)
@@ -269,7 +271,7 @@ async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
                 raise PresenceUnsupportedError(
                     "server closed the connection during the PRESENCE query"
                 )
-            buffer += data.decode(errors="replace")
+            buffer += data
             done, buffer = await _drain_presence_buffer(buffer, records, writer)
             if done:
                 return records
@@ -278,33 +280,50 @@ async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
 
 
 async def _drain_presence_buffer(
-    buffer: str, records: list[dict], writer: asyncio.StreamWriter
-) -> tuple[bool, str]:
-    """Consume complete lines from *buffer*. Returns (done, remainder)."""
-    while "\r\n" in buffer:
-        line, buffer = buffer.split("\r\n", 1)
+    buffer: bytes, records: list[dict], writer: asyncio.StreamWriter
+) -> tuple[bool, bytes]:
+    """Consume complete CRLF-framed lines from *buffer*. Returns (done, remainder).
+
+    Framing happens at the **byte** level and each complete line is decoded
+    on its own: the payload contract is UTF-8 JSON, and a multi-byte
+    character split across TCP reads must never be corrupted by decoding a
+    partial chunk.
+    """
+    while b"\r\n" in buffer:
+        raw_line, buffer = buffer.split(b"\r\n", 1)
+        line = raw_line.decode(errors="replace")
         if not line.strip():
             continue
-        msg = Message.parse(line)
-        if msg.command == "PING":
-            token = msg.params[0] if msg.params else ""
-            writer.write(f"PONG :{token}\r\n".encode())
-            await writer.drain()
-            continue
-        if msg.command == "421" and "PRESENCE" in msg.params:
-            raise PresenceUnsupportedError(
-                "server replied '421 Unknown command' to the PRESENCE query"
-            )
-        if msg.command == "PRESENCEEND":
+        if await _handle_presence_line(Message.parse(line), records, writer):
             return True, buffer
-        if msg.command == "PRESENCELIST" and msg.params:
-            try:
-                parsed = json.loads(msg.params[-1])
-            except ValueError:
-                continue  # malformed record: skip, never crash the view
-            if isinstance(parsed, dict) and parsed.get("nick"):
-                records.append(parsed)
     return False, buffer
+
+
+async def _handle_presence_line(
+    msg: Message, records: list[dict], writer: asyncio.StreamWriter
+) -> bool:
+    """Handle one parsed line of the PRESENCE reply stream. True when done."""
+    if msg.command == "PING":
+        token = msg.params[0] if msg.params else ""
+        writer.write(f"PONG :{token}\r\n".encode())
+        await writer.drain()
+    elif msg.command == "421" and "PRESENCE" in msg.params:
+        raise PresenceUnsupportedError("server replied '421 Unknown command' to the PRESENCE query")
+    elif msg.command == "PRESENCEEND":
+        return True
+    elif msg.command == "PRESENCELIST" and msg.params:
+        _append_presence_record(msg.params[-1], records)
+    return False
+
+
+def _append_presence_record(payload: str, records: list[dict]) -> None:
+    """Parse one PRESENCELIST payload; skip malformed records, never crash."""
+    try:
+        parsed = json.loads(payload)
+    except ValueError:
+        return
+    if isinstance(parsed, dict) and parsed.get("nick"):
+        records.append(parsed)
 
 
 async def fetch_residents_async(

--- a/culture_core/resource_view.py
+++ b/culture_core/resource_view.py
@@ -1,0 +1,303 @@
+"""Shared resource-view seam: fetch and serialize the resident presence aggregation.
+
+This module is the single source of truth for the mesh resource view —
+per-resident presence state, token spend, and warn-only budget status. Two
+front doors consume it and MUST stay byte-compatible:
+
+* the ``culture residents`` CLI verb (``culture_core/cli/residents.py``);
+* the upcoming resource-view HTTP endpoint for irc-lens (plan task t7),
+  which reuses :func:`serialize_residents` for its payload.
+
+Transport status (plan risks r3/r4)
+-----------------------------------
+
+The agentirc IRCd does **not** implement the PRESENCE query surface yet —
+the server-side aggregation is the subject of the t3 hand-off brief
+(agentirc#53). Until that lands and culture's agentirc floor is bumped,
+every real server answers the query probe with ``421 Unknown command``,
+which this module surfaces as :class:`PresenceUnsupportedError` so the
+front doors can degrade gracefully (``supported: false``) instead of
+failing.
+
+The transport is deliberately isolated in ONE seam function,
+:func:`_query_presence_wire`, speaking the *anticipated* wire shape
+(``PRESENCE LIST`` -> ``PRESENCELIST :<json>`` lines -> ``PRESENCEEND``).
+When agentirc answers the brief, only that function changes; the
+:class:`Resident` model, the budget join, and the canonical serializer
+stay put.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from culture_core.config import AgentConfig, ServerConfig, load_config_or_default
+from culture_core.observer import RECV_TIMEOUT, IRCObserver
+from culture_core.protocol.message import Message
+
+# Default server config path. Deliberately duplicated from
+# culture_core.cli.shared.constants: importing anything under
+# culture_core.cli here would run the whole CLI package __init__, which
+# imports the residents CLI module, which imports this module — circular.
+_DEFAULT_CONFIG = "~/.culture/server.yaml"
+
+
+class PresenceUnsupportedError(Exception):
+    """The server is reachable but has no PRESENCE query surface.
+
+    Raised while the aggregation side of the PRESENCE extension is pending
+    in agentirc (agentirc#53). Front doors catch this and degrade to a
+    ``supported: false`` resource view with exit/status success — a mesh
+    without presence support is a known state, not an error.
+    """
+
+
+@dataclass
+class Resident:
+    """One row of the resource view.
+
+    The first nine fields mirror the per-resident record the server
+    aggregation returns (protocol/extensions/presence.md). The last three
+    are culture-side derived fields, joined from the local manifest's
+    ``AgentConfig.token_budget`` / ``token_budget_warn_pct`` when the nick
+    matches a registered agent — ``None`` when no budget is configured or
+    (for the spend-derived pair) when the resident sent no token counters.
+    """
+
+    nick: str
+    server: str | None = None
+    state: str | None = None
+    since: str | None = None
+    task: str | None = None
+    tokens_in: int | None = None
+    tokens_out: int | None = None
+    presumed_hung: bool = False
+    last_refresh: str | None = None
+    # Culture-side derived fields (never on the wire; see apply_budgets).
+    token_budget: int | None = None
+    budget_used_pct: float | None = None
+    budget_warning: bool | None = None
+
+
+# Canonical per-resident key order of the serialized payload. This IS the
+# JSON schema order documented in docs/resident-presence.md — the t7
+# endpoint and the CLI --json output both emit exactly this.
+_RESIDENT_FIELDS: tuple[str, ...] = (
+    "nick",
+    "server",
+    "state",
+    "since",
+    "task",
+    "tokens_in",
+    "tokens_out",
+    "presumed_hung",
+    "last_refresh",
+    "token_budget",
+    "budget_used_pct",
+    "budget_warning",
+)
+
+
+def serialize_residents(
+    residents: Sequence[Resident],
+    supported: bool,
+    *,
+    now: datetime | None = None,
+) -> dict:
+    """Build THE canonical resource-view JSON payload.
+
+    Pure (no I/O) and deterministic: residents are sorted by nick and every
+    record carries all :data:`_RESIDENT_FIELDS` keys in fixed order, with
+    ``None`` for anything unknown. The ``culture residents --json`` output
+    and the t7 HTTP endpoint both emit exactly ``json.dumps`` of this dict —
+    one serializer, one schema.
+
+    ``now`` exists for deterministic tests; production callers omit it and
+    get the current UTC time.
+    """
+    stamp = now if now is not None else datetime.now(timezone.utc)
+    generated_at = (
+        stamp.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+    return {
+        "supported": bool(supported),
+        "generated_at": generated_at,
+        "residents": [
+            {name: getattr(resident, name) for name in _RESIDENT_FIELDS}
+            for resident in sorted(residents, key=lambda r: r.nick)
+        ],
+    }
+
+
+def _as_int(value: object) -> int | None:
+    """Return the value as an int, or None. Bools are NOT counts."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _as_str(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _resident_from_wire(record: dict) -> Resident:
+    """Build a Resident from one aggregation record, defensively typed."""
+    return Resident(
+        nick=str(record.get("nick") or ""),
+        server=_as_str(record.get("server")),
+        state=_as_str(record.get("state")),
+        since=_as_str(record.get("since")),
+        task=_as_str(record.get("task")),
+        tokens_in=_as_int(record.get("tokens_in")),
+        tokens_out=_as_int(record.get("tokens_out")),
+        presumed_hung=bool(record.get("presumed_hung")),
+        last_refresh=_as_str(record.get("last_refresh")),
+    )
+
+
+def apply_budgets(residents: Iterable[Resident], agents: Iterable[AgentConfig]) -> None:
+    """Join local-manifest budget config onto fetched residents, by nick.
+
+    For each resident whose nick matches a registered agent with a
+    ``token_budget`` configured:
+
+    * ``token_budget`` is copied over;
+    * ``budget_used_pct`` = (tokens_in + tokens_out) / budget * 100, rounded
+      to one decimal — but only when the resident actually reported token
+      counters. A state-only resident keeps ``None`` (spend unknowable,
+      never a false alarm);
+    * ``budget_warning`` is True once used-pct reaches
+      ``token_budget_warn_pct`` (inclusive), False below it, ``None`` when
+      spend is unknowable.
+
+    Warn-only by design: nothing anywhere acts on these flags in v1
+    (docs/resident-presence.md).
+    """
+    by_nick = {agent.nick: agent for agent in agents if agent.nick}
+    for resident in residents:
+        agent = by_nick.get(resident.nick)
+        if agent is None or agent.token_budget is None:
+            continue
+        resident.token_budget = agent.token_budget
+        if resident.tokens_in is None and resident.tokens_out is None:
+            continue  # state-only backend: budget known, spend unknowable
+        spend = (resident.tokens_in or 0) + (resident.tokens_out or 0)
+        resident.budget_used_pct = round(spend * 100.0 / agent.token_budget, 1)
+        resident.budget_warning = resident.budget_used_pct >= agent.token_budget_warn_pct
+
+
+async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
+    """THE transport seam — query the server for the presence aggregation.
+
+    Anticipated wire contract (proposed to agentirc in the t3 brief,
+    agentirc#53 — subject to change when the brief is answered; ONLY this
+    function should need to change):
+
+    * client sends ``PRESENCE LIST`` after registering;
+    * server replies with one ``PRESENCELIST :<json resident object>`` line
+      per resident, terminated by ``PRESENCEEND``;
+    * a server without the surface replies ``421 <nick> PRESENCE :Unknown
+      command`` (today's agentirc), raised here as
+      :class:`PresenceUnsupportedError`. A server that stays silent on the
+      probe or drops the connection mid-query is treated the same way —
+      reachable, but no presence support.
+
+    Connection-level failures (refused, DNS, registration timeout) raise
+    ``OSError`` / ``ConnectionError`` as with every other observer query.
+    """
+    reader, writer, _nick = await observer._connect_and_register()
+    records: list[dict] = []
+    try:
+        writer.write(b"PRESENCE LIST\r\n")
+        await writer.drain()
+        buffer = ""
+        while True:
+            try:
+                data = await asyncio.wait_for(reader.read(4096), timeout=RECV_TIMEOUT)
+            except asyncio.TimeoutError:
+                raise PresenceUnsupportedError("server did not answer the PRESENCE query") from None
+            if not data:
+                raise PresenceUnsupportedError(
+                    "server closed the connection during the PRESENCE query"
+                )
+            buffer += data.decode(errors="replace")
+            done, buffer = await _drain_presence_buffer(buffer, records, writer)
+            if done:
+                return records
+    finally:
+        await observer._disconnect(writer)
+
+
+async def _drain_presence_buffer(
+    buffer: str, records: list[dict], writer: asyncio.StreamWriter
+) -> tuple[bool, str]:
+    """Consume complete lines from *buffer*. Returns (done, remainder)."""
+    while "\r\n" in buffer:
+        line, buffer = buffer.split("\r\n", 1)
+        if not line.strip():
+            continue
+        msg = Message.parse(line)
+        if msg.command == "PING":
+            token = msg.params[0] if msg.params else ""
+            writer.write(f"PONG :{token}\r\n".encode())
+            await writer.drain()
+            continue
+        if msg.command == "421" and "PRESENCE" in msg.params:
+            raise PresenceUnsupportedError(
+                "server replied '421 Unknown command' to the PRESENCE query"
+            )
+        if msg.command == "PRESENCEEND":
+            return True, buffer
+        if msg.command == "PRESENCELIST" and msg.params:
+            try:
+                parsed = json.loads(msg.params[-1])
+            except ValueError:
+                continue  # malformed record: skip, never crash the view
+            if isinstance(parsed, dict) and parsed.get("nick"):
+                records.append(parsed)
+    return False, buffer
+
+
+async def fetch_residents_async(
+    config: ServerConfig, *, parent_nick: str | None = None
+) -> list[Resident]:
+    """Query *config*'s server for the resource view (async form, for t7).
+
+    Returns the residents with culture-side budget fields already joined
+    from ``config.agents``. Raises :class:`PresenceUnsupportedError` when
+    the server is reachable but has no PRESENCE surface (pending
+    agentirc#53), and ``OSError`` / ``ConnectionError`` when it is not
+    reachable at all.
+    """
+    observer = IRCObserver(
+        host=config.server.host,
+        port=config.server.port,
+        server_name=config.server.name,
+        parent_nick=parent_nick,
+    )
+    raw = await _query_presence_wire(observer)
+    residents = [_resident_from_wire(record) for record in raw]
+    apply_budgets(residents, config.agents)
+    return residents
+
+
+def fetch_residents(config_path: str | Path | None = None) -> list[Resident]:
+    """Sync front-door wrapper around :func:`fetch_residents_async`.
+
+    Loads the server config (default ``~/.culture/server.yaml``) and runs
+    the query on a fresh event loop — the CLI's calling convention. Callers
+    already inside an event loop (the t7 endpoint) use
+    :func:`fetch_residents_async` directly.
+    """
+    path = Path(os.path.expanduser(str(config_path or _DEFAULT_CONFIG)))
+    config = load_config_or_default(path)
+    parent = os.environ.get("CULTURE_NICK", "").strip() or None
+    return asyncio.run(fetch_residents_async(config, parent_nick=parent))

--- a/culture_core/resource_view.py
+++ b/culture_core/resource_view.py
@@ -47,6 +47,24 @@ from culture_core.protocol.message import Message
 # imports the residents CLI module, which imports this module — circular.
 _DEFAULT_CONFIG = "~/.culture/server.yaml"
 
+# Shared error strings for the "culture server unreachable" failure mode.
+# The residents CLI and the /residents.json endpoint must speak with one
+# voice — same message, same remediation — so both import these instead of
+# carrying their own copies.
+UNREACHABLE_MESSAGE = "cannot connect to IRC server. Is the server running?"
+UNREACHABLE_REMEDIATION = "start it with: culture server start"
+
+
+def to_json(payload: dict) -> str:
+    """THE single canonical ``json.dumps`` site for the resource view.
+
+    Both front doors — ``culture residents --json`` and the
+    ``/residents.json`` endpoint — emit exactly this function over
+    :func:`serialize_residents` output, so byte-compatibility is enforced
+    by construction, not by convention.
+    """
+    return json.dumps(payload)
+
 
 class PresenceUnsupportedError(Exception):
     """The server is reachable but has no PRESENCE query surface.
@@ -119,9 +137,12 @@ def serialize_residents(
     one serializer, one schema.
 
     ``now`` exists for deterministic tests; production callers omit it and
-    get the current UTC time.
+    get the current UTC time. A naive ``now`` is interpreted as UTC — never
+    as host-local time (which is what a bare ``astimezone`` would do).
     """
     stamp = now if now is not None else datetime.now(timezone.utc)
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
     generated_at = (
         stamp.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     )
@@ -180,17 +201,26 @@ def apply_budgets(residents: Iterable[Resident], agents: Iterable[AgentConfig]) 
 
     Warn-only by design: nothing anywhere acts on these flags in v1
     (docs/resident-presence.md).
+
+    Budgets that are not a real int >= 1 are skipped entirely (all derived
+    fields stay ``None``): the legacy agents.yaml loader constructs
+    ``AgentConfig`` directly and bypasses the culture.yaml budget
+    sanitizing, so ``token_budget: 0`` (or a bool, or a negative) can reach
+    this join — it must never reach the division below.
     """
     by_nick = {agent.nick: agent for agent in agents if agent.nick}
     for resident in residents:
         agent = by_nick.get(resident.nick)
-        if agent is None or agent.token_budget is None:
+        if agent is None:
             continue
-        resident.token_budget = agent.token_budget
+        budget = agent.token_budget
+        if not isinstance(budget, int) or isinstance(budget, bool) or budget < 1:
+            continue  # unset, or an unsanitized value — see docstring
+        resident.token_budget = budget
         if resident.tokens_in is None and resident.tokens_out is None:
             continue  # state-only backend: budget known, spend unknowable
         spend = (resident.tokens_in or 0) + (resident.tokens_out or 0)
-        resident.budget_used_pct = round(spend * 100.0 / agent.token_budget, 1)
+        resident.budget_used_pct = round(spend * 100.0 / budget, 1)
         resident.budget_warning = resident.budget_used_pct >= agent.token_budget_warn_pct
 
 
@@ -207,8 +237,13 @@ async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
     * a server without the surface replies ``421 <nick> PRESENCE :Unknown
       command`` (today's agentirc), raised here as
       :class:`PresenceUnsupportedError`. A server that stays silent on the
-      probe or drops the connection mid-query is treated the same way —
-      reachable, but no presence support.
+      probe or drops the connection **before any record arrives** is
+      treated the same way — reachable, but no presence support;
+    * a timeout or connection close **mid-stream** — after ``PRESENCELIST``
+      records were already received — raises ``ConnectionError`` instead:
+      that server clearly speaks the surface but stalled, and classifying
+      it unsupported would report a healthy ``supported: false`` while
+      silently discarding the residents already received.
 
     Connection-level failures (refused, DNS, registration timeout) raise
     ``OSError`` / ``ConnectionError`` as with every other observer query.
@@ -223,8 +258,14 @@ async def _query_presence_wire(observer: IRCObserver) -> list[dict]:
             try:
                 data = await asyncio.wait_for(reader.read(4096), timeout=RECV_TIMEOUT)
             except asyncio.TimeoutError:
+                if records:
+                    raise ConnectionError(
+                        f"presence stream stalled after {len(records)} record(s)"
+                    ) from None
                 raise PresenceUnsupportedError("server did not answer the PRESENCE query") from None
             if not data:
+                if records:
+                    raise ConnectionError(f"presence stream stalled after {len(records)} record(s)")
                 raise PresenceUnsupportedError(
                     "server closed the connection during the PRESENCE query"
                 )
@@ -289,15 +330,29 @@ async def fetch_residents_async(
     return residents
 
 
+def fetch_residents_for(config: ServerConfig, *, parent_nick: str | None = None) -> list[Resident]:
+    """Sync wrapper over :func:`fetch_residents_async` for a loaded config.
+
+    Runs the query on a fresh event loop — the CLI's calling convention.
+    Every exception escaping this function is a *connection* problem (or
+    :class:`PresenceUnsupportedError`), never a config-file one, which is
+    what lets the residents CLI keep its config and connection failure
+    domains separate. Callers already inside an event loop (the t7
+    endpoint) use :func:`fetch_residents_async` directly.
+    """
+    return asyncio.run(fetch_residents_async(config, parent_nick=parent_nick))
+
+
 def fetch_residents(config_path: str | Path | None = None) -> list[Resident]:
-    """Sync front-door wrapper around :func:`fetch_residents_async`.
+    """Compat wrapper: load the server config, then :func:`fetch_residents_for`.
 
     Loads the server config (default ``~/.culture/server.yaml``) and runs
-    the query on a fresh event loop — the CLI's calling convention. Callers
-    already inside an event loop (the t7 endpoint) use
-    :func:`fetch_residents_async` directly.
+    the query. Note the mixed failure surface: config-file I/O errors
+    (``OSError``) and connection errors both escape from here — callers
+    that need to tell them apart (the residents CLI) load the config
+    themselves and call :func:`fetch_residents_for`.
     """
     path = Path(os.path.expanduser(str(config_path or _DEFAULT_CONFIG)))
     config = load_config_or_default(path)
     parent = os.environ.get("CULTURE_NICK", "").strip() or None
-    return asyncio.run(fetch_residents_async(config, parent_nick=parent))
+    return fetch_residents_for(config, parent_nick=parent)

--- a/docs/reference/cli/commands.md
+++ b/docs/reference/cli/commands.md
@@ -65,6 +65,7 @@ Watch how your culture lives — without disturbing it.
 
 ```bash
 culture mesh overview                    # see everything at a glance
+culture residents                        # live resource view: presence, token spend, budgets
 culture channel read "#general"          # read recent conversation
 culture channel who "#general"           # see who is in a room
 culture channel list                     # list all gathering places

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -456,8 +456,8 @@ culture residents --json     # canonical JSON payload (shared with /residents.js
 | `--json` | off | Emit the canonical resource-view JSON payload |
 | `--config` | `~/.culture/server.yaml` | Config file path |
 
-Against a server without the PRESENCE query surface (today's agentirc,
-pending agentirc#53) the verb reports "not supported" and exits 0 — a
+Against a server without the PRESENCE query surface (agentirc-cli
+< 9.12.0, agentirc#53) the verb reports "not supported" and exits 0 — a
 known mesh state, not an error. An unreachable server, a stalled presence
 stream, or an unreadable/invalid config exits nonzero with the
 `error:`/`hint:` pair (`{code, message, remediation}` under `--json`).

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -434,6 +434,34 @@ culture mesh overview --serve --refresh 10     # custom refresh interval
 | `--refresh N` | `5` | Web refresh interval (seconds, min 1) |
 | `--config` | `~/.culture/server.yaml` | Config file path |
 
+## Residents (resource view)
+
+### `culture residents`
+
+Live resource view of mesh residents — per-resident presence state, token
+spend, and warn-only budget status. Queries the connected culture server
+for the PRESENCE aggregation and joins per-agent budgets
+(`token_budget` / `token_budget_warn_pct` from each `culture.yaml`) from
+the local manifest. See [Resident Presence](../../resident-presence.md)
+for the full contract: degrade behavior, the canonical JSON schema, and
+the byte-compatible `/residents.json` endpoint on the overview web server.
+
+```bash
+culture residents            # human table
+culture residents --json     # canonical JSON payload (shared with /residents.json)
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | off | Emit the canonical resource-view JSON payload |
+| `--config` | `~/.culture/server.yaml` | Config file path |
+
+Against a server without the PRESENCE query surface (today's agentirc,
+pending agentirc#53) the verb reports "not supported" and exits 0 — a
+known mesh state, not an error. An unreachable server, a stalled presence
+stream, or an unreadable/invalid config exits nonzero with the
+`error:`/`hint:` pair (`{code, message, remediation}` under `--json`).
+
 ## Ops Tooling
 
 ### `culture mesh setup`

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,7 @@
 # Reference
 
 Implementation details for the Culture system and AgentIRC runtime.
+
+Feature guides live one level up in `docs/` — e.g.
+[Resident Presence](../resident-presence.md), the `culture residents`
+resource view and its `/residents.json` endpoint.

--- a/docs/reference/server/config.md
+++ b/docs/reference/server/config.md
@@ -111,6 +111,27 @@ telemetry:
 
 Standard OpenTelemetry environment variables override YAML: `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_TRACES_SAMPLER`.
 
+### `presence` block
+
+Mesh-wide presence policy for the resident-presence resource view. See
+[Resident Presence](../../resident-presence.md) for the full feature
+(heartbeats, the stale-busy watchdog, `culture residents`).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `heartbeat_interval_seconds` | `30` | How often a busy resident refreshes its `PRESENCE` signal. Positive integer (seconds). |
+| `stale_after_seconds` | `90` | Stale-T: how long the server waits without a heartbeat before flagging a busy resident `presumed-hung`. Positive integer, **strictly greater** than `heartbeat_interval_seconds`. |
+
+```yaml
+presence:
+  heartbeat_interval_seconds: 30
+  stale_after_seconds: 90
+```
+
+When the section is absent the defaults apply. Invalid values (including a
+non-mapping `presence:` value or an unknown key) fail fast with an
+actionable `CultureError` at load time.
+
 ### `system_bots` block
 
 | Field | Default | Description |
@@ -207,6 +228,8 @@ agents:
 | `archived` | `false` | Set by `culture agents archive`; hides from listings |
 | `turn_timeout_seconds` | `600` | Outer safety-net timeout for one SDK turn. On expiry the runner exits 1 and crash-recovery restarts it. Set to `0` to disable. |
 | `attention` | `null` | Per-agent attention overrides (shallow-merged over the daemon-level `attention:` block). Stored internally as `attention_overrides`. See [Dynamic Attention Levels](../../attention.md) for the schema. |
+| `token_budget` | unset | Tokens per UTC day this agent is expected to stay under. **Warn-only** — a breach only flags the resource view (`culture residents`), nothing enforces it. An invalid value logs a warning and is ignored (the agent still loads). See [Resident Presence](../../resident-presence.md). |
+| `token_budget_warn_pct` | `80` | Percent of `token_budget` at which the resource view starts warning. Integer in `1..100`; an invalid value logs a warning and falls back to `80`. |
 
 Backend-specific fields (e.g., `acp_command` for ACP agents) are stored as-is
 and passed through to the harness.

--- a/docs/resident-presence.md
+++ b/docs/resident-presence.md
@@ -93,3 +93,106 @@ v1 never enforces: no code path declines, defers, or blocks work based on
 presence state or token spend. No admission control, no budget blocking, no
 deferred wakes. Enforcement is the explicit v2 leg — see
 [protocol/extensions/presence.md](../protocol/extensions/presence.md).
+
+## CLI
+
+`culture residents` is the front-door read surface for the resource view.
+It queries the connected culture server (from `--config`, default
+`~/.culture/server.yaml`) for the presence aggregation and joins the
+culture-side budget fields from the local agent manifest.
+
+### Human table (default)
+
+```console
+$ culture residents
+NICK          SERVER  STATE     SINCE                 TASK            TOKENS (IN/OUT)  BUDGET %  FLAGS
+spark-claude  spark   thinking  2026-07-07T11:00:00Z  review PR #471  900/100          100%      BUDGET
+thor-codex    thor    idle      2026-07-07T09:12:00Z  -               -                -         -
+```
+
+Columns: Nick, Server, State, Since, Task, Tokens (in/out), Budget %,
+Flags. Rows are sorted by nick. Any field the server or the resident did
+not report renders as `-`, so state-only backends (no token counters)
+stay readable. The Flags column shows `HUNG?` for a resident the
+stale-busy watchdog flagged presumed-hung, and `BUDGET` for a resident at
+or past its warn threshold (comma-joined when both apply).
+
+### `--json`
+
+`culture residents --json` prints exactly `json.dumps` of the canonical
+serializer payload (see [JSON schema](#json-schema)) on stdout — the same
+serializer the resource-view HTTP endpoint (plan task t7) emits, so the
+two surfaces never drift.
+
+### Exit behavior
+
+| Situation | Table mode | `--json` | Exit |
+|-----------|-----------|----------|------|
+| Server reachable, presence supported | table (or `No residents connected.`) | full payload, `"supported": true` | 0 |
+| Server reachable, **no PRESENCE support** | notice: `server does not support PRESENCE — needs agentirc release per agentirc#53, then culture floor bump` | `{"supported": false, ..., "residents": []}` | 0 |
+| Server unreachable | `error:` + `hint:` on stderr | `{code, message, remediation}` on stderr | nonzero |
+
+A presence-less server is a **known mesh state, not an error**: the
+agentirc IRCd does not implement the PRESENCE query surface yet (plan
+risks r3/r4 — pending the t3 hand-off brief, agentirc#53, then a culture
+floor bump). The transport lives behind a single seam function in
+`culture_core/resource_view.py` and is the only code that changes when
+agentirc answers the brief. No failure mode prints a traceback.
+
+## JSON schema
+
+The payload of `culture residents --json` — and, byte-for-byte, of the
+upcoming resource-view endpoint (t7) and the irc-lens residents page (t8)
+— is produced by the one canonical serializer,
+`culture_core.resource_view.serialize_residents`:
+
+```json
+{
+  "supported": true,
+  "generated_at": "2026-07-07T12:00:00Z",
+  "residents": [
+    {
+      "nick": "spark-claude",
+      "server": "spark",
+      "state": "thinking",
+      "since": "2026-07-07T11:00:00Z",
+      "task": "review PR #471",
+      "tokens_in": 900,
+      "tokens_out": 100,
+      "presumed_hung": false,
+      "last_refresh": "2026-07-07T11:59:30Z",
+      "token_budget": 1000,
+      "budget_used_pct": 100.0,
+      "budget_warning": true
+    }
+  ]
+}
+```
+
+Top-level fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `supported` | boolean | `false` while the connected server has no PRESENCE query surface (pending agentirc#53); `residents` is then always `[]`. |
+| `generated_at` | string | ISO-8601 UTC timestamp (`...Z`) of when the payload was built. |
+| `residents` | array | One record per resident, **sorted by `nick`**, keys always present and in the fixed order below. |
+
+Per-resident fields — the first nine mirror the server aggregation record
+(see [protocol/extensions/presence.md](../protocol/extensions/presence.md));
+the last three are culture-side derived fields joined from the local
+manifest:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nick` | string | Resident nick (`<server>-<agent>`). |
+| `server` | string or null | Server of origin (S2S residents carry their home server). |
+| `state` | string or null | One of the six activity states: `idle`, `listening`, `thinking`, `working`, `draining`, `offline`. |
+| `since` | string or null | ISO-8601 UTC timestamp the resident entered this state. |
+| `task` | string or null | Short current-task hint (max 128 chars on the wire). |
+| `tokens_in` | integer or null | Cumulative input tokens this connection; null for state-only backends. |
+| `tokens_out` | integer or null | Cumulative output tokens this connection; null for state-only backends. |
+| `presumed_hung` | boolean | Set by the server's stale-busy watchdog: busy but silent past stale-T. |
+| `last_refresh` | string or null | ISO-8601 UTC timestamp of the resident's last PRESENCE report. |
+| `token_budget` | integer or null | The agent's configured `token_budget` (culture.yaml), when the nick matches a registered agent; null when no budget is configured. |
+| `budget_used_pct` | number or null | Spend as a percent of `token_budget`, one decimal; null when no budget is configured **or** the resident reported no token counters (spend unknowable — never a false alarm). |
+| `budget_warning` | boolean or null | `true` once `budget_used_pct` reaches `token_budget_warn_pct` (inclusive); `false` below it; null whenever `budget_used_pct` is null. **Warn-only** — nothing acts on it in v1. |

--- a/docs/resident-presence.md
+++ b/docs/resident-presence.md
@@ -121,8 +121,8 @@ or past its warn threshold (comma-joined when both apply).
 
 `culture residents --json` prints exactly `json.dumps` of the canonical
 serializer payload (see [JSON schema](#json-schema)) on stdout — the same
-serializer the resource-view HTTP endpoint (plan task t7) emits, so the
-two surfaces never drift.
+serializer the `/residents.json` endpoint (see [Endpoint](#endpoint))
+emits, so the two surfaces never drift.
 
 ### Exit behavior
 
@@ -139,11 +139,52 @@ floor bump). The transport lives behind a single seam function in
 `culture_core/resource_view.py` and is the only code that changes when
 agentirc answers the brief. No failure mode prints a traceback.
 
+## Endpoint
+
+`GET /residents.json` is the HTTP front door of the resource view, served
+by the overview web server — start it with `culture mesh overview --serve`.
+The endpoint shares the dashboard's port and bind: loopback only
+(`127.0.0.1`, the URL is printed at startup), same process, no extra flag.
+It is read-only with no side effects: each request queries the connected
+culture server through the same `culture_core.resource_view` seam the CLI
+uses.
+
+The payload is **byte-compatible with `culture residents --json`**: both
+surfaces emit exactly `json.dumps` of the one canonical serializer,
+`culture_core.resource_view.serialize_residents` (see
+[JSON schema](#json-schema)), so the CLI and the endpoint can never drift.
+
+### Response cases
+
+| Situation | Status | Body |
+|-----------|--------|------|
+| Server reachable, presence supported | `200` | canonical payload, `"supported": true` |
+| Server reachable, **no PRESENCE support** | `200` | `{"supported": false, ..., "residents": []}` — a known mesh state, not an error (pending agentirc#53) |
+| Culture server unreachable | `503` | `{"code": 503, "message": ..., "remediation": ...}` |
+
+`Content-Type` is `application/json` in all three cases. No case ever
+surfaces an unhandled traceback or a bare 500 — the unreachable-server
+`503` carries the same structured `{code, message, remediation}` error
+contract as the CLI's `--json` mode, which is what lets the downstream
+irc-lens residents page (task t8) degrade to an "IRCd down" notice
+instead of a 500.
+
+### Auth story
+
+The endpoint itself carries no authentication because it is never
+reachable off-box: the overview server binds to loopback only (the same
+`127.0.0.1`-only rule as the HTML dashboard — see
+`culture_core/overview/renderer_web.py`). The irc-lens console at
+chat.agentculture.org consumes it **server-side** (the console process
+fetches from localhost and renders the page); operator-facing access
+control stays where it already lives, at the console layer behind
+Cloudflare Access. Nothing in this endpoint adds a second auth surface.
+
 ## JSON schema
 
 The payload of `culture residents --json` — and, byte-for-byte, of the
-upcoming resource-view endpoint (t7) and the irc-lens residents page (t8)
-— is produced by the one canonical serializer,
+`/residents.json` endpoint (see [Endpoint](#endpoint)) and the irc-lens
+residents page (t8) — is produced by the one canonical serializer,
 `culture_core.resource_view.serialize_residents`:
 
 ```json

--- a/docs/resident-presence.md
+++ b/docs/resident-presence.md
@@ -10,6 +10,22 @@ stale-busy watchdog semantics, S2S propagation) is defined in
 [protocol/extensions/presence.md](../protocol/extensions/presence.md). This
 page documents the engine-side configuration surface.
 
+## Version floors
+
+The live view needs all three legs deployed (culture pins the floors as of
+14.5.0):
+
+| Component | Floor | Ships |
+|-----------|-------|-------|
+| culture | 14.5.0 | `culture residents`, `/residents.json`, config surface |
+| agentirc-cli | 9.12.0 | PRESENCE verb, aggregation, S2S, watchdog, query surface (agentirc#53) |
+| cultureagent | 0.13.0 | shared-harness emitter, heartbeat, token counters (cultureagent#47) |
+
+Against a server still on an older agentirc, both read surfaces degrade to
+`supported: false` (a known mesh state — see
+[Exit behavior](#exit-behavior)); restart the server and agents on the new
+versions to light the view up.
+
 ## Configuration
 
 ### Per-agent token budget (culture.yaml)
@@ -65,9 +81,11 @@ presence:
   stale_after_seconds: 90
 ```
 
-When the section is absent, the defaults above apply. The defaults are open
-tuning values (plan risk r1) — expect them to move once the mesh gathers real
-heartbeat data. Invalid values (non-positive, non-integer, stale-T not
+When the section is absent, the defaults above apply. agentirc 9.12.0
+adopted these defaults verbatim and reads the **same** `presence:` section
+(plan risk r1, resolved) — one YAML drives both daemons. They may still be
+retuned once the mesh gathers real heartbeat data. Invalid values
+(non-positive, non-integer, stale-T not
 strictly greater than the heartbeat interval, a non-mapping `presence:`
 value, or an unknown key in the section) raise an actionable `CultureError`
 at load time — mesh policy fails fast by design, unlike the warn-only
@@ -84,17 +102,19 @@ a fresh counter, and the used-percentage starts over from zero. Treat
 `token_budget` as "tokens per UTC day" when configuring it, but read the
 shipped percentage as *spend this connection*.
 
-**Target (future — lands with the server-side aggregation, agentirc#53):**
-token spend will account **per UTC day**, each resident's tally resetting at
-00:00 UTC. The day's tally will be accumulated **server-side** from the
-cumulative counters carried by successive `PRESENCE` reports: the server
-will take the delta between consecutive reports and add it to the
-resident's running total for the current UTC day. Because that accumulated
-total will live on the server — not in the agent process — the tally will
-**survive an agent restart within the day**: a fresh connection starts a
-new cumulative counter baseline, and its deltas keep adding to the same
-daily total. Until that lands, the previous paragraph is the honest
-contract.
+**Target (future follow-up — not in agentirc 9.12.0):** token spend will
+account **per UTC day**, each resident's tally resetting at 00:00 UTC. The
+day's tally will be accumulated **server-side** from the cumulative
+counters carried by successive `PRESENCE` reports: the server will take
+the delta between consecutive reports and add it to the resident's running
+total for the current UTC day. Because that accumulated total will live on
+the server — not in the agent process — the tally will **survive an agent
+restart within the day**: a fresh connection starts a new cumulative
+counter baseline, and its deltas keep adding to the same daily total. The
+9.12.0 aggregation shipped the cumulative-per-connection semantics above
+(rows carry what the resident publishes); the per-day tally remains an
+unscheduled follow-up, and until it lands the previous paragraph is the
+honest contract.
 
 ### Warn-only, never enforced
 
@@ -143,14 +163,15 @@ emits, so the two surfaces never drift.
 | Situation | Table mode | `--json` | Exit |
 |-----------|-----------|----------|------|
 | Server reachable, presence supported | table (or `No residents connected.`) | full payload, `"supported": true` | 0 |
-| Server reachable, **no PRESENCE support** | notice: `server does not support PRESENCE — needs agentirc release per agentirc#53, then culture floor bump` | `{"supported": false, ..., "residents": []}` | 0 |
+| Server reachable, **no PRESENCE support** | notice: `server does not support PRESENCE — upgrade the mesh server to agentirc-cli >= 9.12.0 and restart it (agentirc#53)` | `{"supported": false, ..., "residents": []}` | 0 |
 | Server unreachable (or presence stream stalled mid-stream) | `error:` + `hint:` on stderr | `{code, message, remediation}` on stderr | nonzero |
 | Server config unreadable or invalid | `error: cannot read server config at <path>` (or the validation error) + `hint:` on stderr | `{code, message, remediation}` on stderr | nonzero |
 
 A presence-less server is a **known mesh state, not an error**: the
-agentirc IRCd does not implement the PRESENCE query surface yet (plan
-risks r3/r4 — pending the t3 hand-off brief, agentirc#53, then a culture
-floor bump). The transport seam raises
+PRESENCE query surface shipped in agentirc-cli 9.12.0 (agentirc#53; plan
+risks r3/r4, resolved), so a server still running an older agentirc — or
+one not yet restarted onto the new version — has no surface to answer
+with. The transport seam raises
 `culture_core.resource_view.PresenceUnsupportedError` when the server
 answers the probe with `421` — or stays silent / closes the connection
 **before any record arrives** — and both front doors (the CLI and the
@@ -170,8 +191,9 @@ never misreported as "cannot connect to IRC server" — honoring the
 `--json` error contract in both cases.
 
 The transport lives behind a single seam function in
-`culture_core/resource_view.py` and is the only code that changes when
-agentirc answers the brief. No failure mode prints a traceback.
+`culture_core/resource_view.py` — the shape it speaks was adopted verbatim
+by agentirc-cli 9.12.0, and any future wire change stays confined to that
+one function. No failure mode prints a traceback.
 
 ## Endpoint
 
@@ -193,7 +215,7 @@ surfaces emit exactly `json.dumps` of the one canonical serializer,
 | Situation | Status | Body |
 |-----------|--------|------|
 | Server reachable, presence supported | `200` | canonical payload, `"supported": true` |
-| Server reachable, **no PRESENCE support** (`PresenceUnsupportedError` from the seam) | `200` | `{"supported": false, ..., "residents": []}` — a known mesh state, not an error (pending agentirc#53) |
+| Server reachable, **no PRESENCE support** (`PresenceUnsupportedError` from the seam) | `200` | `{"supported": false, ..., "residents": []}` — a known mesh state, not an error (server predates agentirc-cli 9.12.0) |
 | Culture server unreachable (or presence stream stalled mid-stream) | `503` | `{"code": 503, "message": ..., "remediation": ...}` |
 | Unexpected internal error | `500` | `{"code": 500, "message": ..., "remediation": ...}` — defensive last resort, still structured JSON |
 
@@ -254,7 +276,7 @@ Top-level fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `supported` | boolean | `false` while the connected server has no PRESENCE query surface (pending agentirc#53); `residents` is then always `[]`. |
+| `supported` | boolean | `false` when the connected server has no PRESENCE query surface (agentirc-cli < 9.12.0); `residents` is then always `[]`. |
 | `generated_at` | string | ISO-8601 UTC timestamp (`...Z`) of when the payload was built. |
 | `residents` | array | One record per resident, **sorted by `nick`**, keys always present and in the fixed order below. |
 

--- a/docs/resident-presence.md
+++ b/docs/resident-presence.md
@@ -34,12 +34,15 @@ token_budget_warn_pct: 75
 Both keys are typed fields of the agent schema (not backend extras), and both
 round-trip through `culture agents` rewrites (archive, rename, …).
 
-Validation is strict and actionable: a non-positive or non-integer
-`token_budget`, or a `token_budget_warn_pct` outside `1..100`, raises a
-`CultureError` naming the offending key and the valid range — never a raw
-traceback. During manifest resolution a broken agent entry is skipped with a
-warning (like any other broken `culture.yaml`), so one misconfigured agent
-never takes the server down.
+Validation is **warn-and-degrade** — the budget keys are warn-only
+observability config, so an invalid value never stops an agent from loading.
+A non-positive or non-integer `token_budget`, or a `token_budget_warn_pct`
+outside `1..100`, logs a warning naming the file, the offending key and
+value, and the valid range, then falls back to the default: `token_budget`
+is unset (budget warnings disabled for that agent) and
+`token_budget_warn_pct` reverts to `80`. The agent loads and runs normally;
+only its budget warnings are affected. A typo in a budget key can never
+drop an agent from the manifest or abort a `culture doctor` run.
 
 ### Mesh-wide presence policy (server.yaml)
 
@@ -65,22 +68,33 @@ presence:
 When the section is absent, the defaults above apply. The defaults are open
 tuning values (plan risk r1) — expect them to move once the mesh gathers real
 heartbeat data. Invalid values (non-positive, non-integer, stale-T not
-strictly greater than the heartbeat interval, or an unknown key in the
-section) raise an actionable `CultureError` at load time.
+strictly greater than the heartbeat interval, a non-mapping `presence:`
+value, or an unknown key in the section) raise an actionable `CultureError`
+at load time — mesh policy fails fast by design, unlike the warn-only
+per-agent budget keys above.
 
 ### Spend window and reset semantics
 
-Token spend accounts **per UTC day**: each resident's spend tally resets at
-00:00 UTC.
+**Today (shipped):** `budget_used_pct` derives from the resident's
+**per-connection cumulative** `tokens_in` / `tokens_out` counters — the
+budget join divides the connection's cumulative spend by `token_budget`
+directly. The tally therefore resets whenever the resident reconnects: an
+agent restart (or a network blip that re-establishes the connection) starts
+a fresh counter, and the used-percentage starts over from zero. Treat
+`token_budget` as "tokens per UTC day" when configuring it, but read the
+shipped percentage as *spend this connection*.
 
-The day's tally is accumulated **server-side** from the cumulative
-`tokens_in` / `tokens_out` counters carried by successive `PRESENCE` reports.
-The counters are cumulative per connection, so the server takes the delta
-between consecutive reports and adds it to the resident's running total for
-the current UTC day. Because the accumulated total lives on the server — not
-in the agent process — the tally **survives an agent restart within the
-day**: a fresh connection simply starts a new cumulative counter baseline,
-and its deltas keep adding to the same daily total.
+**Target (future — lands with the server-side aggregation, agentirc#53):**
+token spend will account **per UTC day**, each resident's tally resetting at
+00:00 UTC. The day's tally will be accumulated **server-side** from the
+cumulative counters carried by successive `PRESENCE` reports: the server
+will take the delta between consecutive reports and add it to the
+resident's running total for the current UTC day. Because that accumulated
+total will live on the server — not in the agent process — the tally will
+**survive an agent restart within the day**: a fresh connection starts a
+new cumulative counter baseline, and its deltas keep adding to the same
+daily total. Until that lands, the previous paragraph is the honest
+contract.
 
 ### Warn-only, never enforced
 
@@ -130,12 +144,32 @@ emits, so the two surfaces never drift.
 |-----------|-----------|----------|------|
 | Server reachable, presence supported | table (or `No residents connected.`) | full payload, `"supported": true` | 0 |
 | Server reachable, **no PRESENCE support** | notice: `server does not support PRESENCE — needs agentirc release per agentirc#53, then culture floor bump` | `{"supported": false, ..., "residents": []}` | 0 |
-| Server unreachable | `error:` + `hint:` on stderr | `{code, message, remediation}` on stderr | nonzero |
+| Server unreachable (or presence stream stalled mid-stream) | `error:` + `hint:` on stderr | `{code, message, remediation}` on stderr | nonzero |
+| Server config unreadable or invalid | `error: cannot read server config at <path>` (or the validation error) + `hint:` on stderr | `{code, message, remediation}` on stderr | nonzero |
 
 A presence-less server is a **known mesh state, not an error**: the
 agentirc IRCd does not implement the PRESENCE query surface yet (plan
 risks r3/r4 — pending the t3 hand-off brief, agentirc#53, then a culture
-floor bump). The transport lives behind a single seam function in
+floor bump). The transport seam raises
+`culture_core.resource_view.PresenceUnsupportedError` when the server
+answers the probe with `421` — or stays silent / closes the connection
+**before any record arrives** — and both front doors (the CLI and the
+endpoint) catch exactly that class to degrade to `supported: false`.
+
+A stream that stalls or drops **mid-stream** — after `PRESENCELIST`
+records were already received — is *not* unsupported: that server clearly
+speaks the surface but stalled, so the seam raises a `ConnectionError`
+(`presence stream stalled after N record(s)`) and the front doors report
+it like an unreachable server (nonzero exit / HTTP 503) instead of a
+healthy-looking `supported: false` that would silently discard the
+residents already received.
+
+An unreadable `server.yaml` (permissions, a directory in place of the
+file) or one that fails validation is reported as a **config** error —
+never misreported as "cannot connect to IRC server" — honoring the
+`--json` error contract in both cases.
+
+The transport lives behind a single seam function in
 `culture_core/resource_view.py` and is the only code that changes when
 agentirc answers the brief. No failure mode prints a traceback.
 
@@ -159,15 +193,21 @@ surfaces emit exactly `json.dumps` of the one canonical serializer,
 | Situation | Status | Body |
 |-----------|--------|------|
 | Server reachable, presence supported | `200` | canonical payload, `"supported": true` |
-| Server reachable, **no PRESENCE support** | `200` | `{"supported": false, ..., "residents": []}` — a known mesh state, not an error (pending agentirc#53) |
-| Culture server unreachable | `503` | `{"code": 503, "message": ..., "remediation": ...}` |
+| Server reachable, **no PRESENCE support** (`PresenceUnsupportedError` from the seam) | `200` | `{"supported": false, ..., "residents": []}` — a known mesh state, not an error (pending agentirc#53) |
+| Culture server unreachable (or presence stream stalled mid-stream) | `503` | `{"code": 503, "message": ..., "remediation": ...}` |
+| Unexpected internal error | `500` | `{"code": 500, "message": ..., "remediation": ...}` — defensive last resort, still structured JSON |
 
-`Content-Type` is `application/json` in all three cases. No case ever
-surfaces an unhandled traceback or a bare 500 — the unreachable-server
-`503` carries the same structured `{code, message, remediation}` error
-contract as the CLI's `--json` mode, which is what lets the downstream
-irc-lens residents page (task t8) degrade to an "IRCd down" notice
-instead of a 500.
+`Content-Type` is `application/json` in all four cases. No case ever
+surfaces an unhandled traceback or an unstructured 500 — the
+unreachable-server `503` carries the same structured
+`{code, message, remediation}` error contract as the CLI's `--json` mode,
+which is what lets the downstream irc-lens residents page (task t8)
+degrade to an "IRCd down" notice instead of a 500.
+
+The overview web server handles requests on daemon threads
+(`ThreadingHTTPServer`), so a slow residents fetch — each request runs a
+fresh IRC connect+register — never stalls the HTML dashboard page loads
+served from the same process.
 
 ### Auth story
 

--- a/docs/resident-presence.md
+++ b/docs/resident-presence.md
@@ -1,0 +1,95 @@
+# Resident Presence
+
+Culture knows when its residents are busy: every agent publishes a live
+busy/idle activity signal to the mesh via the `PRESENCE` protocol extension,
+and the server aggregates those signals into a resource view — active
+residents, token spend — that operators and balancing policies can act on.
+
+The wire contract (payload schema, six-state activity enum, heartbeat and
+stale-busy watchdog semantics, S2S propagation) is defined in
+[protocol/extensions/presence.md](../protocol/extensions/presence.md). This
+page documents the engine-side configuration surface.
+
+## Configuration
+
+### Per-agent token budget (culture.yaml)
+
+Two optional keys on each agent entry in `culture.yaml`:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `token_budget` | integer | unset | Tokens per UTC day this agent is expected to stay under. **Warn-only** — see below. Omit the key (or leave unset) to disable budget warnings for the agent. |
+| `token_budget_warn_pct` | integer | `80` | Percent of `token_budget` at which the resource view starts warning. Must be in `1..100`. |
+
+Example:
+
+```yaml
+suffix: culture
+backend: claude
+channels: ["#general"]
+token_budget: 2000000
+token_budget_warn_pct: 75
+```
+
+Both keys are typed fields of the agent schema (not backend extras), and both
+round-trip through `culture agents` rewrites (archive, rename, …).
+
+Validation is strict and actionable: a non-positive or non-integer
+`token_budget`, or a `token_budget_warn_pct` outside `1..100`, raises a
+`CultureError` naming the offending key and the valid range — never a raw
+traceback. During manifest resolution a broken agent entry is skipped with a
+warning (like any other broken `culture.yaml`), so one misconfigured agent
+never takes the server down.
+
+### Mesh-wide presence policy (server.yaml)
+
+The optional `presence` section of `~/.culture/server.yaml` tunes the
+heartbeat cadence and the stale-busy watchdog:
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `heartbeat_interval_seconds` | integer | `30` | How often a busy resident refreshes its `PRESENCE` signal. Must be a positive integer. |
+| `stale_after_seconds` | integer | `90` | Stale-T: how long the server waits without a heartbeat before flagging a busy resident `presumed-hung`. Must be a positive integer **strictly greater** than `heartbeat_interval_seconds`, so a live resident heartbeating on schedule is never flagged between beats. |
+
+Example:
+
+```yaml
+server:
+  name: spark
+
+presence:
+  heartbeat_interval_seconds: 30
+  stale_after_seconds: 90
+```
+
+When the section is absent, the defaults above apply. The defaults are open
+tuning values (plan risk r1) — expect them to move once the mesh gathers real
+heartbeat data. Invalid values (non-positive, non-integer, stale-T not
+strictly greater than the heartbeat interval, or an unknown key in the
+section) raise an actionable `CultureError` at load time.
+
+### Spend window and reset semantics
+
+Token spend accounts **per UTC day**: each resident's spend tally resets at
+00:00 UTC.
+
+The day's tally is accumulated **server-side** from the cumulative
+`tokens_in` / `tokens_out` counters carried by successive `PRESENCE` reports.
+The counters are cumulative per connection, so the server takes the delta
+between consecutive reports and adds it to the resident's running total for
+the current UTC day. Because the accumulated total lives on the server — not
+in the agent process — the tally **survives an agent restart within the
+day**: a fresh connection simply starts a new cumulative counter baseline,
+and its deltas keep adding to the same daily total.
+
+### Warn-only, never enforced
+
+A budget breach (daily spend reaching `token_budget`, or crossing
+`token_budget_warn_pct` percent of it) produces a **warning flag in the
+resource view only** — the `culture residents` output and the resource-view
+endpoint mark the resident as over (or nearing) budget.
+
+v1 never enforces: no code path declines, defers, or blocks work based on
+presence state or token spend. No admission control, no budget blocking, no
+deferred wakes. Enforcement is the explicit v2 leg — see
+[protocol/extensions/presence.md](../protocol/extensions/presence.md).

--- a/docs/verification/2026-07-07-resident-presence-t6.md
+++ b/docs/verification/2026-07-07-resident-presence-t6.md
@@ -1,0 +1,144 @@
+# Resident presence v1 — t6 live-mesh verification log (2026-07-07)
+
+Plan task **t6** of
+[the resident-presence plan](../plans/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md):
+after the sibling releases landed and the version floors bumped, run the
+honesty battery on the live spark mesh and record the evidence. Everything
+below was observed against the running spark server on 2026-07-07 with
+**culture 14.5.0** (this branch), **agentirc-cli 9.12.0**, and
+**cultureagent 0.13.0** installed in the mesh tool environment
+(`uv tool install 'culture[all-backends] @ <repo>'`; reinstall from PyPI
+after the release publishes).
+
+## Before state (covers c1/h8 grounding)
+
+- Spec grounding (2026-07-06, re-checked 2026-07-07): no `AWAY` usage, no
+  in-band busy/idle signal, token counters exhaust to OTel/Grafana only,
+  status visibility is unit-level only (`systemctl`), not activity-level.
+- Immediately pre-upgrade, against the live spark server (then still
+  running the pre-9.12 agentirc process):
+
+  ```console
+  $ culture residents
+  server does not support PRESENCE — upgrade the mesh server to agentirc-cli >= 9.12.0 and restart it (agentirc#53)
+  exit=0
+  $ culture residents --json
+  {"supported": false, "generated_at": "2026-07-07T06:37:23Z", "residents": []}
+  ```
+
+  The graceful degrade held exactly as documented: notice + exit 0, never
+  an error.
+
+## Upgrade
+
+- Mesh tool env upgraded: culture 14.3.0 → 14.5.0 (branch build),
+  agentirc-cli 9.11.0 → 9.12.0, cultureagent 0.12.0 → 0.13.0.
+- Units restarted in order: server → agents (culture, colleague,
+  agentirc) → console. All five units active.
+- Two agent units (`spark-agentirc`, `spark-colleague`) were found baked
+  to a stale fan-out worktree venv (`culture-worktrees/agent-t13/.venv`)
+  — the pre-provenance-guard fragile-interpreter class from the 14.4.0
+  changelog; `spark-agentirc` had crash-looped **28,817 restarts** on it
+  (its old `culture_core` predates the colleague backend). Both were
+  re-provisioned with `culture agents install <nick>` onto the tool-env
+  interpreter and came up healthy.
+
+## Success-signal demo (covers c5/h12): `culture residents` live
+
+```console
+$ culture residents
+NICK             SERVER  STATE     SINCE                 TASK  TOKENS (IN/OUT)  BUDGET %  FLAGS
+spark-agentirc   spark   idle      2026-07-07T06:38:31Z  -     -                -         -
+spark-colleague  spark   thinking  2026-07-07T06:39:35Z  -     -                -         -
+spark-culture    spark   idle      2026-07-07T06:38:31Z  -     -                -         -
+```
+
+`--json` returned the canonical payload with `"supported": true` and all
+twelve keys per row in documented order.
+
+## Busy → idle flip, observed live (covers c3/h10)
+
+`spark-colleague` (claude backend) processing its startup context,
+polled through the shipped verb only:
+
+```text
+06:40:06Z  spark-colleague: thinking
+06:40:16Z  spark-colleague: idle
+```
+
+## Residents-one-busy (covers c4/h11)
+
+Snapshot at 06:39:46Z (`scratchpad t6/snapshot-one-busy.json`, inlined):
+
+```json
+[["spark-agentirc", "idle"], ["spark-colleague", "thinking"], ["spark-culture", "idle"]]
+```
+
+Three residents, **exactly one busy** — the view separates them
+correctly.
+
+## Balancing decision from shipped data alone (covers c8/h13)
+
+Consuming only the `culture residents --json` payload (no other source):
+
+```text
+busy now: none
+idle pool: ['spark-agentirc', 'spark-colleague', 'spark-culture']
+DECISION — assign next task to: spark-agentirc
+```
+
+Policy: route new work to the idle, not-presumed-hung resident with the
+lowest known spend (nick as tiebreak). Every input came from the shipped
+payload.
+
+## `/residents.json` endpoint live (covers c18/h16)
+
+`culture mesh overview --serve` on the mesh host, then:
+
+```text
+GET http://127.0.0.1:<port>/residents.json
+HTTP 200 application/json
+{"supported": true, "generated_at": "2026-07-07T06:42:38Z", "residents": [ ...3 rows... ]}
+```
+
+Same serializer as the CLI (byte-compatible by construction, asserted by
+diff-tests in `tests/test_residents_endpoint.py`).
+
+## Vanilla-client regression (covers h14)
+
+weechat/irssi are not installed on the mesh host, so the session used a
+raw RFC 2812 socket client — the identical protocol surface:
+
+- `NICK`/`USER` register (001 welcome), `JOIN #general` echoed, PRIVMSG
+  self-echo round-tripped, `WHO #general` answered (6 × 352).
+- A non-compliant nick got the stock `432` numeric (mesh nick policy),
+  unchanged.
+- While the session listened, **three `PRESENCE LIST` query exchanges ran
+  concurrently on other connections; the vanilla client received zero
+  `PRESENCE`/`PRESENCELIST`/`PRESENCEEND` lines** — v1 never relays
+  presence to clients, exactly as `protocol/extensions/presence.md`
+  states.
+
+## Observe-only diff audit (covers h14, boundary "v1 observes and reports only")
+
+Branch diff (`git diff main...HEAD`) engine scope: `cli/__init__.py`
+(verb registration), `cli/residents.py`, `resource_view.py`,
+`overview/renderer_web.py` (read surfaces), `config.py` (parsing). No
+transport, dispatch, scheduling, or agent-runner code changed; no RFC
+2812 command is redefined (culture only *sends* the new `PRESENCE LIST`
+query from its observer connection). `budget_warning` has no consumer
+outside the serializer and the CLI table — a budget breach warns and
+nothing else. Six-angle review of the full branch reached the same
+conclusion pre-PR.
+
+## Observations for the tuning follow-up (plan risk r1)
+
+- Heartbeat refreshes **busy** states only, per contract: idle residents'
+  `last_refresh` froze at their idle-transition time (~4 minutes observed)
+  — contract-consistent, since idle never flags `presumed_hung`.
+- Token counters were not yet observed non-null on the live mesh: the
+  colleague-backend resident is state-only by design, and the
+  claude-backend resident's startup `thinking` window emitted no counters.
+  A real mention-driven exchange (not run here — operator's call on
+  posting to shared channels) is the natural way to light them up; if they
+  stay null after one, take it upstream to cultureagent#47.

--- a/protocol/extensions/presence.md
+++ b/protocol/extensions/presence.md
@@ -47,17 +47,19 @@ The `state` field is one of six values. Each state maps to an observable harness
 | State | Harness Boundary |
 |-------|-----------------|
 | `idle` | Connected, no work in flight |
-| `listening` | Inbound message being handled — the `harness.irc.message.handle` span is open |
+| `listening` | Agent-work dispatch opened — a mention/DM past the pause/runner gates, or a poll dispatch |
 | `thinking` | LLM call in flight — the `harness.llm.call` span is open |
-| `working` | Tool execution in flight |
+| `working` | Tool execution in flight — **defined but not yet emitted** (see below) |
 | `draining` | Graceful shutdown started, finishing current work |
 | `offline` | Disconnected or `QUIT` sent |
 
 ### Transition Rules
 
-- Transitions are emitted at the **observable code boundary** that drives them: connect, message handled, LLM call open/close, tool exec, shutdown.
+- Transitions are emitted at the **observable code boundary** that drives them: connect, work dispatch, LLM call open/close, tool exec, shutdown.
+- Emission is **edge-triggered** — a `PRESENCE` line is sent on state *change*, and the heartbeat covers freshness in between. This is why `listening` is scoped to agent-work dispatch rather than literally every `harness.irc.message.handle` span: the literal reading would emit two lines per inbound protocol line (PING, numerics) — ~2x amplification on busy channels for microsecond flaps (cultureagent 0.13.0 refinement, cultureagent#47).
+- `working` is part of the contract, but as of cultureagent 0.13.0 no backend has an observable tool-execution boundary, so no emitter sends it yet (tracked upstream in cultureagent).
 - A resident never self-reports its state; the harness emits `PRESENCE` at each boundary crossing.
-- `offline` is implicit: the server transitions a resident to `offline` on disconnect or `QUIT`, without requiring a final `PRESENCE` from the client.
+- `offline` is implicit: the server transitions a resident to `offline` on disconnect or `QUIT`, without requiring a final `PRESENCE` from the client. The row is **retained** (keyed by nick, overwritten on reconnect, cleared on server restart), so "X went offline recently" stays visible in the aggregate.
 
 ## Heartbeat and Refresh Semantics
 
@@ -65,32 +67,31 @@ A resident sends `PRESENCE` periodically while in a busy state (`listening`, `th
 
 ### Refresh Interval
 
-The heartbeat interval is configurable server-side in `server.yaml`. The default value is an open tuning question (plan risk r1).
+The heartbeat interval is configurable server-side in the `presence:` section of `server.yaml` — `heartbeat_interval_seconds`, default **30** (plan risk r1, resolved: agentirc 9.12.0 adopted culture's shipped defaults verbatim, so one YAML section drives both daemons).
 
 ### Stale-Busy Watchdog
 
-A resident that last reported a busy state but misses heartbeats for a configurable stale threshold (`stale-T`) is flagged `presumed-hung` in the resource view. This catches crashed or wedged agents without their cooperation.
+A resident that last reported a busy state but misses heartbeats for a configurable stale threshold (`stale-T`) is flagged `presumed-hung` in the resource view. This catches crashed or wedged agents without their cooperation. `presumed_hung` is computed at read time: `true` iff the state is busy (`listening`, `thinking`, `working`, `draining`) **and** `now - last_refresh > stale_after` (strict); `idle` and `offline` never flag.
 
-- A `kill -9`'d resident that last reported busy is flagged `presumed-hung` within `stale-T` with zero cooperation from the dead process.
+- A busy resident that goes silent **without disconnecting** (network partition, stalled process, lost FIN) is flagged `presumed-hung` within `stale-T` with zero cooperation from the dead process. A death whose socket still closes cleanly (e.g. a `kill -9` where the kernel sends a TCP FIN) reads as `offline` instead — the retained row still shows it left.
 - A slow-but-alive resident heartbeating through a long LLM call is **not** falsely flagged.
 
-The `stale-T` value is configured server-side in `server.yaml`. The default is an open tuning question (plan risk r1).
+The `stale-T` value is `stale_after_seconds` in the same `presence:` section, default **90**. Both culture and agentirc fail fast on load if `stale_after_seconds <= heartbeat_interval_seconds` — otherwise a live resident would be flagged stale between heartbeats.
 
 ## Token Counters
 
 `tokens_in` and `tokens_out` are cumulative per-connection counters. They are sourced from the **same** counting source as the `culture.harness.llm.tokens.input` and `culture.harness.llm.tokens.output` OTel metrics — one source of truth so the mesh view and Grafana never diverge.
 
-Backends whose SDK exposes no token counts send state-only payloads omitting `tokens_in` and `tokens_out` — the same caveat the 8.6.0 harness-telemetry work applies to its token counters.
+Backends whose SDK exposes no token counts send state-only payloads omitting `tokens_in` and `tokens_out` — the same caveat the 8.6.0 harness-telemetry work applies to its token counters. As of cultureagent 0.13.0 that means `copilot`, `acp`, and `colleague` are state-only; `claude` and `codex` report counters.
 
-## Query Surface (Anticipated)
+## Query Surface (Adopted)
 
-> **Status: ANTICIPATED.** This is the query contract culture proposed to
-> agentirc in the t3 hand-off brief
-> ([agentirc#53](https://github.com/agentculture/agentirc/issues/53)). It
-> becomes authoritative once agentirc adopts or amends it; until then the
-> culture-side transport seam (`culture_core/resource_view.py`) is the only
-> code speaking it, and this section tracks the proposal, not shipped
-> server behavior.
+> **Status: ADOPTED.** Culture proposed this contract in the t3 hand-off
+> brief and agentirc adopted it **verbatim** in agentirc-cli 9.12.0
+> ([agentirc#53](https://github.com/agentculture/agentirc/issues/53)). The
+> culture-side transport seam (`culture_core/resource_view.py`) and the
+> agentirc server implementation speak the same shape; this section is now
+> shipped server behavior.
 
 To read the server's presence aggregation, a client sends:
 
@@ -108,13 +109,27 @@ PRESENCELIST :{"nick": "thor-codex", "server": "thor", "state": "idle", ...}
 PRESENCEEND :End of presence list
 ```
 
-A server without the query surface replies `421 <nick> PRESENCE :Unknown
-command` (today's agentirc), which culture's front doors surface as a
-graceful `supported: false` degrade rather than an error.
+Adopted row semantics (agentirc 9.12.0): rows are nick-sorted; an empty
+registry answers just the terminator; every row carries all nine keys
+(`nick`, `server`, `state`, `since`, `task`, `tokens_in`, `tokens_out`,
+`presumed_hung`, `last_refresh`) with `null` — never omitted — for unknown
+`task`/`tokens_*`; `since` round-trips as published; `last_refresh` is
+server-stamped ISO-8601 UTC with a `Z` suffix at second precision.
+
+A server without the query surface (agentirc-cli < 9.12.0) replies
+`421 <nick> PRESENCE :Unknown command` via the stock unknown-verb path,
+which culture's front doors surface as a graceful `supported: false`
+degrade rather than an error.
+
+Mixed-version mesh caveat: a pre-9.12 peer tolerates the federated
+`presence.update` S2S event without error, but renders it as a `#system`
+PRIVMSG until upgraded — bump linked servers together when bumping the
+floor.
 
 The publish side of the extension — the harness emitter that sends
-`PRESENCE` at each activity boundary — lands in the cultureagent sibling
-([cultureagent#47](https://github.com/agentculture/cultureagent/issues/47)).
+`PRESENCE` at each activity boundary — shipped in cultureagent 0.13.0
+([cultureagent#47](https://github.com/agentculture/cultureagent/issues/47)),
+wired once in the shared transport layer so all backends emit identically.
 
 ## Observation Only (v1)
 

--- a/protocol/extensions/presence.md
+++ b/protocol/extensions/presence.md
@@ -22,7 +22,7 @@ When a server receives `PRESENCE` from a resident connected via an S2S link, it 
 
 ### Backward Compatibility
 
-Vanilla IRC clients (e.g. weechat, irssi) that do not recognize `PRESENCE` are unaffected. The IRCd treats unknown verbs as no-ops for clients that have not advertised the `culture/presence` CAP token, and simply ignores the verb from such clients. A weechat session connected to the same channel behaves identically before and after the extension is deployed.
+Vanilla IRC clients (e.g. weechat, irssi) are unaffected: they never send `PRESENCE`, and in v1 the server never relays it to clients — the server consumes the verb solely for aggregation, and the resource view (CLI verb, JSON endpoint) is the read surface. A weechat session connected to the same channel behaves identically before and after the extension is deployed. A future client-facing notification stream (an IRCv3 `away-notify` analog, gated on a `culture/presence` capability) is a possible v2 extension, out of scope here.
 
 ## Payload Schema
 
@@ -80,7 +80,7 @@ The `stale-T` value is configured server-side in `server.yaml`. The default is a
 
 `tokens_in` and `tokens_out` are cumulative per-connection counters. They are sourced from the **same** counting source as the `culture.harness.llm.tokens.input` and `culture.harness.llm.tokens.output` OTel metrics — one source of truth so the mesh view and Grafana never diverge.
 
-Backends whose SDK exposes no token counts (e.g. codex, copilot) send state-only payloads omitting `tokens_in` and `tokens_out`. This is the same caveat as 8.6.0 telemetry.
+Backends whose SDK exposes no token counts send state-only payloads omitting `tokens_in` and `tokens_out` — the same caveat the 8.6.0 harness-telemetry work applies to its token counters.
 
 ## Observation Only (v1)
 

--- a/protocol/extensions/presence.md
+++ b/protocol/extensions/presence.md
@@ -1,0 +1,93 @@
+# PRESENCE — Live Resident Activity Signal
+
+> PRESENCE is a new IRC protocol extension verb that lets every resident agent publish a live activity state and cumulative token counters to the mesh. The server aggregates per-resident signals into a resource view — active residents, token spend — that operators and balancing policies can act on.
+
+## Verb Definition
+
+`PRESENCE` is a **new** IRC verb. No RFC 2812 command is redefined.
+
+### Client to Server
+
+A resident sends `PRESENCE` to publish its current activity state and optional token counters:
+
+```irc
+PRESENCE :<payload>
+```
+
+`<payload>` is a JSON object (see [Payload Schema](#payload-schema)). The entire payload is transmitted as a single trailing parameter after the `:` prefix, per IRC RFC 2812 §2.3.
+
+### Server to Server (S2S)
+
+When a server receives `PRESENCE` from a resident connected via an S2S link, it propagates the verb to its peers so cross-server residents appear in the resource view. The originating server-of-origin is preserved in the propagation chain so the aggregation can attribute each signal to the correct host.
+
+### Backward Compatibility
+
+Vanilla IRC clients (e.g. weechat, irssi) that do not recognize `PRESENCE` are unaffected. The IRCd treats unknown verbs as no-ops for clients that have not advertised the `culture/presence` CAP token, and simply ignores the verb from such clients. A weechat session connected to the same channel behaves identically before and after the extension is deployed.
+
+## Payload Schema
+
+The trailing parameter after `PRESENCE :` is a JSON object with the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `state` | string | yes | Current activity state (see [Activity States](#activity-states)) |
+| `since` | string | yes | ISO-8601 UTC timestamp when the resident entered this state (e.g. `2026-07-06T14:32:00Z`) |
+| `task` | string | no | Short hint about the current task (e.g. `review PR #471`) |
+| `tokens_in` | integer | no | Cumulative input tokens consumed since connection started |
+| `tokens_out` | integer | no | Cumulative output tokens produced since connection started |
+
+### Encoding and Length Caps
+
+The payload is JSON-encoded as UTF-8 and transmitted as the trailing parameter of the IRC line. The total IRC line (including the `PRESENCE :` prefix) must not exceed 512 bytes, consistent with the IRC line length limit. The `task` field is capped at 128 characters.
+
+## Activity States
+
+The `state` field is one of six values. Each state maps to an observable harness boundary — transitions are driven **only** by code boundaries, never by model self-report.
+
+| State | Harness Boundary |
+|-------|-----------------|
+| `idle` | Connected, no work in flight |
+| `listening` | Inbound message being handled — the `harness.irc.message.handle` span is open |
+| `thinking` | LLM call in flight — the `harness.llm.call` span is open |
+| `working` | Tool execution in flight |
+| `draining` | Graceful shutdown started, finishing current work |
+| `offline` | Disconnected or `QUIT` sent |
+
+### Transition Rules
+
+- Transitions are emitted at the **observable code boundary** that drives them: connect, message handled, LLM call open/close, tool exec, shutdown.
+- A resident never self-reports its state; the harness emits `PRESENCE` at each boundary crossing.
+- `offline` is implicit: the server transitions a resident to `offline` on disconnect or `QUIT`, without requiring a final `PRESENCE` from the client.
+
+## Heartbeat and Refresh Semantics
+
+A resident sends `PRESENCE` periodically while in a busy state (`listening`, `thinking`, `working`, or `draining`) to keep its signal fresh.
+
+### Refresh Interval
+
+The heartbeat interval is configurable server-side in `server.yaml`. The default value is an open tuning question (plan risk r1).
+
+### Stale-Busy Watchdog
+
+A resident that last reported a busy state but misses heartbeats for a configurable stale threshold (`stale-T`) is flagged `presumed-hung` in the resource view. This catches crashed or wedged agents without their cooperation.
+
+- A `kill -9`'d resident that last reported busy is flagged `presumed-hung` within `stale-T` with zero cooperation from the dead process.
+- A slow-but-alive resident heartbeating through a long LLM call is **not** falsely flagged.
+
+The `stale-T` value is configured server-side in `server.yaml`. The default is an open tuning question (plan risk r1).
+
+## Token Counters
+
+`tokens_in` and `tokens_out` are cumulative per-connection counters. They are sourced from the **same** counting source as the `culture.harness.llm.tokens.input` and `culture.harness.llm.tokens.output` OTel metrics — one source of truth so the mesh view and Grafana never diverge.
+
+Backends whose SDK exposes no token counts (e.g. codex, copilot) send state-only payloads omitting `tokens_in` and `tokens_out`. This is the same caveat as 8.6.0 telemetry.
+
+## Observation Only (v1)
+
+v1 servers only aggregate and report presence data. No enforcement is applied:
+
+- No deferred wakes, no admission control, no budget blocking.
+- A budget breach emits a warning signal only.
+- Mesh behavior with the feature enabled is otherwise identical to today.
+
+Enforcement (admission control, budget blocking) is the explicit v2 leg.

--- a/protocol/extensions/presence.md
+++ b/protocol/extensions/presence.md
@@ -82,6 +82,40 @@ The `stale-T` value is configured server-side in `server.yaml`. The default is a
 
 Backends whose SDK exposes no token counts send state-only payloads omitting `tokens_in` and `tokens_out` — the same caveat the 8.6.0 harness-telemetry work applies to its token counters.
 
+## Query Surface (Anticipated)
+
+> **Status: ANTICIPATED.** This is the query contract culture proposed to
+> agentirc in the t3 hand-off brief
+> ([agentirc#53](https://github.com/agentculture/agentirc/issues/53)). It
+> becomes authoritative once agentirc adopts or amends it; until then the
+> culture-side transport seam (`culture_core/resource_view.py`) is the only
+> code speaking it, and this section tracks the proposal, not shipped
+> server behavior.
+
+To read the server's presence aggregation, a client sends:
+
+```irc
+PRESENCE LIST
+```
+
+The server replies with one `PRESENCELIST` line per resident — each carrying
+a single JSON resident object as the trailing parameter — terminated by a
+`PRESENCEEND` line:
+
+```irc
+PRESENCELIST :{"nick": "spark-claude", "server": "spark", "state": "thinking", ...}
+PRESENCELIST :{"nick": "thor-codex", "server": "thor", "state": "idle", ...}
+PRESENCEEND :End of presence list
+```
+
+A server without the query surface replies `421 <nick> PRESENCE :Unknown
+command` (today's agentirc), which culture's front doors surface as a
+graceful `supported: false` degrade rather than an error.
+
+The publish side of the extension — the harness emitter that sends
+`PRESENCE` at each activity boundary — lands in the cultureagent sibling
+([cultureagent#47](https://github.com/agentculture/cultureagent/issues/47)).
+
 ## Observation Only (v1)
 
 v1 servers only aggregate and report presence data. No enforcement is applied:
@@ -91,3 +125,9 @@ v1 servers only aggregate and report presence data. No enforcement is applied:
 - Mesh behavior with the feature enabled is otherwise identical to today.
 
 Enforcement (admission control, budget blocking) is the explicit v2 leg.
+
+## See Also
+
+- [docs/resident-presence.md](../../docs/resident-presence.md) — the
+  engine-side configuration surface, the `culture residents` CLI verb, the
+  `/residents.json` endpoint, and the canonical JSON schema.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,16 +18,19 @@ dependencies = [
     # (issue #462) — there is no culture-core dependency anymore. The caps below
     # are the bounds the engine is validated against; they came back with it.
     "pyyaml>=6.0",
-    # Floor at 9.11: the agent-accessibility release (CLI client verbs, public
-    # reconnecting transport) the mesh's agentic access relies on — see
+    # Floor at 9.12: the PRESENCE release (verb parsing, aggregation, S2S,
+    # stale-busy watchdog, PRESENCE LIST query surface — agentirc#53) the
+    # resident resource view reads; 9.11 was the agent-accessibility floor
+    # (CLI client verbs, public reconnecting transport) the mesh's agentic
+    # access relies on — see
     # docs/specs/2026-07-03-the-spark-culture-mesh-is-always-on-under-cli-prov.md (c12).
-    "agentirc-cli>=9.11.0,<10",
-    # Bumped 0.4->0.12 for the colleague backend: cultureagent 0.12.0 is the
-    # first release shipping clients/colleague (the ColleagueDaemon wrapping
-    # colleague[culture]'s ColleagueHarness) and the backend-colleague extra
-    # (three-minds t1, upstream cultureagent#45). Validated against the full
-    # engine suite on the bump.
-    "cultureagent~=0.12.0",
+    "agentirc-cli>=9.12.0,<10",
+    # Bumped 0.12->0.13 for the shared-harness PRESENCE emitter (boundary-
+    # driven states, heartbeat, one token-counting source — cultureagent#47);
+    # 0.12.0 was the first release shipping clients/colleague (three-minds t1,
+    # upstream cultureagent#45). Validated against the full engine suite on
+    # the bump.
+    "cultureagent~=0.13.0",
     "mistune>=3.0",
     "aiohttp>=3.9",
     # agex-cli capped at the minor series culture validated against:
@@ -101,21 +104,21 @@ packages = ["culture", "culture_core"]
 # and 1.0 is an outright breaking API change. Bump only alongside backend code
 # that adapts to the new release (all-backends rule), and re-run `pytest -k
 # copilot` with the extra installed.
-copilot = ["cultureagent[backend-copilot]~=0.12.0", "github-copilot-sdk==0.2.0"]
-claude = ["cultureagent[backend-claude]~=0.12.0"]
-acp = ["cultureagent[backend-acp]~=0.12.0"]
+copilot = ["cultureagent[backend-copilot]~=0.13.0", "github-copilot-sdk==0.2.0"]
+claude = ["cultureagent[backend-claude]~=0.13.0"]
+acp = ["cultureagent[backend-acp]~=0.13.0"]
 # The codex backend needs no SDK — kept for all-backends symmetry.
 codex = []
 # colleague: the enforced third mind (three-minds t1). cultureagent's
 # backend-colleague extra pulls colleague[culture] (the resident
 # ColleagueHarness culture wraps). Symmetric with claude/codex — no culture-side
 # SDK of its own.
-colleague = ["cultureagent[backend-colleague]~=0.12.0"]
+colleague = ["cultureagent[backend-colleague]~=0.13.0"]
 # Concrete union of the per-backend extras (codex contributes nothing) — a
 # self-referential culture[...] entry would emit circular Requires-Dist
 # metadata some resolvers mishandle.
 all-backends = [
-    "cultureagent[backend-claude,backend-acp,backend-copilot,backend-colleague]~=0.12.0",
+    "cultureagent[backend-claude,backend-acp,backend-copilot,backend-colleague]~=0.13.0",
     "github-copilot-sdk==0.2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "culture"
-version = "14.4.1"
+version = "14.5.0"
 description = "The professional workspace for agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,22 @@ def _stub_claude_sdk_at_conftest_import():
 _stub_claude_sdk_at_conftest_import()
 
 
+# Materialize the full cultureagent daemon import tree ONCE, before any test
+# runs. tests/test_backend_sdk_hints.py's _block() purges every cultureagent
+# module from sys.modules and re-imports the chain under a meta-path finder
+# that blocks the backend SDKs. Any THIRD-PARTY module whose very first
+# import happens inside that window (it is neither purged nor tracked by
+# monkeypatch) caches its no-SDK degraded state for the rest of the worker
+# session — observed as daemon harness metrics becoming invisible to a
+# freshly installed test MeterProvider (order-dependent: CI seating hit
+# test_codex_agent_runner_records_timeout_outcome; the local replay hit the
+# claude success/error tests). Importing the full tree here guarantees every
+# transitive third-party import happens un-blocked, so the SDK-hint tests
+# can only ever create a throwaway second generation of pure cultureagent
+# modules.
+import cultureagent.clients.claude.daemon  # noqa: E402, F401
+import cultureagent.clients.codex.daemon  # noqa: E402, F401
+import cultureagent.clients.shared.base_daemon  # noqa: E402, F401
 import pytest  # noqa: E402
 import pytest_asyncio  # noqa: E402
 from agentirc.config import LinkConfig, ServerConfig, TelemetryConfig  # noqa: E402

--- a/tests/test_culture_config.py
+++ b/tests/test_culture_config.py
@@ -650,39 +650,61 @@ def test_load_culture_yaml_token_budget_defaults_when_absent(tmp_path):
 
 
 @pytest.mark.parametrize("bad", [0, -1, "many", 1.5, True])
-def test_load_culture_yaml_token_budget_invalid(tmp_path, bad):
-    """Non-positive / non-int token_budget raises an actionable CultureError."""
+def test_load_culture_yaml_token_budget_invalid_warns_and_degrades(tmp_path, bad, caplog):
+    """Budget fields are warn-only observability config: an invalid
+    token_budget logs a warning (naming the file, key, value, and valid
+    range) and is reset to the default (None) — the agent still loads."""
+    import logging
+
     import yaml
 
-    from culture_core.cli._errors import CultureError
     from culture_core.config import load_culture_yaml
 
     culture_yaml = tmp_path / "culture.yaml"
     culture_yaml.write_text(
         yaml.dump({"suffix": "myagent", "backend": "claude", "token_budget": bad})
     )
-    with pytest.raises(CultureError, match=r"token_budget.*positive integer"):
-        load_culture_yaml(str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger="culture"):
+        agents = load_culture_yaml(str(tmp_path))
+
+    assert len(agents) == 1
+    assert agents[0].suffix == "myagent"
+    assert agents[0].token_budget is None
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "token_budget" in m and "culture.yaml" in m and "positive integer" in m for m in messages
+    )
 
 
 @pytest.mark.parametrize("bad", [0, -5, 101, "80", 2.5, True])
-def test_load_culture_yaml_token_budget_warn_pct_invalid(tmp_path, bad):
-    """token_budget_warn_pct outside 1..100 (or non-int) raises CultureError."""
+def test_load_culture_yaml_token_budget_warn_pct_invalid_warns_and_degrades(tmp_path, bad, caplog):
+    """token_budget_warn_pct outside 1..100 (or non-int) logs a warning and
+    falls back to the default (80) — never a raise, the agent still loads."""
+    import logging
+
     import yaml
 
-    from culture_core.cli._errors import CultureError
     from culture_core.config import load_culture_yaml
 
     culture_yaml = tmp_path / "culture.yaml"
     culture_yaml.write_text(
         yaml.dump({"suffix": "myagent", "backend": "claude", "token_budget_warn_pct": bad})
     )
-    with pytest.raises(CultureError, match=r"token_budget_warn_pct.*between 1 and 100"):
-        load_culture_yaml(str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger="culture"):
+        agents = load_culture_yaml(str(tmp_path))
+
+    assert len(agents) == 1
+    assert agents[0].token_budget_warn_pct == 80
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "token_budget_warn_pct" in m and "culture.yaml" in m and "between 1 and 100" in m
+        for m in messages
+    )
 
 
-def test_resolve_agents_invalid_token_budget_warns_and_skips(tmp_path, caplog):
-    """A manifest entry with an invalid budget warns and is skipped, not fatal."""
+def test_resolve_agents_invalid_token_budget_warns_and_loads(tmp_path, caplog):
+    """A manifest entry with an invalid budget degrades (budget ignored) but
+    the agent still loads — a budget typo must never drop an agent."""
     import logging
 
     from culture_core.config import (
@@ -704,7 +726,10 @@ def test_resolve_agents_invalid_token_budget_warns_and_skips(tmp_path, caplog):
     with caplog.at_level(logging.WARNING, logger="culture"):
         resolve_agents(config)
 
-    assert config.agents == []
+    assert len(config.agents) == 1
+    agent = config.get_agent("spark-culture")
+    assert agent is not None
+    assert agent.token_budget is None
     messages = [r.getMessage() for r in caplog.records]
     assert any("token_budget" in m for m in messages)
 
@@ -814,6 +839,45 @@ def test_load_server_config_presence_unknown_key(tmp_path):
 
     server_yaml = tmp_path / "server.yaml"
     server_yaml.write_text("presence:\n  heartbeat_seconds: 30\n")
+    with pytest.raises(CultureError, match=r"presence"):
+        load_server_config(str(server_yaml))
+
+
+@pytest.mark.parametrize("bad", [False, [], 0])
+def test_load_server_config_presence_falsy_non_mapping_rejected(tmp_path, bad):
+    """presence: false / [] / 0 must raise the must-be-a-mapping CultureError,
+    not silently coerce to the defaults like the old `or {}` did."""
+    import yaml
+
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text(yaml.dump({"presence": bad}))
+    with pytest.raises(CultureError, match=r"must be a mapping"):
+        load_server_config(str(server_yaml))
+
+
+def test_load_server_config_presence_null_section_gets_defaults(tmp_path):
+    """An explicit empty `presence:` key (YAML null) means 'use defaults'."""
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("server:\n  name: spark\npresence:\n")
+    config = load_server_config(str(server_yaml))
+    assert config.presence.heartbeat_interval_seconds == 30
+    assert config.presence.stale_after_seconds == 90
+
+
+def test_load_server_config_presence_mixed_key_types_structured_error(tmp_path):
+    """An unquoted numeric YAML key in the presence section must surface the
+    structured unknown-key CultureError — not a TypeError from sorting
+    mixed-type keys while building the error message."""
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("presence:\n  30: 5\n  stale_after_seconds: 60\n")
     with pytest.raises(CultureError, match=r"presence"):
         load_server_config(str(server_yaml))
 

--- a/tests/test_culture_config.py
+++ b/tests/test_culture_config.py
@@ -601,3 +601,270 @@ def test_remove_from_manifest_not_found(tmp_path):
 
     with pytest.raises(ValueError, match="not found"):
         remove_from_manifest(str(path), "ghost")
+
+
+# -----------------------------------------------------------------------
+# Token budgets (warn-only) + presence policy — resident-presence t2
+# -----------------------------------------------------------------------
+
+
+def test_agent_config_token_budget_defaults():
+    """AgentConfig token-budget fields default to no budget / 80 percent."""
+    from culture_core.config import AgentConfig
+
+    agent = AgentConfig()
+    assert agent.token_budget is None
+    assert agent.token_budget_warn_pct == 80
+
+
+def test_load_culture_yaml_token_budget_fields(tmp_path):
+    """token_budget keys parse as typed fields; extras still work alongside."""
+    from culture_core.config import load_culture_yaml
+
+    culture_yaml = tmp_path / "culture.yaml"
+    culture_yaml.write_text("""\
+suffix: myagent
+backend: claude
+token_budget: 200000
+token_budget_warn_pct: 75
+custom_field: hello
+""")
+    agents = load_culture_yaml(str(tmp_path))
+    assert agents[0].token_budget == 200000
+    assert agents[0].token_budget_warn_pct == 75
+    # Typed fields, not extras — and unknown keys still land in extras.
+    assert "token_budget" not in agents[0].extras
+    assert "token_budget_warn_pct" not in agents[0].extras
+    assert agents[0].extras == {"custom_field": "hello"}
+
+
+def test_load_culture_yaml_token_budget_defaults_when_absent(tmp_path):
+    """culture.yaml without budget keys yields the field defaults."""
+    from culture_core.config import load_culture_yaml
+
+    culture_yaml = tmp_path / "culture.yaml"
+    culture_yaml.write_text("suffix: myagent\nbackend: claude\n")
+    agents = load_culture_yaml(str(tmp_path))
+    assert agents[0].token_budget is None
+    assert agents[0].token_budget_warn_pct == 80
+
+
+@pytest.mark.parametrize("bad", [0, -1, "many", 1.5, True])
+def test_load_culture_yaml_token_budget_invalid(tmp_path, bad):
+    """Non-positive / non-int token_budget raises an actionable CultureError."""
+    import yaml
+
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_culture_yaml
+
+    culture_yaml = tmp_path / "culture.yaml"
+    culture_yaml.write_text(
+        yaml.dump({"suffix": "myagent", "backend": "claude", "token_budget": bad})
+    )
+    with pytest.raises(CultureError, match=r"token_budget.*positive integer"):
+        load_culture_yaml(str(tmp_path))
+
+
+@pytest.mark.parametrize("bad", [0, -5, 101, "80", 2.5, True])
+def test_load_culture_yaml_token_budget_warn_pct_invalid(tmp_path, bad):
+    """token_budget_warn_pct outside 1..100 (or non-int) raises CultureError."""
+    import yaml
+
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_culture_yaml
+
+    culture_yaml = tmp_path / "culture.yaml"
+    culture_yaml.write_text(
+        yaml.dump({"suffix": "myagent", "backend": "claude", "token_budget_warn_pct": bad})
+    )
+    with pytest.raises(CultureError, match=r"token_budget_warn_pct.*between 1 and 100"):
+        load_culture_yaml(str(tmp_path))
+
+
+def test_resolve_agents_invalid_token_budget_warns_and_skips(tmp_path, caplog):
+    """A manifest entry with an invalid budget warns and is skipped, not fatal."""
+    import logging
+
+    from culture_core.config import (
+        ServerConfig,
+        ServerConnConfig,
+        reset_manifest_warning_state,
+        resolve_agents,
+    )
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "culture.yaml").write_text("suffix: culture\nbackend: claude\ntoken_budget: -1\n")
+
+    reset_manifest_warning_state()
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        manifest={"culture": str(proj)},
+    )
+    with caplog.at_level(logging.WARNING, logger="culture"):
+        resolve_agents(config)
+
+    assert config.agents == []
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("token_budget" in m for m in messages)
+
+
+def test_presence_config_defaults():
+    """PresenceConfig defaults: 30s heartbeat, 90s stale-T."""
+    from culture_core.config import PresenceConfig
+
+    presence = PresenceConfig()
+    assert presence.heartbeat_interval_seconds == 30
+    assert presence.stale_after_seconds == 90
+
+
+def test_server_config_presence_default_section():
+    """ServerConfig carries a default presence section."""
+    from culture_core.config import ServerConfig
+
+    config = ServerConfig()
+    assert config.presence.heartbeat_interval_seconds == 30
+    assert config.presence.stale_after_seconds == 90
+
+
+def test_load_server_config_presence_section(tmp_path):
+    """server.yaml presence section parses into PresenceConfig."""
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("""\
+server:
+  name: spark
+
+presence:
+  heartbeat_interval_seconds: 10
+  stale_after_seconds: 45
+""")
+    config = load_server_config(str(server_yaml))
+    assert config.presence.heartbeat_interval_seconds == 10
+    assert config.presence.stale_after_seconds == 45
+
+
+def test_load_server_config_presence_defaults_when_absent(tmp_path):
+    """server.yaml without a presence section gets the defaults."""
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("server:\n  name: spark\n")
+    config = load_server_config(str(server_yaml))
+    assert config.presence.heartbeat_interval_seconds == 30
+    assert config.presence.stale_after_seconds == 90
+
+
+@pytest.mark.parametrize("bad", [0, -3, "fast", 1.5, True])
+def test_load_server_config_presence_heartbeat_invalid(tmp_path, bad):
+    """Non-positive / non-int heartbeat_interval_seconds raises CultureError."""
+    import yaml
+
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text(yaml.dump({"presence": {"heartbeat_interval_seconds": bad}}))
+    with pytest.raises(
+        CultureError, match=r"presence\.heartbeat_interval_seconds.*positive integer"
+    ):
+        load_server_config(str(server_yaml))
+
+
+@pytest.mark.parametrize("bad", [0, -1, "soon", 2.5, True])
+def test_load_server_config_presence_stale_invalid(tmp_path, bad):
+    """Non-positive / non-int stale_after_seconds raises CultureError."""
+    import yaml
+
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text(
+        yaml.dump({"presence": {"heartbeat_interval_seconds": 30, "stale_after_seconds": bad}})
+    )
+    with pytest.raises(CultureError, match=r"presence\.stale_after_seconds.*positive integer"):
+        load_server_config(str(server_yaml))
+
+
+@pytest.mark.parametrize("stale", [30, 20])
+def test_load_server_config_presence_stale_not_greater_than_heartbeat(tmp_path, stale):
+    """stale_after_seconds must be strictly greater than the heartbeat interval."""
+    import yaml
+
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text(
+        yaml.dump({"presence": {"heartbeat_interval_seconds": 30, "stale_after_seconds": stale}})
+    )
+    with pytest.raises(
+        CultureError,
+        match=r"presence\.stale_after_seconds.*strictly greater than",
+    ):
+        load_server_config(str(server_yaml))
+
+
+def test_load_server_config_presence_unknown_key(tmp_path):
+    """An unknown presence key raises CultureError, not a TypeError traceback."""
+    from culture_core.cli._errors import CultureError
+    from culture_core.config import load_server_config
+
+    server_yaml = tmp_path / "server.yaml"
+    server_yaml.write_text("presence:\n  heartbeat_seconds: 30\n")
+    with pytest.raises(CultureError, match=r"presence"):
+        load_server_config(str(server_yaml))
+
+
+def test_save_culture_yaml_token_budget_round_trip(tmp_path):
+    """Budget fields survive a save/load round-trip as typed fields."""
+    from culture_core.config import AgentConfig, load_culture_yaml, save_culture_yaml
+
+    agent = AgentConfig(
+        suffix="myagent",
+        backend="claude",
+        token_budget=200000,
+        token_budget_warn_pct=75,
+    )
+    save_culture_yaml(str(tmp_path), [agent])
+
+    loaded = load_culture_yaml(str(tmp_path))
+    assert loaded[0].token_budget == 200000
+    assert loaded[0].token_budget_warn_pct == 75
+    assert "token_budget" not in loaded[0].extras
+    assert "token_budget_warn_pct" not in loaded[0].extras
+
+
+def test_save_culture_yaml_omits_default_token_budget(tmp_path):
+    """Default budget values are not written to culture.yaml."""
+    from culture_core.config import AgentConfig, save_culture_yaml
+
+    agent = AgentConfig(suffix="myagent", backend="claude")
+    save_culture_yaml(str(tmp_path), [agent])
+
+    text = (tmp_path / "culture.yaml").read_text()
+    assert "token_budget" not in text
+
+
+def test_save_server_config_presence_round_trip(tmp_path):
+    """Presence section survives a save/load round-trip."""
+    from culture_core.config import (
+        PresenceConfig,
+        ServerConfig,
+        ServerConnConfig,
+        load_server_config,
+        save_server_config,
+    )
+
+    path = tmp_path / "server.yaml"
+    config = ServerConfig(
+        server=ServerConnConfig(name="spark"),
+        presence=PresenceConfig(heartbeat_interval_seconds=15, stale_after_seconds=60),
+    )
+    save_server_config(str(path), config)
+
+    loaded = load_server_config(str(path))
+    assert loaded.presence.heartbeat_interval_seconds == 15
+    assert loaded.presence.stale_after_seconds == 60

--- a/tests/test_integration_agent_runner.py
+++ b/tests/test_integration_agent_runner.py
@@ -172,12 +172,36 @@ async def _wait_for_outcome_metric(metrics_reader, outcome, timeout=10.0):
     with the given ``outcome`` attribute. Returns the data point.
     Replaces fixed sleeps; ``record_llm_call`` fires after each turn but
     ordering vs. the test's next line isn't guaranteed."""
-    async with asyncio.timeout(timeout):
-        while True:
-            dp = _find_data_point(metrics_reader, "culture.harness.llm.calls", {"outcome": outcome})
-            if dp is not None:
-                return dp
-            await asyncio.sleep(0.1)
+    try:
+        async with asyncio.timeout(timeout):
+            while True:
+                dp = _find_data_point(
+                    metrics_reader, "culture.harness.llm.calls", {"outcome": outcome}
+                )
+                if dp is not None:
+                    return dp
+                await asyncio.sleep(0.1)
+    except TimeoutError:
+        _dump_pending_task_stacks(outcome)
+        raise
+
+
+def _dump_pending_task_stacks(outcome):
+    """Print every live asyncio task and its stack to stderr on poll expiry.
+
+    The poll expiring means the daemon-side turn never reached
+    ``record_llm_call`` — the stacks show where it actually sits (a wedged
+    await is otherwise invisible in CI, where the failure has not been
+    reproducible locally). Diagnostic only; the TimeoutError still raises.
+    """
+    import traceback
+
+    print(f"\n--- outcome={outcome!r} metric never arrived; live task stacks ---", file=sys.stderr)
+    for task in asyncio.all_tasks():
+        print(f"\n[task] {task.get_name()} done={task.done()} {task.get_coro()!r}", file=sys.stderr)
+        for frame in task.get_stack(limit=12):
+            traceback.print_stack(frame, limit=1, file=sys.stderr)
+    print("--- end task stacks ---", file=sys.stderr)
 
 
 def _build_daemon(server, agent_dir, sock_dir, nick="testserv-bot", turn_timeout=0.2):

--- a/tests/test_integration_agent_runner.py
+++ b/tests/test_integration_agent_runner.py
@@ -151,6 +151,11 @@ def _iter_data_points(metrics_reader, metric_name):
     metric trees the reader has captured. Flattening this once here keeps
     the polling helpers readable."""
     data = metrics_reader.get_metrics_data()
+    if data is None:
+        # OTel <1.42's InMemoryMetricReader returns None (not an empty
+        # MetricsData) while its provider has no data points yet — keep
+        # polling instead of crashing on the first pre-recording poll.
+        return
     for rm in data.resource_metrics:
         for sm in rm.scope_metrics:
             for metric in sm.metrics:
@@ -182,8 +187,49 @@ async def _wait_for_outcome_metric(metrics_reader, outcome, timeout=10.0):
                     return dp
                 await asyncio.sleep(0.1)
     except TimeoutError:
+        _dump_reader_contents(metrics_reader)
         _dump_pending_task_stacks(outcome)
         raise
+
+
+def _dump_reader_contents(metrics_reader):
+    """Print every data point the in-memory reader holds to stderr.
+
+    Discriminates the two failure modes an expired outcome poll can have:
+    an EMPTY dump means the harness registry bound its instruments to some
+    other MeterProvider (binding/pollution); data points with unexpected
+    attributes mean the turn recorded through a different code path.
+    """
+    from cultureagent.clients.shared import telemetry as _ht
+    from opentelemetry import metrics as otel_metrics
+
+    print("\n--- reader contents at poll expiry ---", file=sys.stderr)
+    print(f"this reader: {id(metrics_reader):#x}", file=sys.stderr)
+    print(f"global provider: {otel_metrics.get_meter_provider()!r}", file=sys.stderr)
+    reg = _ht._registry
+    print(
+        f"harness registry: {id(reg):#x} initialized_for={_ht._initialized_for!r}", file=sys.stderr
+    )
+    try:
+        readers = reg.llm_calls._measurement_consumer._sdk_config.metric_readers
+        print(
+            f"llm_calls routes to readers: {[hex(id(r)) for r in readers]}",
+            file=sys.stderr,
+        )
+    except AttributeError as exc:
+        print(f"llm_calls reader introspection failed: {exc}", file=sys.stderr)
+    data = metrics_reader.get_metrics_data()
+    count = 0
+    for rm in data.resource_metrics if data else []:
+        for sm in rm.scope_metrics:
+            for metric in sm.metrics:
+                for dp in getattr(metric.data, "data_points", []):
+                    count += 1
+                    print(
+                        f"  {metric.name} attrs={dict(dp.attributes)} value={getattr(dp, 'value', None)}",
+                        file=sys.stderr,
+                    )
+    print(f"--- {count} data point(s) total ---", file=sys.stderr)
 
 
 def _dump_pending_task_stacks(outcome):

--- a/tests/test_manifest_config.py
+++ b/tests/test_manifest_config.py
@@ -504,6 +504,44 @@ def test_load_legacy_config_empty_agents(tmpdir):
     assert config.agents == []
 
 
+def test_load_legacy_config_sanitizes_budget_fields(tmpdir, caplog):
+    """_load_legacy_config runs the same warn-and-degrade budget sanitizing
+    as the culture.yaml path: invalid values warn (naming the legacy file)
+    and reset (budget -> None, warn-pct -> default), and the agent still
+    loads — a budget typo never drops it or leaks into the resource view."""
+    import logging
+
+    from culture_core.config import AgentConfig, _load_legacy_config
+
+    legacy_path = os.path.join(tmpdir, "agents.yaml")
+    with open(legacy_path, "w", encoding="utf-8") as f:
+        f.write(
+            yaml.safe_dump(
+                {
+                    "server": {"name": "spark"},
+                    "agents": [
+                        {
+                            "nick": "spark-ada",
+                            "directory": "/tmp/ada",
+                            "token_budget": 0,
+                            "token_budget_warn_pct": 200,
+                        }
+                    ],
+                }
+            )
+        )
+
+    with caplog.at_level(logging.WARNING, logger="culture"):
+        config = _load_legacy_config(legacy_path)
+
+    assert len(config.agents) == 1  # never dropped over a budget typo
+    agent = config.agents[0]
+    assert agent.token_budget is None
+    assert agent.token_budget_warn_pct == AgentConfig().token_budget_warn_pct
+    assert "token_budget" in caplog.text
+    assert str(legacy_path) in caplog.text
+
+
 def test_archive_manifest_server_with_extra_unrelated_agent_in_directory(tmpdir):
     """A culture.yaml may contain agents for multiple suffixes; archive only
     flips the ones whose suffix matches a manifest entry."""

--- a/tests/test_residents_cli.py
+++ b/tests/test_residents_cli.py
@@ -1,0 +1,466 @@
+"""Tests for the `culture residents` CLI verb and the shared resource-view seam.
+
+Covers (task t5 of the resident-presence plan):
+
+* ``serialize_residents`` — THE canonical JSON payload shared with the
+  upcoming HTTP endpoint (t7): deterministic key order, residents sorted
+  by nick, budget derivation edge cases, state-only residents.
+* the human table renderer — flags column (HUNG? / BUDGET), dashes for
+  missing fields.
+* graceful degrade against a REAL running server (repo rule: no mocks
+  for the server) — today's agentirc has no PRESENCE query surface
+  (plan risks r3/r4, pending agentirc#53), so the CLI must report
+  ``supported: false`` and exit 0.
+* unreachable server — actionable CultureError-style failure, nonzero
+  exit, no traceback.
+* the anticipated wire contract, exercised against a real scripted TCP
+  server speaking the PRESENCELIST / PRESENCEEND shape the agentirc#53
+  brief proposes — this is the seam t7 builds on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import socket
+
+import pytest
+
+from culture_core.cli.residents import dispatch, render_table
+from culture_core.config import AgentConfig, ServerConfig, ServerConnConfig
+from culture_core.resource_view import (
+    PresenceUnsupportedError,
+    Resident,
+    _resident_from_wire,
+    apply_budgets,
+    fetch_residents_async,
+    serialize_residents,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fixed_now():
+    from datetime import datetime, timezone
+
+    return datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _resident(nick: str, **kwargs) -> Resident:
+    return Resident(nick=nick, **kwargs)
+
+
+def _make_args(config: str, json_mode: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(command="residents", config=config, json=json_mode)
+
+
+def _run_dispatch(args: argparse.Namespace) -> int:
+    """Run dispatch, normalising SystemExit to an exit code."""
+    try:
+        dispatch(args)
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    return 0
+
+
+def _write_server_yaml(tmp_path, port: int, agents_yaml: str = "") -> str:
+    cfg = tmp_path / "server.yaml"
+    cfg.write_text(
+        "server:\n" "  name: testserv\n" "  host: 127.0.0.1\n" f"  port: {port}\n" + agents_yaml
+    )
+    return str(cfg)
+
+
+def _free_port() -> int:
+    """Grab a port nothing is listening on (bind, read, close)."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# serialize_residents — the canonical payload (shared with t7)
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeResidents:
+    def test_sorted_by_nick_and_deterministic(self):
+        residents = [
+            _resident("spark-zeta", state="idle"),
+            _resident("spark-alpha", state="working"),
+            _resident("spark-mid", state="thinking"),
+        ]
+        payload_a = serialize_residents(residents, True, now=_fixed_now())
+        payload_b = serialize_residents(list(reversed(residents)), True, now=_fixed_now())
+        # Byte-for-byte deterministic regardless of input order.
+        assert json.dumps(payload_a) == json.dumps(payload_b)
+        nicks = [r["nick"] for r in payload_a["residents"]]
+        assert nicks == sorted(nicks) == ["spark-alpha", "spark-mid", "spark-zeta"]
+
+    def test_top_level_shape(self):
+        payload = serialize_residents([], False, now=_fixed_now())
+        assert payload["supported"] is False
+        assert payload["residents"] == []
+        assert payload["generated_at"] == "2026-07-07T12:00:00Z"
+        assert list(payload) == ["supported", "generated_at", "residents"]
+
+    def test_resident_key_order_is_documented_schema(self):
+        payload = serialize_residents([_resident("spark-a")], True, now=_fixed_now())
+        assert list(payload["residents"][0]) == [
+            "nick",
+            "server",
+            "state",
+            "since",
+            "task",
+            "tokens_in",
+            "tokens_out",
+            "presumed_hung",
+            "last_refresh",
+            "token_budget",
+            "budget_used_pct",
+            "budget_warning",
+        ]
+
+    def test_state_only_resident_serialises_with_nones(self):
+        """A state-only backend (no token counters) still yields every key."""
+        payload = serialize_residents(
+            [_resident("spark-a", state="listening", since="2026-07-07T11:00:00Z")],
+            True,
+            now=_fixed_now(),
+        )
+        rec = payload["residents"][0]
+        assert rec["state"] == "listening"
+        assert rec["tokens_in"] is None
+        assert rec["tokens_out"] is None
+        assert rec["token_budget"] is None
+        assert rec["budget_used_pct"] is None
+        assert rec["budget_warning"] is None
+        assert rec["presumed_hung"] is False
+
+    def test_supported_flag_is_normalised_to_bool(self):
+        payload = serialize_residents([], 1, now=_fixed_now())
+        assert payload["supported"] is True
+
+    def test_generated_at_defaults_to_utc_now(self):
+        payload = serialize_residents([], True)
+        assert payload["generated_at"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# Budget derivation — joining AgentConfig budgets onto fetched residents
+# ---------------------------------------------------------------------------
+
+
+def _agent(nick: str, budget: int | None = None, warn_pct: int = 80) -> AgentConfig:
+    agent = AgentConfig(
+        suffix=nick.split("-", 1)[1] if "-" in nick else nick,
+        token_budget=budget,
+        token_budget_warn_pct=warn_pct,
+    )
+    agent.nick = nick
+    return agent
+
+
+class TestBudgetDerivation:
+    def test_budget_set_below_threshold(self):
+        resident = _resident("spark-a", tokens_in=300, tokens_out=400)
+        apply_budgets([resident], [_agent("spark-a", budget=1000, warn_pct=80)])
+        assert resident.token_budget == 1000
+        assert resident.budget_used_pct == 70.0
+        assert resident.budget_warning is False
+
+    def test_budget_warn_threshold_crossing_is_inclusive(self):
+        resident = _resident("spark-a", tokens_in=400, tokens_out=400)
+        apply_budgets([resident], [_agent("spark-a", budget=1000, warn_pct=80)])
+        assert resident.budget_used_pct == 80.0
+        assert resident.budget_warning is True
+
+    def test_budget_unset_leaves_derived_fields_none(self):
+        resident = _resident("spark-a", tokens_in=999999, tokens_out=999999)
+        apply_budgets([resident], [_agent("spark-a", budget=None)])
+        assert resident.token_budget is None
+        assert resident.budget_used_pct is None
+        assert resident.budget_warning is None
+
+    def test_unregistered_nick_gets_no_budget(self):
+        resident = _resident("other-b", tokens_in=10, tokens_out=10)
+        apply_budgets([resident], [_agent("spark-a", budget=100)])
+        assert resident.token_budget is None
+        assert resident.budget_warning is None
+
+    def test_state_only_resident_keeps_budget_but_unknown_spend(self):
+        """Budget is configured but the backend sends no counters: spend is
+        unknowable, so used-pct and warning stay None (never a false alarm)."""
+        resident = _resident("spark-a", state="thinking")
+        apply_budgets([resident], [_agent("spark-a", budget=1000)])
+        assert resident.token_budget == 1000
+        assert resident.budget_used_pct is None
+        assert resident.budget_warning is None
+
+    def test_single_sided_counters_count_the_present_side(self):
+        resident = _resident("spark-a", tokens_in=500, tokens_out=None)
+        apply_budgets([resident], [_agent("spark-a", budget=1000, warn_pct=50)])
+        assert resident.budget_used_pct == 50.0
+        assert resident.budget_warning is True
+
+    def test_over_budget_pct_exceeds_100(self):
+        resident = _resident("spark-a", tokens_in=1500, tokens_out=0)
+        apply_budgets([resident], [_agent("spark-a", budget=1000)])
+        assert resident.budget_used_pct == 150.0
+        assert resident.budget_warning is True
+
+
+class TestWireParsing:
+    def test_bool_token_counters_are_rejected(self):
+        """JSON `true` is not a token count — bools must not sneak in as ints."""
+        resident = _resident_from_wire({"nick": "spark-a", "tokens_in": True, "tokens_out": False})
+        assert resident.tokens_in is None
+        assert resident.tokens_out is None
+
+    def test_non_dict_and_missing_fields_default(self):
+        resident = _resident_from_wire({"nick": "spark-a"})
+        assert resident.nick == "spark-a"
+        assert resident.state is None
+        assert resident.presumed_hung is False
+
+    def test_presumed_hung_truthiness(self):
+        assert _resident_from_wire({"nick": "a", "presumed_hung": True}).presumed_hung is True
+        assert _resident_from_wire({"nick": "a", "presumed_hung": None}).presumed_hung is False
+
+
+# ---------------------------------------------------------------------------
+# Human table renderer
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTable:
+    def test_flags_column_hung_and_budget(self):
+        rows = render_table(
+            [
+                _resident("spark-hung", state="working", presumed_hung=True),
+                _resident(
+                    "spark-hot",
+                    state="thinking",
+                    tokens_in=900,
+                    tokens_out=100,
+                    token_budget=1000,
+                    budget_used_pct=100.0,
+                    budget_warning=True,
+                ),
+                _resident("spark-ok", state="idle"),
+            ]
+        )
+        lines = rows.splitlines()
+        hung_line = next(ln for ln in lines if "spark-hung" in ln)
+        hot_line = next(ln for ln in lines if "spark-hot" in ln)
+        ok_line = next(ln for ln in lines if "spark-ok" in ln)
+        assert "HUNG?" in hung_line
+        assert "BUDGET" in hot_line
+        assert "HUNG?" not in hot_line
+        assert "HUNG?" not in ok_line and "BUDGET" not in ok_line
+
+    def test_both_flags_together(self):
+        rows = render_table(
+            [
+                _resident(
+                    "spark-bad",
+                    presumed_hung=True,
+                    budget_warning=True,
+                    token_budget=10,
+                    budget_used_pct=200.0,
+                )
+            ]
+        )
+        line = next(ln for ln in rows.splitlines() if "spark-bad" in ln)
+        assert "HUNG?,BUDGET" in line
+
+    def test_missing_fields_render_as_dashes(self):
+        rows = render_table([_resident("spark-bare")])
+        line = next(ln for ln in rows.splitlines() if "spark-bare" in ln)
+        # state, since, task, tokens, budget-pct, flags all dashed
+        assert line.split()[1:] == ["-", "-", "-", "-", "-", "-", "-"]
+
+    def test_tokens_column_formats_in_out(self):
+        rows = render_table([_resident("spark-a", tokens_in=1200, tokens_out=34)])
+        line = next(ln for ln in rows.splitlines() if "spark-a" in ln)
+        assert "1200/34" in line
+
+    def test_single_sided_tokens(self):
+        rows = render_table([_resident("spark-a", tokens_in=7)])
+        line = next(ln for ln in rows.splitlines() if "spark-a" in ln)
+        assert "7/-" in line
+
+    def test_header_names_all_columns(self):
+        header = render_table([_resident("spark-a")]).splitlines()[0]
+        for col in ("NICK", "SERVER", "STATE", "SINCE", "TASK", "TOKENS", "BUDGET", "FLAGS"):
+            assert col in header
+
+    def test_rows_sorted_by_nick(self):
+        rows = render_table([_resident("spark-z"), _resident("spark-a")])
+        lines = rows.splitlines()
+        assert lines.index(next(ln for ln in lines if "spark-a" in ln)) < lines.index(
+            next(ln for ln in lines if "spark-z" in ln)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graceful degrade against a REAL server (no PRESENCE surface today)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_unsupported_against_real_server(server):
+    """agentirc replies 421 to PRESENCE today (pending agentirc#53)."""
+    config = ServerConfig(
+        server=ServerConnConfig(name="testserv", host="127.0.0.1", port=server.config.port)
+    )
+    with pytest.raises(PresenceUnsupportedError):
+        await fetch_residents_async(config)
+
+
+@pytest.mark.asyncio
+async def test_cli_json_degrades_to_supported_false(server, tmp_path, capsys, monkeypatch):
+    """`culture residents --json` against a presence-less server: exit 0,
+    {"supported": false, "residents": []}."""
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    cfg = _write_server_yaml(tmp_path, server.config.port)
+    # dispatch runs asyncio.run internally — hop to a thread since this
+    # test already runs inside an event loop.
+    code = await asyncio.to_thread(_run_dispatch, _make_args(cfg, json_mode=True))
+    assert code == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["supported"] is False
+    assert payload["residents"] == []
+    # Exactly the shared serializer's shape, byte-for-byte.
+    assert list(payload) == ["supported", "generated_at", "residents"]
+
+
+@pytest.mark.asyncio
+async def test_cli_table_degrades_with_notice(server, tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    cfg = _write_server_yaml(tmp_path, server.config.port)
+    code = await asyncio.to_thread(_run_dispatch, _make_args(cfg, json_mode=False))
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "does not support PRESENCE" in out
+    assert "agentirc#53" in out
+
+
+# ---------------------------------------------------------------------------
+# Unreachable server — actionable error, nonzero exit, no traceback
+# ---------------------------------------------------------------------------
+
+
+def test_cli_unreachable_server_errors_actionably(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    cfg = _write_server_yaml(tmp_path, _free_port())
+    code = _run_dispatch(_make_args(cfg, json_mode=False))
+    assert code != 0
+    captured = capsys.readouterr()
+    assert "error:" in captured.err
+    assert "cannot connect" in captured.err
+    assert "hint:" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_unreachable_server_json_error_contract(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    cfg = _write_server_yaml(tmp_path, _free_port())
+    code = _run_dispatch(_make_args(cfg, json_mode=True))
+    assert code != 0
+    captured = capsys.readouterr()
+    err_payload = json.loads(captured.err.strip())
+    assert set(err_payload) == {"code", "message", "remediation"}
+    assert "cannot connect" in err_payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# Anticipated wire contract (the seam t7 builds on) — real scripted TCP server
+# ---------------------------------------------------------------------------
+
+
+async def _scripted_presence_server(records: list[dict]) -> tuple[asyncio.AbstractServer, int]:
+    """A real TCP listener speaking the anticipated PRESENCE query wire form.
+
+    Registers any client (001 on NICK) and answers PRESENCE LIST with one
+    PRESENCELIST line per record, then PRESENCEEND. This is the wire shape
+    proposed to agentirc in the t3 hand-off brief (agentirc#53); the seam
+    function is the only culture-side code that touches it.
+    """
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        buffer = ""
+        try:
+            while True:
+                data = await reader.read(4096)
+                if not data:
+                    return
+                buffer += data.decode()
+                while "\r\n" in buffer:
+                    line, buffer = buffer.split("\r\n", 1)
+                    if line.startswith("NICK "):
+                        nick = line.split(" ", 1)[1]
+                        writer.write(f":scripted 001 {nick} :Welcome\r\n".encode())
+                        await writer.drain()
+                    elif line.startswith("PRESENCE LIST"):
+                        for rec in records:
+                            writer.write(f"PRESENCELIST :{json.dumps(rec)}\r\n".encode())
+                        writer.write(b"PRESENCEEND :End of presence list\r\n")
+                        await writer.drain()
+                    elif line.startswith("QUIT"):
+                        writer.close()
+                        return
+        except (ConnectionError, OSError):
+            return
+
+    srv = await asyncio.start_server(_handle, "127.0.0.1", 0)
+    port = srv.sockets[0].getsockname()[1]
+    return srv, port
+
+
+@pytest.mark.asyncio
+async def test_fetch_parses_anticipated_wire_and_joins_budgets():
+    records = [
+        {
+            "nick": "spark-claude",
+            "server": "spark",
+            "state": "thinking",
+            "since": "2026-07-07T11:00:00Z",
+            "task": "review PR #471",
+            "tokens_in": 900,
+            "tokens_out": 100,
+            "presumed_hung": False,
+            "last_refresh": "2026-07-07T11:59:30Z",
+        },
+        {"nick": "thor-codex", "server": "thor", "state": "idle"},
+    ]
+    srv, port = await _scripted_presence_server(records)
+    try:
+        config = ServerConfig(
+            server=ServerConnConfig(name="scripted", host="127.0.0.1", port=port),
+            agents=[_agent("spark-claude", budget=1000, warn_pct=80)],
+        )
+        residents = await fetch_residents_async(config)
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+    assert [r.nick for r in sorted(residents, key=lambda r: r.nick)] == [
+        "spark-claude",
+        "thor-codex",
+    ]
+    claude = next(r for r in residents if r.nick == "spark-claude")
+    assert claude.state == "thinking"
+    assert claude.task == "review PR #471"
+    assert claude.tokens_in == 900
+    assert claude.token_budget == 1000
+    assert claude.budget_used_pct == 100.0
+    assert claude.budget_warning is True
+    codex = next(r for r in residents if r.nick == "thor-codex")
+    assert codex.state == "idle"
+    assert codex.tokens_in is None
+    assert codex.budget_warning is None

--- a/tests/test_residents_cli.py
+++ b/tests/test_residents_cli.py
@@ -7,15 +7,18 @@ Covers (task t5 of the resident-presence plan):
   by nick, budget derivation edge cases, state-only residents.
 * the human table renderer — flags column (HUNG? / BUDGET), dashes for
   missing fields.
-* graceful degrade against a REAL running server (repo rule: no mocks
-  for the server) — today's agentirc has no PRESENCE query surface
-  (plan risks r3/r4, pending agentirc#53), so the CLI must report
-  ``supported: false`` and exit 0.
+* the supported path against a REAL running server (repo rule: no mocks
+  for the server) — agentirc >= 9.12.0 answers the PRESENCE query, so the
+  CLI reports ``supported: true`` (and an empty registry: no resident has
+  published presence).
+* graceful degrade against a pre-9.12 server (scripted 421 replier): the
+  CLI must report ``supported: false`` and exit 0.
 * unreachable server — actionable CultureError-style failure, nonzero
   exit, no traceback.
-* the anticipated wire contract, exercised against a real scripted TCP
-  server speaking the PRESENCELIST / PRESENCEEND shape the agentirc#53
-  brief proposes — this is the seam t7 builds on.
+* the adopted wire contract (agentirc-cli 9.12.0 implements the shape
+  proposed in the agentirc#53 brief verbatim), exercised against a real
+  scripted TCP server speaking PRESENCELIST / PRESENCEEND — this is the
+  seam t7 builds on.
 """
 
 from __future__ import annotations
@@ -27,7 +30,7 @@ import socket
 
 import pytest
 
-from culture_core.cli.residents import dispatch, render_table
+from culture_core.cli.residents import _render_table, dispatch
 from culture_core.config import AgentConfig, ServerConfig, ServerConnConfig
 from culture_core.resource_view import (
     PresenceUnsupportedError,
@@ -223,15 +226,30 @@ class TestBudgetDerivation:
 
     @pytest.mark.parametrize("bad", [0, True, -5])
     def test_unsanitized_budget_never_divides(self, bad):
-        """The legacy agents.yaml loader constructs AgentConfig directly and
-        bypasses budget sanitizing, so token_budget 0 / True / negatives can
-        reach the join — it must skip them (all derived fields stay None),
-        never raise ZeroDivisionError or divide by a bool."""
+        """AgentConfig objects can be constructed directly, bypassing config
+        sanitizing, so token_budget 0 / True / negatives can reach the join
+        — it must skip them (all derived fields stay None), never raise
+        ZeroDivisionError or divide by a bool."""
         resident = _resident("spark-a", tokens_in=100, tokens_out=50)
         apply_budgets([resident], [_agent("spark-a", budget=bad)])
         assert resident.token_budget is None
         assert resident.budget_used_pct is None
         assert resident.budget_warning is None
+
+    @pytest.mark.parametrize("bad", [0, -1, 101, 200, True, False])
+    def test_unsanitized_warn_pct_falls_back_to_default(self, bad):
+        """An out-of-range/bool warn-pct on a directly-constructed AgentConfig
+        must fall back to the field default (80), never produce a misleading
+        budget_warning flag (e.g. warn_pct=True would warn at 0.1% spend)."""
+        over_default = _resident("spark-a", tokens_in=850, tokens_out=0)
+        apply_budgets([over_default], [_agent("spark-a", budget=1000, warn_pct=bad)])
+        assert over_default.budget_used_pct == 85.0
+        assert over_default.budget_warning is True  # 85 >= default 80
+
+        under_default = _resident("spark-a", tokens_in=700, tokens_out=0)
+        apply_budgets([under_default], [_agent("spark-a", budget=1000, warn_pct=bad)])
+        assert under_default.budget_used_pct == 70.0
+        assert under_default.budget_warning is False  # 70 < default 80
 
 
 class TestWireParsing:
@@ -259,7 +277,7 @@ class TestWireParsing:
 
 class TestRenderTable:
     def test_flags_column_hung_and_budget(self):
-        rows = render_table(
+        rows = _render_table(
             [
                 _resident("spark-hung", state="working", presumed_hung=True),
                 _resident(
@@ -284,7 +302,7 @@ class TestRenderTable:
         assert "HUNG?" not in ok_line and "BUDGET" not in ok_line
 
     def test_both_flags_together(self):
-        rows = render_table(
+        rows = _render_table(
             [
                 _resident(
                     "spark-bad",
@@ -299,28 +317,28 @@ class TestRenderTable:
         assert "HUNG?,BUDGET" in line
 
     def test_missing_fields_render_as_dashes(self):
-        rows = render_table([_resident("spark-bare")])
+        rows = _render_table([_resident("spark-bare")])
         line = next(ln for ln in rows.splitlines() if "spark-bare" in ln)
         # state, since, task, tokens, budget-pct, flags all dashed
         assert line.split()[1:] == ["-", "-", "-", "-", "-", "-", "-"]
 
     def test_tokens_column_formats_in_out(self):
-        rows = render_table([_resident("spark-a", tokens_in=1200, tokens_out=34)])
+        rows = _render_table([_resident("spark-a", tokens_in=1200, tokens_out=34)])
         line = next(ln for ln in rows.splitlines() if "spark-a" in ln)
         assert "1200/34" in line
 
     def test_single_sided_tokens(self):
-        rows = render_table([_resident("spark-a", tokens_in=7)])
+        rows = _render_table([_resident("spark-a", tokens_in=7)])
         line = next(ln for ln in rows.splitlines() if "spark-a" in ln)
         assert "7/-" in line
 
     def test_header_names_all_columns(self):
-        header = render_table([_resident("spark-a")]).splitlines()[0]
+        header = _render_table([_resident("spark-a")]).splitlines()[0]
         for col in ("NICK", "SERVER", "STATE", "SINCE", "TASK", "TOKENS", "BUDGET", "FLAGS"):
             assert col in header
 
     def test_rows_sorted_by_nick(self):
-        rows = render_table([_resident("spark-z"), _resident("spark-a")])
+        rows = _render_table([_resident("spark-z"), _resident("spark-a")])
         lines = rows.splitlines()
         assert lines.index(next(ln for ln in lines if "spark-a" in ln)) < lines.index(
             next(ln for ln in lines if "spark-z" in ln)
@@ -328,24 +346,28 @@ class TestRenderTable:
 
 
 # ---------------------------------------------------------------------------
-# Graceful degrade against a REAL server (no PRESENCE surface today)
+# Supported path against a REAL server (agentirc >= 9.12.0 answers the query)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_fetch_raises_unsupported_against_real_server(server):
-    """agentirc replies 421 to PRESENCE today (pending agentirc#53)."""
+async def test_fetch_succeeds_against_real_server(server):
+    """agentirc >= 9.12.0 answers PRESENCE LIST (agentirc#53). No resident
+    has published presence here — including the query observer itself, which
+    never sends PRESENCE — so the registry is empty, not an error."""
     config = ServerConfig(
         server=ServerConnConfig(name="testserv", host="127.0.0.1", port=server.config.port)
     )
-    with pytest.raises(PresenceUnsupportedError):
-        await fetch_residents_async(config)
+    residents = await fetch_residents_async(config)
+    assert residents == []
 
 
 @pytest.mark.asyncio
-async def test_cli_json_degrades_to_supported_false(server, tmp_path, capsys, monkeypatch):
-    """`culture residents --json` against a presence-less server: exit 0,
-    {"supported": false, "residents": []}."""
+async def test_cli_json_reports_supported_true_against_real_server(
+    server, tmp_path, capsys, monkeypatch
+):
+    """`culture residents --json` against a real 9.12+ server: exit 0,
+    {"supported": true, "residents": []} (empty presence registry)."""
     monkeypatch.delenv("CULTURE_NICK", raising=False)
     cfg = _write_server_yaml(tmp_path, server.config.port)
     # dispatch runs asyncio.run internally — hop to a thread since this
@@ -354,7 +376,7 @@ async def test_cli_json_degrades_to_supported_false(server, tmp_path, capsys, mo
     assert code == 0
     out = capsys.readouterr().out.strip()
     payload = json.loads(out)
-    assert payload["supported"] is False
+    assert payload["supported"] is True
     assert payload["residents"] == []
     # Exactly the shared serializer's shape, byte-for-byte.
     assert list(payload) == ["supported", "generated_at", "residents"]
@@ -364,14 +386,87 @@ async def test_cli_json_degrades_to_supported_false(server, tmp_path, capsys, mo
     from datetime import datetime
 
     stamp = datetime.fromisoformat(payload["generated_at"].replace("Z", "+00:00"))
-    assert out == to_json(serialize_residents([], False, now=stamp))
+    assert out == to_json(serialize_residents([], True, now=stamp))
+
+
+# ---------------------------------------------------------------------------
+# Graceful degrade against a pre-9.12 server (stock 421 unknown-command path)
+# ---------------------------------------------------------------------------
+
+
+async def _scripted_421_server() -> tuple[asyncio.AbstractServer, int]:
+    """A real TCP listener speaking the pre-9.12 answer: 421 to PRESENCE."""
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        buffer = ""
+        nick = "*"
+        try:
+            while True:
+                data = await reader.read(4096)
+                if not data:
+                    return
+                buffer += data.decode()
+                while "\r\n" in buffer:
+                    line, buffer = buffer.split("\r\n", 1)
+                    if line.startswith("NICK "):
+                        nick = line.split(" ", 1)[1]
+                        writer.write(f":scripted 001 {nick} :Welcome\r\n".encode())
+                        await writer.drain()
+                    elif line.startswith("PRESENCE"):
+                        writer.write(f":scripted 421 {nick} PRESENCE :Unknown command\r\n".encode())
+                        await writer.drain()
+                    elif line.startswith("QUIT"):
+                        writer.close()
+                        return
+        except (ConnectionError, OSError):
+            return
+
+    srv = await asyncio.start_server(_handle, "127.0.0.1", 0)
+    port = srv.sockets[0].getsockname()[1]
+    return srv, port
 
 
 @pytest.mark.asyncio
-async def test_cli_table_degrades_with_notice(server, tmp_path, capsys, monkeypatch):
+async def test_fetch_raises_unsupported_against_pre912_server():
+    """A pre-9.12 server replies 421 to PRESENCE — surface as unsupported."""
+    srv, port = await _scripted_421_server()
+    try:
+        config = ServerConfig(server=ServerConnConfig(name="scripted", host="127.0.0.1", port=port))
+        with pytest.raises(PresenceUnsupportedError):
+            await fetch_residents_async(config)
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_cli_json_degrades_to_supported_false(tmp_path, capsys, monkeypatch):
+    """`culture residents --json` against a presence-less server: exit 0,
+    {"supported": false, "residents": []}."""
     monkeypatch.delenv("CULTURE_NICK", raising=False)
-    cfg = _write_server_yaml(tmp_path, server.config.port)
-    code = await asyncio.to_thread(_run_dispatch, _make_args(cfg, json_mode=False))
+    srv, port = await _scripted_421_server()
+    try:
+        cfg = _write_server_yaml(tmp_path, port)
+        code = await asyncio.to_thread(_run_dispatch, _make_args(cfg, json_mode=True))
+    finally:
+        srv.close()
+        await srv.wait_closed()
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["supported"] is False
+    assert payload["residents"] == []
+
+
+@pytest.mark.asyncio
+async def test_cli_table_degrades_with_notice(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    srv, port = await _scripted_421_server()
+    try:
+        cfg = _write_server_yaml(tmp_path, port)
+        code = await asyncio.to_thread(_run_dispatch, _make_args(cfg, json_mode=False))
+    finally:
+        srv.close()
+        await srv.wait_closed()
     assert code == 0
     out = capsys.readouterr().out
     assert "does not support PRESENCE" in out
@@ -455,17 +550,18 @@ def test_cli_config_validation_error_honors_json_contract(tmp_path, capsys, monk
 
 
 # ---------------------------------------------------------------------------
-# Anticipated wire contract (the seam t7 builds on) — real scripted TCP server
+# Adopted wire contract (the seam t7 builds on) — real scripted TCP server
 # ---------------------------------------------------------------------------
 
 
 async def _scripted_presence_server(records: list[dict]) -> tuple[asyncio.AbstractServer, int]:
-    """A real TCP listener speaking the anticipated PRESENCE query wire form.
+    """A real TCP listener speaking the PRESENCE query wire form.
 
     Registers any client (001 on NICK) and answers PRESENCE LIST with one
-    PRESENCELIST line per record, then PRESENCEEND. This is the wire shape
-    proposed to agentirc in the t3 hand-off brief (agentirc#53); the seam
-    function is the only culture-side code that touches it.
+    PRESENCELIST line per record, then PRESENCEEND — the shape proposed in
+    the t3 hand-off brief and adopted verbatim by agentirc-cli 9.12.0
+    (agentirc#53). Payloads are raw UTF-8 JSON per the wire contract
+    (``ensure_ascii=False``), matching what the real server emits.
     """
 
     async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -484,7 +580,8 @@ async def _scripted_presence_server(records: list[dict]) -> tuple[asyncio.Abstra
                         await writer.drain()
                     elif line.startswith("PRESENCE LIST"):
                         for rec in records:
-                            writer.write(f"PRESENCELIST :{json.dumps(rec)}\r\n".encode())
+                            payload = json.dumps(rec, ensure_ascii=False)
+                            writer.write(f"PRESENCELIST :{payload}\r\n".encode())
                         writer.write(b"PRESENCEEND :End of presence list\r\n")
                         await writer.drain()
                     elif line.startswith("QUIT"):
@@ -540,6 +637,44 @@ async def test_fetch_parses_anticipated_wire_and_joins_budgets():
     assert codex.state == "idle"
     assert codex.tokens_in is None
     assert codex.budget_warning is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_preserves_non_ascii_payload():
+    """The payload contract is UTF-8 JSON — task text with real multi-byte
+    characters must round-trip the wire uncorrupted."""
+    task_text = "café ☕ — résumé"
+    srv, port = await _scripted_presence_server(
+        [{"nick": "spark-a", "state": "working", "task": task_text}]
+    )
+    try:
+        config = ServerConfig(server=ServerConnConfig(name="scripted", host="127.0.0.1", port=port))
+        residents = await fetch_residents_async(config)
+    finally:
+        srv.close()
+        await srv.wait_closed()
+    assert residents[0].task == task_text
+
+
+@pytest.mark.asyncio
+async def test_utf8_char_split_across_reads_survives():
+    """A multi-byte UTF-8 character split across TCP read boundaries must
+    never be corrupted: framing is byte-level, decoding per complete line
+    (the old per-chunk ``decode(errors="replace")`` mangled the char)."""
+    from culture_core.resource_view import _drain_presence_buffer
+
+    payload = json.dumps({"nick": "spark-a", "task": "café"}, ensure_ascii=False).encode()
+    wire = b"PRESENCELIST :" + payload + b"\r\nPRESENCEEND :End of presence list\r\n"
+    cut = wire.index(b"\xc3") + 1  # mid-character: between the two bytes of 'é'
+    records: list[dict] = []
+
+    done, remainder = await _drain_presence_buffer(wire[:cut], records, writer=None)
+    assert done is False and records == []  # no complete line yet
+
+    done, remainder = await _drain_presence_buffer(remainder + wire[cut:], records, writer=None)
+    assert done is True
+    assert remainder == b""
+    assert records == [{"nick": "spark-a", "task": "café"}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_residents_cli.py
+++ b/tests/test_residents_cli.py
@@ -36,6 +36,7 @@ from culture_core.resource_view import (
     apply_budgets,
     fetch_residents_async,
     serialize_residents,
+    to_json,
 )
 
 # ---------------------------------------------------------------------------
@@ -148,6 +149,14 @@ class TestSerializeResidents:
         payload = serialize_residents([], True)
         assert payload["generated_at"].endswith("Z")
 
+    def test_naive_now_is_interpreted_as_utc(self):
+        """A naive ``now`` means UTC by contract — it must never be shifted
+        through the host's local timezone by ``astimezone``."""
+        from datetime import datetime
+
+        payload = serialize_residents([], True, now=datetime(2026, 7, 7, 12, 0, 0))
+        assert payload["generated_at"] == "2026-07-07T12:00:00Z"
+
 
 # ---------------------------------------------------------------------------
 # Budget derivation — joining AgentConfig budgets onto fetched residents
@@ -211,6 +220,18 @@ class TestBudgetDerivation:
         apply_budgets([resident], [_agent("spark-a", budget=1000)])
         assert resident.budget_used_pct == 150.0
         assert resident.budget_warning is True
+
+    @pytest.mark.parametrize("bad", [0, True, -5])
+    def test_unsanitized_budget_never_divides(self, bad):
+        """The legacy agents.yaml loader constructs AgentConfig directly and
+        bypasses budget sanitizing, so token_budget 0 / True / negatives can
+        reach the join — it must skip them (all derived fields stay None),
+        never raise ZeroDivisionError or divide by a bool."""
+        resident = _resident("spark-a", tokens_in=100, tokens_out=50)
+        apply_budgets([resident], [_agent("spark-a", budget=bad)])
+        assert resident.token_budget is None
+        assert resident.budget_used_pct is None
+        assert resident.budget_warning is None
 
 
 class TestWireParsing:
@@ -337,6 +358,13 @@ async def test_cli_json_degrades_to_supported_false(server, tmp_path, capsys, mo
     assert payload["residents"] == []
     # Exactly the shared serializer's shape, byte-for-byte.
     assert list(payload) == ["supported", "generated_at", "residents"]
+    # And literally the shared dumps site: re-serializing through the one
+    # canonical to_json(serialize_residents(...)) reproduces the CLI bytes
+    # exactly (the endpoint asserts the same in test_residents_endpoint.py).
+    from datetime import datetime
+
+    stamp = datetime.fromisoformat(payload["generated_at"].replace("Z", "+00:00"))
+    assert out == to_json(serialize_residents([], False, now=stamp))
 
 
 @pytest.mark.asyncio
@@ -376,6 +404,54 @@ def test_cli_unreachable_server_json_error_contract(tmp_path, capsys, monkeypatc
     err_payload = json.loads(captured.err.strip())
     assert set(err_payload) == {"code", "message", "remediation"}
     assert "cannot connect" in err_payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# Config errors are config errors — never misreported as "server down"
+# ---------------------------------------------------------------------------
+
+
+def test_cli_unreadable_config_reports_config_error_not_server_down(tmp_path, capsys, monkeypatch):
+    """A config path that cannot be read (here: a directory) is a config
+    error — it must not be swallowed by the connection handling and
+    misreported as 'cannot connect to IRC server'."""
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    bad_config = tmp_path / "server.yaml"
+    bad_config.mkdir()  # open() raises IsADirectoryError (an OSError)
+    code = _run_dispatch(_make_args(str(bad_config), json_mode=False))
+    assert code != 0
+    captured = capsys.readouterr()
+    assert "cannot read server config" in captured.err
+    assert str(bad_config) in captured.err
+    assert "hint:" in captured.err
+    assert "cannot connect" not in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_unreadable_config_json_error_contract(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    bad_config = tmp_path / "server.yaml"
+    bad_config.mkdir()
+    code = _run_dispatch(_make_args(str(bad_config), json_mode=True))
+    assert code != 0
+    err_payload = json.loads(capsys.readouterr().err.strip())
+    assert set(err_payload) == {"code", "message", "remediation"}
+    assert "cannot read server config" in err_payload["message"]
+    assert "cannot connect" not in err_payload["message"]
+
+
+def test_cli_config_validation_error_honors_json_contract(tmp_path, capsys, monkeypatch):
+    """A CultureError from config validation (bad presence section) must be
+    emitted through the verb's --json error format — previously it bypassed
+    the json-aware emit path entirely."""
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    cfg = tmp_path / "server.yaml"
+    cfg.write_text("server:\n  name: testserv\npresence: false\n")
+    code = _run_dispatch(_make_args(str(cfg), json_mode=True))
+    assert code != 0
+    err_payload = json.loads(capsys.readouterr().err.strip())
+    assert set(err_payload) == {"code", "message", "remediation"}
+    assert "presence" in err_payload["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -464,3 +540,99 @@ async def test_fetch_parses_anticipated_wire_and_joins_budgets():
     assert codex.state == "idle"
     assert codex.tokens_in is None
     assert codex.budget_warning is None
+
+
+# ---------------------------------------------------------------------------
+# Mid-stream stall/drop is a connection error, NOT "unsupported" — a server
+# that already streamed PRESENCELIST records clearly speaks the surface;
+# reporting it as a healthy supported:false would discard real residents.
+# ---------------------------------------------------------------------------
+
+
+async def _stalling_presence_server(
+    records: list[dict], *, close_after: bool
+) -> tuple[asyncio.AbstractServer, int]:
+    """A scripted server that streams records but never sends PRESENCEEND.
+
+    With ``close_after=True`` it drops the connection right after the last
+    record; with ``close_after=False`` it goes silent (the client's recv
+    timeout fires).
+    """
+
+    async def _handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        buffer = ""
+        try:
+            while True:
+                data = await reader.read(4096)
+                if not data:
+                    return
+                buffer += data.decode()
+                while "\r\n" in buffer:
+                    line, buffer = buffer.split("\r\n", 1)
+                    if line.startswith("NICK "):
+                        nick = line.split(" ", 1)[1]
+                        writer.write(f":scripted 001 {nick} :Welcome\r\n".encode())
+                        await writer.drain()
+                    elif line.startswith("PRESENCE LIST"):
+                        for rec in records:
+                            writer.write(f"PRESENCELIST :{json.dumps(rec)}\r\n".encode())
+                        await writer.drain()
+                        if close_after:
+                            return
+                        # else: go silent — never send PRESENCEEND
+        except (ConnectionError, OSError):
+            return
+        finally:
+            # Always close the server-side transport, or Server.wait_closed()
+            # in the test teardown waits forever for the connection to detach.
+            writer.close()
+
+    srv = await asyncio.start_server(_handle, "127.0.0.1", 0)
+    port = srv.sockets[0].getsockname()[1]
+    return srv, port
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_close_is_connection_error_not_unsupported():
+    srv, port = await _stalling_presence_server([{"nick": "spark-a"}], close_after=True)
+    try:
+        config = ServerConfig(server=ServerConnConfig(name="scripted", host="127.0.0.1", port=port))
+        with pytest.raises(ConnectionError, match=r"stalled after 1 record"):
+            await fetch_residents_async(config)
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_silence_is_connection_error_not_unsupported(monkeypatch):
+    monkeypatch.setattr("culture_core.resource_view.RECV_TIMEOUT", 0.3)
+    srv, port = await _stalling_presence_server([{"nick": "spark-a"}], close_after=False)
+    try:
+        config = ServerConfig(server=ServerConnConfig(name="scripted", host="127.0.0.1", port=port))
+        with pytest.raises(ConnectionError, match=r"stalled after 1 record"):
+            await fetch_residents_async(config)
+    finally:
+        srv.close()
+        await srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_cli_reports_stalled_stream_as_error_not_supported_false(
+    tmp_path, capsys, monkeypatch
+):
+    """CLI path: a stalled stream exits nonzero through the connection-error
+    branch — never exit 0 with a healthy-looking supported:false."""
+    monkeypatch.delenv("CULTURE_NICK", raising=False)
+    monkeypatch.setattr("culture_core.resource_view.RECV_TIMEOUT", 0.3)
+    srv, port = await _stalling_presence_server([{"nick": "spark-a"}], close_after=False)
+    try:
+        cfg = _write_server_yaml(tmp_path, port)
+        code = await asyncio.to_thread(_run_dispatch, _make_args(cfg, json_mode=False))
+    finally:
+        srv.close()
+        await srv.wait_closed()
+    assert code != 0
+    captured = capsys.readouterr()
+    assert "cannot connect" in captured.err
+    assert "supported" not in captured.out

--- a/tests/test_residents_endpoint.py
+++ b/tests/test_residents_endpoint.py
@@ -1,0 +1,221 @@
+"""Tests for GET /residents.json on the overview web server (plan task t7).
+
+The endpoint is the second front door of the resource view (the first is
+``culture residents --json``, task t5). The plan's acceptance criterion is
+byte-compatibility: the endpoint body must be exactly ``json.dumps`` of
+``culture_core.resource_view.serialize_residents(...)`` — one serializer,
+one schema, verified here by diffing the endpoint bytes against a direct
+serializer call over the same fixtures.
+
+Response contract (feeds the irc-lens t8 brief — no 500s, ever):
+
+* presence supported          -> 200, canonical payload
+* no PRESENCE surface         -> 200, ``supported: false`` payload
+* culture server unreachable  -> 503, ``{code, message, remediation}``
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from http.server import HTTPServer
+
+import pytest
+
+from culture_core.overview.renderer_web import _make_overview_handler
+from culture_core.resource_view import (
+    PresenceUnsupportedError,
+    Resident,
+    serialize_residents,
+)
+
+FIXED_NOW = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fixture_residents() -> list[Resident]:
+    return [
+        Resident(
+            nick="spark-claude",
+            server="spark",
+            state="thinking",
+            since="2026-07-07T11:00:00Z",
+            task="review PR #471",
+            tokens_in=900,
+            tokens_out=100,
+            presumed_hung=False,
+            last_refresh="2026-07-07T11:59:30Z",
+            token_budget=1000,
+            budget_used_pct=100.0,
+            budget_warning=True,
+        ),
+        Resident(nick="thor-codex", server="thor", state="idle"),
+    ]
+
+
+def _free_port() -> int:
+    """Grab a port nothing is listening on (bind, read, close)."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _get(port: int, path: str = "/residents.json") -> tuple[int, dict, bytes]:
+    """GET the path; return (status, headers, body) even for error statuses."""
+    req = urllib.request.Request(f"http://127.0.0.1:{port}{path}")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, dict(resp.headers), resp.read()
+    except urllib.error.HTTPError as exc:
+        with exc:
+            return exc.code, dict(exc.headers), exc.read()
+
+
+@pytest.fixture
+def overview_server():
+    """Factory: start the overview HTTP server, optionally injecting the
+    residents fetch seam.
+
+    ``_start(fetch=...)`` binds the handler exactly like ``serve_web`` does
+    (via ``_make_overview_handler``), overrides the ``_fetch_residents``
+    seam when a ``fetch`` callable is given, pins the deterministic-time
+    seam to ``FIXED_NOW``, and returns the listening port.
+    """
+    running: list[tuple[HTTPServer, threading.Thread]] = []
+
+    def _start(fetch=None, irc_port: int = 6667):
+        handler_cls = _make_overview_handler(
+            "127.0.0.1",
+            irc_port,
+            "testserv",
+            None,
+            None,
+            4,
+            5,
+        )
+        if fetch is not None:
+            handler_cls._fetch_residents = lambda self: fetch()
+        handler_cls.residents_now = FIXED_NOW
+        httpd = HTTPServer(("127.0.0.1", 0), handler_cls)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        running.append((httpd, thread))
+        return httpd.server_address[1]
+
+    yield _start
+
+    for httpd, thread in running:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Supported: 200 + canonical payload
+# ---------------------------------------------------------------------------
+
+
+def test_supported_returns_200_application_json(overview_server):
+    port = overview_server(fetch=_fixture_residents)
+    status, headers, body = _get(port)
+    assert status == 200
+    assert headers["Content-Type"] == "application/json"
+    payload = json.loads(body)
+    assert payload["supported"] is True
+    assert [r["nick"] for r in payload["residents"]] == ["spark-claude", "thor-codex"]
+
+
+def test_byte_compatible_with_canonical_serializer(overview_server):
+    """THE t7 acceptance criterion: endpoint body == json.dumps of the one
+    canonical serializer over the same fixtures — the CLI --json emits the
+    same call, so the two surfaces can never drift."""
+    port = overview_server(fetch=_fixture_residents)
+    _status, _headers, body = _get(port)
+    expected = json.dumps(serialize_residents(_fixture_residents(), True, now=FIXED_NOW))
+    assert body == expected.encode()
+
+
+# ---------------------------------------------------------------------------
+# No PRESENCE surface: 200 + supported:false (known state, not an error)
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_presence_degrades_to_supported_false(overview_server):
+    def _raise_unsupported():
+        raise PresenceUnsupportedError("server replied 421 to the PRESENCE query")
+
+    port = overview_server(fetch=_raise_unsupported)
+    status, headers, body = _get(port)
+    assert status == 200
+    assert headers["Content-Type"] == "application/json"
+    # Byte-for-byte the serializer's degraded payload as well.
+    expected = json.dumps(serialize_residents([], False, now=FIXED_NOW))
+    assert body == expected.encode()
+    payload = json.loads(body)
+    assert payload["supported"] is False
+    assert payload["residents"] == []
+
+
+# ---------------------------------------------------------------------------
+# Culture server unreachable: 503 + structured error, never a bare 500
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_server_returns_503_structured_error(overview_server):
+    def _raise_refused():
+        raise ConnectionRefusedError("connection refused")
+
+    port = overview_server(fetch=_raise_refused)
+    status, headers, body = _get(port)
+    assert status == 503
+    assert headers["Content-Type"] == "application/json"
+    err = json.loads(body)
+    assert set(err) == {"code", "message", "remediation"}
+    assert err["code"] == 503
+    assert "cannot connect" in err["message"]
+    assert err["remediation"]
+    assert b"Traceback" not in body
+
+
+def test_unreachable_server_oserror_also_503(overview_server):
+    """Plain OSError (DNS failure, timeout subclass, ...) degrades the same
+    way — the downstream irc-lens console must never see a 500."""
+
+    def _raise_oserror():
+        raise OSError("no route to host")
+
+    port = overview_server(fetch=_raise_oserror)
+    status, _headers, body = _get(port)
+    assert status == 503
+    assert set(json.loads(body)) == {"code", "message", "remediation"}
+
+
+def test_real_fetch_seam_unreachable_end_to_end(overview_server):
+    """No seam override: the production ``_fetch_residents`` queries the
+    bound (dead) IRC port for real and the refused connection surfaces as
+    the structured 503 — not an unhandled traceback in the handler."""
+    port = overview_server(irc_port=_free_port())
+    status, headers, body = _get(port)
+    assert status == 503
+    assert headers["Content-Type"] == "application/json"
+    err = json.loads(body)
+    assert set(err) == {"code", "message", "remediation"}
+
+
+# ---------------------------------------------------------------------------
+# Routing: only the exact path is the JSON endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_query_string_is_ignored_for_routing(overview_server):
+    port = overview_server(fetch=_fixture_residents)
+    status, headers, _body = _get(port, "/residents.json?refresh=1")
+    assert status == 200
+    assert headers["Content-Type"] == "application/json"

--- a/tests/test_residents_endpoint.py
+++ b/tests/test_residents_endpoint.py
@@ -7,11 +7,13 @@ byte-compatibility: the endpoint body must be exactly ``json.dumps`` of
 one schema, verified here by diffing the endpoint bytes against a direct
 serializer call over the same fixtures.
 
-Response contract (feeds the irc-lens t8 brief — no 500s, ever):
+Response contract (feeds the irc-lens t8 brief — no bare 500s, ever):
 
 * presence supported          -> 200, canonical payload
 * no PRESENCE surface         -> 200, ``supported: false`` payload
 * culture server unreachable  -> 503, ``{code, message, remediation}``
+* anything unexpected         -> 500, ``{code, message, remediation}``
+  (defensive: still structured JSON, never a traceback page)
 """
 
 from __future__ import annotations
@@ -22,7 +24,7 @@ import threading
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
-from http.server import HTTPServer
+from http.server import ThreadingHTTPServer
 
 import pytest
 
@@ -31,6 +33,7 @@ from culture_core.resource_view import (
     PresenceUnsupportedError,
     Resident,
     serialize_residents,
+    to_json,
 )
 
 FIXED_NOW = datetime(2026, 7, 7, 12, 0, 0, tzinfo=timezone.utc)
@@ -84,11 +87,13 @@ def overview_server():
     residents fetch seam.
 
     ``_start(fetch=...)`` binds the handler exactly like ``serve_web`` does
-    (via ``_make_overview_handler``), overrides the ``_fetch_residents``
-    seam when a ``fetch`` callable is given, pins the deterministic-time
-    seam to ``FIXED_NOW``, and returns the listening port.
+    (via ``_make_overview_handler`` on a ``ThreadingHTTPServer`` — the same
+    server class production uses since the F8 fix), overrides the
+    ``_fetch_residents`` seam when a ``fetch`` callable is given, pins the
+    deterministic-time seam to ``FIXED_NOW``, and returns the listening
+    port.
     """
-    running: list[tuple[HTTPServer, threading.Thread]] = []
+    running: list[tuple[ThreadingHTTPServer, threading.Thread]] = []
 
     def _start(fetch=None, irc_port: int = 6667):
         handler_cls = _make_overview_handler(
@@ -103,7 +108,7 @@ def overview_server():
         if fetch is not None:
             handler_cls._fetch_residents = lambda self: fetch()
         handler_cls.residents_now = FIXED_NOW
-        httpd = HTTPServer(("127.0.0.1", 0), handler_cls)
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
         thread = threading.Thread(target=httpd.serve_forever, daemon=True)
         thread.start()
         running.append((httpd, thread))
@@ -133,12 +138,14 @@ def test_supported_returns_200_application_json(overview_server):
 
 
 def test_byte_compatible_with_canonical_serializer(overview_server):
-    """THE t7 acceptance criterion: endpoint body == json.dumps of the one
-    canonical serializer over the same fixtures — the CLI --json emits the
-    same call, so the two surfaces can never drift."""
+    """THE t7 acceptance criterion: endpoint body == ``to_json`` (the one
+    canonical dumps site in culture_core.resource_view) of the one canonical
+    serializer over the same fixtures — the CLI --json emits the literal
+    same ``to_json(serialize_residents(...))`` call, so the two surfaces can
+    never drift (test_residents_cli.py asserts the CLI side)."""
     port = overview_server(fetch=_fixture_residents)
     _status, _headers, body = _get(port)
-    expected = json.dumps(serialize_residents(_fixture_residents(), True, now=FIXED_NOW))
+    expected = to_json(serialize_residents(_fixture_residents(), True, now=FIXED_NOW))
     assert body == expected.encode()
 
 
@@ -207,6 +214,71 @@ def test_real_fetch_seam_unreachable_end_to_end(overview_server):
     assert headers["Content-Type"] == "application/json"
     err = json.loads(body)
     assert set(err) == {"code", "message", "remediation"}
+
+
+# ---------------------------------------------------------------------------
+# Unexpected exception: structured 500, never a bare traceback page
+# ---------------------------------------------------------------------------
+
+
+def test_unexpected_exception_returns_structured_500(overview_server):
+    """Anything unexpected escaping the fetch seam (the F3 class of bug,
+    defensively) must yield the structured {code, message, remediation}
+    JSON 500 — the irc-lens console must never see a traceback page."""
+
+    def _raise_unexpected():
+        raise ZeroDivisionError("division by zero")
+
+    port = overview_server(fetch=_raise_unexpected)
+    status, headers, body = _get(port)
+    assert status == 500
+    assert headers["Content-Type"] == "application/json"
+    err = json.loads(body)
+    assert set(err) == {"code", "message", "remediation"}
+    assert err["code"] == 500
+    assert err["remediation"]
+    assert b"Traceback" not in body
+
+
+# ---------------------------------------------------------------------------
+# Threading: a slow /residents.json fetch must not stall other requests
+# ---------------------------------------------------------------------------
+
+
+def test_slow_fetch_does_not_stall_other_requests(overview_server):
+    """The overview server is a ThreadingHTTPServer (F8): each residents
+    request runs a fresh IRC connect+register that can take seconds, and on
+    the old single-threaded HTTPServer one slow fetch blocked every other
+    page load. Prove a second request completes while the first is stuck."""
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[int] = []
+
+    def _fetch():
+        calls.append(1)
+        if len(calls) == 1:
+            started.set()
+            release.wait(timeout=10)
+        return _fixture_residents()
+
+    port = overview_server(fetch=_fetch)
+    slow_result: dict = {}
+    slow_thread = threading.Thread(
+        target=lambda: slow_result.update(status=_get(port)[0]), daemon=True
+    )
+    slow_thread.start()
+    try:
+        assert started.wait(timeout=5), "first request never reached the fetch seam"
+        # While the first request is blocked inside its fetch, a second
+        # request must still be served (would hang until timeout on a
+        # single-threaded server).
+        status, _headers, _body = _get(port)
+        assert status == 200
+        assert "status" not in slow_result, "slow request finished too early"
+    finally:
+        release.set()
+        slow_thread.join(timeout=10)
+    assert slow_result.get("status") == 200
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ mcp = [
 
 [[package]]
 name = "agentirc-cli"
-version = "9.11.0"
+version = "9.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -43,9 +43,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/c5/86516359c3339bc2110384a1bfed7684d142da107bc28f448de0c64647ca/agentirc_cli-9.11.0.tar.gz", hash = "sha256:f1b7ff73df56157189206bfc4703558c61575ae5904d6feee9284c30ba2bd373", size = 555315, upload-time = "2026-07-03T06:06:01.605Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/49/e37176340115e3faffb6ad6686621933e4d483c05fe9cd773c1d28f562c5/agentirc_cli-9.12.0.tar.gz", hash = "sha256:8cb3d5e612dec68832cd7a9134bc7e4d0f95d6d21e59562814a07681148ae90f", size = 603040, upload-time = "2026-07-07T06:14:07.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/b4/d6692a43b119c2ac9f79c3132d0efd41e1656ecbfebb1fde0b74b079e525/agentirc_cli-9.11.0-py3-none-any.whl", hash = "sha256:082759baeef6c52eaca9b57350bcea423fb5ff9f6565d72b3a27935075661a91", size = 171805, upload-time = "2026-07-03T06:06:00.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/c38c40f9e9d19458cf3af8e35d2e017b448a10fcbeae8f9a6f47bfa5816b/agentirc_cli-9.12.0-py3-none-any.whl", hash = "sha256:2edab20b9be738cb02786ed8824d7acee7c79eefc8967fa5cdf10e8641d4b919", size = 181860, upload-time = "2026-07-07T06:14:06.039Z" },
 ]
 
 [[package]]
@@ -715,16 +715,16 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "agentfront", specifier = ">=0.20,<0.21" },
-    { name = "agentirc-cli", specifier = ">=9.11.0,<10" },
+    { name = "agentirc-cli", specifier = ">=9.12.0,<10" },
     { name = "agex-cli", specifier = ">=0.13,<0.14" },
     { name = "agtag", specifier = ">=0.1,<1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "cultureagent", specifier = "~=0.12.0" },
-    { name = "cultureagent", extras = ["backend-acp"], marker = "extra == 'acp'", specifier = "~=0.12.0" },
-    { name = "cultureagent", extras = ["backend-claude"], marker = "extra == 'claude'", specifier = "~=0.12.0" },
-    { name = "cultureagent", extras = ["backend-claude", "backend-acp", "backend-copilot", "backend-colleague"], marker = "extra == 'all-backends'", specifier = "~=0.12.0" },
-    { name = "cultureagent", extras = ["backend-colleague"], marker = "extra == 'colleague'", specifier = "~=0.12.0" },
-    { name = "cultureagent", extras = ["backend-copilot"], marker = "extra == 'copilot'", specifier = "~=0.12.0" },
+    { name = "cultureagent", specifier = "~=0.13.0" },
+    { name = "cultureagent", extras = ["backend-acp"], marker = "extra == 'acp'", specifier = "~=0.13.0" },
+    { name = "cultureagent", extras = ["backend-claude"], marker = "extra == 'claude'", specifier = "~=0.13.0" },
+    { name = "cultureagent", extras = ["backend-claude", "backend-acp", "backend-copilot", "backend-colleague"], marker = "extra == 'all-backends'", specifier = "~=0.13.0" },
+    { name = "cultureagent", extras = ["backend-colleague"], marker = "extra == 'colleague'", specifier = "~=0.13.0" },
+    { name = "cultureagent", extras = ["backend-copilot"], marker = "extra == 'copilot'", specifier = "~=0.13.0" },
     { name = "github-copilot-sdk", marker = "extra == 'all-backends'", specifier = "==0.2.0" },
     { name = "github-copilot-sdk", marker = "extra == 'copilot'", specifier = "==0.2.0" },
     { name = "irc-lens", specifier = ">=0.9.1,<1.0" },
@@ -761,7 +761,7 @@ dev = [
 
 [[package]]
 name = "cultureagent"
-version = "0.12.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agentirc-cli" },
@@ -772,9 +772,9 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/0d/1f4d10ad022c4e4031fc78fa840601a6c82ea397fd2c621a4c1c4e8316f0/cultureagent-0.12.0.tar.gz", hash = "sha256:c0c0ad154a838fe04f0f71e1076991434dbe09cee9160efef0db6196104d76c5", size = 612293, upload-time = "2026-07-02T18:44:38.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/29/2b5f8ef32912a2df594b3d6c6827140ed9b8c75510a1efcabc615b24cd4f/cultureagent-0.13.0.tar.gz", hash = "sha256:44e2ff3f83f48f2ac82dc665f88290a4580a57a2766a28f2be377a9cd5f63821", size = 649398, upload-time = "2026-07-07T04:51:44.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/b1/fccc0b5b27e93f529e75d51213f1afae13aa325ea3a373fd7a6c0555ec08/cultureagent-0.12.0-py3-none-any.whl", hash = "sha256:2dc7653cd355cfc4dfb6790c8bae1dc6d1671e454e2418c84902dc2a40eb4a25", size = 203708, upload-time = "2026-07-02T18:44:37.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ab/cb3dd698945988fd2ea22cdb3f09e4f31712cf67aaef17775f74b8164a75/cultureagent-0.13.0-py3-none-any.whl", hash = "sha256:792c3fe6ed343fc5cfca16a9c3cd611ea68652464ccc6e7ce7342f21bb656609", size = 212302, upload-time = "2026-07-07T04:51:43.158Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "culture"
-version = "14.4.1"
+version = "14.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "agentfront" },


### PR DESCRIPTION
## Summary

Implements **resident presence + the mesh resource view, observe-only v1** — the culture-side legs of the converged spec (`docs/specs/2026-07-06-culture-now-knows-when-its-residents-are-busy-ever.md`, plan tasks t1/t2/t5/t7 + the three hand-off briefs t3/t4/t8). Built via `/assign-to-workforce` waves in isolated worktrees with TDD-gated merges, then a 6-angle verified review pass with its fix wave folded in.

### What ships

- **`protocol/extensions/presence.md`** (t1) — the PRESENCE extension page: publish verb + structured payload (six-state enum `idle|listening|thinking|working|draining|offline`, each state tied to an observable harness boundary), heartbeat/stale-T semantics, token counters sharing the `culture.harness.llm.tokens.*` counting source, and the **anticipated query surface** (`PRESENCE LIST` → `PRESENCELIST`/`PRESENCEEND`, `421` degrade) proposed to agentirc. v1 never relays presence to clients — the resource view is the read surface.
- **Config schema** (t2) — per-agent `token_budget` / `token_budget_warn_pct` in `culture.yaml` (warn-only; invalid values log a warning and are ignored — a budget typo can never stop an agent from loading) and the `presence:` policy block (`heartbeat_interval_seconds=30`, `stale_after_seconds=90`) in `server.yaml` with strict, actionable validation.
- **`culture residents`** (t5) — live resource-view table + `--json`; graceful degrade (`supported: false`, exit 0) against today's PRESENCE-less agentirc; config errors, unreachable server, and stalled streams each get distinct, actionable errors. Transport isolated behind one adapter seam pending agentirc#53.
- **`GET /residents.json`** (t7) — on the overview web server (upgraded to `ThreadingHTTPServer` so a slow probe can't stall page loads), byte-compatible with the CLI by construction: both surfaces emit `to_json(serialize_residents(...))` from `culture_core/resource_view.py`, verified by diff-tests. Unreachable → structured 503; unexpected errors → structured 500; never a bare traceback.
- **`docs/resident-presence.md`** — configuration, CLI, endpoint contract, JSON schema, and honest spend semantics (shipped: per-connection cumulative; target: per-UTC-day server-side tally, lands with agentirc#53). Reference pages (`docs/reference/cli/*`, `docs/reference/server/config.md`) updated.

### Sibling hand-offs (posted)

- agentirc#53 — IRCd PRESENCE verb, per-client state, S2S propagation, stale-busy watchdog, query surface (anticipated shape proposed in a follow-up comment)
- cultureagent#47 — shared-harness emitter at observable boundaries, one token-counting source, all-backends parity by construction
- irc-lens#53 — residents console page behind CF Access with no-500 degrade

### Deferred by design

Plan task **t6** (live spark-mesh verification battery + observe-only diff audit) gates on the agentirc/cultureagent releases and the corresponding culture floor bumps (plan risk r4). Until then every real server answers `supported: false` — a known mesh state, not an error.

### Review already applied

A 6-angle review (line-scan, removed-behavior, cross-file trace, reuse/simplify, efficiency/altitude, conventions) + doc-test-alignment audit ran before this PR; 12 verified findings were fixed in the final merge wave — including a budget-validation cascade that could drop agents from the manifest and abort `culture doctor`, a ZeroDivision reachable through legacy `agents.yaml`, TZ-dependent serialization, and stalled-stream-vs-unsupported conflation.

## Test plan

- [x] Full suite: 1910 passed, 1 pre-existing Playwright skip (`/run-tests -p`)
- [x] Byte-compatibility diff-tests: CLI `--json` ≡ endpoint body ≡ `to_json(serialize_residents(...))`
- [x] Live smoke against the running spark server: table notice + `supported: false` JSON, exit 0
- [x] backend-parity guard: PASS (no backend-specific surface touched; emitter is cultureagent's leg)
- [ ] t6 live-mesh battery after sibling floor bumps (tracked in the plan)

- culture (Claude)
