### PR TITLE
Add devague/colleague agent skills: scope, deviate, summarize-delivery

### DIFF
--- a/.claude/skills/challenge/SKILL.md
+++ b/.claude/skills/challenge/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: challenge
+description: >
+  Run a risk-scaled blind-spot discovery pass over a converged, exported
+  frame BETWEEN /think and /spec-to-plan (the seventh origin skill, third
+  leg in flow order): pressure-test the spec through structured lenses,
+  route every finding back through the existing deterministic moves as
+  proposed-only content the human adjudicates, and on a clean pass record
+  the examined lenses/surfaces and residual uncertainty — never a claim
+  that there are no unknown unknowns. Use when the user says "challenge
+  this spec", "blind-spot pass", "pressure-test the frame", "what are we
+  missing", "unknown unknowns", or after /think exports and before
+  `devague plan new`. Authored and maintained in agentculture/devague
+  (origin = devague); guildmaster pulls this skill from here and broadcasts
+  it to the AgentCulture mesh — it is NOT vendored from guildmaster like
+  the inbound skills here.
+type: command
+---
+
+# challenge — hunt the blind spots before the plan inherits them
+
+The skill is named **`challenge`**; it is the **blind-spot discovery leg** of
+the devague method — the *seventh* origin skill, sitting *third* in flow
+order, between the spec leg and the plan leg:
+
+```text
+scope -> think -> challenge -> spec-to-plan -> assign-to-workforce -> deviate -> summarize-delivery
+```
+
+Before this leg existed, a frame could converge on precisely stated claims
+while the original framing was still incomplete: open questions only captured
+uncertainty someone had already noticed — **nothing actively hunted omitted
+dimensions, hidden dependencies, or assumptions shared by everyone in the
+frame, and no record existed of which surfaces were ever examined**
+(issue 73's problem statement). Strictly speaking, an unknown unknown cannot
+be listed directly — once articulated, it becomes a known unknown. The useful
+capability is therefore to **raise the odds of discovering blind spots and
+lower the cost of the surprises that remain**, not to promise their
+elimination.
+
+That is the surprise-cost rationale: an articulated blind spot becomes a
+known unknown the method can manage; an unexamined one surfaces later as a
+mid-run `/deviate` or a production surprise. Discovery *before* planning is
+cheaper than either — a proposed claim the human rejects costs minutes; the
+same gap found mid-fan-out stops a wave, and found in production it costs
+whatever the blast radius costs.
+
+This doc is written for two readers. The **operator** — the main agent — runs
+the pass: sweeps the lenses, drives the deterministic CLI move by move, and
+proposes findings. The **gate-owning human** adjudicates: every finding lands
+`proposed`, and confirming, rejecting, or resolving it is the human exercising
+the existing **spec gate** (gate 1) — challenge adds no fourth gate, mirroring
+how `/deviate` amends gate 2 rather than adding one.
+
+## When it runs
+
+The timing is a recorded decision — quote it, don't re-derive it:
+
+> the challenge pass runs after /think exports: challenge the converged,
+> exported frame before `devague plan new`; findings reopen the frame,
+> reconverge, and re-export the same dated spec file — /think stays
+> self-contained (resolves q1)
+
+— decision c17 in `docs/specs/2026-07-15-challenge-skill.md`.
+
+Concretely: `/think` finishes its own arc (converge, export) untouched. Then
+`/challenge` pressure-tests the exported spec **before** `devague plan new`
+seeds a plan from it. Findings land as proposed claims, honesty conditions,
+questions, or parks — which reopens the frame — the human adjudicates, the
+frame **reconverges**, and `devague export` **re-exports the same dated
+file** (`docs/specs/<created-date>-<slug>.md`; exports are prefixed with the
+frame's creation date, so a re-export overwrites in place rather than
+spawning a duplicate). That reconverge-and-re-export loop repeats until the
+pass's findings are all adjudicated and the spec artifact carries them.
+
+## Proportionality — scale the pass to the risk
+
+The pass is **mandatory but proportional**: lightweight for ordinary work,
+rigorous for high-risk work (integration option 1 from issue 73, per the
+issue author — a distinct operator skill, no new CLI engine until the
+workflow proves it needs one). Which work is high-risk is likewise a recorded
+decision:
+
+> the named escalation signals that deepen the pass from lightweight to
+> rigorous: migrations, security-sensitive work, distributed state, hardware,
+> destructive operations, other hard-to-reverse changes, concurrency hazards,
+> and any surface that can lose user data (resolves q3)
+
+— decision c19 in `docs/specs/2026-07-15-challenge-skill.md`.
+
+If **any** escalation signal applies, run the rigorous form: every lens,
+deliberate counter-evidence hunting, and cheap probes where they would settle
+a real question. If none applies, a lightweight sweep — one pass over the
+lenses against the exported spec, minutes not hours — satisfies the method.
+Lightweight never means skipped: even the lightest pass leaves durable
+records (see the hard rules).
+
+## The lenses
+
+Sweep the exported spec, the live frame, and the surfaces the idea touches
+through these structured lenses (from issue 73):
+
+- **adjacent systems and hidden dependencies** — what else reads, writes, or
+  assumes the thing being changed;
+- **unstated assumptions and missing counter-evidence** — what everyone in
+  the frame believes without a claim saying so, and what was never checked
+  because nobody argued the other side;
+- **overlooked actors, lifecycle stages, data flows, and failure modes** —
+  who and what the frame forgot: other users, upgrade/downgrade paths,
+  half-completed operations;
+- **security, migration, concurrency, operations, and reversibility** — the
+  classic hard surfaces, each also an escalation signal when present;
+- **missing observability, containment, rollback, and recovery paths** —
+  when the surprise happens anyway, how it is seen, bounded, and undone;
+- **cheap probes or experiments** — small, scratch-space checks that could
+  expose a surprise now instead of mid-run (probes never mutate the repo or
+  `.devague/` state).
+
+## The method
+
+1. **Confirm the entry condition.** A converged frame that `/think` has
+   already exported, and no plan seeded from it yet (`devague status` shows
+   where the frame stands; the exported spec-md is the artifact under
+   challenge).
+2. **Set the depth.** Check the idea against the c19 escalation signals
+   above. Any hit → rigorous; none → lightweight. Say which you chose and
+   why — the depth decision is part of the pass's record.
+3. **Sweep the lenses read-only.** Read the exported spec claim by claim,
+   the frame's parked vagueness and resolved questions, and the actual
+   surfaces the idea touches. Nothing mutates during the sweep; the only
+   mutations are the deterministic moves that record findings.
+4. **Route every finding through an existing move.** Use the routing table
+   below. Everything the agent proposes carries `--origin llm` and lands
+   `proposed` — the pass cannot silently convert speculation into confirmed
+   requirements.
+5. **Let the human adjudicate.** `devague review` lists every proposal with
+   ids; `devague confirm` / `devague reject` / `devague question --resolve`
+   are user-only decisions. This is the existing spec gate doing its job.
+6. **Reconverge and re-export.** `devague converge`, then `devague export` —
+   the same dated spec file now carries the adjudicated findings and the
+   pass's provenance (the exported spec renders scope entries in its
+   Scope exploration section).
+7. **On a clean pass, record the pass itself.** A sweep that finds nothing
+   still records which lenses and surfaces were examined (`devague scope`
+   entries, one per lens/surface, e.g. `challenge pass / concurrency lens:
+   devague/store.py`) and what residual uncertainty remains (`park`). A bare
+   "no issues found" is not an outcome this skill produces.
+
+## Where findings land
+
+Challenge keeps **no parallel prose-only artifact** — the frame is the
+record, and every output category from issue 73 has an existing deterministic
+move to land in:
+
+| Output category (issue 73) | What it is | Landing move |
+|----------------------------|------------|--------------|
+| known facts | something the pass established, with provenance | `capture --kind requirement` / `--kind decision` / `--kind boundary` (`--origin llm` → lands `proposed`) |
+| assumptions | beliefs the frame leaned on unstated | `capture --kind assumption --origin llm`, then pressure-test with `interrogate --honesty` / `--hard-question` / `--contradicts` |
+| known unknowns / open questions | articulated uncertainty | `question "<text>"` when it needs a user decision; `park --kind unknown_nonblocking\|unknown_blocking` when not decidable now |
+| unexamined surfaces | what this pass did not (or could not) look at | `devague scope "<surface>" --finding "<what was and wasn't examined, and why>"` |
+| residual surprise risk | uncertainty that survives the pass | `park` on the frame while speccing; `devague plan risk --kind <kind>` once the plan exists |
+| resilience measures | containment, rollback, recovery the surprise cost demands | spec-side `capture --kind requirement` / `--kind boundary`; plan-side `devague plan risk` (see below) |
+
+Every finding names the **lens and surface** it came from (the
+`challenge pass / <lens>: <surface>` convention in scope entries; provenance
+citations inside claim text). That provenance bar is how the method hunts
+blind spots **without encouraging speculative issue generation** — a finding
+you cannot trace to something you actually read is speculation, not a
+finding.
+
+## Resilience placement — spec-side or plan-side
+
+Where a resilience measure lands is a recorded decision:
+
+> resilience measures land in both spec and plan by nature: spec-side as
+> requirement/boundary claims when they change what to build, plan-side as
+> plan risks or tasks when they change how to build it — the skill coaches
+> which is which (resolves q2)
+
+— decision c18 in `docs/specs/2026-07-15-challenge-skill.md`.
+
+The coaching: ask *"does this change **what** ships, or **how** it gets
+built?"* A rollback path the user needs, a fail-closed version check, a
+containment boundary — those change the product: `capture` them spec-side as
+`requirement` / `boundary` claims so the re-exported spec carries them.
+A staging sequence, a merge-order constraint, an uncertainty the workforce
+must build around — those change the build: land them plan-side via
+`devague plan risk --kind <kind>` (blocking or nonblocking, honestly chosen)
+once `/spec-to-plan` seeds the plan, where the plan's convergence gate keeps
+blocking risks visible until resolved.
+
+## Hard rules (do not violate)
+
+- **Never conclude there are no unknown unknowns.** Not after a rigorous
+  pass, not after a clean one. The only honest clean-pass output is a record
+  of which lenses and surfaces were examined — `devague scope` entries — plus
+  the residual uncertainty that remains — `park` — so the pass leaves durable
+  provenance instead of a comforting absolute (issue 73 success criteria;
+  the anti-fabrication contract in `docs/llm-guidance.md`).
+- **LLM-origin findings stay proposed until the user confirms.** Every
+  finding the agent proposes carries `--origin llm` and lands `proposed`;
+  only the user's `confirm` makes it real. The pass must not be able to
+  silently convert speculation into confirmed requirements.
+- **Findings route through existing deterministic moves only.** `capture`,
+  `interrogate`, `question`, `park`, `devague scope`, `devague plan risk` —
+  nothing else. No parallel prose artifact, no new CLI verb, engine, or
+  state model (issue 20; issue 73's stated preference). If it didn't land in
+  a move, it didn't land.
+- **Provenance on every finding.** Name the lens and the surface it came
+  from. If you didn't read it, don't claim it — same bar as `/scope`.
+- **Proportional, never skipped.** Lightweight is the floor, not an
+  exemption; any c19 escalation signal makes the rigorous form mandatory.
+  Skipping the pass entirely is not a depth setting.
+- **Not a fourth standing gate.** The three human gates stay: exported spec,
+  implementation split plan, final PR. Challenge output is adjudicated
+  inside the existing spec gate — mirroring how `/deviate` amends gate 2
+  rather than adding one.
+- **The sweep is read-only until it routes.** Reading spec, frame, and
+  surfaces never edits files or state; probes run in scratch space. The only
+  mutations are the recording moves themselves.
+
+## Worked example
+
+Challenging the exported spec for a store-schema migration (illustrative
+slug `store-schema-v3`) — "migrations" and "any surface that can lose user
+data" are both c19 escalation signals, so the pass runs rigorous:
+
+```bash
+# Entry condition: /think exported docs/specs/2026-07-15-store-schema-v3.md
+# and no plan exists yet. Depth: rigorous (migration + data-loss signals).
+
+# adjacent-systems lens: an older installed devague reads the same store
+devague capture --origin llm --kind assumption "older installed devague binaries refuse a v3 store via the fail-closed schema_version check in devague/store.py"
+devague interrogate c9 --origin llm --honesty "a v2-reading binary pointed at a v3 store exits with the version hint, not a traceback"
+devague scope "challenge pass / adjacent-systems lens: devague/store.py schema_version gate" --finding "older binaries fail closed on v3; seeded the compat assumption" --seeds c9
+
+# failure-mode lens: the migration can die halfway
+devague capture --origin llm --kind requirement "migration writes to a temp file and renames — a killed run never leaves a half-written store"
+
+# overlooked-actors lens: needs a user decision, not a guess
+devague question "do mesh agents share one store, or does each checkout own its own?"
+
+# reversibility lens: genuinely unknown, not decidable now
+devague park "whether a v3->v2 downgrade path is ever needed" --kind unknown_nonblocking
+
+# concurrency lens found nothing — record the clean pass, not a conclusion
+devague scope "challenge pass / concurrency lens: devague/store.py + delivery_store.py" --finding "single-writer CLI, no locking today; clean pass — residual risk only if two agents ever share a checkout"
+
+# --- HUMAN adjudicates: the existing spec gate at work ---
+devague review
+devague confirm c9 h4 c10
+devague question --resolve q1 --decision "each checkout owns its own store"
+
+# Reconverge and re-export — the SAME dated file, now carrying the pass
+devague converge
+devague export
+
+# Residual risk that changes HOW to build lands plan-side once
+# /spec-to-plan seeds the plan:
+devague plan new --frame store-schema-v3
+devague plan risk "two agents sharing a checkout could interleave store writes mid-migration" --kind unknown_nonblocking
+```
+
+Every finding above is traceable to a lens and a surface; the clean lens is
+recorded as examined rather than silently dropped; and nothing the agent
+proposed became confirmed without the human's `confirm`.
+
+## After the pass — hand off to /spec-to-plan
+
+Once the frame reconverges and the same dated spec file is re-exported, the
+pass is done — the examined surfaces, residual uncertainty, and adjudicated
+findings all live in frame state and render into the spec artifact. Continue
+with `/spec-to-plan` as usual: the plan seeds from the challenged frame, and
+any residual surprise risk you routed plan-side lands via
+`devague plan risk` as first-class plan state. If a surprise still gets
+through mid-fan-out, that is `/deviate`'s job — and every approved `dN`
+deviation record is evidence for what the *next* challenge pass's lenses
+should look harder at.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, the
+*seventh* in the outbound family after `/scope`, `/think`, `/spec-to-plan`,
+`/assign-to-workforce`, `/deviate`, and `/summarize-delivery`, sitting third
+in flow order as the blind-spot discovery leg between `/think` and
+`/spec-to-plan`. guildmaster pulls it from here and broadcasts it to the
+AgentCulture mesh; because devague is upstream, it is **never re-vendored
+back** from guildmaster's re-broadcast copy. The `cite, don't import` policy
+still holds: downstream repos copy it, they don't symlink or depend on it.
+See `docs/skill-sources.md`.

--- a/.claude/skills/deviate/SKILL.md
+++ b/.claude/skills/deviate/SKILL.md
@@ -11,7 +11,7 @@ description: >
   matches reality partway through a workforce run. Authored and maintained in
   agentculture/devague (origin = devague); guildmaster pulls this skill from
   here and broadcasts it to the AgentCulture mesh — it is NOT vendored from
-  guildmaster like the other skills here.
+  guildmaster like the inbound skills here.
 type: command
 ---
 

--- a/.claude/skills/deviate/SKILL.md
+++ b/.claude/skills/deviate/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: deviate
+description: >
+  Stop an in-flight assign-to-workforce run the moment execution must diverge
+  from the confirmed plan, get explicit human approval for the divergence, and
+  record it as a first-class, append-only deviation record via `devague
+  deviate` before resuming — never fold a deviation silently into drift after
+  the fact. Use when the user says "deviate from the plan", "we need to change
+  the plan mid-run", "record a deviation", "this isn't matching the plan
+  anymore", or when a task agent discovers the confirmed plan no longer
+  matches reality partway through a workforce run. Authored and maintained in
+  agentculture/devague (origin = devague); guildmaster pulls this skill from
+  here and broadcasts it to the AgentCulture mesh — it is NOT vendored from
+  guildmaster like the other skills here.
+type: command
+---
+
+# deviate — record an approved mid-run departure from the confirmed plan
+
+The skill is named **`deviate`**; it is the **execution-time leg** of the
+devague method — the *sixth* leg, sitting between the two execution skills:
+
+```text
+scope -> think -> spec-to-plan -> assign-to-workforce -> deviate -> summarize-delivery
+```
+
+Where `/assign-to-workforce` fans out a converged plan's waves and
+`/summarize-delivery` closes the loop afterward, `/deviate` runs **during**
+the fan-out, at the exact moment reality stops matching the plan the human
+approved at gate 2 (the implementation split plan). It is not a new standing
+gate — it is the human owner of gate 2 **amending** the approved split
+mid-flight, scoped to the one deviation in front of them.
+
+The plan the user confirmed is a contract. Task agents hit constraints,
+discover a dependency was wrong, or find the acceptance criteria no longer
+make sense once code is in front of them. Until this skill existed, that
+reality either silently reshaped what got built (undocumented drift) or the
+run stalled with no recorded path forward. `/deviate` is that path: the
+departure is named, approved, and recorded **before** anyone keeps building
+against it.
+
+## The method
+
+1. **STOP the run.** The moment a task agent (or the main agent) discovers
+   the confirmed plan no longer matches what needs to happen, halt — do not
+   keep implementing against the stale contract and do not let the fan-out
+   continue past this task.
+2. **Present what, why, and what it affects.** Lay out, for the human:
+   - **what** is diverging — the specific change from the confirmed task(s);
+   - **why** — the constraint or discovery that forced it;
+   - **what it affects** — the plan item ref(s) involved (`--task`), any
+     other task ids or coverage targets it touches (`--affects`), and which
+     acceptance criteria are no longer accurate.
+3. **Get explicit human approval.** This is the one non-negotiable step. A
+   deviation is not real until a human says yes to *this specific* departure
+   — not a standing blanket permission, not an inference from silence.
+4. **Record it via `devague deviate`.** Once approved, record the deviation
+   as a first-class ledger entry (never edit the plan itself — the plan
+   stays the untouched historical contract; see `devague/delivery.py`). An
+   `--origin llm` record lands `proposed` and still needs the user's
+   `--confirm` — recording is not the same as approval landing as final.
+5. **Adjust the affected task briefs.** Update the working instructions the
+   task agent(s) are building against so they reflect the approved
+   departure, not the stale plan text.
+6. **Resume.** Only after the record exists (and, for an `llm`-origin record,
+   only after it is confirmed) does the fan-out continue.
+
+Deviations are never silently folded into drift after the fact — by the time
+`/summarize-delivery` runs, every departure from the plan already has a
+`dN` record with a reason, an approval, and an optional classification. The
+delivery summary quotes these records; it does not reconstruct drift from
+memory.
+
+## The shipped CLI surface
+
+This skill invokes the CLI directly and stays self-contained (if `devague`
+isn't on your PATH: `uv tool install devague`). Deviation state persists
+under `.devague/deliveries/<plan-slug>.json` — a peer of the plan store, keyed
+by the plan slug, and never touches the plan JSON itself.
+
+| Move | What it does |
+|------|---------------|
+| `devague deviate "<what>" --task <tN> --reason "<text>"` | Record a deviation against plan item `<tN>`. User-origin (the default) auto-approves. |
+| `devague deviate "<what>" --task <tN> --reason "<text>" --affects <ref> [<ref> ...]` | Same, also naming every other plan item ref or coverage target the deviation touches (repeatable). |
+| `devague deviate "<what>" --task <tN> --reason "<text>" --classification acceptable\|risky\|needs-follow-up` | Same, tagging the deviation with the classification the drift-entry contract consumes downstream. |
+| `devague deviate "<what>" --task <tN> --reason "<text>" --origin llm` | An LLM-proposed record; lands `proposed`, not `approved`. |
+| `devague deviate --confirm <dN>` | User-only: approve a `proposed` deviation. |
+| `devague deviate --reject <dN>` | User-only: reject a `proposed` (or any) deviation. |
+| `devague deviate --list [--json]` | Read every recorded deviation back (also the default action with no positional/flag). |
+| `devague deviate ... --plan <slug>` | Target a plan other than the current one. |
+
+`--reason` is required on every record — omitting it is refused with a hint.
+`--task` naming the plan item ref is likewise required.
+
+## Hard rules (do not violate)
+
+- **Never record a deviation the human did not approve.** `devague deviate`
+  without `--origin llm` auto-approves the instant it is run — so a
+  user-origin record IS the approval. Only run it after the human has said
+  yes to this specific departure, never preemptively "to be safe."
+- **Never continue past a refused approval.** If the human does not approve,
+  the run stays stopped on that task. Do not record the deviation anyway, do
+  not quietly implement the diverging approach, and do not advance the wave.
+- **LLM-origin records stay proposed until the user confirms.** `--origin
+  llm` lands `proposed`; only `devague deviate --confirm <dN>` (user-only)
+  makes it `approved`. Same anti-fabrication contract as every other origin
+  in the method — an agent's own proposal never self-confirms.
+- **Deviations are never silently folded into drift after the fact.** Every
+  departure from the confirmed plan gets a `dN` record at the moment it
+  happens — not reconstructed from memory when `/summarize-delivery` runs
+  later.
+- **The CLI stays non-orchestrating (issue #20).** `devague deviate` records
+  a decision the human already made; it does not spawn agents, gate merges,
+  mark tasks done, or make the approval decision itself. Recording is
+  deterministic — no LLM calls inside the CLI.
+- **This is not a fourth standing gate.** `/assign-to-workforce`'s three
+  human gates are the exported spec, the implementation split plan, and the
+  final PR. `/deviate` does not add a fourth — it is the human owner of gate
+  2 amending the approved split for one scoped, in-flight decision.
+
+## Worked example
+
+Mid-fan-out on task `t4`, the task agent discovers the acceptance criteria
+assumed a helper that task `t2` never actually shipped:
+
+```bash
+# 1. STOP — the main agent halts t4's worktree before more code lands
+#    against a criterion that can't be met as written.
+
+# 2. Present what/why/what-it-affects to the human:
+#    what:    t4's acceptance criterion 2 assumes a `--json` flag on a
+#             helper that t2 shipped without one
+#    why:     t2's scope was cut to land its wave on time
+#    affects: t4 (this task), and coverage target c9 (the criterion in
+#             question)
+
+# --- HUMAN: approves dropping the --json assumption from t4's criterion ---
+
+# 3. Record the approved deviation
+devague deviate "drop the --json assumption from t4's acceptance criterion" \
+  --task t4 --reason "t2 shipped its helper without --json to land its wave on time" \
+  --affects t2 --affects c9 --classification acceptable
+
+# 4. Adjust t4's working brief to match what was approved, then resume the
+#    task agent against the corrected instruction.
+
+# Read the ledger back at any point:
+devague deviate --list
+devague deviate --list --json
+```
+
+If the agent had proposed the record itself (`--origin llm`), the same
+record would land `proposed` and need an explicit
+`devague deviate --confirm d1` from the user before `/summarize-delivery`
+could cite it as approved.
+
+## After recording — resume, then hand off to /summarize-delivery
+
+Once the affected task briefs are adjusted and the fan-out resumes, nothing
+further is needed from this skill — the record already lives in the delivery
+store. When the run reaches `/summarize-delivery`, that skill's Drift From
+Plan and Mid-work Decisions sections quote these records by their `dN` id
+instead of reconstructing drift from memory, so the connective tissue between
+the confirmed plan and the delivery summary is the ledger this skill wrote,
+not anyone's recollection of the run.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, the
+*sixth* in the outbound family after `/scope`, `/think`, `/spec-to-plan`,
+`/assign-to-workforce`, and `/summarize-delivery`, covering the execution-time
+leg that runs inside an `/assign-to-workforce` fan-out. guildmaster pulls it
+from here and broadcasts it to the AgentCulture mesh; because devague is
+upstream, it is **never re-vendored back** from guildmaster's re-broadcast
+copy. The `cite, don't import` policy still holds: downstream repos copy it,
+they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -158,8 +158,10 @@ LLM-proposed claims there, as always.
 ## Provenance
 
 This is a **first-party** skill — its origin is `agentculture/devague`, the
-*fourth* in the outbound family after `/think`, `/spec-to-plan`, and
-`/assign-to-workforce`, covering the pre-frame exploration leg. guildmaster
-pulls it from here and broadcasts it to the AgentCulture mesh. The
+*fourth* authored in the outbound family (after `/think`, `/spec-to-plan`, and
+`/assign-to-workforce`) but the **opening leg** of the flow, covering the
+pre-frame exploration that runs before `/think`. guildmaster pulls it from here
+and broadcasts it to the AgentCulture mesh; because devague is upstream, it is
+**never re-vendored back** from guildmaster's re-broadcast copy. The
 `cite, don't import` policy still holds: downstream repos copy it, they don't
 symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/scope/SKILL.md
+++ b/.claude/skills/scope/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: scope
+description: >
+  Explore the scope of a vague idea BEFORE framing it into a spec (the
+  idea→scope leg; the optional opening move ahead of /think). Survey the
+  surfaces the idea touches — code, docs, skills, CI, sibling repos — and seed
+  the coming Announcement Frame with boundary, non-goal, and assumption claims
+  that cite what was actually explored (provenance, not generic disclaimers).
+  Use when the user says "explore scope", "scope this idea", "what does this
+  touch", "map the scope", "scope exploration", or when an idea touches an
+  existing codebase and speccing it cold would mean guessing its boundaries.
+  Hand off to the sibling /think skill to build the frame. Authored and
+  maintained in agentculture/devague (origin = devague); guildmaster pulls this
+  skill from here and broadcasts it to the AgentCulture mesh — it is NOT
+  vendored from guildmaster like the inbound skills here.
+type: command
+---
+
+# scope — explore what an idea touches before you frame it
+
+The skill is named **`scope`**; it is the **opening leg** of the devague method
+— run it *before* the sibling **`/think`** skill frames an idea into a spec.
+Where `/think` converges on *what* to build, `/scope` grounds *where the idea
+lives*: which surfaces it touches, which it must not, and what is genuinely
+unknown — so the frame starts from explored territory instead of guesses.
+
+This comes from the sharper end-to-end method spec (devague#53): scope grounded
+up front means convergence measures real coverage instead of vibes. The
+exploration itself is **agent-side work** — the devague CLI stays deterministic
+and never explores anything (#20).
+
+## When to use — and when to skip
+
+Use `/scope` when the idea touches an existing codebase or ecosystem: a feature
+in a real repo, a process change across skills, anything where boundaries are
+discoverable rather than invented.
+
+**Skip it freely for small ideas.** Scope exploration is *not* a mandatory
+first stage — the move-driven adaptive arc stays intact, and an idea that fits
+in one announcement can go straight to `/think`. (This is a recorded non-goal
+of the method: no wizard.)
+
+## The method
+
+1. **Enumerate candidate surfaces.** List what the idea *might* touch: source
+   packages, CLI verbs, renderers, schemas, tests, docs, skills, CI workflows,
+   sibling repos. `git ls-files` and the repo's `CLAUDE.md` are the usual map.
+2. **Explore each surface read-only.** Read enough of each candidate to decide:
+   touched, not touched, or unknown. Exploration never mutates anything —
+   no edits, no state changes, no CLI moves yet.
+3. **Classify every finding.** Each explored surface yields one of:
+   - **in scope** — the idea changes it → becomes a `requirement` or
+     `assumption` claim in the frame;
+   - **out of scope** — the idea must not change it → becomes a `boundary` or
+     `non_goal` claim;
+   - **genuinely unknown** — can't tell without a decision → becomes a `park`
+     (open vagueness) or a `question` (pending user decision).
+4. **Record findings on the frame, with provenance.** Start the frame with
+   `devague new "<announcement>" --title "<short>"` (this is also `/think`'s
+   first move) — scope entries live on the frame, so it must exist first.
+   Record each explored surface as a first-class finding:
+   `` `devague scope "<surface>" --finding "<text>" [--seeds <claim-id> ...]` ``
+   — text that **cites the surface explored** ("the CLI stays deterministic
+   per issue 20; scope exploration is agent-side" beats "we won't overreach").
+   Capture the claim it seeded first (`capture --kind ...`), then pass its id
+   to `--seeds` — an unknown seed id is refused with a hint. Provenance, not
+   generic disclaimers: a reviewer should be able to trace every boundary claim
+   back to something you read.
+
+## How findings land (the shipped surface)
+
+This skill invokes the CLI directly and stays self-contained (if `devague`
+isn't on your PATH: `uv tool install devague`).
+
+The **primary** landing surface is the deterministic `devague scope` move,
+shipped in task t3 of the committed sharper-end-to-end-method plan
+(`docs/plans/2026-07-01-devague-ships-a-sharper-end-to-end-method-a-guided.md`,
+devague#53). It records an explored surface + finding as first-class frame
+state (`Frame.scope_entries` / `ScopeEntry`: `id` (`sN`), `surface`, `finding`,
+`seeds`) — deterministic recording only, no LLM calls, no subprocess, no
+filesystem exploration inside the CLI. Like `capture`, it needs a frame to
+already exist, so run `devague new` first:
+
+| Move | What it does |
+|------|--------------|
+| `devague scope "<surface>" --finding "<text>"` | Record a finding on the current frame. |
+| `devague scope "<surface>" --finding "<text>" --seeds <claim-id> [<claim-id> ...]` | Record a finding, linking it to the claim id(s) it went on to seed. An unknown seed id is refused with a hint (`run 'devague show' to see valid claim ids`). |
+| `devague scope --list [--json]` | Read every recorded entry back. |
+
+Boundary / non-goal / in-scope claims still land the same way they always
+did, through the normal frame moves — `devague scope` documents *what surface
+you explored and what you learned*, `capture` records *the claim that
+followed*:
+
+| Finding | Move |
+|---------|------|
+| in scope (the idea changes this) | `capture --kind requirement` / `--kind assumption` (with `--origin llm` if you proposed it) |
+| out of scope (must not change) | `capture --kind boundary` / `--kind non_goal` |
+| genuinely unknown, needs a user decision | `question "<text>"` (later `question --resolve <qid> --decision "<text>"`) |
+| genuinely unknown, not decidable now | `park "<text>" --kind unknown_blocking\|unknown_nonblocking` |
+
+## Hard rules (do not violate)
+
+- **Exploration is read-only.** Surveying scope never edits files, never
+  mutates frame state, never runs a mutating CLI move.
+- **Provenance in every seeded claim.** A scope-derived claim cites what was
+  explored. If you didn't read it, don't claim it.
+- **LLM proposals stay proposed.** Findings you capture with `--origin llm`
+  land `proposed`; the user confirms. Same anti-fabrication contract as
+  `/think`.
+- **Don't become a wizard.** Scope exploration is optional-by-size and
+  adaptive. Never block a small idea on a survey it doesn't need.
+
+## Worked example
+
+Scoping "devague exports should carry per-item instructions" against the
+devague repo itself:
+
+```bash
+# 1–2. enumerate + explore (read-only)
+git ls-files devague/ | head -30       # the CLI package map
+# read: devague/frame.py (claim model), devague/render/spec_md.py (renderer),
+#       docs/spec-contract.md (schema contract), .claude/skills/think/SKILL.md
+
+# 3. start the frame (also /think's first move — scope entries live on it)
+devague new "devague exports carry per-item instructions" --title "per-item instructions"
+
+# 4. capture each finding as a claim, then record the scope entry that seeded it
+devague capture --origin llm --kind requirement "claims gain an optional instruction field — devague/frame.py claim model + docs/spec-contract.md schema both need a bump"
+devague scope "devague/frame.py" --finding "claim model needs an optional instruction field per docs/spec-contract.md's schema contract" --seeds c2
+
+devague capture --origin llm --kind boundary "render/spec_md.py renders instructions verbatim; absent instructions render nothing — the renderer never fabricates filler"
+devague scope "render/spec_md.py" --finding "renderer must render instructions verbatim; absent instructions render nothing — never fabricate filler" --seeds c3
+
+devague capture --origin llm --kind non_goal "no LLM calls land inside the CLI (issue 20) — instruction text is authored by the operator/user, never generated in-CLI"
+devague scope "issue 20 (no LLM calls in-CLI)" --finding "instruction text is authored by the operator/user, never generated in-CLI" --seeds c4
+
+devague question "do instructions attach to frame claims, plan tasks, or both?"
+devague scope --list   # read every recorded finding back, with its seeded claim ids
+```
+
+Every claim above names the file or issue that was actually read — that is the
+provenance bar. Note the order: `--seeds` needs the claim id to already exist,
+so `capture` runs first and the matching `scope` call cites it back.
+
+## After scoping — hand off to /think
+
+The recorded scope entries and the claims captured alongside them both live on
+the same frame — there is nothing separate to export. `devague scope --list`
+is the durable, citable record of what was explored; a converged frame's
+exported spec-md also renders a `## Scope exploration` section from the same
+entries (surface, finding, and seeded claim ids), so the provenance survives
+into the buildable artifact (#53 t6). When the survey is done, continue with
+`/think`'s remaining moves (`interrogate`, `confirm`/`reject`, `converge`,
+`export`) to take the frame the rest of the way. The user confirms
+LLM-proposed claims there, as always.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, the
+*fourth* in the outbound family after `/think`, `/spec-to-plan`, and
+`/assign-to-workforce`, covering the pre-frame exploration leg. guildmaster
+pulls it from here and broadcasts it to the AgentCulture mesh. The
+`cite, don't import` policy still holds: downstream repos copy it, they don't
+symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/summarize-delivery/SKILL.md
+++ b/.claude/skills/summarize-delivery/SKILL.md
@@ -1,0 +1,440 @@
+---
+name: summarize-delivery
+description: >
+  Close the loop after an assign-to-workforce run by turning what actually
+  happened into an accountability artifact — planned versus actual delivery,
+  mid-work decisions, plan drift, evidence-backed delivery claims, and remaining
+  work. The plan the user confirmed is the contract; this skill records where
+  execution obeyed it, where it changed, and what is genuinely safe to claim as
+  delivered. Runs on complete, partial, AND failed runs — failure is reported
+  faithfully, never smoothed over. Use when the user says "summarize delivery",
+  "delivery summary", "wrap up", "close the loop", "what did we actually ship",
+  or "plan versus actual", or after assign-to-workforce merges (or fails to
+  merge) a plan's waves. Authored and maintained in agentculture/devague
+  (origin = devague); guildmaster pulls this skill from here and broadcasts it
+  to the AgentCulture mesh — it is NOT vendored from guildmaster like the
+  inbound skills here.
+type: command
+---
+
+# summarize-delivery — turn a workforce run into an accountability artifact
+
+The skill is named **`summarize-delivery`**; it is the **delivery-side closure
+leg** that closes the devague method's six-leg flow:
+
+```text
+scope -> think -> spec-to-plan -> assign-to-workforce -> deviate -> summarize-delivery
+```
+
+It runs *after* the sibling **`/assign-to-workforce`** skill has executed (or
+attempted to execute) a converged plan — and after any **`/deviate`** records
+that run produced, since `/deviate` slots in **between**
+`/assign-to-workforce` and this skill, recording approved mid-run departures
+the moment they happen during the fan-out. Where `/assign-to-workforce` takes
+the plan to delivery, this skill *summarizes* that delivery: it separates
+what was **planned** from what was **actually delivered**, records the
+**mid-work decisions** and **plan drift** the execution produced — quoting
+`/deviate`'s approved `dN` records as the recorded ground truth wherever they
+cover an item — states **delivery claims** with evidence and confidence, and
+names the **remaining work**.
+
+The plan the user confirmed is a **contract, not a fiction**. Agents make
+mid-work decisions, hit constraints, cut scope, and produce delivery claims
+that were never in the plan. Until now the flow had no wrap-up leg to record
+any of it. This skill is that leg: the summary records where execution obeyed
+the contract, where it changed, and what is actually safe to claim as
+delivered.
+
+It is **not** a polite progress report and **not** a restatement of the plan.
+It is an accountability artifact — auditable by a human who never watched the
+run.
+
+## The three readers
+
+Write for exactly these three, and no one who was present for the execution:
+
+1. **The operator (main agent)** closing a workforce run — assembling the
+   ground truth of what merged, what failed, and what still needs doing.
+2. **The human owner at the final PR gate** — who uses the artifact as the
+   review map: every delivery claim traces to a plan task or an explicit drift
+   entry, so the plan-versus-actual comparison is mechanical, not rhetorical.
+3. **Any later reader** who needs to know what actually shipped without
+   replaying the execution transcript. The artifact is committed and
+   self-contained; nothing in it depends on unrecorded memory of the run.
+
+## Method-only — no script, no CLI verb
+
+This is a **method-only** skill (v1), modelled on `/scope` at its birth: a
+`SKILL.md` with an output template and no entry-point script, no new CLI verb.
+The deterministic devague CLI surface is **unchanged** — Devague never spawns
+agents, marks tasks done, gates merges (`/assign-to-workforce` owns the TDD
+gate), or mutates delivery state. The CLI stays deterministic and
+non-orchestrating (issue
+[#20](https://github.com/agentculture/devague/issues/20)); the summary is
+agent-side work. A future devague *delivery engine* — a third structural peer
+with a delivery store and a deterministic no-overclaim gate — is parked as
+follow-up, deferred until dogfooding the method shows machine state is needed.
+
+Because there is no script, this skill invokes the read-only devague moves
+directly (if `devague` isn't on your PATH: `uv tool install devague`).
+
+## The method
+
+1. **Establish the planned-work baseline — verbatim, starting from the
+   skeleton.** Run `devague summary [--plan <slug>] [--json]` first. It
+   renders the eight-section template pre-filled, verbatim, from the plan's
+   tasks, the plan's live source frame, and the delivery (deviation) store —
+   with `<fill: ...>` placeholders standing in for everything
+   execution-dependent (run status, per-task delivery status, evidence,
+   delivery claims). Continue filling in that skeleton rather than retyping
+   it from scratch — fewer transcription errors, same verbatim-baseline rule.
+   **Fall back to hand-assembly** when `devague summary` isn't available at
+   all — the verb is missing (an older devague predates the command) or the
+   underlying state it needs can't be read (no current plan, or a delivery
+   record written by a newer devague) — by reconstructing the baseline
+   read-only via `` `devague plan show [--json]` `` and
+   `` `devague plan waves --json` ``, the same enriched payload
+   `/assign-to-workforce` fans out, keyed by task id with each task's
+   `summary`, `instruction`, `acceptance_criteria`, and `covers`. If no plan
+   state exists at all, degrade further still (see "Degrading when there is
+   no plan state"). **Whichever path was taken, say so in the artifact's
+   `baseline:` line** — one of `` `devague summary skeleton` ``,
+   `` `devague plan (hand-assembled)` ``, or
+   `` `git+PR history (no plan state)` ``. Quote task ids and summaries
+   **verbatim** into the Planned Work section either way — mirroring the
+   verbatim-brief rule in `/assign-to-workforce`. Drift is then measured
+   against the contract the user confirmed, never against a paraphrase.
+2. **Establish actual delivery.** Reconcile the baseline against what merged:
+   the merged branches, commits, and PRs of the run. **Every** plan task must
+   be accounted for as **delivered / partial / dropped / blocked**, keyed by
+   task id — 100 %, no silent omissions.
+3. **Record mid-work decisions.** Every constraint discovered, scope cut, or
+   choice made during execution that was *not* in the plan.
+4. **Classify drift against the plan.** Any plan task whose delivery differs
+   from its contract becomes a drift entry — exhaustive relative to the plan,
+   never silently normalized. Each entry names the plan item it diverges from,
+   the reason, and **exactly one** classification: `acceptable` / `risky` /
+   `needs-follow-up`.
+5. **Gather evidence, read-only.** You may run read-only verification — the
+   test suite, the linters, `git log` — to substantiate a claim *before* you
+   write it. Verification never mutates code or state. A claim you cannot
+   verify stays `unverified`.
+6. **State delivery claims with confidence + evidence.** Each claim carries a
+   confidence level (`high` / `medium` / `low` / `unverified`) and at least one
+   **resolvable** evidence pointer, or an explicit `unverified` marker. A claim
+   without evidence is `unverified` — never asserted as done.
+7. **Name the remaining work.** What is incomplete, deferred, or newly
+   discovered — including any failure and its cause.
+8. **Write the artifact and commit it.** Fill the eight-section template into a
+   committed, durable file at `docs/deliveries/<created-date>-<slug>.md` — the
+   structural peer of `docs/specs/` and `docs/plans/`. Reads of plan and frame
+   state stay read-only; producing the artifact leaves `.devague/` byte-
+   identical.
+
+## The eight-section template
+
+Fill this in verbatim — all eight sections, in this order. Every section stays
+writable for a **partial or failed** run; nothing here requires all waves
+merged, and there is no completion precondition (a run that merged zero waves
+is still a valid input).
+
+```markdown
+# Delivery Summary — <plan title>
+
+plan: `<slug>` · run: `<complete | partial | failed>` · date: `<created-date>`
+baseline: `<devague summary skeleton | devague plan (hand-assembled) | git+PR history (no plan state)>`
+
+## Intent
+
+<One paragraph: what this run set out to deliver, and the plan it executed.>
+
+## Planned Work
+
+<The plan's tasks, quoted VERBATIM from the `devague summary` skeleton (or,
+when hand-assembling, `devague plan waves --json`) — task id and summary,
+never paraphrased. When no plan state exists, quote the git/PR baseline
+instead and SAY SO here.>
+
+- `t1` — <task summary, verbatim>
+- `t2` — <task summary, verbatim>
+- ...
+
+## Actual Delivery
+
+<Every plan task accounted for — 100 %, keyed by task id — as one of
+delivered / partial / dropped / blocked.>
+
+| Plan task | Status | What actually landed |
+|-----------|--------|----------------------|
+| `t1` | delivered | <what merged> |
+| `t2` | partial | <what merged, what is missing> |
+| `t3` | blocked | <why it could not proceed> |
+
+## Mid-work Decisions
+
+<Constraints discovered, scope cuts, and choices made during execution that
+were not in the plan. When a delivery store exists for this plan, quote each
+approved deviation by its `dN` id — the record is the decision, consumed here,
+not re-litigated. A decision no record covers is still captured directly. One
+per bullet.>
+
+- `d2` — <what deviated, from the record> — <the record's reason>
+- <decision not covered by any deviation record> — <why it was made>
+
+## Drift From Plan
+
+<Every plan task whose delivery differs from its contract. Exhaustive relative
+to the plan. When a delivery store exists, an entry covered by an approved
+deviation names the plan item as `` `tN` (`dN`) `` and inherits that record's
+reason and classification verbatim. Drift NOT covered by any record is still
+recorded here exhaustively, exactly as before — never silently normalized. If
+nothing drifted, state "no drift" and back it with the task-by-task accounting
+above.>
+
+| Plan item | Reason for divergence | Classification |
+|-----------|-----------------------|----------------|
+| `t2` (`d2`) | <quoted from the `d2` record's reason> | needs-follow-up |
+| `t3` | <what changed vs. the confirmed task — no record covers this> | risky |
+
+## Evidence
+
+<The read-only checks run to substantiate the claims below: test node ids that
+ran, lint results, `git log` ranges, PR/issue numbers. This section is what
+makes every claim resolvable.>
+
+- tests: `<pytest node id>` — <pass | fail>
+- lint: `<command>` — <result>
+- commits: `<sha>..<sha>`
+- PRs / issues: <#NN, ...>
+
+## Delivery Claims
+
+<Each claim: the assertion, a confidence level, and a resolvable evidence
+pointer — or an explicit `unverified` marker. No claim is asserted as done
+without evidence.>
+
+| Claim | Confidence | Evidence |
+|-------|------------|----------|
+| <what was delivered> | high | commit `<sha>` / file `<path>` |
+| <what was delivered> | medium | PR `#<n>` · test `<node id>` |
+| <what is asserted but not checked> | unverified | (no evidence — not claimed done) |
+
+## Remaining Work / Follow-up
+
+<What is incomplete, deferred, blocked, or newly discovered — including any
+failure and its cause. Every partial/dropped/blocked task from Actual Delivery
+reappears here with its next step.>
+
+- <remaining item> — <next step / owner>
+```
+
+### Delivery Claims — the row contract
+
+Every Delivery Claims row carries three fields:
+
+- **Claim** — the specific thing asserted as delivered.
+- **Confidence** — exactly one of `high` / `medium` / `low` / `unverified`.
+- **Evidence** — at least one **resolvable** pointer, or the explicit
+  `unverified` marker. A resolvable pointer is one a reader can follow: a
+  **commit SHA** that exists, a **file path** that is present, a **PR or issue
+  number** that is real, or a **test node id** that ran. "It works" is not
+  evidence.
+
+### Drift From Plan — the entry contract
+
+Every Drift From Plan entry names three things:
+
+- **The plan item** it diverges from (by task id, quoted from the plan).
+- **The reason** for the divergence.
+- **Exactly one** classification: `acceptable` (a defensible deviation),
+  `risky` (may cause a problem; flag it), or `needs-follow-up` (leaves work
+  the plan assumed done).
+
+When a delivery store exists and an approved `devague deviate` record covers
+the item, cite it by its `dN` id and inherit its reason and classification
+verbatim — the record is the recorded ground truth, not something this skill
+re-derives. An item no record covers still gets an entry here, worked out the
+same way as before.
+
+## Degrading when there is no plan state
+
+The summary is producible from **durable** inputs — plan state, git history, PR
+links, test output — and never depends on unrecorded memory of the run. There
+are three tiers, most to least mechanical, and the artifact's `baseline:` line
+names which one applied:
+
+1. **`devague summary` skeleton** — the plan (and, if any, its delivery
+   record) can both be read; the render is fully mechanical.
+   `baseline: devague summary skeleton`.
+2. **Hand-assembly** — `devague summary` isn't available (the verb is missing,
+   or the state it needs can't be read) but the plan itself can still be read:
+   reconstruct the baseline read-only via `devague plan show [--json]` and
+   `devague plan waves --json`. `baseline: devague plan (hand-assembled)`.
+3. **Git + PR history** — no devague plan state exists at all: degrade to git
+   history and PR history as the planned-work baseline.
+   `baseline: git+PR history (no plan state)`.
+
+**Whichever tier applied, SAY SO in the artifact** (in the `baseline:` line
+and the Planned Work section). The delivery summary is still a valid
+accountability artifact either way; it just names its baseline honestly
+instead of pretending a more mechanical path was used.
+
+## The only devague moves this skill uses — all read-only
+
+This skill **never mutates devague state**. The complete set of devague moves
+it documents is read-only:
+
+| Move | What it reads |
+|------|---------------|
+| `devague summary [--pr] [--json]` | The eight-section delivery-summary skeleton (or condensed `--pr` skeleton), pre-filled verbatim from the plan's tasks, its live source frame, and the delivery (deviation) store — the primary planned-work baseline (Method step 1). |
+| `devague deviate --list [--json]` | Every recorded deviation, read back by `dN` id — the source Drift From Plan and Mid-work Decisions quote. Recording or confirming a deviation is `/deviate`'s job, never this skill's. |
+| `devague plan show [--json]` | The plan's tasks, acceptance criteria, dependencies — the hand-assembly fallback when `devague summary` (or the state it needs) is unavailable. |
+| `devague plan waves --json` | The wave batches + per-task `summary` / `instruction` / `acceptance_criteria` / `covers`, keyed by id — the hand-assembly fallback's verbatim planned-work baseline. |
+| `devague scope --list [--json]` | Recorded scope-exploration findings, if the frame carried any. |
+| `devague show [--json]` | A frame / plan rendered for reading. |
+| `devague status [--json]` | Where a frame stands (read-only next-move helper). |
+
+No other devague command appears in this method. Producing a delivery summary
+leaves `.devague/` byte-identical (issue
+[#20](https://github.com/agentculture/devague/issues/20)).
+
+## Hard rules (do not violate)
+
+These are the point of the method — a delivery summary must be trustworthy.
+
+- **No overclaiming.** A delivery claim without evidence is marked `unverified`,
+  never asserted as done. The `unverified` marker survives into the committed
+  artifact; no downstream step upgrades a claim's confidence without new
+  evidence.
+- **Partial and failed runs are valid inputs.** There is no completion
+  precondition — a run that merged zero waves is still a valid input. Failure
+  is reported faithfully: it appears under Drift and Remaining Work with its
+  cause, and no delivery claim says "done". No section ever becomes unwritable.
+- **Verification is read-only.** You may run the test suite, the linters, and
+  `git log` to substantiate a claim before writing it. Verification **never**
+  mutates code or state. A claim you cannot verify stays `unverified`.
+- **No devague state mutation.** The only devague moves this skill uses are the
+  read-only `summary`, `deviate --list`, `plan show`, `plan waves`,
+  `scope --list`, `show`, and `status` (see the table above). `deviate --list`
+  is read-only — recording or confirming a deviation belongs to `/deviate`,
+  never this skill. Never run a mutating devague command, and never run
+  `devague plan` inside a task worktree to "mark a task done" — that is
+  `/assign-to-workforce`'s boundary too (#20).
+- **Account for 100 % of plan tasks.** Every plan task appears in Actual
+  Delivery as delivered / partial / dropped / blocked — no silent omissions.
+  Both the task count and the claim-evidence coverage are checkable by
+  inspecting the artifact alone, with no hidden context.
+- **Quote the plan verbatim.** Planned Work quotes task ids and summaries
+  verbatim from the `devague summary` skeleton (or `devague plan waves --json`
+  when hand-assembling). Drift is measured against the confirmed contract, not
+  a reworded version of it.
+
+## Worked example
+
+A **partial** run: three tasks were planned; `t1` merged cleanly, `t2` merged
+after an approved mid-run deviation, and `t3` failed its post-merge TDD gate
+and was reverted. Every section is still writable — nothing about the failure
+makes the artifact unproducible.
+
+```bash
+# 1. Establish the planned-work baseline — read-only, quoted verbatim.
+devague summary                # -> pre-filled eight-section skeleton, keyed by
+                               #     task id, `<fill: ...>` placeholders for
+                               #     everything execution-dependent
+devague deviate --list         # -> d1 (approved, acceptable): t2 dropped an
+                               #     assumed flag mid-run
+
+# 2. Establish actual delivery — read-only reconciliation.
+git log --oneline main~4..main   # what merged
+gh pr view 71                    # the run's PR (evidence pointers)
+uv run pytest tests/test_export.py::test_widget_round_trips -q  # verify a claim
+```
+
+The resulting `docs/deliveries/2026-07-09-widget-export.md`:
+
+```markdown
+# Delivery Summary — widget export
+
+plan: `widget-export` · run: `partial` · date: `2026-07-09`
+baseline: `devague summary skeleton`
+
+## Intent
+
+Ship the `widget export` command as three independent tasks fanned out by
+/assign-to-workforce.
+
+## Planned Work
+
+Quoted verbatim from the `devague summary` skeleton:
+
+- `t1` — add the `export` verb to the CLI chassis
+- `t2` — implement the widget-md renderer
+- `t3` — wire the convergence gate into `export`
+
+## Actual Delivery
+
+| Plan task | Status | What actually landed |
+|-----------|--------|----------------------|
+| `t1` | delivered | `export` verb registered; merged in PR `#71` |
+| `t2` | delivered | renderer added at `devague/render/widget_md.py` |
+| `t3` | blocked | post-merge tests failed; merge reverted |
+
+## Mid-work Decisions
+
+- `d1` — dropped the `--verbose` flag from `t2`'s CLI surface — the plan
+  assumed it, but the renderer never needed a verbose mode (recorded via
+  `/deviate`, approved)
+- t2 also renders an absent field as an empty line rather than filler — no
+  deviation record covers this; captured here directly, matching the
+  no-fabrication rule the plan assumed but did not spell out.
+
+## Drift From Plan
+
+| Plan item | Reason for divergence | Classification |
+|-----------|-----------------------|----------------|
+| `t2` (`d1`) | dropped the `--verbose` flag — the plan assumed it, but the renderer never needed a verbose mode | acceptable |
+| `t3` | gate raised on an unconverged plan; reverted, not delivered | needs-follow-up |
+
+## Evidence
+
+- tests: `tests/test_export.py::test_widget_round_trips` — pass
+- tests: `tests/test_export.py::test_gate_blocks_unconverged` — fail
+- commits: `main~4..main`
+- PRs: `#71`
+
+## Delivery Claims
+
+| Claim | Confidence | Evidence |
+|-------|------------|----------|
+| the `export` verb ships and round-trips | high | test `tests/test_export.py::test_widget_round_trips` · PR `#71` |
+| the widget-md renderer exists | high | file `devague/render/widget_md.py` |
+| the convergence gate blocks unconverged exports | unverified | t3 reverted — not claimed done |
+
+## Remaining Work / Follow-up
+
+- `t3` — fix the gate wiring so `test_gate_blocks_unconverged` passes, then
+  re-run the TDD merge gate. Blocking for the feature's completeness.
+```
+
+Note what the failure did: it flowed into Actual Delivery (`blocked`), Drift
+(`needs-follow-up`), Delivery Claims (`unverified`), and Remaining Work — and
+no claim overstated it. That is the whole point.
+
+## After the summary — the final PR gate
+
+The delivery summary is the review map for `/assign-to-workforce`'s third human
+gate (the final PR). Commit `docs/deliveries/<created-date>-<slug>.md` alongside
+the run's work so the reviewer can audit planned-versus-actual without replaying
+the transcript. This skill does not open the PR or mutate any state — it
+produces the artifact the human reviews.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, the
+*fifth* in the outbound family after `/scope`, `/think`, `/spec-to-plan`, and
+`/assign-to-workforce`, covering the delivery-side closure leg after a plan is
+executed. guildmaster pulls it from here and broadcasts it to the AgentCulture
+mesh; because devague is upstream, it is **never re-vendored back** from
+guildmaster's re-broadcast copy. The `cite, don't import` policy still holds:
+downstream repos copy it, they don't symlink or depend on it. See
+`docs/skill-sources.md`.


### PR DESCRIPTION
## Propagate the devague/colleague agent-skill family

Vendors the following resident-agent skills into `.claude/skills/`, copied
**verbatim** from their origin working trees (cite-don't-import — provenance
sections preserved, no localization):

- **`scope`** — explore what an idea touches before framing it into a spec _(origin: agentculture/devague)_
- **`deviate`** — record an approved mid-run departure from the confirmed plan _(origin: agentculture/devague)_
- **`summarize-delivery`** — close the loop — planned vs actual delivery accountability _(origin: agentculture/devague)_

These complete this repo's copy of the shared devague planning arc
(`scope → think → spec-to-plan → assign-to-workforce → deviate → summarize-delivery`)
plus the colleague second-opinion skill, so the resident agent here carries
the same kit as its mesh peers.

Propagated deterministically via rollout-cli's `/mass-update` (verbatim file
drops into a fresh clone; no LLM). Companion tracking issue: #479.

- rollout-cli (Claude)
